### PR TITLE
Fixes Event Log Journal Naming Issue + Other Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## UNRELEASED
 
+* MISC
+  * Renamed the event log to M365DSC to avoid journal conflicts;
+
 ## 1.20.716.1
 
 * MISC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * Updated Microsoft.Graph.Authentication module version to 0.7.1;
   * Updated Microsoft.PowerApps.Administration.PowerShell version to
     2.0.72;
+  * Updated SharePointPnPPowerShellOnline version to 3.23.2007.1;
 
 ## 1.20.716.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ## UNRELEASED
 
+* SPOAPP
+  * Added property Path as a key for the SPOApp resource to
+    prevent conflict where two solutions could have the same
+    name;
 * MISC
   * Renamed the event log to M365DSC to avoid journal conflicts;
+* Metadata
+  * Updated Microsoft.Graph.Authentication module version to 0.7.1;
+  * Updated Microsoft.PowerApps.Administration.PowerShell version to
+    2.0.72;
 
 ## 1.20.716.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOApp/MSFT_SPOApp.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOApp/MSFT_SPOApp.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_SPOApp : OMI_BaseResource
 {
     [Key, Description("The name of the App.")] string Identity;
-    [Required, Description("The path the the app package on disk.")] string Path;
+    [Key, Description("The path the the app package on disk.")] string Path;
     [Write, Description("This will deploy/trust an app into the app catalog.")] boolean Publish;
     [Write, Description("Overwrites the existing app package if it already exists.")] boolean Overwrite;
     [Write, Description("Present ensures the site collection exists, absent ensures it is removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;

--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -65,7 +65,7 @@
         },
         @{
             ModuleName      = "Microsoft.Graph.Authentication"
-            RequiredVersion = "0.7.0"
+            RequiredVersion = "0.7.1"
         },
         @{
             ModuleName      = "Microsoft.Graph.Groups.Planner"

--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -81,7 +81,7 @@
         },
         @{
             ModuleName      = "Microsoft.PowerApps.Administration.PowerShell"
-            RequiredVersion = "2.0.70"
+            RequiredVersion = "2.0.72"
         },
         @{
             ModuleName      = "MicrosoftTeams"
@@ -97,7 +97,7 @@
         },
         @{
             ModuleName      = "SharePointPnPPowerShellOnline"
-            RequiredVersion = "3.23.2007.0"
+            RequiredVersion = "3.23.2007.1"
         }
     )
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCLogEngine.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCLogEngine.psm1
@@ -80,7 +80,7 @@ function Add-M365DSCEvent
         $EventID = 1
     )
 
-    $LogName = 'Microsoft365DSC'
+    $LogName = 'M365DSC'
 
     if ([System.Diagnostics.EventLog]::SourceExists($Source))
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes an issue where the Event Viewer only looks at the first 8 characters and could throw errors due to naming conflict. Renamed the Even Log Journal to simply 'M365DSC'

#### This Pull Request (PR) fixes the following issues
- Fixes #668 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/692)
<!-- Reviewable:end -->
