### PR TITLE
Capture PowerShell Version used as part of Telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * MISC
   * Deprecated the Assert-M365DSCTemplate cmdlet;
   * Added Telemetry for version of PowerShell used;
+  * Added a timeout on new version check from the
+    PowerShell Gallery;
 
 ## 1.20.1028.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## 1.20.1028.1
 
 * EXOOutboundConnector
-  * Fixed issue #821
+  * Fixed issue #821;
 * O365OrgCustomizationSetting
   * Fixes an issue where the resource was not being exported;
 * O365User

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * MISC
   * Deprecated the Assert-M365DSCTemplate cmdlet;
+  * Added Telemetry for version of PowerShell used;
 
 ## 1.20.1028.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCTelemetryEngine.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCTelemetryEngine.psm1
@@ -30,11 +30,11 @@ function Add-M365DSCTelemetryEvent
         $Type = 'Flow',
 
         [Parameter()]
-        [System.Collections.Generic.Dictionary[[System.String],[System.String]]]
+        [System.Collections.Generic.Dictionary[[System.String], [System.String]]]
         $Data,
 
         [Parameter()]
-        [System.Collections.Generic.Dictionary[[System.String],[System.Double]]]
+        [System.Collections.Generic.Dictionary[[System.String], [System.Double]]]
         $Metrics
     )
 
@@ -43,7 +43,7 @@ function Add-M365DSCTelemetryEvent
     Test-M365DSCNewVersionAvailable
 
     $TelemetryEnabled = [System.Environment]::GetEnvironmentVariable('M365DSCTelemetryEnabled', `
-        [System.EnvironmentVariableTarget]::Machine)
+            [System.EnvironmentVariableTarget]::Machine)
 
     if ($null -eq $TelemetryEnabled -or $TelemetryEnabled -eq $true)
     {
@@ -52,7 +52,7 @@ function Add-M365DSCTelemetryEvent
         try
         {
             $ProjectName = [System.Environment]::GetEnvironmentVariable('M365DSCTelemetryProjectName', `
-                [System.EnvironmentVariableTarget]::Machine)
+                    [System.EnvironmentVariableTarget]::Machine)
 
             if ($null -ne $ProjectName)
             {
@@ -73,6 +73,12 @@ function Add-M365DSCTelemetryEvent
             $Data.Remove("TenandId") | Out-Null
             $Data.Remove("Principal") | Out-Null
 
+            # Capture PowerShell Version Info
+            $Data.Add("PSVersion", $PSVersionTable.PSVersion.ToString())
+            $Data.Add("PSEdition", $PSVersionTable.PSEdition.ToString())
+            $Data.Add("PSBuildVersion", $PSVersionTable.BuildVersion.ToString())
+            $Data.Add("PSCLRVersion", $PSVersionTable.CLRVersion.ToString())
+
             if ($null -ne $Data.Resource)
             {
                 if ($Data.Resource.StartsWith("MSFT_AAD") -or $Data.Resource.StartsWith("AAD"))
@@ -83,7 +89,7 @@ function Add-M365DSCTelemetryEvent
                 {
                     $Data.Add("Workload", "Exchange Online")
                 }
-                elseif ($Data.Resource.StartsWith("MSFT_Intune") -or $Data.Resource.StartsWith("Intune")) 
+                elseif ($Data.Resource.StartsWith("MSFT_Intune") -or $Data.Resource.StartsWith("Intune"))
                 {
                     $Data.Add("Workload", "Intune")
                 }
@@ -129,7 +135,7 @@ function Add-M365DSCTelemetryEvent
                 $dependencies = $manifest.RequiredModules
 
                 $dependenciesContent = ""
-                foreach($dependency in $dependencies)
+                foreach ($dependency in $dependencies)
                 {
                     $dependenciesContent += Get-Module $dependency.ModuleName | Out-String
                 }
@@ -170,19 +176,19 @@ function Set-M365DSCTelemetryOption
     if ($null -ne $Enabled)
     {
         [System.Environment]::SetEnvironmentVariable('M365DSCTelemetryEnabled', $Enabled, `
-            [System.EnvironmentVariableTarget]::Machine)
+                [System.EnvironmentVariableTarget]::Machine)
     }
 
     if ($null -ne $InstrumentationKey)
     {
         [System.Environment]::SetEnvironmentVariable('M365DSCTelemetryInstrumentationKey', $InstrumentationKey, `
-            [System.EnvironmentVariableTarget]::Machine)
+                [System.EnvironmentVariableTarget]::Machine)
     }
 
     if ($null -ne $ProjectName)
     {
         [System.Environment]::SetEnvironmentVariable('M365DSCTelemetryProjectName', $ProjectName, `
-            [System.EnvironmentVariableTarget]::Machine)
+                [System.EnvironmentVariableTarget]::Machine)
     }
 }
 
@@ -194,15 +200,16 @@ function Get-M365DSCTelemetryOption
     try
     {
         return @{
-            Enabled = [System.Environment]::GetEnvironmentVariable('M365DSCTelemetryEnabled', `
-                [System.EnvironmentVariableTarget]::Machine)
+            Enabled            = [System.Environment]::GetEnvironmentVariable('M365DSCTelemetryEnabled', `
+                    [System.EnvironmentVariableTarget]::Machine)
             InstrumentationKey = [System.Environment]::GetEnvironmentVariable('M365DSCTelemetryInstrumentationKey', `
-                [System.EnvironmentVariableTarget]::Machine)
-            ProjectName = [System.Environment]::GetEnvironmentVariable('M365DSCTelemetryProjectName', `
-            [System.EnvironmentVariableTarget]::Machine)
+                    [System.EnvironmentVariableTarget]::Machine)
+            ProjectName        = [System.Environment]::GetEnvironmentVariable('M365DSCTelemetryProjectName', `
+                    [System.EnvironmentVariableTarget]::Machine)
         }
     }
-    catch {
+    catch
+    {
         throw $_
     }
 }

--- a/Modules/Microsoft365DSC/Modules/M365DSCTelemetryEngine.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCTelemetryEngine.psm1
@@ -74,6 +74,7 @@ function Add-M365DSCTelemetryEvent
             $Data.Remove("Principal") | Out-Null
 
             # Capture PowerShell Version Info
+            $Data.Add("PSMainVersion", $PSVersionTable.PSVersion.Major.ToString() + "." + $PSVersionTable.PSVersion.Minor.ToString())
             $Data.Add("PSVersion", $PSVersionTable.PSVersion.ToString())
             $Data.Add("PSEdition", $PSVersionTable.PSEdition.ToString())
             $Data.Add("PSBuildVersion", $PSVersionTable.BuildVersion.ToString())

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1582,7 +1582,7 @@ function Assert-M365DSCTemplate
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    Write-Host $GLobal:M365DSCEmojiYellowCircle -NoNewline
+    Write-Host $Global:M365DSCEmojiYellowCircle -NoNewline
     Write-Host " Assert-M365DSCTemplate is deprecated. Please use the new improved Assert-M365DSCBlueprint cmdlet instead." -ForegroundColor Yellow
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Telemetry will now capture information about what versions of PowerShell is used. This will help the team troubleshoot issues and help get a better sense as to how users are using the M365DSC tool.

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/882)
<!-- Reviewable:end -->
