### PR TITLE
Fixes for Issue 591

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   * Improved event log function
 * EXOEmailAddressPolicy
   * Converted hardcoded tenant name into variables;
+* EXOOutboundConnector
+  * Fixed an issue where if the connector was created with a source
+    of 'AdminUI', we now convert it to 'Default' in the Get function;
 * TeamsTenantDialPlan
   * Fixed an issue extraction plans without any normalization rules;
 * Modules

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOutboundConnector/MSFT_EXOOutboundConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOutboundConnector/MSFT_EXOOutboundConnector.psm1
@@ -98,12 +98,18 @@ function Get-TargetResource
     }
     else
     {
+        $ConnectorSourceValue = $OutBoundConnector.ConnectorSource
+        if ($ConnectorSourceValue -eq 'AdminUI')
+        {
+            $ConnectorSourceValue = 'Default'
+        }
+
         $result = @{
             Identity                      = $Identity
             AllAcceptedDomains            = $OutBoundConnector.AllAcceptedDomains
             CloudServicesMailEnabled      = $OutBoundConnector.CloudServicesMailEnabled
             Comment                       = $OutBoundConnector.Comment
-            ConnectorSource               = $OutBoundConnector.ConnectorSource
+            ConnectorSource               = $ConnectorSource
             ConnectorType                 = $OutBoundConnector.ConnectorType
             Enabled                       = $OutBoundConnector.Enabled
             IsTransportRuleScoped         = $OutBoundConnector.IsTransportRuleScoped

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOOutboundConnector.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOOutboundConnector.Tests.ps1
@@ -220,6 +220,58 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
         }
 
+        Context -Name "Connector Source is AdminUI" -Fixture {
+            $testParams = @{
+                Ensure                        = 'Present'
+                GlobalAdminAccount            = $GlobalAdminAccount
+                Identity                      = 'TestOutboundConnector'
+                CloudServicesMailEnabled      = $false
+                Comment                       = 'Test outbound connector'
+                Enabled                       = $true
+                ConnectorSource               = 'Default'
+                ConnectorType                 = 'Partner'
+                IsTransportRuleScoped         = $false
+                RecipientDomains              = @('fabrikam.com', 'contoso.com')
+                RouteAllMessagesViaOnPremises = $false
+                SmartHosts                    = @('mail.contoso.com')
+                TestMode                      = $false
+                TlsDomain                     = '*.contoso.com'
+                TlsSettings                   = 'EncryptionOnly'
+                UseMxRecord                   = $false
+                ValidationRecipients          = @('test@contoso.com')
+            }
+
+
+            Mock -CommandName Get-OutboundConnector -MockWith {
+                return @{
+                    Ensure                        = 'Present'
+                    Identity                      = 'TestOutboundConnector'
+                    CloudServicesMailEnabled      = $false
+                    Comment                       = 'Test outbound connector'
+                    Enabled                       = $true
+                    ConnectorSource               = 'AdminUI'
+                    ConnectorType                 = 'Partner'
+                    IsTransportRuleScoped         = $false
+                    RecipientDomains              = @('fabrikam.com', 'contoso.com')
+                    RouteAllMessagesViaOnPremises = $false
+                    SmartHosts                    = @('mail.contoso.com')
+                    TestMode                      = $false
+                    TlsDomain                     = '*.contoso.com'
+                    TlsSettings                   = 'EncryptionOnly'
+                    UseMxRecord                   = $false
+                    ValidationRecipients          = @('test@contoso.com')
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should Be $true
+            }
+
+            It 'Should return Default as the source from the Get method' {
+                (Get-TargetResource @testParams).ConnectorSource | Should Be 'Default'
+            }
+        }
+
         Context -Name "ReverseDSC Tests" -Fixture {
             $testParams = @{
                 GlobalAdminAccount = $GlobalAdminAccount


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes an issue where if the connector was created via the Admin UI, the ConnectorSource property retuned is set to AdminUI which is not a valid value for the New cmdlet. Instead the Get function now returns 'Default'.

#### This Pull Request (PR) fixes the following issues
- Fixes #591

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/621)
<!-- Reviewable:end -->
