### PR TITLE
EXOTransportRule: Adding SCLOver parameters and minor fixes

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.psm1
@@ -937,6 +937,16 @@ function Get-TargetResource
             TenantId                                      = $TenantId
         }
 
+        # Formats DateTime as String
+        if ($null -ne $result.ActivationDate)
+        {
+            $result.ActivationDate = $TransportRule.ActivationDate.ToUniversalTime().ToString()
+        }
+        if ($null -ne $result.ExpiryDate)
+        {
+            $result.ExpiryDate = $TransportRule.ExpiryDate.ToUniversalTime().ToString()
+        }
+
         Write-Verbose -Message "Found Transport Rule $($Name)"
         return $result
     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.psm1
@@ -672,7 +672,7 @@ function Get-TargetResource
         $SubjectMatchesPatterns,
 
         [Parameter()]
-        [System.String]
+        [System.String[]]
         $SubjectOrBodyContainsWords,
 
         [Parameter()]
@@ -1605,7 +1605,7 @@ function Set-TargetResource
         $SubjectMatchesPatterns,
 
         [Parameter()]
-        [System.String]
+        [System.String[]]
         $SubjectOrBodyContainsWords,
 
         [Parameter()]
@@ -2370,7 +2370,7 @@ function Test-TargetResource
         $SubjectMatchesPatterns,
 
         [Parameter()]
-        [System.String]
+        [System.String[]]
         $SubjectOrBodyContainsWords,
 
         [Parameter()]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.psm1
@@ -354,6 +354,10 @@ function Get-TargetResource
         $ExceptIfRecipientInSenderList,
 
         [Parameter()]
+        [System.String]
+        $ExceptIfSCLOver,
+
+        [Parameter()]
         [System.String[]]
         $ExceptIfSenderADAttributeContainsWords,
 
@@ -600,6 +604,10 @@ function Get-TargetResource
         $RuleSubType,
 
         [Parameter()]
+        [System.String]
+        $SCLOver,
+
+        [Parameter()]
         [System.String[]]
         $SenderADAttributeContainsWords,
 
@@ -839,6 +847,7 @@ function Get-TargetResource
             ExceptIfRecipientAddressMatchesPatterns       = $TransportRule.ExceptIfRecipientAddressMatchesPatterns
             ExceptIfRecipientDomainIs                     = $TransportRule.ExceptIfRecipientDomainIs
             ExceptIfRecipientInSenderList                 = $TransportRule.ExceptIfRecipientInSenderList
+            ExceptIfSCLOver                               = $TransportRule.ExceptIfSCLOver
             ExceptIfSenderADAttributeContainsWords        = $TransportRule.ExceptIfSenderADAttributeContainsWords
             ExceptIfSenderADAttributeMatchesPatterns      = $TransportRule.ExceptIfSenderADAttributeMatchesPatterns
             ExceptIfSenderDomainIs                        = $TransportRule.ExceptIfSenderDomainIs
@@ -898,6 +907,7 @@ function Get-TargetResource
             RouteMessageOutboundRequireTls                = $TransportRule.RouteMessageOutboundRequireTls
             RuleErrorAction                               = $TransportRule.RuleErrorAction
             RuleSubType                                   = $TransportRule.RuleSubType
+            SCLOver                                       = $TransportRule.SCLOver
             SenderADAttributeContainsWords                = $TransportRule.SenderADAttributeContainsWords
             SenderADAttributeMatchesPatterns              = $TransportRule.SenderADAttributeMatchesPatterns
             SenderAddressLocation                         = $TransportRule.SenderAddressLocation
@@ -1287,6 +1297,10 @@ function Set-TargetResource
         $ExceptIfRecipientInSenderList,
 
         [Parameter()]
+        [System.String]
+        $ExceptIfSCLOver,
+
+        [Parameter()]
         [System.String[]]
         $ExceptIfSenderADAttributeContainsWords,
 
@@ -1531,6 +1545,10 @@ function Set-TargetResource
         [ValidateSet('Dlp', 'None')]
         [System.String]
         $RuleSubType,
+
+        [Parameter()]
+        [System.String]
+        $SCLOver,
 
         [Parameter()]
         [System.String[]]
@@ -2052,6 +2070,10 @@ function Test-TargetResource
         $ExceptIfRecipientInSenderList,
 
         [Parameter()]
+        [System.String]
+        $ExceptIfSCLOver,
+
+        [Parameter()]
         [System.String[]]
         $ExceptIfSenderADAttributeContainsWords,
 
@@ -2296,6 +2318,10 @@ function Test-TargetResource
         [ValidateSet('Dlp', 'None')]
         [System.String]
         $RuleSubType,
+
+        [Parameter()]
+        [System.String]
+        $SCLOver,
 
         [Parameter()]
         [System.String[]]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.schema.mof
@@ -86,6 +86,7 @@ class MSFT_EXOTransportRule : OMI_BaseResource
     [Write, Description("The ExceptIfRecipientAddressMatchesPatterns parameter specifies an exception that looks for text patterns in recipient email addresses by using regular expressions.")] String ExceptIfRecipientAddressMatchesPatterns[];
     [Write, Description("The ExceptIfRecipientDomainIs parameter specifies an exception that looks for recipients with email address in the specified domains.")] String ExceptIfRecipientDomainIs[];
     [Write, Description("This parameter is reserved for internal Microsoft use.")] String ExceptIfRecipientInSenderList[];
+    [Write, Description("The ExceptIfSCLOver parameter specifies an exception that looks for the SCL value of messages")] String ExceptIfSCLOver;
     [Write, Description("The ExceptIfSenderADAttributeContainsWords parameter specifies an exception that looks for words in Active Directory attributes of message senders.")] String ExceptIfSenderADAttributeContainsWords[];
     [Write, Description("The ExceptIfSenderADAttributeMatchesPatterns parameter specifies an exception that looks for text patterns in Active Directory attributes of message senders by using regular expressions.")] String ExceptIfSenderADAttributeMatchesPatterns[];
     [Write, Description("The ExceptIfSenderDomainIs parameter specifies an exception that looks for senders with email address in the specified domains.")] String ExceptIfSenderDomainIs[];
@@ -145,6 +146,7 @@ class MSFT_EXOTransportRule : OMI_BaseResource
     [Write, Description("The RouteMessageOutboundRequireTls parameter specifies an action that uses Transport Layer Security (TLS) encryption to deliver messages outside your organization.")] Boolean RouteMessageOutboundRequireTls;
     [Write, Description("The RuleErrorAction parameter specifies what to do if rule processing can't be completed on messages."), ValueMap{"Ignore","Defer"}, Values{"Ignore","Defer"}] String RuleErrorAction;
     [Write, Description("The RuleSubType parameter specifies the rule type."), ValueMap{"Dlp","None"}, Values{"Dlp","None"}] String RuleSubType;
+    [Write, Description("The SCLOver parameter specifies a condition that looks for the SCL value of messages")] String SCLOver;
     [Write, Description("The SenderADAttributeContainsWords parameter specifies a condition that looks for words in Active Directory attributes of message senders.")] String SenderADAttributeContainsWords[];
     [Write, Description("The SenderADAttributeMatchesPatterns parameter specifies a condition that looks for text patterns in Active Directory attributes of message senders by using regular expressions.")] String SenderADAttributeMatchesPatterns[];
     [Write, Description("The SenderAddressLocation parameter specifies where to look for sender addresses in conditions and exceptions that examine sender email addresses."), ValueMap{"Header","Envelope","HeaderOrEnvelope"}, Values{"Header","Envelope","HeaderOrEnvelope"}] String SenderAddressLocation;


### PR DESCRIPTION
#### Pull Request (PR) description
Adding `ExceptIfSCLOver` and `SCLOver`.
Fixes `SubjectOrBodyContainsWords` parameter not being an array.
Fixes DateTime formating on `ExpiryDate` and `ActivationDate`

#### This Pull Request (PR) fixes the following issues

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1190)
<!-- Reviewable:end -->
