### PR TITLE
Fixes for SPOPropertyBag incorrectly detecting properties as absent

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOPropertyBag/MSFT_SPOPropertyBag.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOPropertyBag/MSFT_SPOPropertyBag.psm1
@@ -70,7 +70,6 @@ function Get-TargetResource
     }
     if ($property.Length -eq 0)
     {
-        "`r`nContext: $(Get-PnpConnection | Out-String)`r`nCouldn't find $Key on {$Url}" | Out-File C:\DSC\NotFound.txt -Append
         Write-Verbose -Message "SPOPropertyBag $Key does not exist at {$Url}."
         $result = $PSBoundParameters
         $result.Ensure = 'Absent'

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -263,9 +263,9 @@ function Start-M365DSCConfigurationExtract
                     {
                         $parameters.Add("GlobalAdminAccount", $GlobalAdminAccount)
                     }
-                    if ($MaxProcessesExists -and -not [System.String]::IsNullOrEmpty($MaxProcessesExists))
+                    if ($MaxProcessesExists -and -not [System.String]::IsNullOrEmpty($MaxProcesses))
                     {
-                        $parameters.Add("MaxProcesses", $MaxProcessesExists)
+                        $parameters.Add("MaxProcesses", $MaxProcesses)
                     }
                     if ($AppSecretExists -and -not [System.String]::IsNullOrEmpty($ApplicationSecret))
                     {


### PR DESCRIPTION
#### Pull Request (PR) description
The Get-TargetResource sometimes incorrectly detected Properties as absent.

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/662)
<!-- Reviewable:end -->
