### PR TITLE
Fixes Issues 685

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log for Microsoft365DSC
 
+## UNRELEASED
+
+* MISC
+  * Fixes an issue in the Install-M365DSCDevBranch function
+    where if the manifest file had a leading 0 in the version
+    number (e.g. 1.20.0902.1), it would create the folder as
+    a version with the '0' where the Gallery trims it.
+    (Issue #685)
+
 ## 1.20.909.1
 
 * EXOApplicationAccessPolicy

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1405,7 +1405,7 @@ function Install-M365DSCDevBranch
 
     #region Install M365DSC
     $defaultPath = 'C:\Program Files\WindowsPowerShell\Modules\Microsoft365DSC\'
-    $currentVersionPath = $defaultPath + $($manifest.ModuleVersion)
+    $currentVersionPath = $defaultPath + ([Version]$($manifest.ModuleVersion)).ToString()
     if (Test-Path $currentVersionPath)
     {
         Remove-Item $currentVersionPath -Recurse -Confirm:$false


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes an issue in the Install-M365DSCDevBranch function where if the manifest file had a leading 0 in the version number (e.g. 1.20.0902.1), it would create the folder as a version with the '0' where the Gallery trims it.


#### This Pull Request (PR) fixes the following issues
- Fixes #685

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/776)
<!-- Reviewable:end -->
