### PR TITLE
Remove-EmptyValue - Fixes boolean value comparison

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1739,7 +1739,7 @@ function Remove-EmptyValue
                 }
                 else
                 {
-                    if ($null -eq $Hashtable[$Key] -or $Hashtable[$Key] -eq '' -or ($Hashtable[$Key] -is [System.Collections.IList] -and $Hashtable[$Key].Count -eq 0)) 
+                    if ($null -eq $Hashtable[$Key] -or ($Hashtable[$Key] -is [string] -and $Hashtable[$Key] -eq '') -or ($Hashtable[$Key] -is [System.Collections.IList] -and $Hashtable[$Key].Count -eq 0))
                     {
                         $Hashtable.Remove($Key)
                     }
@@ -1747,7 +1747,7 @@ function Remove-EmptyValue
             }
             else
             {
-                if ($null -eq $Hashtable[$Key] -or $Hashtable[$Key] -eq '' -or ($Hashtable[$Key] -is [System.Collections.IList] -and $Hashtable[$Key].Count -eq 0))
+                if ($null -eq $Hashtable[$Key] -or ($Hashtable[$Key] -is [string] -and $Hashtable[$Key] -eq '') -or ($Hashtable[$Key] -is [System.Collections.IList] -and $Hashtable[$Key].Count -eq 0))
                 {
                     $Hashtable.Remove($Key)
                 }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.Utils.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.Utils.Tests.ps1
@@ -125,4 +125,48 @@
         Remove-EmptyValue -Splat $SplatDictionary -Recursive
         $SplatDictionary.Keys | Should -not -Contain 'Test7'
     }
+    It 'Testing edge cases' {
+        $Splat = [ordered]@{
+            PageContent = 'Text'
+            Settings    = 'Oops', 'oops'
+            Margins     = @{
+                MarginLeft    = 250
+                MarginTop     = 250
+                MarginBottom  = 200
+                MarginRight   = 100
+                MarginRight1  = 0
+                MarginRight2  = $null
+                TestBool1     = $True
+                TestBool2     = $false
+                TestBoolArray = $false, $true
+            }
+            PageSize    = 'A4'
+            Rotate1     = $False, $True, $false
+            Rotate2     = $False
+            Rotate3     = $true
+            Rotate4     = $true, $false
+            Rotate5     = ''
+            Rotate6     = $null, ''
+        }
+
+        Remove-EmptyValue -Hashtable $Splat
+        $Splat.Keys | Should -Contain 'Rotate6'
+        $Splat.Keys | Should -Not -Contain 'Rotate5'
+        $Splat.Keys | Should -Contain 'Rotate4'
+        $Splat.Keys | Should -Contain 'Rotate3'
+        $Splat.Keys | Should -Contain 'Rotate2'
+        $Splat.Keys | Should -Contain 'Rotate1'
+        $Splat.Margins.Keys | Should -Contain MarginLeft
+        $Splat.Margins.Keys | Should -Contain MarginTop
+        $Splat.Margins.Keys | Should -Contain MarginBottom
+        $Splat.Margins.Keys | Should -Contain MarginRight
+        $Splat.Margins.Keys | Should -Contain MarginRight1
+        $Splat.Margins.Keys | Should -Contain MarginRight2
+        $Splat.Margins.Keys | Should -Contain TestBool1
+        $Splat.Margins.Keys | Should -Contain TestBool2
+        $Splat.Margins.Keys | Should -Contain TestBoolArray
+
+        Remove-EmptyValue -Hashtable $Splat -Recursive
+        $Splat.Margins.Keys | Should -Not -Contain MarginRight2
+    }
 }


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description

I'm sorry. For some reason I was unaware that `$false -eq ''` results in $true and therefoer it would remove properties with Boolean value. 

So now I'm explicitly checking if $Hashtable[$Key] -is [string] before doing comparison. I've added a lot more tests for this behavior. Hopefully won't find any more edge cases.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/728)
<!-- Reviewable:end -->
