### PR TITLE
Uses Variables for SPOSite Urls in Export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+## 1.20.925.1
+
+* DEPENDENCIES
+  * MSCloudLoginAssistant Updated to 1.0.39;
+  * ReverseDSC Updated to 2.0.0.7;
+
 ## 1.20.916.1
 
 * AADServicePrincipal

--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -89,11 +89,11 @@
         },
         @{
             ModuleName      = "MSCloudLoginAssistant"
-            RequiredVersion = "1.0.38"
+            RequiredVersion = "1.0.39"
         },
         @{
             ModuleName      = "ReverseDSC"
-            RequiredVersion = "2.0.0.6"
+            RequiredVersion = "2.0.0.7"
         },
         @{
             ModuleName      = "SharePointPnPPowerShellOnline"

--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -89,7 +89,7 @@
         },
         @{
             ModuleName      = "MSCloudLoginAssistant"
-            RequiredVersion = "1.0.39"
+            RequiredVersion = "1.0.38"
         },
         @{
             ModuleName      = "ReverseDSC"


### PR DESCRIPTION
#### Pull Request (PR) description
A regression bug was introduced when we streamlined the export process. Urls for SPOSite are now using variablesto make them dynamic across tenant like they were before the change.

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/789)
<!-- Reviewable:end -->
