### PR TITLE
Fixes Remove-EmptyValue for edge case when dealing with GenericLists

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1739,7 +1739,7 @@ function Remove-EmptyValue
                 }
                 else
                 {
-                    if ([string]::IsNullOrEmpty($Hashtable[$Key]))
+                    if ($null -eq $Hashtable[$Key] -or $Hashtable[$Key] -eq '') {
                     {
                         $Hashtable.Remove($Key)
                     }
@@ -1747,7 +1747,7 @@ function Remove-EmptyValue
             }
             else
             {
-                if ([string]::IsNullOrEmpty($Hashtable[$Key]))
+                if ($null -eq $Hashtable[$Key] -or $Hashtable[$Key] -eq '') {
                 {
                     $Hashtable.Remove($Key)
                 }

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1739,7 +1739,7 @@ function Remove-EmptyValue
                 }
                 else
                 {
-                    if ($null -eq $Hashtable[$Key] -or $Hashtable[$Key] -eq '') {
+                    if ($null -eq $Hashtable[$Key] -or $Hashtable[$Key] -eq '')
                     {
                         $Hashtable.Remove($Key)
                     }
@@ -1747,7 +1747,7 @@ function Remove-EmptyValue
             }
             else
             {
-                if ($null -eq $Hashtable[$Key] -or $Hashtable[$Key] -eq '') {
+                if ($null -eq $Hashtable[$Key] -or $Hashtable[$Key] -eq '')
                 {
                     $Hashtable.Remove($Key)
                 }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.Utils.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.Utils.Tests.ps1
@@ -73,4 +73,27 @@
         Remove-EmptyValue -Splat $SplatDictionary -Recursive
         $SplatDictionary.Keys | Should -not -Contain 'Test7'
     }
+    It 'From OrderedDictionary Recursive with ILIST check' {
+        $SplatDictionary = [ordered] @{
+            Test  = $NotExistingParameter
+            Test1 = 'Existing Entry'
+            Test2 = $null
+            Test3 = ''
+            Test5 = 0
+            Test6 = [System.Collections.Generic.List[PSCustomObject]]::new()
+            Test7 = @{}
+        }
+        $DummyObject = [PSCustomObject] @{
+            Test  = 1
+            Test1 = 2
+        }
+        $SplatDictionary.Test6.Add($DummyObject)
+
+        Remove-EmptyValue -Splat $SplatDictionary
+        $SplatDictionary.Keys | Should -Contain 'Test6'
+        $SplatDictionary.Keys | Should -Contain 'Test7'
+
+        Remove-EmptyValue -Splat $SplatDictionary -Recursive
+        $SplatDictionary.Keys | Should -not -Contain 'Test7'
+    }
 }


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description

Fixes an edge case where if entries are generic list with 1 element it would be removed anyways. I reverted it back to verifying for null and empty string rather then using [string]::EmptyOrNull which was giving true in that case.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
No reported issues - edge case found in other project

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/724)
<!-- Reviewable:end -->
