### PR TITLE
Added SharedChannel options in TeamsChannelsPolicy

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelsPolicy/MSFT_TeamsChannelsPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelsPolicy/MSFT_TeamsChannelsPolicy.psm1
@@ -14,6 +14,10 @@ function Get-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $AllowChannelSharingToExternalUser,
+
+        [Parameter()]
+        [System.Boolean]
         $AllowOrgWideTeamCreation,
 
         [Parameter()]
@@ -23,6 +27,14 @@ function Get-TargetResource
         [Parameter()]
         [System.Boolean]
         $AllowPrivateChannelCreation,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowSharedChannelCreation,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowUserToParticipateInExternalSharedChannel,
 
         [Parameter()]
         [ValidateSet("Present", "Absent")]
@@ -66,13 +78,16 @@ function Get-TargetResource
         }
         Write-Verbose -Message "Found Teams Channel Policy {$Identity}"
         return @{
-            Identity                    = $Identity
-            Description                 = $policy.Description
-            AllowOrgWideTeamCreation    = $policy.AllowOrgWideTeamCreation
-            AllowPrivateTeamDiscovery   = $policy.AllowPrivateTeamDiscovery
-            AllowPrivateChannelCreation = $policy.AllowPrivateChannelCreation
-            Ensure                      = 'Present'
-            Credential          = $Credential
+            Identity                                      = $Identity
+            Description                                   = $policy.Description
+            AllowChannelSharingToExternalUser             = $policy.AllowChannelSharingToExternalUser
+            AllowOrgWideTeamCreation                      = $policy.AllowOrgWideTeamCreation
+            AllowPrivateTeamDiscovery                     = $policy.AllowPrivateTeamDiscovery
+            AllowPrivateChannelCreation                   = $policy.AllowPrivateChannelCreation
+            AllowSharedChannelCreation                    = $policy.AllowSharedChannelCreation
+            AllowUserToParticipateInExternalSharedChannel = $policy.AllowUserToParticipateInExternalSharedChannel
+            Ensure                                        = 'Present'
+            Credential                                    = $Credential
         }
     }
     catch
@@ -116,6 +131,10 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $AllowChannelSharingToExternalUser,
+
+        [Parameter()]
+        [System.Boolean]
         $AllowOrgWideTeamCreation,
 
         [Parameter()]
@@ -125,6 +144,14 @@ function Set-TargetResource
         [Parameter()]
         [System.Boolean]
         $AllowPrivateChannelCreation,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowSharedChannelCreation,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowUserToParticipateInExternalSharedChannel,
 
         [Parameter()]
         [ValidateSet("Present", "Absent")]
@@ -194,6 +221,10 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $AllowChannelSharingToExternalUser,
+
+        [Parameter()]
+        [System.Boolean]
         $AllowOrgWideTeamCreation,
 
         [Parameter()]
@@ -203,6 +234,14 @@ function Test-TargetResource
         [Parameter()]
         [System.Boolean]
         $AllowPrivateChannelCreation,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowSharedChannelCreation,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowUserToParticipateInExternalSharedChannel,
 
         [Parameter()]
         [ValidateSet("Present", "Absent")]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelsPolicy/MSFT_TeamsChannelsPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelsPolicy/MSFT_TeamsChannelsPolicy.schema.mof
@@ -3,10 +3,12 @@ class MSFT_TeamsChannelsPolicy : OMI_BaseResource
 {
     [Key, Description("Identity of the Teams Channel Policy.")] String Identity;
     [Write, Description("Description of the Teams Channel Policy.")] String Description;
+    [Write, Description("Determines whether a user is allowed to share a shared channel with an external user. Set this to TRUE to allow. Set this FALSE to prohibit.")] Boolean AllowChannelSharingToExternalUser;
     [Write, Description("Determines whether a user is allowed to create an org-wide team. Set this to TRUE to allow. Set this FALSE to prohibit.")] Boolean AllowOrgWideTeamCreation;
     [Write, Description("Determines whether a user is allowed to discover private teams in suggestions and search results. Set this to TRUE to allow. Set this FALSE to prohibit.")] Boolean AllowPrivateTeamDiscovery;
     [Write, Description("Determines whether a user is allowed to create a private channel. Set this to TRUE to allow. Set this FALSE to prohibit.")] Boolean AllowPrivateChannelCreation;
+    [Write, Description("Determines whether a user is allowed to create a shared channel. Set this to TRUE to allow. Set this FALSE to prohibit.")] Boolean AllowSharedChannelCreation;
+    [Write, Description("Determines whether a user is allowed to participate in a shared channel that has been shared by an external user. Set this to TRUE to allow. Set this FALSE to prohibit.")] Boolean AllowUserToParticipateInExternalSharedChannel;
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Required, Description("Credentials of the Teams Global Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
 };
-

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsChannelsPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsChannelsPolicy.Tests.ps1
@@ -104,7 +104,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         Identity                                      = 'Test Channels Policy'
                         Description                                   = 'Test Description'
                         AllowChannelSharingToExternalUser             = $True;
-                        AllowOrgWideTeamCreation                      = $True;
+                        AllowOrgWideTeamCreation                      = $False;
                         AllowPrivateChannelCreation                   = $True;
                         AllowPrivateTeamDiscovery                     = $True;
                         AllowSharedChannelCreation                    = $True;

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsChannelsPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsChannelsPolicy.Tests.ps1
@@ -2,41 +2,41 @@
 param(
 )
 $M365DSCTestFolder = Join-Path -Path $PSScriptRoot `
-                        -ChildPath "..\..\Unit" `
-                        -Resolve
+    -ChildPath '..\..\Unit' `
+    -Resolve
 $CmdletModule = (Join-Path -Path $M365DSCTestFolder `
-            -ChildPath "\Stubs\Microsoft365.psm1" `
-            -Resolve)
+        -ChildPath '\Stubs\Microsoft365.psm1' `
+        -Resolve)
 $GenericStubPath = (Join-Path -Path $M365DSCTestFolder `
-    -ChildPath "\Stubs\Generic.psm1" `
-    -Resolve)
+        -ChildPath '\Stubs\Generic.psm1' `
+        -Resolve)
 Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
-        -ChildPath "\UnitTestHelper.psm1" `
+        -ChildPath '\UnitTestHelper.psm1' `
         -Resolve)
 
 $Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
-    -DscResource "TeamsChannelsPolicy" -GenericStubModule $GenericStubPath
+    -DscResource 'TeamsChannelsPolicy' -GenericStubModule $GenericStubPath
 
 Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
     InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
         Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
 
         BeforeAll {
-            $secpasswd = ConvertTo-SecureString "Pass@word1)" -AsPlainText -Force
-            $Credential = New-Object System.Management.Automation.PSCredential ("tenantadmin", $secpasswd)
+            $secpasswd = ConvertTo-SecureString 'Pass@word1)' -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin', $secpasswd)
 
-            $Global:PartialExportFileName = "c:\TestPath"
+            $Global:PartialExportFileName = 'c:\TestPath'
             Mock -CommandName Update-M365DSCExportAuthenticationResults -MockWith {
                 return @{}
             }
 
             Mock -CommandName Get-M365DSCExportContentForResource -MockWith {
-                return "FakeDSCContent"
+                return 'FakeDSCContent'
             }
             Mock -CommandName Save-M365DSCPartialExport -MockWith {
             }
             Mock -CommandName New-M365DSCConnection -MockWith {
-                return "Credential"
+                return 'Credential'
             }
 
             Mock -CommandName New-CsTeamsChannelsPolicy -MockWith {
@@ -53,13 +53,16 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "When Channel Policy doesn't exist but should" -Fixture {
             BeforeAll {
                 $testParams = @{
-                    Identity                    = 'Test Channels Policy'
-                    Description                 = 'Test Description'
-                    AllowOrgWideTeamCreation    = $True;
-                    AllowPrivateChannelCreation = $True;
-                    AllowPrivateTeamDiscovery   = $True;
-                    Ensure                      = 'Present'
-                    Credential          = $Credential
+                    Identity                                      = 'Test Channels Policy'
+                    Description                                   = 'Test Description'
+                    AllowChannelSharingToExternalUser             = $True;
+                    AllowOrgWideTeamCreation                      = $True;
+                    AllowPrivateChannelCreation                   = $True;
+                    AllowPrivateTeamDiscovery                     = $True;
+                    AllowSharedChannelCreation                    = $True;
+                    AllowUserToParticipateInExternalSharedChannel = $True;
+                    Ensure                                        = 'Present'
+                    Credential                                    = $Credential
                 }
 
                 Mock -CommandName Get-CsTeamsChannelsPolicy -MockWith {
@@ -67,128 +70,146 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 }
             }
 
-            It "Should return absent from the Get method" {
+            It 'Should return absent from the Get method' {
                 (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
             }
 
-            It "Should return false from the Test method" {
+            It 'Should return false from the Test method' {
                 Test-TargetResource @testParams | Should -Be $false
             }
 
-            It "Should create the policy in the Set method" {
+            It 'Should create the policy in the Set method' {
                 Set-TargetResource @testParams
                 Should -Invoke -CommandName New-CsTeamsChannelsPolicy -Exactly 1
             }
         }
 
-        Context -Name "Policy exists but is not in the Desired State" -Fixture {
+        Context -Name 'Policy exists but is not in the Desired State' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    Identity                    = 'Test Channels Policy'
-                    Description                 = 'Test Description'
-                    AllowOrgWideTeamCreation    = $True;
-                    AllowPrivateChannelCreation = $True;
-                    AllowPrivateTeamDiscovery   = $True;
-                    Ensure                      = 'Present'
-                    Credential          = $Credential
+                    Identity                                      = 'Test Channels Policy'
+                    Description                                   = 'Test Description'
+                    AllowChannelSharingToExternalUser             = $True;
+                    AllowOrgWideTeamCreation                      = $True;
+                    AllowPrivateChannelCreation                   = $True;
+                    AllowPrivateTeamDiscovery                     = $True;
+                    AllowSharedChannelCreation                    = $True;
+                    AllowUserToParticipateInExternalSharedChannel = $True;
+                    Ensure                                        = 'Present'
+                    Credential                                    = $Credential
                 }
 
                 Mock -CommandName Get-CsTeamsChannelsPolicy -MockWith {
                     return @{
-                        Identity                    = 'Test Channels Policy'
-                        Description                 = 'Test Description'
-                        AllowOrgWideTeamCreation    = $False;
-                        AllowPrivateChannelCreation = $True;
-                        AllowPrivateTeamDiscovery   = $True;
+                        Identity                                      = 'Test Channels Policy'
+                        Description                                   = 'Test Description'
+                        AllowChannelSharingToExternalUser             = $True;
+                        AllowOrgWideTeamCreation                      = $True;
+                        AllowPrivateChannelCreation                   = $True;
+                        AllowPrivateTeamDiscovery                     = $True;
+                        AllowSharedChannelCreation                    = $True;
+                        AllowUserToParticipateInExternalSharedChannel = $True;
                     }
                 }
             }
 
-            It "Should return Present from the Get method" {
+            It 'Should return Present from the Get method' {
                 (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
             }
 
-            It "Should return false from the Test method" {
+            It 'Should return false from the Test method' {
                 Test-TargetResource @testParams | Should -Be $false
             }
 
-            It "Should update the settings from the Set method" {
+            It 'Should update the settings from the Set method' {
                 Set-TargetResource @testParams
                 Should -Invoke -CommandName Set-CsTeamsChannelsPolicy -Exactly 1
                 Should -Invoke -CommandName New-CSTeamsChannelsPolicy -Exactly 0
             }
         }
 
-        Context -Name "Policy exists and is already in the Desired State" -Fixture {
+        Context -Name 'Policy exists and is already in the Desired State' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    Identity                    = 'Test Channels Policy'
-                    Description                 = 'Test Description'
-                    AllowOrgWideTeamCreation    = $True;
-                    AllowPrivateChannelCreation = $True;
-                    AllowPrivateTeamDiscovery   = $True;
-                    Ensure                      = 'Present'
-                    Credential          = $Credential
+                    Identity                                      = 'Test Channels Policy'
+                    Description                                   = 'Test Description'
+                    AllowChannelSharingToExternalUser             = $True;
+                    AllowOrgWideTeamCreation                      = $True;
+                    AllowPrivateChannelCreation                   = $True;
+                    AllowPrivateTeamDiscovery                     = $True;
+                    AllowSharedChannelCreation                    = $True;
+                    AllowUserToParticipateInExternalSharedChannel = $True;
+                    Ensure                                        = 'Present'
+                    Credential                                    = $Credential
                 }
 
                 Mock -CommandName Get-CsTeamsChannelsPolicy -MockWith {
                     return @{
-                        Identity                    = 'Test Channels Policy'
-                        Description                 = 'Test Description'
-                        AllowOrgWideTeamCreation    = $True;
-                        AllowPrivateChannelCreation = $True;
-                        AllowPrivateTeamDiscovery   = $True;
+                        Identity                                      = 'Test Channels Policy'
+                        Description                                   = 'Test Description'
+                        AllowChannelSharingToExternalUser             = $True;
+                        AllowOrgWideTeamCreation                      = $True;
+                        AllowPrivateChannelCreation                   = $True;
+                        AllowPrivateTeamDiscovery                     = $True;
+                        AllowSharedChannelCreation                    = $True;
+                        AllowUserToParticipateInExternalSharedChannel = $True;
                     }
                 }
             }
 
-            It "Should return Present from the Get method" {
+            It 'Should return Present from the Get method' {
                 (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
             }
 
-            It "Should return true from the Test method" {
+            It 'Should return true from the Test method' {
                 Test-TargetResource @testParams | Should -Be $true
             }
         }
 
-        Context -Name "Policy exists but it should not" -Fixture {
+        Context -Name 'Policy exists but it should not' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    Identity                    = 'Test Channels Policy'
-                    Description                 = 'Test Description'
-                    AllowOrgWideTeamCreation    = $True;
-                    AllowPrivateChannelCreation = $True;
-                    AllowPrivateTeamDiscovery   = $True;
-                    Ensure                      = 'Absent'
-                    Credential          = $Credential
+                    Identity                                      = 'Test Channels Policy'
+                    Description                                   = 'Test Description'
+                    AllowChannelSharingToExternalUser             = $True;
+                    AllowOrgWideTeamCreation                      = $True;
+                    AllowPrivateChannelCreation                   = $True;
+                    AllowPrivateTeamDiscovery                     = $True;
+                    AllowSharedChannelCreation                    = $True;
+                    AllowUserToParticipateInExternalSharedChannel = $True;
+                    Ensure                                        = 'Absent'
+                    Credential                                    = $Credential
                 }
 
                 Mock -CommandName Get-CsTeamsChannelsPolicy -MockWith {
                     return @{
-                        Identity                    = 'Test Channels Policy'
-                        Description                 = 'Test Description'
-                        AllowOrgWideTeamCreation    = $True;
-                        AllowPrivateChannelCreation = $True;
-                        AllowPrivateTeamDiscovery   = $True;
+                        Identity                                      = 'Test Channels Policy'
+                        Description                                   = 'Test Description'
+                        AllowChannelSharingToExternalUser             = $True;
+                        AllowOrgWideTeamCreation                      = $True;
+                        AllowPrivateChannelCreation                   = $True;
+                        AllowPrivateTeamDiscovery                     = $True;
+                        AllowSharedChannelCreation                    = $True;
+                        AllowUserToParticipateInExternalSharedChannel = $True;
                     }
                 }
             }
 
-            It "Should return Present from the Get method" {
+            It 'Should return Present from the Get method' {
                 (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
             }
 
-            It "Should return false from the Test method" {
+            It 'Should return false from the Test method' {
                 Test-TargetResource @testParams | Should -Be $false
             }
 
-            It "Should remove the policy from the Set method" {
+            It 'Should remove the policy from the Set method' {
                 Set-TargetResource @testParams
                 Should -Invoke -CommandName Remove-CsTeamsChannelsPolicy -Exactly 1
             }
         }
 
-        Context -Name "ReverseDSC Tests" -Fixture {
+        Context -Name 'ReverseDSC Tests' -Fixture {
             BeforeAll {
                 $testParams = @{
                     Credential = $Credential
@@ -196,16 +217,19 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
                 Mock -CommandName Get-CsTeamsChannelsPolicy -MockWith {
                     return @{
-                        Identity                    = 'Test Channels Policy'
-                        Description                 = 'Test Description'
-                        AllowOrgWideTeamCreation    = $True;
-                        AllowPrivateChannelCreation = $True;
-                        AllowPrivateTeamDiscovery   = $True;
+                        Identity                                      = 'Test Channels Policy'
+                        Description                                   = 'Test Description'
+                        AllowChannelSharingToExternalUser             = $True;
+                        AllowOrgWideTeamCreation                      = $True;
+                        AllowPrivateChannelCreation                   = $True;
+                        AllowPrivateTeamDiscovery                     = $True;
+                        AllowSharedChannelCreation                    = $True;
+                        AllowUserToParticipateInExternalSharedChannel = $True;
                     }
                 }
             }
 
-            It "Should Reverse Engineer resource from the Export method" {
+            It 'Should Reverse Engineer resource from the Export method' {
                 Export-TargetResource @testParams
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description
Added extra parameters in TeamsChannelsPolicy:

- AllowChannelSharingToExternalUser
- AllowSharedChannelCreation
- AllowUserToParticipateInExternalSharedChannel

#### This Pull Request (PR) fixes the following issues
No issues fixed.
