### PR TITLE
TeamsMeetingPolicy: Added check for AllowCloudRecording

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingPolicy/MSFT_TeamsMeetingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingPolicy/MSFT_TeamsMeetingPolicy.psm1
@@ -531,6 +531,11 @@ function Set-TargetResource
         {
             $SetParameters.Remove("AllowAnonymousUsersToDialOut") | Out-Null
         }
+        if ($SetParameters.AllowCloudRecording -eq $false )
+        {
+            $SetParameters.Remove("RecordingStorageMode")
+            $SetParameters.Remove("AllowRecordingStorageOutsideRegion")
+        }
         Set-CsTeamsMeetingPolicy @SetParameters
     }
     elseif ($Ensure -eq 'Absent' -and $CurrentValues.Ensure -eq 'Present')


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
The `Set-CsTeamsMeetingPolicy` would fail if recording settings are changed while the `AllowCloudRecording` is set to false

#### This Pull Request (PR) fixes the following issues
Fixes #1134

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1135)
<!-- Reviewable:end -->
