### PR TITLE
EXOSafeLinksRule - Fixed typo in try/catch clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * AADConditionalAccessPolicy
   * Initial Release;
+* EXOSafeLinksRule
+  * Fixed typo in a try/catch clause;
 * O365User
   * Added support for removing existing users with
     Ensure = 'Absent';

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksRule/MSFT_EXOSafeLinksRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksRule/MSFT_EXOSafeLinksRule.psm1
@@ -499,7 +499,7 @@ function Export-TargetResource
     }
     catch
     {
-        Wtry
+        try
         {
             Write-Verbose -Message $_
             $tenantIdValue = ""


### PR DESCRIPTION
#### Pull Request (PR) description
Fixed a typo that caused a try/catch clause to throw a command not found error.

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/977)
<!-- Reviewable:end -->
