### PR TITLE
M365DSCReverse Bugfix: PartialExportFileName already ends with ".partial.ps1"

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -734,7 +734,7 @@ function Start-M365DSCConfigurationExtract
     catch
     {
         Write-Host $_
-        $partialPath = Join-Path $env:TEMP -ChildPath "$($Global:PartialExportFileName).ps1.partial"
+        $partialPath = Join-Path $env:TEMP -ChildPath "$($Global:PartialExportFileName)"
         Write-Host "Partial Export file was saved at: $partialPath"
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
M365DSCReverse.psm1 displays an incorrect filename in case of a partial export (`<guid>.partial.ps1.ps1.partial`). This is incorrect as the actual filename is without ".ps1.partial" at the end.

#### This Pull Request (PR) fixes the following issues
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/microsoft365dsc/1425)
<!-- Reviewable:end -->
