### PR TITLE
Fix Exomobiledevicemailboxpolicy 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+* EXOMobileDeviceMailboxPolicy
+  * Fixed an error where if no MinPasswordLength was specified
+    the Set-TargetResource threw n error trying to create a new
+    policy;
 * ODSettings
   * Fixed an issue where the GrooveBlockOption setting was never
     set properly;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMobileDeviceMailboxPolicy/MSFT_EXOMobileDeviceMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMobileDeviceMailboxPolicy/MSFT_EXOMobileDeviceMailboxPolicy.psm1
@@ -762,6 +762,12 @@ function Set-TargetResource
     $SetMobileDeviceMailboxPolicyParams = $NewMobileDeviceMailboxPolicyParams.Clone()
     $SetMobileDeviceMailboxPolicyParams.Add('Identity', $Name)
 
+    # Remove the MinPasswordLength property if it is empty
+    if ([System.String]::IsNullOrEmpty($MinPasswordLength))
+    {
+        $NewMobileDeviceMailboxPolicyParams.Remove("MinPasswordLength") | Out-Null
+    }
+
     # CASE: Mobile Device Mailbox Policy doesn't exist but should;
     if ($Ensure -eq "Present" -and $currentMobileDeviceMailboxPolicyConfig.Ensure -eq "Absent")
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Fixed an error where if no MinPasswordLength was specified the Set-TargetResource threw n error trying to create a new policy;

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/732)
<!-- Reviewable:end -->
