### PR TITLE
EXOTransportRule: Changed ExceptIfSenderInRecipientList to array

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.schema.mof
@@ -90,7 +90,7 @@ class MSFT_EXOTransportRule : OMI_BaseResource
     [Write, Description("The ExceptIfSenderADAttributeContainsWords parameter specifies an exception that looks for words in Active Directory attributes of message senders.")] String ExceptIfSenderADAttributeContainsWords[];
     [Write, Description("The ExceptIfSenderADAttributeMatchesPatterns parameter specifies an exception that looks for text patterns in Active Directory attributes of message senders by using regular expressions.")] String ExceptIfSenderADAttributeMatchesPatterns[];
     [Write, Description("The ExceptIfSenderDomainIs parameter specifies an exception that looks for senders with email address in the specified domains.")] String ExceptIfSenderDomainIs[];
-    [Write, Description("This parameter is reserved for internal Microsoft use.")] String ExceptIfSenderInRecipientList;
+    [Write, Description("This parameter is reserved for internal Microsoft use.")] String ExceptIfSenderInRecipientList[];
     [Write, Description("The ExceptIfSenderIpRanges parameter specifies an exception that looks for senders whose IP addresses matches the specified value, or fall within the specified ranges.")] String ExceptIfSenderIpRanges[];
     [Write, Description("The ExceptIfSenderManagementRelationship parameter specifies an exception that looks for the relationship between the sender and recipients in messages."), ValueMap{"Manager","DirectReport"}, Values{"Manager","DirectReport"}] String ExceptIfSenderManagementRelationship;
     [Write, Description("The ExceptIfSentTo parameter specifies an exception that looks for recipients in messages. You can use any value that uniquely identifies the recipient.")] String ExceptIfSentTo[];


### PR DESCRIPTION
#### Pull Request (PR) description
The `ExceptIfSenderInRecipientList` were miss configured in the MOF schema. It should have been an array.

#### This Pull Request (PR) fixes the following issues
- Fixes #1230

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1233)
<!-- Reviewable:end -->
