### PR TITLE
ODSettings: Removed SPO module

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
@@ -104,7 +104,7 @@ function Get-TargetResource
         $ctx = (Get-PnPConnection).Context
         $tenant = [Microsoft.Online.SharePoint.TenantAdministration.Tenant]::new($ctx)
         $ctx.Load($tenant)
-        $ctx.ExecuteQuery();
+        Execute-CSOMQueryRetry -Context $ctx
 
         if ($null -eq $tenant)
         {

--- a/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
+++ b/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
@@ -2111,6 +2111,7 @@ function Execute-CSOMQueryRetry
     [Microsoft.SharePoint.Client.ClientContextExtensions]::ExecuteQueryRetry($context)
 }
 
+# https://social.msdn.microsoft.com/Forums/vstudio/en-US/63e84666-512d-4d56-8bc9-adebf39771fb/powershell-csom-include-additional-properties-in-clientobject?forum=sharepointdevelopment
 <#
 .Synopsis
     Facilitates the loading of specific properties of a Microsoft.SharePoint.Client.ClientObject object or Microsoft.SharePoint.Client.ClientObjectCollection object.

--- a/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
+++ b/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
@@ -2099,3 +2099,113 @@ function Get-AllSPOPackages
     }
     return $filesToDownload
 }
+
+<#
+.Synopsis
+    Facilitates the loading of specific properties of a Microsoft.SharePoint.Client.ClientObject object or Microsoft.SharePoint.Client.ClientObjectCollection object.
+.DESCRIPTION
+    Replicates what you would do with a lambda expression in C#.
+    For example, "ctx.Load(list, l => list.Title, l => list.Id)" becomes
+    "Load-CSOMProperties -object $list -propertyNames @('Title', 'Id')".
+.EXAMPLE
+    Load-CSOMProperties -parentObject $web -collectionObject $web.Fields -propertyNames @("InternalName", "Id") -parentPropertyName "Fields" -executeQuery
+    $web.Fields | select InternalName, Id
+.EXAMPLE
+   Load-CSOMProperties -object $web -propertyNames @("Title", "Url", "AllProperties") -executeQuery
+   $web | select Title, Url, AllProperties
+#>
+function Load-CSOMProperties {
+    [CmdletBinding(DefaultParameterSetName='ClientObject')]
+    param (
+        # The Microsoft.SharePoint.Client.ClientObject to populate.
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0, ParameterSetName = "ClientObject")]
+        [Microsoft.SharePoint.Client.ClientObject]
+        $object,
+
+        # The Microsoft.SharePoint.Client.ClientObject that contains the collection object.
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0, ParameterSetName = "ClientObjectCollection")]
+        [Microsoft.SharePoint.Client.ClientObject]
+        $parentObject,
+
+        # The Microsoft.SharePoint.Client.ClientObjectCollection to populate.
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 1, ParameterSetName = "ClientObjectCollection")]
+        [Microsoft.SharePoint.Client.ClientObjectCollection]
+        $collectionObject,
+
+        # The object properties to populate
+        [Parameter(Mandatory = $true, Position = 1, ParameterSetName = "ClientObject")]
+        [Parameter(Mandatory = $true, Position = 2, ParameterSetName = "ClientObjectCollection")]
+        [string[]]
+        $propertyNames,
+
+        # The parent object's property name corresponding to the collection object to retrieve (this is required to build the correct lamda expression).
+        [Parameter(Mandatory = $true, Position = 3, ParameterSetName = "ClientObjectCollection")]
+        [string]
+        $parentPropertyName,
+
+        # If specified, execute the ClientContext.ExecuteQuery() method.
+        [Parameter(Mandatory = $false, Position = 4)]
+        [switch]
+        $executeQuery
+    )
+
+    begin { }
+    process {
+        if ($PsCmdlet.ParameterSetName -eq "ClientObject") {
+            $type = $object.GetType()
+        } else {
+            $type = $collectionObject.GetType()
+            if ($collectionObject -is [Microsoft.SharePoint.Client.ClientObjectCollection]) {
+                $type = $collectionObject.GetType().BaseType.GenericTypeArguments[0]
+            }
+        }
+
+        $exprType = [System.Linq.Expressions.Expression]
+        $parameterExprType = [System.Linq.Expressions.ParameterExpression].MakeArrayType()
+        $lambdaMethod = $exprType.GetMethods() | ? { $_.Name -eq "Lambda" -and $_.IsGenericMethod -and $_.GetParameters().Length -eq 2 -and $_.GetParameters()[1].ParameterType -eq $parameterExprType }
+        $lambdaMethodGeneric = Invoke-Expression "`$lambdaMethod.MakeGenericMethod([System.Func``2[$($type.FullName),System.Object]])"
+        $expressions = @()
+
+        foreach ($propertyName in $propertyNames) {
+            $param1 = [System.Linq.Expressions.Expression]::Parameter($type, "p")
+            try {
+                $name1 = [System.Linq.Expressions.Expression]::Property($param1, $propertyName)
+            } catch {
+                Write-Error "Instance property '$propertyName' is not defined for type $type"
+                return
+            }
+            $body1 = [System.Linq.Expressions.Expression]::Convert($name1, [System.Object])
+            $expression1 = $lambdaMethodGeneric.Invoke($null, [System.Object[]] @($body1, [System.Linq.Expressions.ParameterExpression[]] @($param1)))
+
+            if ($collectionObject -ne $null) {
+                $expression1 = [System.Linq.Expressions.Expression]::Quote($expression1)
+            }
+            $expressions += @($expression1)
+        }
+
+
+        if ($PsCmdlet.ParameterSetName -eq "ClientObject") {
+            $object.Context.Load($object, $expressions)
+            if ($executeQuery) { $object.Context.ExecuteQuery() }
+        } else {
+            $newArrayInitParam1 = Invoke-Expression "[System.Linq.Expressions.Expression``1[System.Func````2[$($type.FullName),System.Object]]]"
+            $newArrayInit = [System.Linq.Expressions.Expression]::NewArrayInit($newArrayInitParam1, $expressions)
+
+            $collectionParam = [System.Linq.Expressions.Expression]::Parameter($parentObject.GetType(), "cp")
+            $collectionProperty = [System.Linq.Expressions.Expression]::Property($collectionParam, $parentPropertyName)
+
+            $expressionArray = @($collectionProperty, $newArrayInit)
+            $includeMethod = [Microsoft.SharePoint.Client.ClientObjectQueryableExtension].GetMethod("Include")
+            $includeMethodGeneric = Invoke-Expression "`$includeMethod.MakeGenericMethod([$($type.FullName)])"
+
+            $lambdaMethodGeneric2 = Invoke-Expression "`$lambdaMethod.MakeGenericMethod([System.Func``2[$($parentObject.GetType().FullName),System.Object]])"
+            $callMethod = [System.Linq.Expressions.Expression]::Call($null, $includeMethodGeneric, $expressionArray)
+
+            $expression2 = $lambdaMethodGeneric2.Invoke($null, @($callMethod, [System.Linq.Expressions.ParameterExpression[]] @($collectionParam)))
+
+            $parentObject.Context.Load($parentObject, $expression2)
+            if ($executeQuery) { $parentObject.Context.ExecuteQuery() }
+        }
+    }
+    end { }
+}

--- a/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
+++ b/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
@@ -2100,6 +2100,17 @@ function Get-AllSPOPackages
     return $filesToDownload
 }
 
+function Execute-CSOMQueryRetry
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Microsoft.SharePoint.Client.ClientContext] $context
+    )
+
+    [Microsoft.SharePoint.Client.ClientContextExtensions]::ExecuteQueryRetry($context)
+}
+
 <#
 .Synopsis
     Facilitates the loading of specific properties of a Microsoft.SharePoint.Client.ClientObject object or Microsoft.SharePoint.Client.ClientObjectCollection object.


### PR DESCRIPTION
I think that OD settings are the last thing stopping the removal of the SharePoint Online PowerShell module, at least when the #354 PR is completed.
This PR rewrites the OD settings with CSOM code since I could not find anything in PnP that would be equivalent to the existing resource. Maybe I'm wrong and did not look hard enough, but this is the solution that I came up with.

I also added a utility function that was found floating around the web, Load-CSOMProperties which lets us select the properties that we need when writing a CSOM query. In the end it was not required since all the required properties on the tenant object are loaded by default but it may come in handy in the future.

Execute-CSOMQueryRetry just calls some PnP extension method to keep the same retry behavior that is within PnP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/375)
<!-- Reviewable:end -->
