### PR TITLE
fixed Report Infographic image URL

### DIFF
--- a/docs/docs/home/what-is-M365DSC.md
+++ b/docs/docs/home/what-is-M365DSC.md
@@ -87,7 +87,7 @@ Automatic monitoring of configuration drifts in your tenant and notification abo
 
 See the [Monitoring](../../user-guide/get-started/monitor-tenants) page for more information about possible options.
 
-## Report ![Infographic](../images/Report.png){ align=left width=100 }
+## Report ![Infographic](../images/report.PNG){ align=left width=100 }
 
 Take any Microsoft365DSC configuration and generate a user friendly report from it in an Excel or HTML format. With a single command you can convert any Microsoft365DSC configuration
 


### PR DESCRIPTION
#### Pull Request (PR) description
The Report Infographic image URL is not properly rendered and seems to be case sensitive. I change it from (../images/**Rreport.png)** to (../images/**report.PNG**)
See [What is Microsoft365DSC? > Report](https://microsoft365dsc.com/home/what-is-M365DSC/#report)

#### This Pull Request (PR) fixes the following issues
as this is a minor fix I have not created an issue
