### PR TITLE
Removed confirm parm no longer in PNP cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log for Microsoft365DSC
 
+* SPOSite
+  * Fixed issue when deleting site and confirm parameter
+
 # 1.21.915.1
 
 * EXOAntiPhishPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.psm1
@@ -526,13 +526,19 @@ function Set-TargetResource
         Write-Verbose -Message "Removing site {$Url}"
         try
         {
-            Remove-PnPTenantSite -Url $Url -Confirm:$false -SkipRecycleBin -Force
+            Remove-PnPTenantSite -Url $Url -SkipRecycleBin -Force
         }
         catch
         {
             if ($Error[0].Exception.Message -eq "File Not Found")
             {
                 $Message = "The site $($Url) does not exist."
+                New-M365DSCLogEntry -Error $_ -Message $Message -Source $MyInvocation.MyCommand.ModuleName
+                throw $Message
+            }
+            if ($Error[0].Exception.Message -eq "This site belongs to a Microsoft 365 group. To delete the site, you must delete the group.")
+            {
+                $Message = "This site $($Url) belongs to a Microsoft 365 group. To delete the site, you must delete the group."
                 New-M365DSCLogEntry -Error $_ -Message $Message -Source $MyInvocation.MyCommand.ModuleName
                 throw $Message
             }


### PR DESCRIPTION
Confirm parameter is missing on latest version of PNP so delete SPO site not working. 
#### Pull Request (PR) description
Removed confirm parameter
Added catch block for O365 Group site. 

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
