### PR TITLE
Moved ConnectionMode before telemetry

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsNamingPolicy/MSFT_AADGroupsNamingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsNamingPolicy/MSFT_AADGroupsNamingPolicy.psm1
@@ -45,6 +45,10 @@ function Get-TargetResource
 
     Write-Verbose -Message "Getting configuration of AzureAD Groups Naming Policy"
 
+    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+        -InboundParameters $PSBoundParameters -ProfileName "beta"
+    Select-MgProfile -Name Beta | Out-Null
+
     #region Telemetry
     $ResourceName = $MyInvocation.MyCommand.ModuleName -replace "MSFT_", ""
     $CommandName  = $MyInvocation.MyCommand
@@ -54,9 +58,7 @@ function Get-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
-        -InboundParameters $PSBoundParameters -ProfileName "beta"
-    Select-MgProfile -Name Beta | Out-Null
+
 
     $nullReturn = $PSBoundParameters
     $nullReturn.Ensure = "Absent"
@@ -156,6 +158,10 @@ function Set-TargetResource
     )
 
     Write-Verbose -Message "Setting configuration of Azure AD Groups Naming Policy"
+
+    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+        -InboundParameters $PSBoundParameters -ProfileName "beta"
+    Select-MgProfile -Name Beta | Out-Null
 
     #region Telemetry
     $ResourceName = $MyInvocation.MyCommand.ModuleName -replace "MSFT_", ""
@@ -314,8 +320,8 @@ function Export-TargetResource
 
 
     $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
-      -InboundParameters $PSBoundParameters `
-      -ProfileName "beta"
+        -InboundParameters $PSBoundParameters -ProfileName "beta"
+    Select-MgProfile -Name Beta | Out-Null
 
     #region Telemetry
     $ResourceName = $MyInvocation.MyCommand.ModuleName -replace "MSFT_", ""


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
The resource AADGroupNamingPolicy missed the connection to M365 in the Set Resource part, which I added and I moved the Connection mode part before the Telemetry section

#### This Pull Request (PR) fixes the following issues

