### PR TITLE
Fixed Typo in MSFT_EXOSafeLinksPolicy

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.psm1
@@ -470,7 +470,7 @@ function Export-TargetResource
             else
             {
                 Write-Host "`r`n" -NoNewline
-            }g
+            }
             $i = 1
             foreach ($SafeLinksPolicy in $SafeLinksPolicies)
             {


### PR DESCRIPTION
There was a typo added to MSFT_EXOSafeLinksPolicy with PR #1357.

#### This Pull Request (PR) fixes the following issues
    - Fixes #1367

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1369)
<!-- Reviewable:end -->
