### PR TITLE
Changed MicrosoftTeams module version

### DIFF
--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -85,7 +85,7 @@
         },
         @{
             ModuleName      = "MicrosoftTeams"
-            RequiredVersion = "2.5.0"
+            RequiredVersion = "2.5.1"
         },
         @{
             ModuleName      = "MSCloudLoginAssistant"


### PR DESCRIPTION
#### Pull Request (PR) description
I've changed the MicrosoftTeams Module requirement to 2.5.1. Apparently 2.5.0 is not available anymore 

#### This Pull Request (PR) fixes the following issues
- Fixes #1401

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1408)
<!-- Reviewable:end -->
