### PR TITLE
Removed the AllowPreRelease switch from Install-M365DSCDevBranch

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1405,7 +1405,7 @@ function Install-M365DSCDevBranch
     $dependencies = $manifest.RequiredModules
     foreach ($dependency in $dependencies)
     {
-        Install-Module $dependency.ModuleName -RequiredVersion $dependency.RequiredVersion -Force -AllowClobber -AllowPrerelease
+        Install-Module $dependency.ModuleName -RequiredVersion $dependency.RequiredVersion -Force -AllowClobber
         Import-Module $dependency.ModuleName -Force
     }
     #endregion


### PR DESCRIPTION
#### Pull Request (PR) description
Remove the AllowPrerelease switch from the Install-M365DSCDevBranch because it is no longer required.

#### This Pull Request (PR) fixes the following issues
- Fixes #688

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/694)
<!-- Reviewable:end -->
