### PR TITLE
SPOTenantSettings: Add support for MarkNewFilesSensitiveByDefault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# Unreleased
+
+* SPOTenantSettings
+  * Added support for specifying MarkNewFilesSensitiveByDefault
+
 # 1.21.630.1
 
 * O365User

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
@@ -79,6 +79,11 @@ function Get-TargetResource
         $HideDefaultThemes,
 
         [Parameter()]
+        [ValidateSet("AllowExternalSharing", "BlockExternalSharing")]
+        [System.String]
+        $MarkNewFilesSensitiveByDefault,
+
+        [Parameter()]
         [ValidateSet("Present", "Absent")]
         [System.String]
         $Ensure = "Present",
@@ -160,6 +165,7 @@ function Get-TargetResource
             ApplyAppEnforcedRestrictionsToAdHocRecipients = $SPOTenantSettings.ApplyAppEnforcedRestrictionsToAdHocRecipients
             FilePickerExternalImageSearchEnabled          = $SPOTenantSettings.FilePickerExternalImageSearchEnabled
             HideDefaultThemes                             = $SPOTenantSettings.HideDefaultThemes
+            MarkNewFilesSensitiveByDefault                = $SPOTenantSettings.MarkNewFilesSensitiveByDefault
             GlobalAdminAccount                            = $GlobalAdminAccount
             ApplicationId                                 = $ApplicationId
             TenantId                                      = $TenantId
@@ -276,6 +282,11 @@ function Set-TargetResource
         [Parameter()]
         [System.Boolean]
         $HideDefaultThemes,
+
+        [Parameter()]
+        [ValidateSet("AllowExternalSharing", "BlockExternalSharing")]
+        [System.String]
+        $MarkNewFilesSensitiveByDefault,
 
         [Parameter()]
         [ValidateSet("Present", "Absent")]
@@ -423,6 +434,11 @@ function Test-TargetResource
         $HideDefaultThemes,
 
         [Parameter()]
+        [ValidateSet("AllowExternalSharing", "BlockExternalSharing")]
+        [System.String]
+        $MarkNewFilesSensitiveByDefault,
+
+        [Parameter()]
         [ValidateSet("Present", "Absent")]
         [System.String]
         $Ensure = "Present",
@@ -492,7 +508,9 @@ function Test-TargetResource
             "OwnerAnonymousNotification", `
             "ApplyAppEnforcedRestrictionsToAdHocRecipients", `
             "FilePickerExternalImageSearchEnabled", `
-            "HideDefaultThemes")
+            "HideDefaultThemes", `
+            "MarkNewFilesSensitiveByDefault"
+            )
 
     Write-Verbose -Message "Test-TargetResource returned $TestResult"
     return $TestResult

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.schema.mof
@@ -19,6 +19,7 @@ class MSFT_SPOTenantSettings : OMI_BaseResource
     [Write, Description("")] boolean ApplyAppEnforcedRestrictionsToAdHocRecipients;
     [Write, Description("")] boolean FilePickerExternalImageSearchEnabled;
     [Write, Description("Defines if the default themes are visible or hidden")] boolean HideDefaultThemes;
+    [Write, Description("Allow or block external sharing until at least one Office DLP policy scans the content of the file."), ValueMap{"AllowExternalSharing","BlockExternalSharing"}, Values{"AllowExternalSharing","BlockExternalSharing"}] string MarkNewFilesSensitiveByDefault;
     [Write, Description("Only accepted value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Credentials of the SharePoint Global Admin"), EmbeddedInstance("MSFT_Credential")] string GlobalAdminAccount;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;

--- a/Modules/Microsoft365DSC/Examples/Resources/SPOTenantSettings/1-ConfigureSPOTenantSettings.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/SPOTenantSettings/1-ConfigureSPOTenantSettings.ps1
@@ -34,6 +34,7 @@ Configuration Example
             ApplyAppEnforcedRestrictionsToAdHocRecipients = $true
             FilePickerExternalImageSearchEnabled          = $true
             HideDefaultThemes                             = $false
+            MarkNewFilesSensitiveByDefault                = "AllowExternalSharing"
             Ensure                                        = "Present"
         }
     }


### PR DESCRIPTION
#### Pull Request (PR) description
Add support for configuring MarkNewFilesSensitiveByDefault in SPO tenant settings

#### This Pull Request (PR) fixes the following issues
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1282)
<!-- Reviewable:end -->
