### PR TITLE
SPOSiteScript: Fix unable to update existing item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 # Unreleased
 * MISC
   * Fixed issue with ODSettings and ExcludedFileExtensions
-
+* SPOSiteScript
+  * Fixed issue where an existin site script could not be updated.
+  * Made parameter GlobalAdminAccount in Get-TargetResource
+    optional.
 
 # 1.21.317.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteScript/MSFT_SPOSiteScript.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteScript/MSFT_SPOSiteScript.psm1
@@ -45,7 +45,7 @@ function Get-TargetResource
         [System.String]
         $CertificateThumbprint,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $GlobalAdminAccount
     )
@@ -277,7 +277,7 @@ function Set-TargetResource
                 #
                 #the only way to get the $content is to query the site again, but this time with the ID and not the Title like above
                 $UpdateParams = @{
-                    Id          = $SiteScript[0].Id
+                    Id          = $SiteScripts[0].Id
                     Title       = $Title
                     Content     = $Content
                     Description = $Description
@@ -290,7 +290,7 @@ function Set-TargetResource
         }
         catch
         {
-            Write-Verbose -Message "Unable to update Site Script, {$Title}"
+            Write-Warning -Message "Unable to update Site Script, {$Title}"
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
This PR is a redo of PR #1113 targeting dev branch

SPOSiteScript was unable to update existing item due to wrong variable reference.
Also change the verbose message that the update failed into a warning (should it maybe be an error message)?
Made parameter GlobalAdminAccount optional in SPOSiteScript Get-TargetResource

#### This Pull Request (PR) fixes the following issues

- Fixes #1112 
- Fixes #1108

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1119)
<!-- Reviewable:end -->
