### PR TITLE
Typo in SCComplianceSearchAction

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceSearchAction/MSFT_SCComplianceSearchAction.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceSearchAction/MSFT_SCComplianceSearchAction.psm1
@@ -482,7 +482,7 @@ function Get-ResultProperty
     $start = $ResultString.IndexOf($PropertyName) + $PropertyName.Length + 2
     if ($start -lt 0 -or $start -gt $Result.Length)
     {
-        $return $null
+        return $null
     }
     $end = $ResultString.IndexOf(';', $start)
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceSearchAction/MSFT_SCComplianceSearchAction.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceSearchAction/MSFT_SCComplianceSearchAction.psm1
@@ -52,6 +52,7 @@ function Get-TargetResource
         [System.Management.Automation.PSCredential]
         $GlobalAdminAccount
     )
+    $VerbosePreference = "Continue"
     Write-Verbose -Message "Getting configuration of SCComplianceSearchAction for $SearchName - $Action"
     #region Telemetry
     $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace("MSFT_", "")
@@ -346,7 +347,7 @@ function Test-TargetResource
         [System.Management.Automation.PSCredential]
         $GlobalAdminAccount
     )
-
+    $VerbosePreference = "Continue"
     Write-Verbose -Message "Testing configuration of SCComplianceSearchAction"
 
     $CurrentValues = Get-TargetResource @PSBoundParameters

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCComplianceSearchAction.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCComplianceSearchAction.Tests.ps1
@@ -192,7 +192,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         ActionScope                         = "IndexedItemsOnly";
                         EnableDedupe                        = $False;
                         Results                             = 'Container url:
-                        https://gabwedisccan.blob.core.windows.net/267bbbb1-2630-41ba-d56b-08d73612df43;
+                        https://contoso.blob.core.windows.net/267bbbb1-2630-41ba-d56b-08d73612df43;
                         SAS token: <Specify -IncludeCredential parameter to show the SAS token>;
                         Scenario: RetentionReports; Scope: IndexedItemsOnly; Scope details:
                         AllUnindexed; Max unindexed size: 0; File type exclusions for unindexed: <null>;
@@ -206,8 +206,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 }
             }
 
-            It 'Should return true from the Test method' {
-                Test-TargetResource @testParams | Should -Be $true
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
             }
 
             It 'Should return Present from the Get method' {


### PR DESCRIPTION
#### Pull Request (PR) description
Fixing a typo with the return keyword of the Get-ResultProperty function in SCComplianceSearchAction.

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/736)
<!-- Reviewable:end -->
