### PR TITLE
SPOSiteScript: Remove mandatory GlobalAdminAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# Unreleased
+
+* SPOSiteScript
+  * Removed mandatory parameter GlobalAdminAccount from
+    Get-TargetResource.
+
 # 1.21.317.1
 
 * DEPENDENCIES

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteScript/MSFT_SPOSiteScript.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteScript/MSFT_SPOSiteScript.psm1
@@ -45,7 +45,7 @@ function Get-TargetResource
         [System.String]
         $CertificateThumbprint,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $GlobalAdminAccount
     )


### PR DESCRIPTION
#### Pull Request (PR) description
Removed GlobalAdminAccount as mandatory parameter in SPOSiteScript Get-TargetResource 

#### This Pull Request (PR) fixes the following issues
    - Fixes #1108

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1109)
<!-- Reviewable:end -->
