### PR TITLE
MSFT_EXOHostedContentFilterPolicy: Changed second IF statement

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
@@ -661,7 +661,7 @@ function Set-TargetResource
         $HostedContentFilterPolicyParams.Remove('EndUserSpamNotificationCustomFromAddress') | Out-Null
         Write-Verbose -Message "The EndUserSpamNotificationCustomFromAddress parameter is no longer available and will be depricated."
     }
-    if ($HostedContentFilterPolicyParams.Contains('EndUserSpamNotificationCustomFromAddress'))
+    if ($HostedContentFilterPolicyParams.Contains('EndUserSpamNotificationCustomFromName'))
     {
         $HostedContentFilterPolicyParams.Remove('EndUserSpamNotificationCustomFromName') | Out-Null
         Write-Verbose -Message "The EndUserSpamNotificationCustomFromName parameter is no longer available and will be depricated."


### PR DESCRIPTION

#### Pull Request (PR) description
I changed the If statement in the EXOHostedContentFilterPolicy module, as there were two the same if statements. The second one needed to check on another value. This will probably also fix the error during deployment of the resource

#### This Pull Request (PR) fixes the following issues
- Fixes #1140

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1145)
<!-- Reviewable:end -->
