### PR TITLE
Configuration Drift Monitoring and changing to undefined fix

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -487,14 +487,12 @@ function Get-TargetResource
 
         }
 
-        $IncludeLocations = $null
-        $ExcludeLocations = $null
+        $IncludeLocations = @()
+        $ExcludeLocations = @()
         #translate Location template guids to Location name
         if ($Policy.Conditions.Locations)
         {
             Write-Verbose -Message "Get-TargetResource: Location condition defined, processing"
-            $IncludeLocations = @()
-            $ExcludeLocations = @()
             #build Location translation table
             $Locationlookup = @{}
             foreach ($Location in Get-AzureADMSNamedLocationPolicy)
@@ -612,12 +610,12 @@ function Get-TargetResource
             DisplayName                              = $Policy.DisplayName
             Id                                       = $Policy.Id
             State                                    = $Policy.State
-            IncludeApplications                      = [System.String[]]$Policy.Conditions.Applications.IncludeApplications
-            #no translation of Application GUIDs
-            ExcludeApplications                      = [System.String[]]$Policy.Conditions.Applications.ExcludeApplications
-            #no translation of GUIDs
-            IncludeUserActions                       = [System.String[]]$Policy.Conditions.Applications.IncludeUserActions
-            #no translation needed
+            IncludeApplications                      = [System.String[]](@() + $Policy.Conditions.Applications.IncludeApplications)
+            #no translation of Application GUIDs, return empty string array if undefined
+            ExcludeApplications                      = [System.String[]](@() + $Policy.Conditions.Applications.ExcludeApplications)
+            #no translation of GUIDs, return empty string array if undefined
+            IncludeUserActions                       = [System.String[]](@() + $Policy.Conditions.Applications.IncludeUserActions)
+            #no translation needed, return empty string array if undefined
             IncludeUsers                             = $IncludeUsers
             ExcludeUsers                             = $ExcludeUsers
             IncludeGroups                            = $IncludeGroups
@@ -625,53 +623,48 @@ function Get-TargetResource
             IncludeRoles                             = $IncludeRoles
             ExcludeRoles                             = $ExcludeRoles
 
-            IncludePlatforms                         = [System.String[]]$Policy.Conditions.Platforms.IncludePlatforms
-            #no translation needed
-            ExcludePlatforms                         = [System.String[]]$Policy.Conditions.Platforms.ExcludePlatforms
-            #no translation needed
+            IncludePlatforms                         = [System.String[]](@() + $Policy.Conditions.Platforms.IncludePlatforms)
+            #no translation needed, return empty string array if undefined
+            ExcludePlatforms                         = [System.String[]](@() + $Policy.Conditions.Platforms.ExcludePlatforms)
+            #no translation needed, return empty string array if undefined
             IncludeLocations                         = $IncludeLocations
             ExcludeLocations                         = $ExcludeLocations
-            IncludeDevices                           = [System.String[]]$Policy.Conditions.Devices.IncludeDevices
-            #no translation needed
-            ExcludeDevices                           = [System.String[]]$Policy.Conditions.Devices.ExcludeDevices
-            #no translation needed
-            UserRiskLevels                           = [System.String[]]$Policy.Conditions.UserRiskLevels
-            #no translation needed
-            SignInRiskLevels                         = [System.String[]]$Policy.Conditions.SignInRiskLevels
-            #no translation needed
-            ClientAppTypes                           = [System.String[]]$Policy.Conditions.ClientAppTypes
-            #no translation needed
+            IncludeDevices                           = [System.String[]](@() + $Policy.Conditions.Devices.IncludeDevices)
+            #no translation needed, return empty string array if undefined
+            ExcludeDevices                           = [System.String[]](@() + $Policy.Conditions.Devices.ExcludeDevices)
+            #no translation needed, return empty string array if undefined
+            UserRiskLevels                           = [System.String[]](@() + $Policy.Conditions.UserRiskLevels)
+            #no translation needed, return empty string array if undefined
+            SignInRiskLevels                         = [System.String[]](@() + $Policy.Conditions.SignInRiskLevels)
+            #no translation needed, return empty string array if undefined
+            ClientAppTypes                           = [System.String[]](@() + $Policy.Conditions.ClientAppTypes)
+            #no translation needed, return empty string array if undefined
             GrantControlOperator                     = $Policy.GrantControls._Operator
             #no translation or conversion needed
-            BuiltInControls                          = [System.String[]]$Policy.GrantControls.BuiltInControls
+            BuiltInControls                          = [System.String[]](@() + $Policy.GrantControls.BuiltInControls)
+            #no translation needed, return empty string array if undefined
+            ApplicationEnforcedRestrictionsIsEnabled = $false -or $Policy.SessionControls.ApplicationEnforcedRestrictions.IsEnabled
+            #make false if undefined, true if true
+            CloudAppSecurityIsEnabled                = $false -or $Policy.SessionControls.CloudAppSecurity.IsEnabled
+            #make false if undefined, true if true
+            CloudAppSecurityType                     = [System.String]$Policy.SessionControls.CloudAppSecurity.CloudAppSecurityType
+            #no translation needed, return empty string array if undefined
+            SignInFrequencyIsEnabled                 = $false -or $Policy.SessionControls.SignInFrequency.IsEnabled
+            #make false if undefined, true if true
+            SignInFrequencyValue                     = $Policy.SessionControls.SignInFrequency.Value
+            #no translation or conversion needed, $null returned if undefined
+            SignInFrequencyType                      = [System.String]$Policy.SessionControls.SignInFrequency.Type
             #no translation needed
-            ApplicationEnforcedRestrictionsIsEnabled = $Policy.SessionControls.ApplicationEnforcedRestrictions.IsEnabled
-            #no translation or conversion needed
+            PersistentBrowserIsEnabled               = $false -or $Policy.SessionControls.PersistentBrowser.IsEnabled
+            #make false if undefined, true if true
+            PersistentBrowserMode                    = [System.String]$Policy.SessionControls.PersistentBrowser.Mode
+            #no translation needed
             #Standard part
             Ensure                                   = "Present"
             GlobalAdminAccount                       = $GlobalAdminAccount
             ApplicationId                            = $ApplicationId
             TenantId                                 = $TenantId
             CertificateThumbprint                    = $CertificateThumbprint
-        }
-        #adding CloudAppSecurity values if enabled
-        if ($Policy.SessionControls.CloudAppSecurity.IsEnabled)
-        {
-            $result += @{CloudAppSecurityIsEnabled = $Policy.SessionControls.CloudAppSecurity.IsEnabled }
-            $result += @{CloudAppSecurityType = [System.String]$Policy.SessionControls.CloudAppSecurity.CloudAppSecurityType }
-        }
-        #adding SignInFrequency values if enabled
-        if ($Policy.SessionControls.SignInFrequency.IsEnabled)
-        {
-            $result += @{SignInFrequencyIsEnabled = $Policy.SessionControls.SignInFrequency.IsEnabled }
-            $result += @{SignInFrequencyValue = $Policy.SessionControls.SignInFrequency.Value }
-            $result += @{SignInFrequencyType = [System.String]$Policy.SessionControls.SignInFrequency.Type }
-        }
-        #adding PersistentBrowser values if enabled
-        if ($Policy.SessionControls.PersistentBrowser.IsEnabled)
-        {
-            $result += @{PersistentBrowserIsEnabled = $Policy.SessionControls.PersistentBrowser.IsEnabled }
-            $result += @{PersistentBrowserMode = [System.String]$Policy.SessionControls.PersistentBrowser.Mode }
         }
         Write-Verbose -Message "Get-TargetResource Result: `n $(Convert-M365DscHashtableToString -Hashtable $result)"
         return $result
@@ -883,6 +876,7 @@ function Set-TargetResource
         Write-Verbose -Message "Set-Targetresource: create and provision User Condition object"
         $conditions.Users = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessUserCondition
         Write-Verbose -Message "Set-Targetresource: process includeusers"
+        $conditions.Users.IncludeUsers = @()
         foreach ($includeuser in $IncludeUsers)
         {
             #translate user UPNs to GUID, except id value is GuestsOrExternalUsers or All
@@ -954,6 +948,7 @@ function Set-TargetResource
             }
         }
         Write-Verbose -Message "Set-Targetresource: process excludeusers"
+        $conditions.Users.ExcludeUsers = @()
         foreach ($excludeuser in $ExcludeUsers)
         {
             #translate user UPNs to GUID, except id value is GuestsOrExternalUsers or All
@@ -1025,6 +1020,7 @@ function Set-TargetResource
             }
         }
         Write-Verbose -Message "Set-Targetresource: process includegroups"
+        $conditions.Users.IncludeGroups = @()
         foreach ($includegroup in $IncludeGroups)
         {
             #translate user Group names to GUID
@@ -1116,6 +1112,7 @@ function Set-TargetResource
                 }
             }
         }
+        $conditions.Users.ExcludeGroups = @()
         Write-Verbose -Message "Set-Targetresource: process excludegroups"
         foreach ($ExcludeGroup in $ExcludeGroups)
         {
@@ -1209,6 +1206,7 @@ function Set-TargetResource
             }
         }
         Write-Verbose -Message "Set-Targetresource: process includeroles"
+        $conditions.Users.IncludeRoles = @()
         if ($IncludeRoles)
         {
             #translate role names to template guid if defined
@@ -1252,6 +1250,7 @@ function Set-TargetResource
             }
         }
         Write-Verbose -Message "Set-Targetresource: process excluderoles"
+        $conditions.Users.ExcludeRoles = @()
         if ($ExcludeRoles)
         {
             #translate role names to template guid if defined
@@ -1295,22 +1294,31 @@ function Set-TargetResource
                 }
             }
         }
-        Write-Verbose -Message "Set-Targetresource: process includeplatforms"
+        Write-Verbose -Message "Set-Targetresource: process platform condition"
         if ($IncludePlatforms -or $ExcludePlatforms)
         {
             #create and provision Platform condition object if used
             $conditions.Platforms = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessPlatformCondition
-            $conditions.Platforms.IncludePlatforms = $IncludePlatforms
+            Write-Verbose -Message "Set-Targetresource: IncludePlatforms: $IncludePlatforms"
+            $conditions.Platforms.IncludePlatforms = @() + $IncludePlatforms
             #no translation or conversion needed
-            $conditions.Platforms.ExcludePlatforms = $ExcludePlatforms
+            Write-Verbose -Message "Set-Targetresource: ExcludePlatforms: $ExcludePlatforms"
+            $conditions.Platforms.ExcludePlatforms = @() + $ExcludePlatforms
             #no translation or conversion needed
+        }
+        else
+        {
+            Write-Verbose -Message "Set-Targetresource: setting platform condition to null"
+            $conditions.Platforms = $null
         }
         Write-Verbose -Message "Set-Targetresource: process include and exclude locations"
         if ($IncludeLocations -or $ExcludeLocations)
         {
+            $conditions.Locations = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessLocationCondition
+            $conditions.Locations.IncludeLocations = @()
+            $conditions.Locations.ExcludeLocations = @()
             Write-Verbose -Message "Set-Targetresource: locations specified"
             #create and provision Location condition object if used, translate Location names to guid
-            $conditions.Locations = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessLocationCondition
             $LocationLookup = @{}
             foreach ($Location in Get-AzureADMSNamedLocationPolicy)
             {
@@ -1405,10 +1413,13 @@ function Set-TargetResource
             #no translation or conversion needed
         }
         Write-Verbose -Message "Set-Targetresource: process risk levels and app types"
+        Write-Verbose -Message "Set-Targetresource: UserRiskLevels: $UserRiskLevels"
         $Conditions.UserRiskLevels = $UserRiskLevels
         #no translation or conversion needed
+        Write-Verbose -Message "Set-Targetresource: SignInRiskLevels: $SignInRiskLevels"
         $Conditions.SignInRiskLevels = $SignInRiskLevels
         #no translation or conversion needed
+        Write-Verbose -Message "Set-Targetresource: ClientAppTypes: $ClientAppTypes"
         $Conditions.ClientAppTypes = $ClientAppTypes
         #no translation or conversion needed
         Write-Verbose -Message "Set-Targetresource: Adding processed conditions"
@@ -1424,11 +1435,13 @@ function Set-TargetResource
         $NewParameters.Add("GrantControls", $GrantControls)
         #add GrantControls to the parameter list
         Write-Verbose -Message "Set-Targetresource: process session controls"
+
+        $sessioncontrols = $null
         if ($ApplicationEnforcedRestrictionsIsEnabled -or $CloudAppSecurityIsEnabled -or $SignInFrequencyIsEnabled -or $PersistentBrowserIsEnabled)
         {
-            #create and provision Session Control object if used
-            Write-Verbose -Message "Set-Targetresource: Create and provision Session Control object"
+            Write-Verbose -Message "Set-Targetresource: create provision Session Control object"
             $sessioncontrols = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessSessionControls
+
             if ($ApplicationEnforcedRestrictionsIsEnabled)
             {
                 #create and provision ApplicationEnforcedRestrictions object if used
@@ -1452,15 +1465,15 @@ function Set-TargetResource
             }
             if ($PersistentBrowserIsEnabled)
             {
+                Write-Verbose -Message "Set-Targetresource: Persistent Browser settings defined: PersistentBrowserIsEnabled:$PersistentBrowserIsEnabled, PersistentBrowserMode:$PersistentBrowserMode"
                 #create and provision PersistentBrowser object if used
                 $sessioncontrols.PersistentBrowser = New-Object -TypeName Microsoft.Open.MSGraph.Model.ConditionalAccessPersistentBrowser
                 $sessioncontrols.PersistentBrowser.IsEnabled = $true
                 $sessioncontrols.PersistentBrowser.Mode = $PersistentBrowserMode
             }
-            $NewParameters.Add("SessionControls", $sessioncontrols)
-            #add SessionControls to the parameter list
         }
-
+        $NewParameters.Add("SessionControls", $sessioncontrols)
+        #add SessionControls to the parameter list
     }
     if ($Ensure -eq 'Present' -and $currentPolicy.Ensure -eq 'Present')
     {

--- a/Modules/Microsoft365DSC/Examples/Resources/AADConditionalAccessPolicy/1-ConfigureAADConditionalAccessPolicy.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/AADConditionalAccessPolicy/1-ConfigureAADConditionalAccessPolicy.ps1
@@ -16,34 +16,37 @@ Configuration Example
     {
         AADConditionalAccessPolicy Allin-example
         {
-            GlobalAdminAccount        = $credsGlobalAdmin;
-            BuiltInControls           = @("Mfa", "CompliantDevice", "DomainJoinedDevice", "ApprovedApplication", "CompliantApplication");
-            ClientAppTypes            = @("ExchangeActiveSync", "Browser", "MobileAppsAndDesktopClients", "Other");
-            CloudAppSecurityIsEnabled = $True;
-            CloudAppSecurityType      = "MonitorOnly";
-            DisplayName               = "Allin-example";
-            Ensure                    = "Present";
-            ExcludeApplications       = @("803ee9ca-3f7f-4824-bd6e-0b99d720c35c", "00000012-0000-0000-c000-000000000000", "00000007-0000-0000-c000-000000000000", "Office365");
-            ExcludeDevices            = @("Compliant", "DomainJoined");
-            ExcludeGroups             = @();
-            ExcludeLocations          = @("Blocked Countries");
-            ExcludePlatforms          = @("Windows", "WindowsPhone", "MacOS");
-            ExcludeRoles              = @("Company Administrator", "Application Administrator", "Application Developer", "Cloud Application Administrator", "Cloud Device Administrator");
-            ExcludeUsers              = @("admin@contoso.com", "AAdmin@contoso.com", "CAAdmin@contoso.com", "AllanD@contoso.com", "AlexW@contoso.com", "GuestsOrExternalUsers");
-            GrantControlOperator      = "OR";
-            IncludeApplications       = @("All");
-            IncludeDevices            = @("All");
-            IncludeGroups             = @();
-            IncludeLocations          = @("AllTrusted");
-            IncludePlatforms          = @("Android", "IOS");
-            IncludeUserActions        = @();
-            IncludeUsers              = @("All");
-            SignInFrequencyIsEnabled  = $True;
-            SignInFrequencyType       = "Hours";
-            SignInFrequencyValue      = 5;
-            SignInRiskLevels          = @("High", "Medium");
-            State                     = "disabled";
-            UserRiskLevels            = @("High", "Medium");
+            GlobalAdminAccount         = $credsGlobalAdmin;
+            BuiltInControls            = @("Mfa", "CompliantDevice", "DomainJoinedDevice", "ApprovedApplication", "CompliantApplication");
+            ClientAppTypes             = @("ExchangeActiveSync", "Browser", "MobileAppsAndDesktopClients", "Other");
+            CloudAppSecurityIsEnabled  = $True;
+            CloudAppSecurityType       = "MonitorOnly";
+            DisplayName                = "Allin-example";
+            Ensure                     = "Present";
+            ExcludeApplications        = @("803ee9ca-3f7f-4824-bd6e-0b99d720c35c", "00000012-0000-0000-c000-000000000000", "00000007-0000-0000-c000-000000000000", "Office365");
+            ExcludeDevices             = @("Compliant", "DomainJoined");
+            ExcludeGroups              = @();
+            ExcludeLocations           = @("Blocked Countries");
+            ExcludePlatforms           = @("Windows", "WindowsPhone", "MacOS");
+            ExcludeRoles               = @("Company Administrator", "Application Administrator", "Application Developer", "Cloud Application Administrator", "Cloud Device Administrator");
+            ExcludeUsers               = @("admin@contoso.com", "AAdmin@contoso.com", "CAAdmin@contoso.com", "AllanD@contoso.com", "AlexW@contoso.com", "GuestsOrExternalUsers");
+            GrantControlOperator       = "OR";
+            IncludeApplications        = @("All");
+            IncludeDevices             = @("All");
+            IncludeGroups              = @();
+            IncludeLocations           = @("AllTrusted");
+            IncludePlatforms           = @("Android", "IOS");
+            IncludeRoles               = @("Compliance Administrator");
+            IncludeUserActions         = @();
+            IncludeUsers               = @("Alexw@contoso.com");
+            PersistentBrowserIsEnabled = $false;
+            PersistentBrowserMode      = "";
+            SignInFrequencyIsEnabled   = $True;
+            SignInFrequencyType        = "Hours";
+            SignInFrequencyValue       = 5;
+            SignInRiskLevels           = @("High", "Medium");
+            State                      = "disabled";
+            UserRiskLevels             = @("High", "Medium");
         }
     }
 }


### PR DESCRIPTION

#### Pull Request (PR) description
Configuration drift from undefined to defined is now signaled for each attribute.
Changing attributes to undefined is now possible for all attributes, except:
        $IncludePlatforms
        $IncludeLocations
        $IncludeDevices
        $ApplicationEnforcedRestrictionsIsEnabled
        $CloudAppSecurityIsEnabled
        $CloudAppSecurityType
        $SignInFrequencyValue
        $SignInFrequencyType
        $SignInFrequencyIsEnabled
        $PersistentBrowserMode
        $PersistentBrowserIsEnabled
(AAD Powershell limitation)

#### This Pull Request (PR) fixes the following issues
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1164)
<!-- Reviewable:end -->
