### PR TITLE
Update MSFT_EXOActiveSyncDeviceAccessRule.psm1

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/MSFT_EXOActiveSyncDeviceAccessRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/MSFT_EXOActiveSyncDeviceAccessRule.psm1
@@ -238,6 +238,7 @@ function Set-TargetResource
     {
         Write-Verbose -Message "Active Sync Device Access Rule '$($Identity)' already exists, but needs updating."
         Write-Verbose -Message "Setting Active Sync Device Access Rule $($Identity) with values: $(Convert-M365DscHashtableToString -Hashtable $SetActiveSyncDeviceAccessRuleParams)"
+        $SetActiveSyncDeviceAccessRuleParams.Identity = Get-ActiveSyncDeviceAccessRule | Where {$_.AccessLevel -eq $NewActiveSyncDeviceAccessRuleParams.AccessLevel -and $_.Characteristic -eq $NewActiveSyncDeviceAccessRuleParams.Characteristic -and $_.QueryString -eq $NewActiveSyncDeviceAccessRuleParams.QueryString} | SELECT -ExpandProperty "Identity"
         Set-ActiveSyncDeviceAccessRule @SetActiveSyncDeviceAccessRuleParams
     }
 }


### PR DESCRIPTION
 Get-ActiveSyncDeviceAccessRule "Identity" using $NewActiveSyncDeviceAccessRuleParams

invoke before Set-ActiveSyncDeviceAccessRule @SetActiveSyncDeviceAccessRuleParams as "Identity" is set automatically after creating ActiveSyncDeviceAccessRule
this does not reflect the identity set in $SetActiveSyncDeviceAccessRuleParams and is user given


#### Pull Request (PR) description

when setting a ActiveSyncDeviceAccessRule, Identity is mismatched due to user input / auto generated "Name"
getting the Identity from the access rule set by exchange before running the set command

please double check

#### This Pull Request (PR) fixes the following issues

None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1206)
<!-- Reviewable:end -->
