### PR TITLE
Fixed typo in EXOOwaMailboxPolicy resource 

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
@@ -957,7 +957,7 @@ function Set-TargetResource
     elseif ($Ensure -eq "Absent" -and $currentOwaMailboxPolicyConfig.Ensure -eq "Present")
     {
         Write-Verbose -Message "OWA Mailbox Policy '$($Name)' exists but it shouldn't. Remove it."
-        Remove-OwaMailboxPolicyPolicy -Identity $Name -Confirm:$false
+        Remove-OwaMailboxPolicy -Identity $Name -Confirm:$false
     }
     # CASE: OWA Mailbox Policy exists and it should, but has different values than the desired ones
     elseif ($Ensure -eq "Present" -and $currentOwaMailboxPolicyConfig.Ensure -eq "Present")


### PR DESCRIPTION
The process of removing a OwaMailboxPolicy would fail because it previously used Remove-OwaMailboxPolicyPolicy, which does not exist.

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
The process of removing a OwaMailboxPolicy would fail because it previously used Remove-OwaMailboxPolicyPolicy, which does not exist.

Doc: https://docs.microsoft.com/en-us/powershell/module/exchange/remove-owamailboxpolicy?view=exchange-ps

#### This Pull Request (PR) fixes the following issues
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/946)
<!-- Reviewable:end -->
