### PR TITLE
EXOSafeLinksPolicy: Added missing properties CustomNotificationText, EnableOrganizationBranding, UseTranslatedNotificationText

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.psm1
@@ -13,6 +13,10 @@ function Get-TargetResource
         $AdminDisplayName,
 
         [Parameter()]
+        [System.String]
+        $CustomNotificationText,
+
+        [Parameter()]
         [Boolean]
         $DeliverMessageAfterScan = $false,
 
@@ -34,6 +38,10 @@ function Get-TargetResource
 
         [Parameter()]
         [Boolean]
+        $EnableOrganizationBranding = $false,
+
+        [Parameter()]
+        [Boolean]
         $EnableSafeLinksForTeams = $false,
 
         [Parameter()]
@@ -43,6 +51,10 @@ function Get-TargetResource
         [Parameter()]
         [Boolean]
         $ScanUrls = $false,
+
+        [Parameter()]
+        [Boolean]
+        $UseTranslatedNotificationText = $false,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
@@ -126,23 +138,26 @@ function Get-TargetResource
         else
         {
             $result = @{
-                Identity                 = $SafeLinksPolicy.Identity
-                AdminDisplayName         = $SafeLinksPolicy.AdminDisplayName
-                DeliverMessageAfterScan  = $SafeLinksPolicy.DeliverMessageAfterScan
-                DoNotAllowClickThrough   = $SafeLinksPolicy.DoNotAllowClickThrough
-                DoNotRewriteUrls         = $SafeLinksPolicy.DoNotRewriteUrls
-                DoNotTrackUserClicks     = $SafeLinksPolicy.DoNotTrackUserClicks
-                EnableForInternalSenders = $SafeLinksPolicy.EnableForInternalSenders
-                EnableSafeLinksForTeams  = $SafeLinksPolicy.EnableSafeLinksForTeams
-                IsEnabled                = $SafeLinksPolicy.IsEnabled
-                ScanUrls                 = $SafeLinksPolicy.ScanUrls
-                Ensure                   = 'Present'
-                GlobalAdminAccount       = $GlobalAdminAccount
-                ApplicationId            = $ApplicationId
-                CertificateThumbprint    = $CertificateThumbprint
-                CertificatePath          = $CertificatePath
-                CertificatePassword      = $CertificatePassword
-                TenantId                 = $TenantId
+                Identity                      = $SafeLinksPolicy.Identity
+                AdminDisplayName              = $SafeLinksPolicy.AdminDisplayName
+                CustomNotificationText        = $SafeLinksPolicy.CustomNotificationText
+                DeliverMessageAfterScan       = $SafeLinksPolicy.DeliverMessageAfterScan
+                DoNotAllowClickThrough        = $SafeLinksPolicy.DoNotAllowClickThrough
+                DoNotRewriteUrls              = $SafeLinksPolicy.DoNotRewriteUrls
+                DoNotTrackUserClicks          = $SafeLinksPolicy.DoNotTrackUserClicks
+                EnableForInternalSenders      = $SafeLinksPolicy.EnableForInternalSenders
+                EnableOrganizationBranding    = $SafeLinksPolicy.EnableOrganizationBranding
+                EnableSafeLinksForTeams       = $SafeLinksPolicy.EnableSafeLinksForTeams
+                IsEnabled                     = $SafeLinksPolicy.IsEnabled
+                ScanUrls                      = $SafeLinksPolicy.ScanUrls
+                UseTranslatedNotificationText = $SafeLinksPolicy.UseTranslatedNotificationText
+                Ensure                        = 'Present'
+                GlobalAdminAccount            = $GlobalAdminAccount
+                ApplicationId                 = $ApplicationId
+                CertificateThumbprint         = $CertificateThumbprint
+                CertificatePath               = $CertificatePath
+                CertificatePassword           = $CertificatePassword
+                TenantId                      = $TenantId
             }
 
             Write-Verbose -Message "Found SafeLinksPolicy $($Identity)"
@@ -190,6 +205,10 @@ function Set-TargetResource
         $AdminDisplayName,
 
         [Parameter()]
+        [System.String]
+        $CustomNotificationText,
+
+        [Parameter()]
         [Boolean]
         $DeliverMessageAfterScan = $false,
 
@@ -211,6 +230,10 @@ function Set-TargetResource
 
         [Parameter()]
         [Boolean]
+        $EnableOrganizationBranding = $false,
+
+        [Parameter()]
+        [Boolean]
         $EnableSafeLinksForTeams = $false,
 
         [Parameter()]
@@ -220,6 +243,10 @@ function Set-TargetResource
         [Parameter()]
         [Boolean]
         $ScanUrls = $false,
+
+        [Parameter()]
+        [Boolean]
+        $UseTranslatedNotificationText = $false,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
@@ -313,6 +340,10 @@ function Test-TargetResource
         $AdminDisplayName,
 
         [Parameter()]
+        [System.String]
+        $CustomNotificationText,
+
+        [Parameter()]
         [Boolean]
         $DeliverMessageAfterScan = $false,
 
@@ -334,6 +365,10 @@ function Test-TargetResource
 
         [Parameter()]
         [Boolean]
+        $EnableOrganizationBranding = $false,
+
+        [Parameter()]
+        [Boolean]
         $EnableSafeLinksForTeams = $false,
 
         [Parameter()]
@@ -343,6 +378,10 @@ function Test-TargetResource
         [Parameter()]
         [Boolean]
         $ScanUrls = $false,
+
+        [Parameter()]
+        [Boolean]
+        $UseTranslatedNotificationText = $false,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.schema.mof
@@ -3,15 +3,18 @@ class MSFT_EXOSafeLinksPolicy : OMI_BaseResource
 {
     [Key, Description("The Identity parameter specifies the SafeLinks policy that you want to modify.")] String Identity;
     [Write, Description("Specify if this policy should exist or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Write, Description("The AdminDisplayName parameter specifies a description for the policy. ")] String AdminDisplayName;
+    [Write, Description("The AdminDisplayName parameter specifies a description for the policy.")] String AdminDisplayName;
+    [Write, Description("The custom notification text specifies the customized notification text to show to users.")] String CustomNotificationText;
     [Write, Description("The DeliverMessageAfterScan parameter specifies whether to deliver email messages only after Safe Links scanning is complete. Valid values are: $true: Wait until Safe Links scanning is complete before delivering the message. $false: If Safe Links scanning can't complete, deliver the message anyway. This is the default value.")] Boolean DeliverMessageAfterScan;
     [Write, Description("The DoNotAllowClickThrough parameter specifies whether to allow users to click through to the original URL. Valid values are: $true: The user isn't allowed to click through to the original URL. This is the default value. $false: The user is allowed to click through to the original URL.")] Boolean DoNotAllowClickThrough;
     [Write, Description("The DoNotRewriteUrls parameter specifies a URL that's skipped by Safe Links scanning. You can specify multiple values separated by commas.")] String DoNotRewriteUrls[];
     [Write, Description("The DoNotTrackUserClicks parameter specifies whether to track user clicks related to links in email messages. Valid values are: $true: User clicks aren't tracked. This is the default value. $false: User clicks are tracked.")] Boolean DoNotTrackUserClicks;
-    [Write, Description("EnableForInternalSenders $true or $false")] Boolean EnableForInternalSenders;
+    [Write, Description("The EnableForInternalSenders parameter specifies whether the Safe Links policy is applied to messages sent between internal senders and internal recipients within the same Exchange Online organization.")] Boolean EnableForInternalSenders;
+    [Write, Description("The EnableOrganizationBranding parameter specifies whether your organization's logo is displayed on Safe Links warning and notification pages.")] Boolean EnableOrganizationBranding;
     [Write, Description("The EnableSafeLinksForTeams parameter specifies whether Safe Links is enabled for Microsoft Teams. Valid values are: $true: Safe Links is enabled for Teams. If a protected user clicks a malicious link in a Teams conversation, group chat, or from channels, a warning page will appear in the default web browser. $false: Safe Links isn't enabled for Teams. This is the default value.")] Boolean EnableSafeLinksForTeams;
     [Write, Description("This parameter specifies whether the rule or policy is enabled. ")] Boolean IsEnabled;
     [Write, Description("The ScanUrls parameter specifies whether to enable or disable the scanning of links in email messages. Valid values are: $true: Scanning links in email messages is enabled. $false: Scanning links in email messages is disabled. This is the default value.")] Boolean ScanUrls;
+    [Write, Description("The UseTranslatedNotificationText specifies whether to use Microsoft Translator to automatically localize the custom notification text that you specified with the CustomNotificationText parameter.")] Boolean UseTranslatedNotificationText;
     [Write, Description("Credentials of the Exchange Global Admin"), EmbeddedInstance("MSFT_Credential")] string GlobalAdminAccount;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/readme.md
@@ -29,6 +29,12 @@ AdminDisplayName
 - Description: The AdminDisplayName parameter specifies a
     description for the policy.
 
+CustomNotificationText
+
+- Required: No
+- Description: The custom notification text specifies the customized
+  notification text to show to users
+
 DeliverMessageAfterScan
 
 - Required: No
@@ -69,6 +75,13 @@ EnableForInternalSenders
 - Description: This parameter specifies whether the policy is enabled
   for internal senders. $true or $false
 
+EnableOrganizationBranding
+
+- Required: No
+- Description: The EnableOrganizationBranding parameter specifies whether
+  your organization's logo is displayed on Safe Links warning and
+  notification pages.
+
 EnableSafeLinksForTeams
 
 - Required: No
@@ -93,6 +106,13 @@ ScanUrls
       $true: Scanning links in email messages is enabled.
       $false: Scanning links in email messages is disabled.
       This is the default value.
+
+UseTranslatedNotificationText
+
+- Required: No
+- Description: The UseTranslatedNotificationText specifies whether to use
+  Microsoft Translator to automatically localize the custom notification text
+  that you specified with the CustomNotificationText parameter.
 
 ## Example
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOSafeLinksPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOSafeLinksPolicy.Tests.ps1
@@ -43,18 +43,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Remove-PSSession -MockWith {
 
             }
-
-            Mock -CommandName New-SafeLinksPolicy -MockWith {
-                return @{
-
-                }
-            }
-
-            Mock -CommandName Set-SafeLinksPolicy -MockWith {
-                return @{
-
-                }
-            }
         }
 
         # Test contexts

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOSafeLinksPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOSafeLinksPolicy.Tests.ps1
@@ -61,16 +61,19 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "SafeLinksPolicy creation." -Fixture {
             BeforeAll {
                 $testParams = @{
-                    Ensure                   = 'Present'
-                    Identity                 = 'TestSafeLinksPolicy'
-                    GlobalAdminAccount       = $GlobalAdminAccount
-                    AdminDisplayName         = 'Test SafeLinks Policy'
-                    DoNotAllowClickThrough   = $true
-                    DoNotRewriteUrls         = @('test.contoso.com', 'test.fabrikam.org')
-                    DoNotTrackUserClicks     = $true
-                    EnableForInternalSenders = $false
-                    IsEnabled                = $false
-                    ScanUrls                 = $false
+                    Ensure                        = 'Present'
+                    Identity                      = 'TestSafeLinksPolicy'
+                    GlobalAdminAccount            = $GlobalAdminAccount
+                    AdminDisplayName              = 'Test SafeLinks Policy'
+                    CustomNotificationText        = ''
+                    DoNotAllowClickThrough        = $true
+                    DoNotRewriteUrls              = @('test.contoso.com', 'test.fabrikam.org')
+                    DoNotTrackUserClicks          = $true
+                    EnableForInternalSenders      = $false
+                    EnableOrganizationBranding    = $false
+                    IsEnabled                     = $false
+                    ScanUrls                      = $false
+                    UseTranslatedNotificationText = $false
                 }
 
                 Mock -CommandName Get-SafeLinksPolicy -MockWith {
@@ -92,28 +95,34 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "SafeLinksPolicy update not required." -Fixture {
             BeforeAll {
                 $testParams = @{
-                    Ensure                   = 'Present'
-                    Identity                 = 'TestSafeLinksPolicy'
-                    GlobalAdminAccount       = $GlobalAdminAccount
-                    AdminDisplayName         = 'Test SafeLinks Policy'
-                    DoNotAllowClickThrough   = $true
-                    DoNotRewriteUrls         = @('test.contoso.com', 'test.fabrikam.org')
-                    DoNotTrackUserClicks     = $true
-                    EnableForInternalSenders = $false
-                    IsEnabled                = $false
-                    ScanUrls                 = $false
+                    Ensure                        = 'Present'
+                    Identity                      = 'TestSafeLinksPolicy'
+                    GlobalAdminAccount            = $GlobalAdminAccount
+                    AdminDisplayName              = 'Test SafeLinks Policy'
+                    CustomNotificationText        = ''
+                    DoNotAllowClickThrough        = $true
+                    DoNotRewriteUrls              = @('test.contoso.com', 'test.fabrikam.org')
+                    DoNotTrackUserClicks          = $true
+                    EnableForInternalSenders      = $false
+                    EnableOrganizationBranding    = $false
+                    IsEnabled                     = $false
+                    ScanUrls                      = $false
+                    UseTranslatedNotificationText = $false
                 }
 
                 Mock -CommandName Get-SafeLinksPolicy -MockWith {
                     return @{
-                        Identity                 = 'TestSafeLinksPolicy'
-                        AdminDisplayName         = 'Test SafeLinks Policy'
-                        DoNotAllowClickThrough   = $true
-                        DoNotRewriteUrls         = @('test.contoso.com', 'test.fabrikam.org')
-                        DoNotTrackUserClicks     = $true
-                        EnableForInternalSenders = $false
-                        IsEnabled                = $false
-                        ScanUrls                 = $false
+                        Identity                      = 'TestSafeLinksPolicy'
+                        AdminDisplayName              = 'Test SafeLinks Policy'
+                        CustomNotificationText        = ''
+                        DoNotAllowClickThrough        = $true
+                        DoNotRewriteUrls              = @('test.contoso.com', 'test.fabrikam.org')
+                        DoNotTrackUserClicks          = $true
+                        EnableForInternalSenders      = $false
+                        EnableOrganizationBranding    = $false
+                        IsEnabled                     = $false
+                        ScanUrls                      = $false
+                        UseTranslatedNotificationText = $false
                     }
                 }
             }
@@ -126,30 +135,36 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "SafeLinksPolicy update needed." -Fixture {
             BeforeAll {
                 $testParams = @{
-                    Ensure                   = 'Present'
-                    Identity                 = 'TestSafeLinksPolicy'
-                    GlobalAdminAccount       = $GlobalAdminAccount
-                    AdminDisplayName         = 'Test SafeLinks Policy'
-                    DoNotAllowClickThrough   = $true
-                    DoNotRewriteUrls         = @('test.contoso.com', 'test.fabrikam.org')
-                    DoNotTrackUserClicks     = $true
-                    EnableForInternalSenders = $false
-                    IsEnabled                = $false
-                    ScanUrls                 = $false
+                    Ensure                        = 'Present'
+                    Identity                      = 'TestSafeLinksPolicy'
+                    GlobalAdminAccount            = $GlobalAdminAccount
+                    AdminDisplayName              = 'Test SafeLinks Policy'
+                    CustomNotificationText        = ''
+                    DoNotAllowClickThrough        = $true
+                    DoNotRewriteUrls              = @('test.contoso.com', 'test.fabrikam.org')
+                    DoNotTrackUserClicks          = $true
+                    EnableForInternalSenders      = $false
+                    EnableOrganizationBranding    = $false
+                    IsEnabled                     = $false
+                    ScanUrls                      = $false
+                    UseTranslatedNotificationText = $false
                 }
 
                 Mock -CommandName Get-SafeLinksPolicy -MockWith {
                     return @{
-                        Ensure                   = 'Present'
-                        Identity                 = 'TestSafeLinksPolicy'
-                        GlobalAdminAccount       = $GlobalAdminAccount
-                        AdminDisplayName         = 'Test SafeLinks Policy'
-                        DoNotAllowClickThrough   = $true
-                        DoNotRewriteUrls         = @('test1.contoso.com', 'test.fabrikam.org')
-                        DoNotTrackUserClicks     = $true
-                        EnableForInternalSenders = $true
-                        IsEnabled                = $true
-                        ScanUrls                 = $true
+                        Ensure                        = 'Present'
+                        Identity                      = 'TestSafeLinksPolicy'
+                        GlobalAdminAccount            = $GlobalAdminAccount
+                        AdminDisplayName              = 'Test SafeLinks Policy'
+                        CustomNotificationText        = 'This is a custom notification text'
+                        DoNotAllowClickThrough        = $true
+                        DoNotRewriteUrls              = @('test1.contoso.com', 'test.fabrikam.org')
+                        DoNotTrackUserClicks          = $true
+                        EnableForInternalSenders      = $true
+                        EnableOrganizationBranding    = $true
+                        IsEnabled                     = $true
+                        ScanUrls                      = $true
+                        UseTranslatedNotificationText = $true
                     }
                 }
 
@@ -171,16 +186,19 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "SafeLinksPolicy removal." -Fixture {
             BeforeAll {
                 $testParams = @{
-                    Ensure                   = 'Absent'
-                    Identity                 = 'TestSafeLinksPolicy'
-                    GlobalAdminAccount       = $GlobalAdminAccount
-                    AdminDisplayName         = 'Test SafeLinks Policy'
-                    DoNotAllowClickThrough   = $true
-                    DoNotRewriteUrls         = @('test.contoso.com', 'test.fabrikam.org')
-                    DoNotTrackUserClicks     = $true
-                    EnableForInternalSenders = $false
-                    IsEnabled                = $false
-                    ScanUrls                 = $false
+                    Ensure                        = 'Absent'
+                    Identity                      = 'TestSafeLinksPolicy'
+                    GlobalAdminAccount            = $GlobalAdminAccount
+                    AdminDisplayName              = 'Test SafeLinks Policy'
+                    CustomNotificationText        = ''
+                    DoNotAllowClickThrough        = $true
+                    DoNotRewriteUrls              = @('test.contoso.com', 'test.fabrikam.org')
+                    DoNotTrackUserClicks          = $true
+                    EnableForInternalSenders      = $false
+                    EnableOrganizationBranding    = $false
+                    IsEnabled                     = $false
+                    ScanUrls                      = $false
+                    UseTranslatedNotificationText = $false
                 }
 
                 Mock -CommandName Get-SafeLinksPolicy -MockWith {
@@ -213,14 +231,17 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
                 Mock -CommandName Get-SafeLinksPolicy -MockWith {
                     return @{
-                        Identity                 = 'TestSafeLinksPolicy'
-                        AdminDisplayName         = 'Test SafeLinks Policy'
-                        DoNotAllowClickThrough   = $true
-                        DoNotRewriteUrls         = @('test.contoso.com', 'test.fabrikam.org')
-                        DoNotTrackUserClicks     = $true
-                        EnableForInternalSenders = $false
-                        IsEnabled                = $false
-                        ScanUrls                 = $false
+                        Identity                      = 'TestSafeLinksPolicy'
+                        AdminDisplayName              = 'Test SafeLinks Policy'
+                        CustomNotificationText        = ''
+                        DoNotAllowClickThrough        = $true
+                        DoNotRewriteUrls              = @('test.contoso.com', 'test.fabrikam.org')
+                        DoNotTrackUserClicks          = $true
+                        EnableForInternalSenders      = $false
+                        EnableOrganizationBranding    = $false
+                        IsEnabled                     = $false
+                        ScanUrls                      = $false
+                        UseTranslatedNotificationText = $false
                     }
                 }
             }

--- a/Tests/Unit/Stubs/Generic.psm1
+++ b/Tests/Unit/Stubs/Generic.psm1
@@ -1,3 +1,4 @@
+<#
 function Get-AzureADDirectorySetting
 {
     [CmdletBinding()]
@@ -71,6 +72,7 @@ function Set-AzureADMSGroupLifecyclePolicy
         $AlternateNotificationEmails
     )
 }
+#>
 function Get-PSSession
 {
     [CmdletBinding()]
@@ -85,6 +87,7 @@ function Remove-PSSession
     )
 }
 
+<#
 function New-AzureADMSGroup
 {
     [CmdletBinding()]
@@ -176,7 +179,7 @@ function Set-AzureADMSGroup
         $Visibility
     )
 }
-
+#>
 
 function Get-SPOAdministrationUrl
 {
@@ -239,6 +242,7 @@ function Get-Job
 }
 
 #region Specific to tenants
+<#
 function Get-AtpPolicyForO365
 {
     [CmdletBinding()]
@@ -248,7 +252,7 @@ function Get-AtpPolicyForO365
 
     )
 }
-
+#>
 
 function Set-AddressBookPolicy
 {
@@ -326,6 +330,7 @@ function Remove-DkimSigningConfig
     )
 }
 
+<#
 function New-SafeAttachmentPolicy
 {
     [CmdletBinding()]
@@ -838,7 +843,7 @@ function Remove-SafeLinksRule
     )
 }
 #endregion
-
+#>
 function New-M365DSCLogEntry
 {
     [CmdletBinding()]
@@ -963,6 +968,7 @@ function Set-OfflineAddressBook
     )
 }
 
+<#
 function add-AvailabilityAddressSpace
 {
     [CmdletBinding()]
@@ -1034,7 +1040,7 @@ function remove-AvailabilityAddressSpace
         $Confirm
     )
 }
-
+#>
 function New-OfflineAddressBook
 {
     [CmdletBinding()]
@@ -1067,7 +1073,7 @@ function New-OfflineAddressBook
         $Confirm
     )
 }
-
+<#
 # EXOAddressBookPolicy cmdlets
 function Get-AddressBookPolicy
 {
@@ -1078,7 +1084,7 @@ function Get-AddressBookPolicy
 
     )
 }
-
+#>
 function Set-AddressBookPolicy
 {
     [CmdletBinding()]

--- a/Tests/Unit/Stubs/Generic.psm1
+++ b/Tests/Unit/Stubs/Generic.psm1
@@ -25,7 +25,7 @@ function Remove-AzureADDirectorySetting
         $Id
     )
 }
-
+#>
 function New-AzureADDirectorySetting
 {
     [CmdletBinding()]
@@ -49,7 +49,7 @@ function Set-AzureADDirectorySetting
         $DirectorySetting
     )
 }
-
+<#
 function Set-AzureADMSGroupLifecyclePolicy
 {
     [CmdletBinding()]


### PR DESCRIPTION
#### Pull Request (PR) description
EXOSafeLinksPolicy: Added missing properties CustomNotificationText, EnableOrganizationBranding, UseTranslatedNotificationText

#### This Pull Request (PR) fixes the following issues
None
