### PR TITLE
Update MSFT_EXOOrganizationRelationship.psm1

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
@@ -306,7 +306,7 @@ function Set-TargetResource
         Enabled               = $Enabled
         FreeBusyAccessEnabled = $FreeBusyAccessEnabled
         FreeBusyAccessLevel   = $FreeBusyAccessLevel
-        FreeBusyAccessScope   = $FreeBusyAccessScope
+        #FreeBusyAccessScope   = $FreeBusyAccessScope
         MailboxMoveEnabled    = $MailboxMoveEnabled
         MailTipsAccessEnabled = $MailTipsAccessEnabled
         MailTipsAccessLevel   = $MailTipsAccessLevel
@@ -328,7 +328,7 @@ function Set-TargetResource
         Enabled               = $Enabled
         FreeBusyAccessEnabled = $FreeBusyAccessEnabled
         FreeBusyAccessLevel   = $FreeBusyAccessLevel
-        FreeBusyAccessScope   = $FreeBusyAccessScope
+        #FreeBusyAccessScope   = $FreeBusyAccessScope
         MailboxMoveEnabled    = $MailboxMoveEnabled
         MailTipsAccessEnabled = $MailTipsAccessEnabled
         MailTipsAccessLevel   = $MailTipsAccessLevel
@@ -342,6 +342,14 @@ function Set-TargetResource
         TargetSharingEpr      = $TargetSharingEpr
         Confirm               = $false
     }
+
+   if ($FreeBusyAccessScope)
+        {
+ 		$NewOrganizationRelationshipParams.Add("FreeBusyAccessScope", $FreeBusyAccessScope)
+	    	$SetOrganizationRelationshipParams.Add("FreeBusyAccessScope", $FreeBusyAccessScope)
+        }
+
+
 
     # CASE: Organization Relationship doesn't exist but should;
     if ($Ensure -eq "Present" -and $currentOrgRelationshipConfig.Ensure -eq "Absent")

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
@@ -310,7 +310,7 @@ function Set-TargetResource
         MailboxMoveEnabled    = $MailboxMoveEnabled
         MailTipsAccessEnabled = $MailTipsAccessEnabled
         MailTipsAccessLevel   = $MailTipsAccessLevel
-        MailTipsAccessScope   = $MailTipsAccessScope
+        #MailTipsAccessScope   = $MailTipsAccessScope
         Name                  = $Name
         OrganizationContact   = $OrganizationContact
         PhotosEnabled         = $PhotosEnabled
@@ -332,7 +332,7 @@ function Set-TargetResource
         MailboxMoveEnabled    = $MailboxMoveEnabled
         MailTipsAccessEnabled = $MailTipsAccessEnabled
         MailTipsAccessLevel   = $MailTipsAccessLevel
-        MailTipsAccessScope   = $MailTipsAccessScope
+        #MailTipsAccessScope   = $MailTipsAccessScope
         Identity              = $Name
         OrganizationContact   = $OrganizationContact
         PhotosEnabled         = $PhotosEnabled
@@ -345,11 +345,15 @@ function Set-TargetResource
 
    if ($FreeBusyAccessScope)
         {
- 		$NewOrganizationRelationshipParams.Add("FreeBusyAccessScope", $FreeBusyAccessScope)
-	    	$SetOrganizationRelationshipParams.Add("FreeBusyAccessScope", $FreeBusyAccessScope)
+			$NewOrganizationRelationshipParams.Add("FreeBusyAccessScope", $FreeBusyAccessScope)
+			$SetOrganizationRelationshipParams.Add("FreeBusyAccessScope", $FreeBusyAccessScope)
         }
 
-
+   if ($MailTipsAccessScope)
+        {
+			$NewOrganizationRelationshipParams.Add("MailTipsAccessScope", $MailTipsAccessScope)
+			$SetOrganizationRelationshipParams.Add("MailTipsAccessScope", $MailTipsAccessScope)
+		}
 
     # CASE: Organization Relationship doesn't exist but should;
     if ($Ensure -eq "Present" -and $currentOrgRelationshipConfig.Ensure -eq "Absent")


### PR DESCRIPTION
Fixes bug #645 where error "Cannot process argument transformation on parameter 'FreeBusyAccessScope'" thrown while applying EXO config.

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
Bug fix

#### This Pull Request (PR) fixes the following issues
Fixes #645


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/648)
<!-- Reviewable:end -->
