### PR TITLE
AADConditionalAccessPolicy: fix for default values and new device state attributes

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -76,11 +76,11 @@ function Get-TargetResource
         #ConditionalAccessDevicesCondition
         [Parameter()]
         [System.String[]]
-        $IncludeDeviceStates,
+        $IncludeDevices,
 
         [Parameter()]
         [System.String[]]
-        $ExcludeDeviceStates,
+        $ExcludeDevices,
 
         #Further conditions
         [Parameter()]
@@ -614,9 +614,9 @@ function Get-TargetResource
             #no translation needed
             IncludeLocations                         = $IncludeLocations
             ExcludeLocations                         = $ExcludeLocations
-            IncludeDeviceStates                      = [System.String[]]$Policy.Conditions.Devices.IncludeDeviceStates
+            IncludeDevices                           = $Policy.Conditions.Devices.IncludeDevices
             #no translation needed
-            ExcludeDeviceStates                      = [System.String[]]$Policy.Conditions.Devices.ExcludeDeviceStates
+            ExcludeDevices                           = $Policy.Conditions.Devices.ExcludeDevices
             #no translation needed
             UserRiskLevels                           = [System.String[]]$Policy.Conditions.UserRiskLevels
             #no translation needed
@@ -733,11 +733,11 @@ function Set-TargetResource
         #ConditionalAccessDevicesCondition
         [Parameter()]
         [System.String[]]
-        $IncludeDeviceStates,
+        $IncludeDevices,
 
         [Parameter()]
         [System.String[]]
-        $ExcludeDeviceStates,
+        $ExcludeDevices,
 
         #Further conditions
         [Parameter()]
@@ -1373,13 +1373,13 @@ function Set-TargetResource
         }
 
         Write-Verbose -Message "Set-Targetresource: process device states"
-        if ($IncludeDeviceStates -or $ExcludeDeviceStates)
+        if ($IncludeDevices -or $ExcludeDevices)
         {
             #create and provision Device condition object if used
             $conditions.Devices = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessDevicesCondition
-            $conditions.Devices.IncludeDeviceStates = $IncludeDeviceStates
+            $conditions.Devices.IncludeDevices = $IncludeDevices
             #no translation or conversion needed
-            $conditions.Devices.ExcludeDeviceStates = $ExcludeDeviceStates
+            $conditions.Devices.ExcludeDevices = $ExcludeDevices
             #no translation or conversion needed
         }
         Write-Verbose -Message "Set-Targetresource: process risk levels and app types"
@@ -1627,11 +1627,11 @@ function Test-TargetResource
         #ConditionalAccessDevicesCondition
         [Parameter()]
         [System.String[]]
-        $IncludeDeviceStates,
+        $IncludeDevices,
 
         [Parameter()]
         [System.String[]]
-        $ExcludeDeviceStates,
+        $ExcludeDevices,
 
         #Further conditions
         [Parameter()]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -614,9 +614,9 @@ function Get-TargetResource
             #no translation needed
             IncludeLocations                         = $IncludeLocations
             ExcludeLocations                         = $ExcludeLocations
-            IncludeDevices                           = $Policy.Conditions.Devices.IncludeDevices
+            IncludeDevices                           = [System.String[]]$Policy.Conditions.Devices.IncludeDevices
             #no translation needed
-            ExcludeDevices                           = $Policy.Conditions.Devices.ExcludeDevices
+            ExcludeDevices                           = [System.String[]]$Policy.Conditions.Devices.ExcludeDevices
             #no translation needed
             UserRiskLevels                           = [System.String[]]$Policy.Conditions.UserRiskLevels
             #no translation needed

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -216,10 +216,9 @@ function Get-TargetResource
 
         Write-Verbose -Message "Get-TargetResource: Process IncludeUsers"
         #translate IncludeUser GUIDs to UPN, except id value is GuestsOrExternalUsers or All
-        $IncludeUsers = $null
+        $IncludeUsers = @()
         if ($Policy.Conditions.Users.IncludeUsers)
         {
-            $IncludeUsers = @()
             foreach ($IncludeUserGUID in $Policy.Conditions.Users.IncludeUsers)
             {
                 if ($IncludeUserGUID -notin "GuestsOrExternalUsers", "All")
@@ -266,10 +265,9 @@ function Get-TargetResource
 
         Write-Verbose -Message "Get-TargetResource: Process ExcludeUsers"
         #translate ExcludeUser GUIDs to UPN, except id value is GuestsOrExternalUsers or All
-        $ExcludeUsers = $null
+        $ExcludeUsers = @()
         if ($Policy.Conditions.Users.ExcludeUsers)
         {
-            $ExcludeUsers = @()
             foreach ($ExcludeUserGUID in $Policy.Conditions.Users.ExcludeUsers)
             {
                 if ($ExcludeUserGUID -notin "GuestsOrExternalUsers", "All")
@@ -317,10 +315,9 @@ function Get-TargetResource
 
         Write-Verbose -Message "Get-TargetResource: Process IncludeGroups"
         #translate IncludeGroup GUIDs to DisplayName
-        $IncludeGroups = $null
+        $IncludeGroups = @()
         if ($Policy.Conditions.Users.IncludeGroups)
         {
-            $IncludeGroups = @()
             foreach ($IncludeGroupGUID in $Policy.Conditions.Users.IncludeGroups)
             {
                 $IncludeGroup = $null
@@ -361,10 +358,9 @@ function Get-TargetResource
 
         Write-Verbose -Message "Get-TargetResource: Process ExcludeGroups"
         #translate ExcludeGroup GUIDs to DisplayName
-        $ExcludeGroups = $null
+        $ExcludeGroups = @()
         if ($Policy.Conditions.Users.ExcludeGroups)
         {
-            $ExcludeGroups = @()
             foreach ($ExcludeGroupGUID in $Policy.Conditions.Users.ExcludeGroups)
             {
                 $ExcludeGroup = $null
@@ -404,8 +400,8 @@ function Get-TargetResource
         }
 
 
-        $IncludeRoles = $null
-        $ExcludeRoles = $null
+        $IncludeRoles = @()
+        $ExcludeRoles = @()
         #translate role template guids to role name
         if ($Policy.Conditions.Users.IncludeRoles -or $Policy.Conditions.Users.ExcludeRoles)
         {
@@ -420,7 +416,6 @@ function Get-TargetResource
             Write-Verbose -Message "Get-TargetResource: Processing IncludeRoles"
             if ($Policy.Conditions.Users.IncludeRoles)
             {
-                $IncludeRoles = @()
                 foreach ($IncludeRoleGUID in $Policy.Conditions.Users.IncludeRoles)
                 {
                     if ($null -eq $rolelookup[$IncludeRoleGUID])
@@ -457,7 +452,6 @@ function Get-TargetResource
             Write-Verbose -Message "Get-TargetResource: Processing ExcludeRoles"
             if ($Policy.Conditions.Users.ExcludeRoles)
             {
-                $ExcludeRoles = @()
                 foreach ($ExcludeRoleGUID in $Policy.Conditions.Users.ExcludeRoles)
                 {
                     if ($null -eq $rolelookup[$ExcludeRoleGUID])
@@ -496,9 +490,11 @@ function Get-TargetResource
         $IncludeLocations = $null
         $ExcludeLocations = $null
         #translate Location template guids to Location name
-        if ($Policy.Conditions.Locations.IncludeLocations -or $Policy.Conditions.Locations.ExcludeLocations)
+        if ($Policy.Conditions.Locations)
         {
             Write-Verbose -Message "Get-TargetResource: Location condition defined, processing"
+            $IncludeLocations = @()
+            $ExcludeLocations = @()
             #build Location translation table
             $Locationlookup = @{}
             foreach ($Location in Get-AzureADMSNamedLocationPolicy)
@@ -509,7 +505,6 @@ function Get-TargetResource
             Write-Verbose -Message "Get-TargetResource: Processing IncludeLocations"
             if ($Policy.Conditions.Locations.IncludeLocations)
             {
-                $IncludeLocations = @()
                 foreach ($IncludeLocationGUID in $Policy.Conditions.Locations.IncludeLocations)
                 {
                     if ($IncludeLocationGUID -in "All", "AllTrusted")
@@ -550,7 +545,6 @@ function Get-TargetResource
             Write-Verbose -Message "Get-TargetResource: Processing ExcludeLocations"
             if ($Policy.Conditions.Locations.ExcludeLocations)
             {
-                $ExcludeLocations = @()
                 foreach ($ExcludeLocationGUID in $Policy.Conditions.Locations.ExcludeLocations)
                 {
                     if ($ExcludeLocationGUID -in "All", "AllTrusted")
@@ -590,7 +584,30 @@ function Get-TargetResource
 
 
         }
-
+        if ($Policy.SessionControls.CloudAppSecurity.IsEnabled)
+        {
+            $CloudAppSecurityType = [System.String]$Policy.SessionControls.CloudAppSecurity.CloudAppSecurityType
+        }
+        else
+        {
+            $CloudAppSecurityType = $null
+        }
+        if ($Policy.SessionControls.SignInFrequency.IsEnabled)
+        {
+            $SignInFrequencyType = [System.String]$Policy.SessionControls.SignInFrequency.Type
+        }
+        else
+        {
+            $SignInFrequencyType = $null
+        }
+        if ($Policy.SessionControls.PersistentBrowser.IsEnabled)
+        {
+            $PersistentBrowserMode = [System.String]$Policy.SessionControls.PersistentBrowser.Mode
+        }
+        else
+        {
+            $PersistentBrowserMode = $null
+        }
         $result = @{
             DisplayName                              = $Policy.DisplayName
             Id                                       = $Policy.Id
@@ -630,26 +647,31 @@ function Get-TargetResource
             #no translation needed
             ApplicationEnforcedRestrictionsIsEnabled = $Policy.SessionControls.ApplicationEnforcedRestrictions.IsEnabled
             #no translation or conversion needed
-            CloudAppSecurityIsEnabled                = $Policy.SessionControls.CloudAppSecurity.IsEnabled
-            #no translation or conversion needed
-            CloudAppSecurityType                     = [System.String]$Policy.SessionControls.CloudAppSecurity.CloudAppSecurityType
-            #no translation needed
-            SignInFrequencyValue                     = $Policy.SessionControls.SignInFrequency.Value
-            #no translation or conversion needed
-            SignInFrequencyType                      = [System.String]$Policy.SessionControls.SignInFrequency.Type
-            #no translation needed
-            SignInFrequencyIsEnabled                 = $Policy.SessionControls.SignInFrequency.IsEnabled
-            #no translation or conversion needed
-            PersistentBrowserMode                    = [System.String]$Policy.SessionControls.PersistentBrowser.Mode
-            #no translation needed
-            PersistentBrowserIsEnabled               = $Policy.SessionControls.PersistentBrowser.IsEnabled
-            #no translation or conversion needed
             #Standard part
             Ensure                                   = "Present"
             GlobalAdminAccount                       = $GlobalAdminAccount
             ApplicationId                            = $ApplicationId
             TenantId                                 = $TenantId
             CertificateThumbprint                    = $CertificateThumbprint
+        }
+        #adding CloudAppSecurity values if enabled
+        if ($Policy.SessionControls.CloudAppSecurity.IsEnabled)
+        {
+            $result += @{CloudAppSecurityIsEnabled = $Policy.SessionControls.CloudAppSecurity.IsEnabled }
+            $result += @{CloudAppSecurityType = [System.String]$Policy.SessionControls.CloudAppSecurity.CloudAppSecurityType }
+        }
+        #adding SignInFrequency values if enabled
+        if ($Policy.SessionControls.SignInFrequency.IsEnabled)
+        {
+            $result += @{SignInFrequencyIsEnabled = $Policy.SessionControls.SignInFrequency.IsEnabled }
+            $result += @{SignInFrequencyValue = $Policy.SessionControls.SignInFrequency.Value }
+            $result += @{SignInFrequencyType = [System.String]$Policy.SessionControls.SignInFrequency.Type }
+        }
+        #adding PersistentBrowser values if enabled
+        if ($Policy.SessionControls.PersistentBrowser.IsEnabled)
+        {
+            $result += @{PersistentBrowserIsEnabled = $Policy.SessionControls.PersistentBrowser.IsEnabled }
+            $result += @{PersistentBrowserMode = [System.String]$Policy.SessionControls.PersistentBrowser.Mode }
         }
         Write-Verbose -Message "Get-TargetResource Result: `n $(Convert-M365DscHashtableToString -Hashtable $result)"
         return $result

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.schema.mof
@@ -17,8 +17,8 @@ class MSFT_AADConditionalAccessPolicy : OMI_BaseResource
     [Write, Description("Client Device Platforms out of scope of the Policy.")] String ExcludePlatforms[];
     [Write, Description("AAD Named Locations in scope of the Policy.")] String IncludeLocations[];
     [Write, Description("AAD Named Locations out of scope of the Policy.")] String ExcludeLocations[];
-    [Write, Description("Client Device Compliance states in scope of the Policy.")] String IncludeDeviceStates[];
-    [Write, Description("Client Device Compliance states out of scope of the Policy.")] String ExcludeDeviceStates[];
+    [Write, Description("Client Device Compliance states in scope of the Policy.")] String IncludeDevices[];
+    [Write, Description("Client Device Compliance states out of scope of the Policy.")] String ExcludeDevices[];
     [Write, Description("AAD Identity Protection User Risk Levels in scope of the Policy.")] String UserRiskLevels[];
     [Write, Description("AAD Identity Protection Sign-in Risk Levels in scope of the Policy.")] String SignInRiskLevels[];
     [Write, Description("Client App types in scope of the Policy.")] String ClientAppTypes[];

--- a/Modules/Microsoft365DSC/Examples/Resources/AADConditionalAccessPolicy/1-ConfigureAADConditionalAccessPolicy.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/AADConditionalAccessPolicy/1-ConfigureAADConditionalAccessPolicy.ps1
@@ -25,6 +25,7 @@ Configuration Example
             Ensure                    = "Present";
             ExcludeApplications       = @("803ee9ca-3f7f-4824-bd6e-0b99d720c35c", "00000012-0000-0000-c000-000000000000", "00000007-0000-0000-c000-000000000000", "Office365");
             ExcludeDevices            = @("Compliant", "DomainJoined");
+            ExcludeGroups             = @();
             ExcludeLocations          = @("Blocked Countries");
             ExcludePlatforms          = @("Windows", "WindowsPhone", "MacOS");
             ExcludeRoles              = @("Company Administrator", "Application Administrator", "Application Developer", "Cloud Application Administrator", "Cloud Device Administrator");
@@ -32,11 +33,11 @@ Configuration Example
             GrantControlOperator      = "OR";
             IncludeApplications       = @("All");
             IncludeDevices            = @("All");
+            IncludeGroups             = @();
             IncludeLocations          = @("AllTrusted");
             IncludePlatforms          = @("Android", "IOS");
             IncludeUserActions        = @();
             IncludeUsers              = @("All");
-            PersistentBrowserMode     = "";
             SignInFrequencyIsEnabled  = $True;
             SignInFrequencyType       = "Hours";
             SignInFrequencyValue      = 5;

--- a/Modules/Microsoft365DSC/Examples/Resources/AADConditionalAccessPolicy/1-ConfigureAADConditionalAccessPolicy.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/AADConditionalAccessPolicy/1-ConfigureAADConditionalAccessPolicy.ps1
@@ -24,14 +24,14 @@ Configuration Example
             DisplayName               = "Allin-example";
             Ensure                    = "Present";
             ExcludeApplications       = @("803ee9ca-3f7f-4824-bd6e-0b99d720c35c", "00000012-0000-0000-c000-000000000000", "00000007-0000-0000-c000-000000000000", "Office365");
-            ExcludeDeviceStates       = @("Compliant", "DomainJoined");
+            ExcludeDevices            = @("Compliant", "DomainJoined");
             ExcludeLocations          = @("Blocked Countries");
             ExcludePlatforms          = @("Windows", "WindowsPhone", "MacOS");
             ExcludeRoles              = @("Company Administrator", "Application Administrator", "Application Developer", "Cloud Application Administrator", "Cloud Device Administrator");
             ExcludeUsers              = @("admin@contoso.com", "AAdmin@contoso.com", "CAAdmin@contoso.com", "AllanD@contoso.com", "AlexW@contoso.com", "GuestsOrExternalUsers");
             GrantControlOperator      = "OR";
             IncludeApplications       = @("All");
-            IncludeDeviceStates       = @("All");
+            IncludeDevices            = @("All");
             IncludeLocations          = @("AllTrusted");
             IncludePlatforms          = @("Android", "IOS");
             IncludeUserActions        = @();

--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -53,7 +53,7 @@
     RequiredModules   = @(
         @{
             ModuleName      = "AzureADPreview"
-            RequiredVersion = "2.0.2.129"
+            RequiredVersion = "2.0.2.134"
         },
         @{
             ModuleName      = "DSCParser"

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADConditionalAccessPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADConditionalAccessPolicy.Tests.ps1
@@ -58,7 +58,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     DisplayName                = "Allin"
                     Ensure                     = "Present"
                     ExcludeApplications        = @("00000012-0000-0000-c000-000000000000", "Office365")
-                    ExcludeDeviceStates        = @("Compliant", "DomainJoined")
+                    ExcludeDevices             = @("Compliant", "DomainJoined")
                     ExcludeGroups              = @("Group 01")
                     ExcludeLocations           = "Contoso LAN"
                     ExcludePlatforms           = @("Windows", "WindowsPhone", "MacOS")
@@ -68,7 +68,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     GrantControlOperator       = "AND"
                     Id                         = "bcc0cf19-ee89-46f0-8e12-4b89123ee6f9"
                     IncludeApplications        = @("All")
-                    IncludeDeviceStates        = @("All")
+                    IncludeDevices             = @("All")
                     IncludeGroups              = @("Group 01")
                     IncludeLocations           = "AllTrusted"
                     IncludePlatforms           = @("Android", "IOS")
@@ -139,7 +139,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     DisplayName                              = "Allin"
                     Ensure                                   = "Present"
                     ExcludeApplications                      = @("00000012-0000-0000-c000-000000000000", "Office365")
-                    ExcludeDeviceStates                      = @("Compliant", "DomainJoined")
+                    ExcludeDevices                           = @("Compliant", "DomainJoined")
                     ExcludeGroups                            = @("Group 01")
                     ExcludeLocations                         = "Contoso LAN"
                     ExcludePlatforms                         = @("Windows", "WindowsPhone", "MacOS")
@@ -149,7 +149,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     GrantControlOperator                     = "AND"
                     Id                                       = "bcc0cf19-ee89-46f0-8e12-4b89123ee6f9"
                     IncludeApplications                      = @("All")
-                    IncludeDeviceStates                      = @("All")
+                    IncludeDevices                           = @("All")
                     IncludeGroups                            = @("Group 01")
                     IncludeLocations                         = "AllTrusted"
                     IncludePlatforms                         = @("Android", "IOS")
@@ -194,8 +194,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                 ExcludeLocations = "9e4ca5f3-0ba9-4257-b906-74d3038ac970"
                             }
                             Devices          = @{
-                                IncludeDeviceStates = @("All")
-                                ExcludeDeviceStates = @("Compliant", "DomainJoined")
+                                IncludeDevices = @("All")
+                                ExcludeDevices = @("Compliant", "DomainJoined")
                             }
                             ClientAppTypes   = @("Browser", "MobileAppsAndDesktopClients")
                             SignInRiskLevels = @("High")
@@ -276,7 +276,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     DisplayName                              = "Allin"
                     Ensure                                   = "Present"
                     ExcludeApplications                      = @("00000012-0000-0000-c000-000000000000", "Office365")
-                    ExcludeDeviceStates                      = @("Compliant", "DomainJoined")
+                    ExcludeDevices                           = @("Compliant", "DomainJoined")
                     ExcludeGroups                            = @("Group 01")
                     ExcludeLocations                         = "Contoso LAN"
                     ExcludePlatforms                         = @("Windows", "WindowsPhone", "MacOS")
@@ -286,7 +286,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     GrantControlOperator                     = "AND"
                     Id                                       = "bcc0cf19-ee89-46f0-8e12-4b89123ee6f9"
                     IncludeApplications                      = @("All")
-                    IncludeDeviceStates                      = @("All")
+                    IncludeDevices                           = @("All")
                     IncludeGroups                            = @("Group 01")
                     IncludeLocations                         = "AllTrusted"
                     IncludePlatforms                         = @("Android", "IOS")
@@ -331,8 +331,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                 ExcludeLocations = "9e4ca5f3-0ba9-4257-b906-74d3038ac970"
                             }
                             Devices          = @{
-                                IncludeDeviceStates = @("All")
-                                ExcludeDeviceStates = @("Compliant", "DomainJoined")
+                                IncludeDevices = @("All")
+                                ExcludeDevices = @("Compliant", "DomainJoined")
                             }
                             ClientAppTypes   = @("Browser", "MobileAppsAndDesktopClients")
                             SignInRiskLevels = @("High")
@@ -409,7 +409,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     DisplayName                              = "Allin"
                     Ensure                                   = "Absent"
                     ExcludeApplications                      = @("00000012-0000-0000-c000-000000000000", "Office365")
-                    ExcludeDeviceStates                      = @("Compliant", "DomainJoined")
+                    ExcludeDevices                           = @("Compliant", "DomainJoined")
                     ExcludeGroups                            = @("Group 01")
                     ExcludeLocations                         = "Contoso LAN"
                     ExcludePlatforms                         = @("Windows", "WindowsPhone", "MacOS")
@@ -419,7 +419,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     GrantControlOperator                     = "AND"
                     Id                                       = "bcc0cf19-ee89-46f0-8e12-4b89123ee6f9"
                     IncludeApplications                      = @("All")
-                    IncludeDeviceStates                      = @("All")
+                    IncludeDevices                           = @("All")
                     IncludeGroups                            = @("Group 01")
                     IncludeLocations                         = "AllTrusted"
                     IncludePlatforms                         = @("Android", "IOS")
@@ -464,8 +464,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                 ExcludeLocations = "9e4ca5f3-0ba9-4257-b906-74d3038ac970"
                             }
                             Devices          = @{
-                                IncludeDeviceStates = @("All")
-                                ExcludeDeviceStates = @("Compliant", "DomainJoined")
+                                IncludeDevices = @("All")
+                                ExcludeDevices = @("Compliant", "DomainJoined")
                             }
                             ClientAppTypes   = @("Browser", "MobileAppsAndDesktopClients")
                             SignInRiskLevels = @("High")
@@ -569,8 +569,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                 ExcludeLocations = "9e4ca5f3-0ba9-4257-b906-74d3038ac970"
                             }
                             Devices          = @{
-                                IncludeDeviceStates = @("All")
-                                ExcludeDeviceStates = @("Compliant", "DomainJoined")
+                                IncludeDevices = @("All")
+                                ExcludeDevices = @("Compliant", "DomainJoined")
                             }
                             ClientAppTypes   = @("Browser", "MobileAppsAndDesktopClients")
                             SignInRiskLevels = @("High")


### PR DESCRIPTION
#### Pull Request (PR) description
Update for the AADConditionalAccessPolicy Resource

Fixes the default values if the conditional access policy attributes are undefined, aligned to the returned values by Get-AzureADMSConditionalAccessPolicy:

- Explicitly returning empty array for translated Location, Group, User and Role conditions if undefined
- Session control attributes are not returned by Get-TargetResource if not defined

Uses the new device state attributes:

- IncludeDevices and ExcludeDevices 
- instead of the previously used IncludeDeviceStates and ExcludeDeviceStates
- Requires AAD Powershell version: 2.0.2.134

#### This Pull Request (PR) fixes the following issues

    - Fixes #1036

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1139)
<!-- Reviewable:end -->
