### PR TITLE
Updated TeamsMessagingPolicy with AllowUserEditMessage

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.psm1
@@ -38,6 +38,10 @@ function Get-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $AllowUserEditMessage,
+
+        [Parameter()]
+        [System.Boolean]
         $AllowUserTranslation,
 
         [Parameter()]
@@ -132,6 +136,7 @@ function Get-TargetResource
                 AllowUrlPreviews              = $policy.AllowUrlPreviews
                 AllowUserChat                 = $policy.AllowUserChat
                 AllowUserDeleteMessage        = $policy.AllowUserDeleteMessage
+                AllowUserEditMessage          = $policy.AllowUserEditMessage
                 AllowUserTranslation          = $policy.AllowUserTranslation
                 GiphyRatingType               = $policy.GiphyRatingType
                 ReadReceiptsEnabledType       = $policy.ReadReceiptsEnabledType
@@ -209,6 +214,10 @@ function Set-TargetResource
         [Parameter()]
         [System.Boolean]
         $AllowUserDeleteMessage,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowUserEditMessage,
 
         [Parameter()]
         [System.Boolean]
@@ -335,6 +344,10 @@ function Test-TargetResource
         [Parameter()]
         [System.Boolean]
         $AllowUserDeleteMessage,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowUserEditMessage,
 
         [Parameter()]
         [System.Boolean]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.schema.mof
@@ -5,6 +5,7 @@ class MSFT_TeamsMessagingPolicy : OMI_BaseResource
     [Write, Description("Determines whether a user is allowed to access and post Giphys. Set this to TRUE to allow. Set this FALSE to prohibit.")] boolean AllowGiphy;
     [Write, Description("Determines whether a user is allowed to access and post memes. Set this to TRUE to allow. Set this FALSE to prohibit.")] boolean AllowMemes;
     [Write, Description("Determines whether owners are allowed to delete all the messages in their team. Set this to TRUE to allow. Set this to FALSE to prohibit.")] boolean AllowOwnerDeleteMessage;
+    [Write, Description("Determines whether a user is allowed to edit their own messages. Set this to TRUE to allow. Set this to FALSE to prohibit.")] boolean AllowUserEditMessage;
     [Write, Description("Determines whether a user is allowed to access and post stickers. Set this to TRUE to allow. Set this FALSE to prohibit.")] boolean AllowStickers;
     [Write, Description("Use this setting to turn automatic URL previewing on or off in messages. Set this to TRUE to turn on. Set this to FALSE to turn off.")] boolean AllowUrlPreviews;
     [Write, Description("Determines whether a user is allowed to chat. Set this to TRUE to allow a user to chat across private chat, group chat and in meetings. Set this to FALSE to prohibit all chat.")] boolean AllowUserChat;

--- a/Modules/Microsoft365DSC/Examples/Resources/TeamsMessagingPolicy/1-AddNewMessagePolicy.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/TeamsMessagingPolicy/1-AddNewMessagePolicy.ps1
@@ -24,6 +24,7 @@ Configuration Example
             AllowUrlPreviews              = $false
             AllowUserChat                 = $True
             AllowUserDeleteMessage        = $false
+            AllowUserEditMessage          = $false
             AllowUserTranslation          = $True
             AllowRemoveUser               = $false
             AllowPriorityMessages         = $True


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
Update to the TeamsMessagingPolicy to include the `AllowUserEditMessage` parameter.
Doc: https://docs.microsoft.com/en-us/powershell/module/skype/new-csteamsmessagingpolicy?view=skype-ps

#### This Pull Request (PR) fixes the following issues
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/943)
<!-- Reviewable:end -->
