### PR TITLE
Teams: Fixes handling of teams with duplicate display names (TeamsTeam and TeamsChannel)

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannel/MSFT_TeamsChannel.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannel/MSFT_TeamsChannel.psm1
@@ -223,7 +223,7 @@ function Set-TargetResource
             {
                 $CurrentParameters.Remove("NewDisplayName")
             }
-            Write-Verbose -Message "Creating team channel  $DislayName"
+            Write-Verbose -Message "Creating team channel $DisplayName"
             New-TeamChannel @CurrentParameters
         }
     }
@@ -231,7 +231,7 @@ function Set-TargetResource
     {
         if ($channel.DisplayName)
         {
-            Write-Verbose -Message "Removing team channel $DislayName"
+            Write-Verbose -Message "Removing team channel $DisplayName"
             Remove-TeamChannel -GroupId $team.GroupId -DisplayName $DisplayName
         }
     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -158,7 +158,8 @@ function Get-TargetResource
         {
             Write-Verbose -Message "GroupID was NOT specified"
             ## Can retreive multiple Teams since displayname is not unique
-            $team = Get-Team -DisplayName $DisplayName
+            # Filter on DisplayName as -DisplayName also does partial matches and will report duplicate names that are not real duplicate names
+            $team = Get-Team -DisplayName $DisplayName | Where-Object {$_.DisplayName -eq $DisplayName}
             if ($null -eq $team)
             {
                 Write-Verbose -Message "Teams with displayname $DisplayName doesn't exist"
@@ -689,6 +690,7 @@ function Export-TargetResource
             Write-Host "    |---[$i/$($teams.Length)] $($team.DisplayName)" -NoNewline
             $params = @{
                 DisplayName           = $team.DisplayName
+                GroupID               = $team.GroupId
                 GlobalAdminAccount    = $GlobalAdminAccount
                 ApplicationId         = $ApplicationId
                 TenantId              = $TenantId

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -308,17 +308,20 @@ function Compare-M365DSCConfigurations
         Write-Progress -Activity "Scanning Source $Source...[$i/$($SourceObject.Count)]" -PercentComplete ($i/($SourceObject.Count)*100)
         [array]$destinationResource = $DestinationObject | Where-Object -FilterScript {$_.ResourceName -eq $sourceResource.ResourceName -and $_.($key[0]) -eq $sourceResource.($key[0])}
 
+        $keyname=$key[0..1] -join '\'
+        $SourceKeyValue=$sourceResource.($key[0])
         # Filter on the second key
         if ($key.Count -gt 1)
         {
             [array]$destinationResource = $destinationResource | Where-Object -FilterScript {$_.ResourceName -eq $sourceResource.ResourceName -and $_.($key[1]) -eq $sourceResource.($key[1])}
+            $SourceKeyValue=$sourceResource.($key[0]),$sourceResource.($key[1]) -join '\'
         }
         if ($null -eq $destinationResource)
         {
             $drift = @{
                 ResourceName       = $sourceResource.ResourceName
-                Key                = $key[0]
-                KeyValue           = $sourceResource.($key[0])
+                Key                = $keyName
+                KeyValue           = $SourceKeyValue
                 Properties         = @(@{
                     ParameterName      = 'Ensure'
                     ValueInSource      = 'Present'
@@ -342,8 +345,8 @@ function Compare-M365DSCConfigurations
                     {
                         $drift = @{
                             ResourceName       = $sourceResource.ResourceName
-                            Key                = $key[0]
-                            KeyValue           = $sourceResource.($key[0])
+                            Key                = $keyname
+                            KeyValue           = $SourceKeyValue
                             Properties = @(@{
                                 ParameterName      = $propertyName
                                 ValueInSource      = $sourceResource.$propertyName
@@ -390,8 +393,8 @@ function Compare-M365DSCConfigurations
                     {
                         $drift = @{
                             ResourceName       = $sourceResource.ResourceName
-                            Key                = $key[0]
-                            KeyValue           = $sourceResource.($key[0])
+                            Key                = $keyName
+                            KeyValue           = $SourceKeyValue
                             Properties         = @(@{
                                 ParameterName      = $propertyName
                                 ValueInSource      = $null
@@ -428,18 +431,20 @@ function Compare-M365DSCConfigurations
         $key = Get-M365DSCResourceKey -Resource $currentDestinationResource
         Write-Progress -Activity "Scanning Destination $Destination...[$i/$($DestinationObject.Count)]" -PercentComplete ($i/($DestinationObject.Count)*100)
         $sourceResource = $SourceObject | Where-Object -FilterScript {$_.ResourceName -eq $currentDestinationResource.ResourceName -and $_.($key[0]) -eq $currentDestinationResource.($key[0])}
+        $currentDestinationKeyValue=$currentDestinationResource.($key[0])
 
         # Filter on the second key
         if ($key.Count -gt 1)
         {
             [array]$sourceResource = $sourceResource | Where-Object -FilterScript {$_.ResourceName -eq $currentDestinationResource.ResourceName -and $_.($key[1]) -eq $currentDestinationResource.($key[1])}
+            $currentDestinationKeyValue=$currentDestinationResource.($key[0]),$currentDestinationResource.($key[1]) -join '\'
         }
         if ($null -eq $sourceResource)
         {
             $drift = @{
                 ResourceName       = $currentDestinationResource.ResourceName
-                Key                = $key[0]
-                KeyValue           = $currentDestinationResource.($key[0])
+                Key                = $keyName
+                KeyValue           = $currentDestinationKeyValue
                 Properties         = @(@{
                     ParameterName      = 'Ensure'
                     ValueInSource      = 'Absent'

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -476,6 +476,16 @@ function Get-M365DSCResourceKey
         {
             return @("Id")
         }
+        if ($Resource.ResourceName -eq 'TeamsChannel' -and -not [System.String]::IsNullOrEmpty($Resource.TeamName))
+        {
+            # Teams Channel displaynames are not tenant-unique (e.g. "General" is almost in every team), but should be unique per team
+            return @('TeamName','DisplayName')
+        }
+        if ($Resource.ResourceName -eq 'TeamsTeam' -and -not [System.String]::IsNullOrEmpty($Resource.MailNickName))
+        {
+            # Teams names are not unique
+            return @('MailNickName','DisplayName')
+        }
         return @("DisplayName")
     }
     elseif ($Resource.Contains("Identity"))


### PR DESCRIPTION
#### Pull Request (PR) description

Fixes handling of teams with duplicate display names (TeamsTeam and TeamsChannel resources)
Fixes DeltaReport to show multiple keys when used (e.g. TeamsName\DisplayName for TeamsChannel)

#### This Pull Request (PR) fixes the following issues
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1416)
<!-- Reviewable:end -->
