### PR TITLE
SPOSharingSettings: Changed check for SharingAllowDomainList/SharingBlockDomainList

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSharingSettings/MSFT_SPOSharingSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSharingSettings/MSFT_SPOSharingSettings.psm1
@@ -419,7 +419,7 @@ function Set-TargetResource
         Write-Verbose -Message "Configuring Tenant with: $value"
     }
 
-    if ($null -ne $SharingAllowedDomainList)
+    if ($null -ne $CurrentParameters["SharingAllowedDomainList"])
     {
         foreach ($allowedDomain in $SharingAllowedDomainList)
         {
@@ -429,7 +429,7 @@ function Set-TargetResource
         $CurrentParameters["SharingAllowedDomainList"] = $allowed.trim()
     }
 
-    if ($null -ne $SharingBlockedDomainList)
+    if ($null -ne $CurrentParameters["SharingBlockedDomainList"])
     {
         foreach ($blockedDomain in $SharingBlockedDomainList)
         {


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
I started to get errors when trying to set SPOSharingSettings:
```powershell
You cannot call a method on a null-valued expression.                                                                      
    + CategoryInfo          : InvalidOperation: (:) [], CimException                                                       
    + FullyQualifiedErrorId : InvokeMethodOnNull                                                                           
    + PSComputerName        : localhost
```
One of the lists would have been already removed when it checks if the parameters are not equal to null.
Checking CurrentParameters instead fixes this issue

#### This Pull Request (PR) fixes the following issues
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1005)
<!-- Reviewable:end -->
