### PR TITLE
Custom Header support for delta reports and blueprint assessments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Misc
   * Removed EncryptionTemplateID from SCSensitivityLabel (Issue #758)
   * Added AzureAD app support SPOSiteDesign
+  * Added possibility to provide a custom header to Blueprint
+    assessment and delta reports.
 
 ## 1.20.916.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -500,7 +500,11 @@ function New-M365DSCDeltaReport
 
         [Parameter()]
         [System.Boolean]
-        $IsBlueprintAssessment = $false
+        $IsBlueprintAssessment = $false,
+
+        [Parameter()]
+        [System.String]
+        $HeaderFilePath
     )
 
     #region Telemetry
@@ -513,6 +517,21 @@ function New-M365DSCDeltaReport
     $Delta = Compare-M365DSCConfigurations -Source $Source -Destination $Destination -CaptureTelemetry $false
 
     $reportSB = [System.Text.StringBuilder]::new()
+    #region Custom Header
+    if (-not [System.String]::IsNullOrEmpty($HeaderFilePath))
+    {
+        try
+        {
+            $headerContent = Get-Content $HeaderFilePath
+            [void]$reportSB.AppendLine($headerContent)
+        }
+        catch
+        {
+            Write-Verbose -Message $_
+        }
+    }
+    #endregion
+
     $ReportTitle = "Microsoft365DSC - Delta Report"
     if ($IsBlueprintAssessment)
     {
@@ -538,7 +557,7 @@ function New-M365DSCDeltaReport
     if ($resourcesMissingInSource.Count -eq 0 -and $resourcesMissingInDestination.Count -eq 0 -and `
         $resourcesInDrift.Count -eq 0)
     {
-        [void]$reportSB.AppendLine("<p><strong>No discrepencies have been found!</strong></p>")
+        [void]$reportSB.AppendLine("<p><strong>No discrepancies have been found!</strong></p>")
     }
     elseif (-not $DriftOnly)
     {

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1600,7 +1600,11 @@ function Assert-M365DSCBlueprint
 
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
-        $Credentials
+        $Credentials,
+
+        [Parameter()]
+        [System.String]
+        $HeaderFilePath
     )
     $InformationPreference = 'SilentlyContinue'
     $WarningPreference = 'SilentlyContinue'
@@ -1666,7 +1670,8 @@ function Assert-M365DSCBlueprint
             -Destination $LocalBluePrintPath `
             -OutputPath $OutputReportPath `
             -DriftOnly:$true `
-            -IsBlueprintAssessment:$true
+            -IsBlueprintAssessment:$true `
+            -HeaderFilePath $HeaderFilePath
     }
     else
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Added support for a new -HeaderFilePath parameter for BluePrint assessment and delta reports. This allows users to pass in a path to a local HTML file to include its content at the very top of the generated report.

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/795)
<!-- Reviewable:end -->
