### PR TITLE
Updated Dependencies and TeamsUpgradePolicy Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change log for Microsoft365DSC
 
+# 1.21.609.1
+
+* TeamsUpgradePolicy
+  * Fixes to how we are retrieving users assigned to the
+    Global Upgrade Policy.
+* DEPENDENCIES
+  * Updated ExchangeOnlineManagement to version 2.0.5;
+  * Updated Microsoft.Graph.Planner to version 1.5.0;
+  * Updated Microsoft.Graph.Teams to version 1.5.0;
+  * Updated Microsoft.PowerApps.Administration.PowerShell
+    to version 2.0.125;
+  * Updated PnP.PowerShell to version 1.6.0;
+
 # 1.21.602.1
 
 * AADMSGroups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   * Updated Microsoft.Graph.Planner to version 1.5.0;
   * Updated Microsoft.Graph.Teams to version 1.5.0;
   * Updated Microsoft.PowerApps.Administration.PowerShell
-    to version 2.0.125;
+    to version 2.0.126;
   * Updated PnP.PowerShell to version 1.6.0;
 
 # 1.21.602.1

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpgradePolicy/MSFT_TeamsUpgradePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpgradePolicy/MSFT_TeamsUpgradePolicy.psm1
@@ -41,13 +41,20 @@ function Get-TargetResource
         $policy = Get-CsTeamsUpgradePolicy -Identity $Identity `
             -ErrorAction SilentlyContinue
 
-        try
+        if ($Identity -eq 'Global')
         {
-            [array]$users = Get-CsOnlineUser -Filter "TeamsUpgradePolicy -eq '$Identity'"
+            [array]$users = Get-CsOnlineUser | Where-Object -Filter { $_.TeamsUpgradePolicy -eq $null }
         }
-        catch
+        else
         {
-            [array]$users = Get-CsOnlineUser | Where-Object -Filter { $_.TeamsUpgradePolicy -eq $Identity }
+            try
+            {
+                [array]$users = Get-CsOnlineUser -Filter "TeamsUpgradePolicy -eq '$Identity'"
+            }
+            catch
+            {
+                [array]$users = Get-CsOnlineUser | Where-Object -Filter { $_.TeamsUpgradePolicy -eq $Identity }
+            }
         }
 
         if ($null -eq $policy)

--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -61,7 +61,7 @@
         },
         @{
             ModuleName      = "ExchangeOnlineManagement"
-            RequiredVersion = "2.0.4"
+            RequiredVersion = "2.0.5"
         },
         @{
             ModuleName      = "Microsoft.Graph.Authentication"
@@ -77,15 +77,15 @@
         },
         @{
             ModuleName      = "Microsoft.Graph.Planner"
-            RequiredVersion = "1.4.2"
+            RequiredVersion = "1.5.0"
         },
         @{
             ModuleName      = "Microsoft.Graph.Teams"
-            RequiredVersion = "1.4.2"
+            RequiredVersion = "1.5.0"
         },
         @{
             ModuleName      = "Microsoft.PowerApps.Administration.PowerShell"
-            RequiredVersion = "2.0.112"
+            RequiredVersion = "2.0.125"
         },
         @{
             ModuleName      = "MicrosoftTeams"
@@ -97,7 +97,7 @@
         },
         @{
             ModuleName      = "PnP.PowerShell"
-            RequiredVersion = "1.5.0"
+            RequiredVersion = "1.6.0"
         },
         @{
             ModuleName      = "ReverseDSC"

--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -85,7 +85,7 @@
         },
         @{
             ModuleName      = "Microsoft.PowerApps.Administration.PowerShell"
-            RequiredVersion = "2.0.125"
+            RequiredVersion = "2.0.126"
         },
         @{
             ModuleName      = "MicrosoftTeams"


### PR DESCRIPTION
#### Pull Request (PR) description
* TeamsUpgradePolicy
  * Fixes to how we are retrieving users assigned to the
    Global Upgrade Policy.
* DEPENDENCIES
  * Updated ExchangeOnlineManagement to version 2.0.5;
  * Updated Microsoft.Graph.Planner to version 1.5.0;
  * Updated Microsoft.Graph.Teams to version 1.5.0;
  * Updated Microsoft.PowerApps.Administration.PowerShell
    to version 2.0.125;
  * Updated PnP.PowerShell to version 1.6.0;

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1261)
<!-- Reviewable:end -->
