### PR TITLE
EXOHostedContentFilterPolicy: Parses $PSBoundParameters as Hastable in Set-TargetResource

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
@@ -646,7 +646,7 @@ function Set-TargetResource
     $HostedContentFilterPolicies = Get-HostedContentFilterPolicy
 
     $HostedContentFilterPolicy = $HostedContentFilterPolicies | Where-Object -FilterScript { $_.Identity -eq $Identity }
-    $HostedContentFilterPolicyParams = $PSBoundParameters
+    $HostedContentFilterPolicyParams = [System.Collections.Hashtable]($PSBoundParameters)
     $HostedContentFilterPolicyParams.Remove('Ensure') | Out-Null
     $HostedContentFilterPolicyParams.Remove('GlobalAdminAccount') | Out-Null
     $HostedContentFilterPolicyParams.Remove('MakeDefault') | Out-Null


### PR DESCRIPTION
#### Pull Request (PR) description
`HostedContentFilterPolicyParams` was a `System.Management.Automation.PSBoundParametersDictionary` object, therefore not being able to use the .Contains method


#### This Pull Request (PR) fixes the following issues
- Fixes #1140

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1160)
<!-- Reviewable:end -->
