### PR TITLE
Changed exctract button to be placed relative to the panelMenu

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCReverseGUI.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverseGUI.psm1
@@ -757,12 +757,13 @@ function Show-M365DSCGUI
                 }
             })
         $panelMenu.Controls.Add($txtPassword)
+        $panelMenu.Width = $pnlIntune.Left + $pnlIntune.Width
 
         $btnExtract = New-Object System.Windows.Forms.Button
         $btnExtract.Width = 178
         $btnExtract.Height = 70
         $btnExtract.Top = 5
-        $btnExtract.Left = $form.Width - 200
+        $btnExtract.Left = $panelMenu.Width - 200
         $btnExtract.BackColor = [System.Drawing.Color]::ForestGreen
         $btnExtract.ForeColor = [System.Drawing.Color]::White
         $btnExtract.Text = "Start Extraction"
@@ -856,7 +857,6 @@ function Show-M365DSCGUI
                 }
             })
         $panelMenu.Controls.Add($btnExtract);
-        $panelMenu.Width = $pnlIntune.Left + $pnlIntune.Width
         $pnlMain.Controls.Add($panelMenu);
         #endregion
 


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
Previously the extract button was placed relative to the total window width. If the window were wider than the panelMenu, the button would not be rendered in the form.
Instead the button should be placed relative to the panelMenu width.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
Fixes #831

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/917)
<!-- Reviewable:end -->
