### PR TITLE
MSFT_TeamsChannelTab: Correcting TeamsId to TeamId for parameterSet (current bug)

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelTab/MSFT_TeamsChannelTab.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelTab/MSFT_TeamsChannelTab.psm1
@@ -304,7 +304,7 @@ function Set-TargetResource
     {
         Write-Verbose -Message "Creating new tab {$DisplayName}"
         Write-Verbose -Message "Params: $($CurrentParameters | Out-String)"
-        $CurrentParameters.Add("TeamsId", $tab.TeamId)
+        $CurrentParameters.Add("TeamId", $tab.TeamId)
         $CurrentParameters.Add("ChannelId", $ChannelInstance.Id)
         $CurrentParameters.Remove("TeamName") | Out-Null
         $CurrentParameters.Remove("ChannelName") | Out-Null


### PR DESCRIPTION
#### Pull Request (PR) description
Parameterset gets built wiht TeamsId param to pass to create instructions, however the object being referenced is TeamId.

#### This Pull Request (PR) fixes the following issues
n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1159)
<!-- Reviewable:end -->
