### PR TITLE
Provides function to remove empty splat parameters #653, fixes some issues

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
@@ -321,7 +321,7 @@ function Set-TargetResource
         Confirm               = $false
     }
     # Removes empty properties from Splat to prevent function throwing errors if parameter is null or empty
-    Remove-EmptySplatProperty -Splat $NewOrganizationRelationshipParams
+    Remove-EmptyValue -Splat $NewOrganizationRelationshipParams
 
     $SetOrganizationRelationshipParams = @{
         ArchiveAccessEnabled  = $ArchiveAccessEnabled
@@ -345,7 +345,7 @@ function Set-TargetResource
         Confirm               = $false
     }
     # Removes empty properties from Splat to prevent function throwing errors if parameter is null or empty
-    Remove-EmptySplatProperty -Splat $SetOrganizationRelationshipParams
+    Remove-EmptyValue -Splat $SetOrganizationRelationshipParams
 
     # CASE: Organization Relationship doesn't exist but should;
     if ($Ensure -eq "Present" -and $currentOrgRelationshipConfig.Ensure -eq "Absent")

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
@@ -320,6 +320,8 @@ function Set-TargetResource
         TargetSharingEpr      = $TargetSharingEpr
         Confirm               = $false
     }
+    # Removes empty properties from Splat to prevent function throwing errors if parameter is null or empty
+    Remove-EmptySplatProperty -Splat $NewOrganizationRelationshipParams
 
     $SetOrganizationRelationshipParams = @{
         ArchiveAccessEnabled  = $ArchiveAccessEnabled
@@ -342,6 +344,8 @@ function Set-TargetResource
         TargetSharingEpr      = $TargetSharingEpr
         Confirm               = $false
     }
+    # Removes empty properties from Splat to prevent function throwing errors if parameter is null or empty
+    Remove-EmptySplatProperty -Splat $SetOrganizationRelationshipParams
 
     # CASE: Organization Relationship doesn't exist but should;
     if ($Ensure -eq "Present" -and $currentOrgRelationshipConfig.Ensure -eq "Absent")

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
@@ -162,7 +162,7 @@ function Get-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $NpsMailboxPolicy,
+        $NpsSurveysEnabled,
 
         [Parameter()]
         [System.Boolean]
@@ -382,7 +382,7 @@ function Get-TargetResource
             LocalEventsEnabled                                   = $LocalEventsEnabled
             LogonAndErrorLanguage                                = $LogonAndErrorLanguage
             NotesEnabled                                         = $NotesEnabled
-            NpsMailboxPolicy                                     = $NpsMailboxPolicy
+            NpsSurveysEnabled                                    = $NpsSurveysEnabled
             OrganizationEnabled                                  = $OrganizationEnabled
             OnSendAddinsEnabled                                  = $OnSendAddinsEnabled
             OutboundCharset                                      = $OutboundCharset
@@ -467,7 +467,7 @@ function Get-TargetResource
             LocalEventsEnabled                                   = $OwaMailboxPolicy.LocalEventsEnabled
             LogonAndErrorLanguage                                = $OwaMailboxPolicy.LogonAndErrorLanguage
             NotesEnabled                                         = $OwaMailboxPolicy.NotesEnabled
-            NpsMailboxPolicy                                     = $OwaMailboxPolicy.NpsMailboxPolicy
+            NpsSurveysEnabled                                    = $OwaMailboxPolicy.NpsSurveysEnabled
             OrganizationEnabled                                  = $OwaMailboxPolicy.OrganizationEnabled
             OnSendAddinsEnabled                                  = $OwaMailboxPolicy.OnSendAddinsEnabled
             OutboundCharset                                      = $OwaMailboxPolicy.OutboundCharset
@@ -677,7 +677,7 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $NpsMailboxPolicy,
+        $NpsSurveysEnabled,
 
         [Parameter()]
         [System.Boolean]
@@ -898,6 +898,7 @@ function Set-TargetResource
         LocalEventsEnabled                                   = $LocalEventsEnabled
         LogonAndErrorLanguage                                = $LogonAndErrorLanguage
         NotesEnabled                                         = $NotesEnabled
+        NpsSurveysEnabled                                    = $NpsSurveysEnabled
         OrganizationEnabled                                  = $OrganizationEnabled
         OnSendAddinsEnabled                                  = $OnSendAddinsEnabled
         OutboundCharset                                      = $OutboundCharset
@@ -1130,7 +1131,7 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $NpsMailboxPolicy,
+        $NpsSurveysEnabled,
 
         [Parameter()]
         [System.Boolean]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
@@ -898,7 +898,6 @@ function Set-TargetResource
         LocalEventsEnabled                                   = $LocalEventsEnabled
         LogonAndErrorLanguage                                = $LogonAndErrorLanguage
         NotesEnabled                                         = $NotesEnabled
-        NpsMailboxPolicy                                     = $NpsMailboxPolicy
         OrganizationEnabled                                  = $OrganizationEnabled
         OnSendAddinsEnabled                                  = $OnSendAddinsEnabled
         OutboundCharset                                      = $OutboundCharset

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
@@ -938,6 +938,8 @@ function Set-TargetResource
         WebPartsFrameOptionsType                             = $WebPartsFrameOptionsType
         Confirm                                              = $false
     }
+    # Removes empty properties from Splat to prevent function throwing errors if parameter is null or empty
+    Remove-EmptySplatProperty -Splat $SetOwaMailboxPolicyParams
 
     # CASE: OWA Mailbox Policy doesn't exist but should;
     if ($Ensure -eq "Present" -and $currentOwaMailboxPolicyConfig.Ensure -eq "Absent")

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
@@ -939,7 +939,7 @@ function Set-TargetResource
         Confirm                                              = $false
     }
     # Removes empty properties from Splat to prevent function throwing errors if parameter is null or empty
-    Remove-EmptySplatProperty -Splat $SetOwaMailboxPolicyParams
+    Remove-EmptyValue -Splat $SetOwaMailboxPolicyParams
 
     # CASE: OWA Mailbox Policy doesn't exist but should;
     if ($Ensure -eq "Present" -and $currentOwaMailboxPolicyConfig.Ensure -eq "Absent")

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.schema.mof
@@ -77,7 +77,7 @@ class MSFT_EXOOwaMailboxPolicy : OMI_BaseResource
 
     [Write, Description("The NotesEnabled parameter specifies whether the Notes folder is available in Outlook on the web.")] Boolean NotesEnabled;
 
-    [Write, Description("The NPSMailboxPolicy parameter specifies whether to enable or disable the Net Promoter Score (NPS) survey in Outlook on the web. The survey allows uses to rate Outlook on the web on a scale of 1 to 5, and to provide feedback and suggested improvements in free text.")] Boolean NpsMailboxPolicy;
+    [Write, Description("The NpsSurveysEnabled parameter specifies whether to enable or disable the Net Promoter Score (NPS) survey in Outlook on the web. The survey allows uses to rate Outlook on the web on a scale of 1 to 5, and to provide feedback and suggested improvements in free text.")] Boolean NpsSurveysEnabled;
 
     [Write, Description("When the OrganizationEnabled parameter is set to $false, the Automatic Reply option doesn't include external and internal options, the address book doesn't show the organization hierarchy, and the Resources tab in Calendar forms is disabled.")] Boolean OrganizationEnabled;
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1515,3 +1515,20 @@ function Set-M365DSCAgentCertificateConfiguration
     Remove-Item -Path "./M365AgentConfig" -Recurse -Confirm:$false
     return $thumbprint
 }
+
+
+function Remove-EmptySplatProperty
+{
+    [cmdletBinding()]
+    param(
+        [parameter(Mandatory)][System.Collections.IDictionary] $Splat
+    )
+    foreach ($Key in [string[]]$Splat.Keys)
+    {
+        #if ($null -eq $Splat[$Key] -or $Splat[$Key] -eq '') {
+        if ([string]::IsNullOrEmpty($Splat[$Key]))
+        {
+            $Splat.Remove($Key)
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1521,14 +1521,17 @@ function Remove-EmptySplatProperty
 {
     [cmdletBinding()]
     param(
-        [parameter(Mandatory)][System.Collections.IDictionary] $Splat
+        [Parameter(Mandatory)][System.Collections.IDictionary] $Splat,
+        [string[]] $ExcludeParameter
     )
     foreach ($Key in [string[]]$Splat.Keys)
     {
-        #if ($null -eq $Splat[$Key] -or $Splat[$Key] -eq '') {
-        if ([string]::IsNullOrEmpty($Splat[$Key]))
+        if ($Key -notin $ExcludeParameter)
         {
-            $Splat.Remove($Key)
+            if ([string]::IsNullOrEmpty($Splat[$Key]))
+            {
+                $Splat.Remove($Key)
+            }
         }
     }
 }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.Utils.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.Utils.Tests.ps1
@@ -1,0 +1,42 @@
+﻿Describe -Name 'Removing of empty / null splat properties' {
+    It 'From hashtable' {
+        function Test-FunctionHashtable
+        {
+            [cmdletBinding()]
+            param(
+                [ValidateNotNull()]$Test,
+                [string] $Test1
+            )
+            Write-Verbose "Value for Test is $Test, Value for Test1 is $Test1"
+        }
+
+        $Splat = @{
+            Test  = $NotExistingParameter
+            Test1 = 'Existing Entry'
+            Test2 = $null
+            Test3 = ''
+        }
+
+        Remove-EmptySplatProperty -Splat $Splat
+        { Test-FunctionHashtable @Splat } | Should -Not -Throw
+    }
+    It 'From OrderedDictionary' {
+        function Test-FunctionOrderedDictionary
+        {
+            [cmdletBinding()]
+            param(
+                [ValidateNotNull()]$Test,
+                [string] $Test1
+            )
+            Write-Verbose "Value for Test is $Test, Value for Test1 is $Test1"
+        }
+        $SplatDictionary = [ordered] @{
+            Test  = $NotExistingParameter
+            Test1 = 'Existing Entry'
+            Test2 = $null
+            Test3 = ''
+        }
+        Remove-EmptySplatProperty -Splat $SplatDictionary
+        { Test-FunctionOrderedDictionary @SplatDictionary } | Should -Not -Throw
+    }
+}

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.Utils.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.Utils.Tests.ps1
@@ -5,9 +5,11 @@
             [cmdletBinding()]
             param(
                 [ValidateNotNull()]$Test,
-                [string] $Test1
+                [string] $Test1,
+                [int] $Test5,
+                [int] $Test6
             )
-            Write-Verbose "Value for Test is $Test, Value for Test1 is $Test1"
+            Write-Verbose "Value for Test is $Test, Value for Test1 is $Test1, test5 $Test5, test6 $Test6"
         }
 
         $Splat = @{
@@ -15,6 +17,8 @@
             Test1 = 'Existing Entry'
             Test2 = $null
             Test3 = ''
+            Test5 = 0
+            Test6 = 6
         }
 
         Remove-EmptySplatProperty -Splat $Splat
@@ -26,15 +30,19 @@
             [cmdletBinding()]
             param(
                 [ValidateNotNull()]$Test,
-                [string] $Test1
+                [string] $Test1,
+                [int] $Test5,
+                [int] $Test6
             )
-            Write-Verbose "Value for Test is $Test, Value for Test1 is $Test1"
+            Write-Verbose "Value for Test is $Test, Value for Test1 is $Test1, test5 $Test5, test6 $Test6"
         }
         $SplatDictionary = [ordered] @{
             Test  = $NotExistingParameter
             Test1 = 'Existing Entry'
             Test2 = $null
             Test3 = ''
+            Test5 = 0
+            Test6 = 6
         }
         Remove-EmptySplatProperty -Splat $SplatDictionary
         { Test-FunctionOrderedDictionary @SplatDictionary } | Should -Not -Throw

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.Utils.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.Utils.Tests.ps1
@@ -1,7 +1,6 @@
 ﻿Describe -Name 'Removing of empty / null splat properties' {
     It 'From hashtable' {
-        function Test-FunctionHashtable
-        {
+        function Test-FunctionHashtable {
             [cmdletBinding()]
             param(
                 [ValidateNotNull()]$Test,
@@ -21,12 +20,11 @@
             Test6 = 6
         }
 
-        Remove-EmptySplatProperty -Splat $Splat
+        Remove-EmptyValue -Splat $Splat
         { Test-FunctionHashtable @Splat } | Should -Not -Throw
     }
     It 'From OrderedDictionary' {
-        function Test-FunctionOrderedDictionary
-        {
+        function Test-FunctionOrderedDictionary {
             [cmdletBinding()]
             param(
                 [ValidateNotNull()]$Test,
@@ -44,7 +42,35 @@
             Test5 = 0
             Test6 = 6
         }
-        Remove-EmptySplatProperty -Splat $SplatDictionary
+        Remove-EmptyValue -Splat $SplatDictionary
         { Test-FunctionOrderedDictionary @SplatDictionary } | Should -Not -Throw
+    }
+    It 'From OrderedDictionary but with ExcludedProperty' {
+        $SplatDictionary = [ordered] @{
+            Test  = $NotExistingParameter
+            Test1 = 'Existing Entry'
+            Test2 = $null
+            Test3 = ''
+            Test5 = 0
+            Test6 = 6
+        }
+        Remove-EmptyValue -Splat $SplatDictionary -ExcludeParameter 'Test3'
+        $SplatDictionary['Test3'] | Should -Be ''
+    }
+    It 'From OrderedDictionary Recursive' {
+        $SplatDictionary = [ordered] @{
+            Test  = $NotExistingParameter
+            Test1 = 'Existing Entry'
+            Test2 = $null
+            Test3 = ''
+            Test5 = 0
+            Test6 = 6
+            Test7 = @{}
+        }
+        Remove-EmptyValue -Splat $SplatDictionary
+        $SplatDictionary.Keys | Should -Contain 'Test7'
+
+        Remove-EmptyValue -Splat $SplatDictionary -Recursive
+        $SplatDictionary.Keys | Should -not -Contain 'Test7'
     }
 }


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
As mentioned in #653 issue when passing splat to a function it takes all parameters regardless if they are null or empty and tries to pass them to a function. If a function doesn't accept null or empty it will throw errors. This PR adds a function `Remove-EmptyValue` that when passing hashtable or ordered dictionary removes empty or null properties and just leaves all others in place.

Usage is as simple as adding 1 line before passing splat to final function. 

```powershell
        function Test-FunctionOrderedDictionary
        {
            [cmdletBinding()]
            param(
                [ValidateNotNull()]$Test,
                [string] $Test1
            )
            Write-Verbose "Value for Test is $Test, Value for Test1 is $Test1"
        }
        $SplatDictionary = [ordered] @{
            Test  = $NotExistingParameter
            Test1 = 'Existing Entry'
            Test2 = $null
            Test3 = ''
        }
        Remove-EmptyValue -Splat $SplatDictionary
        Test-FunctionOrderedDictionary @SplatDictionary
```

#### This Pull Request (PR) fixes the following issues

- Fixes #653
- Fixes #645 
- Fixes #646 

It doesn't fix all issues, as I believe all other splat based parameters will have similar issues, but maybe not as impactful because most if not all parameters will always be present. 

The usage of function is simple:

```powershell
Remove-EmptyValue -Splat $Splat
```

I also added a more advanced option if we would like to make sure we keep mandatory parameters always provided such as Identity or Confirm.

```powershell
Remove-EmptyValue -Splat $Splat -ExcludeParameter 'Identity', 'Confirm'
```

I've not used the 2nd version in code, just 1st but if you think it would be better I can update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/661)
<!-- Reviewable:end -->