### PR TITLE
O365AdminAuditLogConfig: Fixed Set-TargetResource not being executed

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365AdminAuditLogConfig/MSFT_O365AdminAuditLogConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365AdminAuditLogConfig/MSFT_O365AdminAuditLogConfig.psm1
@@ -174,12 +174,14 @@ function Set-TargetResource
 
     $ConnectionMode = New-M365DSCConnection -Platform 'ExchangeOnline' `
         -InboundParameters $PSBoundParameters
-
+        
+    $OldErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
     if ($UnifiedAuditLogIngestionEnabled -eq 'Enabled')
     {
         try
         {
-            Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true -EA SilentlyContinue
+            Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true
         }
         catch
         {
@@ -192,7 +194,7 @@ function Set-TargetResource
     {
         try
         {
-            Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $false -EA SilentlyContinue
+            Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $false
         }
         catch
         {
@@ -201,6 +203,7 @@ function Set-TargetResource
             New-M365DSCLogEntry -Error $_ -Message $Message -Source $MyInvocation.MyCommand.ModuleName
         }
     }
+    $ErrorActionPreference = $OldErrorActionPreference
 }
 
 function Test-TargetResource


### PR DESCRIPTION
#### Pull Request (PR) description
Fix for the cmdlet Set-AdminAuditLogConfig not beign executed due to `-ErrorAction` being passed as an option, which is not well supported.

Passing `ErrorAction` option with the command as a global administrator results in the following error:
![image](https://user-images.githubusercontent.com/32768682/114590683-5e364680-9c89-11eb-857e-ddcc53ab6db8.png)

The old code had SilentlyContinue, so this error where never thrown

#### This Pull Request (PR) fixes the following issues
- Fixes #1142

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1149)
<!-- Reviewable:end -->
