### PR TITLE
Fixes Password Issue in O365User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log for Microsoft365DSC
 
+## 1.20.1125.1
+
+* AADRoleDefinition
+  * Initial Release;
+* O365User
+  * Fixes an issue where only the first O365User instance
+    extracted had the PSCredential Password property set
+    correctly;
+
 ## 1.20.1118.1
 
 * EXOMalwareFilterPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
@@ -736,12 +736,13 @@ function Export-TargetResource
                     $Results.Password = Resolve-Credentials -UserName "globaladmin"
                     $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
                         -Results $Results
-                    $dscContent += Get-M365DSCExportContentForResource -ResourceName $ResourceName `
+                    $currentContent = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `
                         -Results $Results `
                         -GlobalAdminAccount $GlobalAdminAccount
-                    $dscContent = Convert-DSCStringParamToVariable -DSCBlock $dscContent -ParameterName "Password"
+                    $currentContent = Convert-DSCStringParamToVariable -DSCBlock $currentContent -ParameterName "Password"
+                    $dscContent += $currentContent
                 }
             }
             Write-Host $Global:M365DSCEmojiGreenCheckMark


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes an issue where only the first O365User instance extracted had the PSCredential Password property set correctly

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/920)
<!-- Reviewable:end -->
