### PR TITLE
Bugfix: Fix version number for Microsoft.PowerApps.Administration.PowerShell

### DIFF
--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -81,7 +81,7 @@
         },
         @{
             ModuleName      = "Microsoft.PowerApps.Administration.PowerShell"
-            RequiredVersion = "2.0.13"
+            RequiredVersion = "2.0.136"
         },
         @{
             ModuleName      = "MicrosoftTeams"


### PR DESCRIPTION
#### Pull Request (PR) description
Version number for Microsoft.PowerApps.Administration.PowerShell seems to be incorrect (2.0.13 instead of 2.0.136). This PR fixes that issue

#### This Pull Request (PR) fixes the following issues
None (commit https://github.com/microsoft/Microsoft365DSC/commit/c1cf338d938332c7ef5efebd44f6804c2e840fd8#diff-eb668a823ee93a1b5f809ad48e9da5def84f73185f80b8f653b53d0a43175f65)