### PR TITLE
Fixed validation set with latest values and export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   * Added logic to New-M365DSCDeltaReport to check if the files specified in the
     Source, Destination and HeaderFilePath parameters actually exist.
   * Fixed issue where Excel wasn't closed after creating the report.
+* PPowerAppsEnvironment
+  * Fixed issue on export to exclude EnvironmenTypes of Notspecified and Developer
+  * Updated validation set of EnvironmentTypes to latest values
 
 # 1.22.518.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.psm1
@@ -14,7 +14,7 @@ function Get-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        [ValidateSet('Production', 'Standard', 'Trial', 'Sandbox')]
+        [ValidateSet('Production', 'Standard', 'Trial', 'Sandbox', 'SubscriptionBasedTrial', 'Teams')]
         $EnvironmentSKU,
 
         [Parameter()]
@@ -48,7 +48,7 @@ function Get-TargetResource
 
     #region Telemetry
     $ResourceName = $MyInvocation.MyCommand.ModuleName -replace "MSFT_", ""
-    $CommandName  = $MyInvocation.MyCommand
+    $CommandName = $MyInvocation.MyCommand
     $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
         -CommandName $CommandName `
         -Parameters $PSBoundParameters
@@ -70,11 +70,11 @@ function Get-TargetResource
 
         Write-Verbose -Message "Found PowerApps Environment {$DisplayName}"
         return @{
-            DisplayName        = $DisplayName
-            Location           = $environment.Location
-            EnvironmentSKU     = $environment.EnvironmentType
-            Ensure             = 'Present'
-            Credential = $Credential
+            DisplayName    = $DisplayName
+            Location       = $environment.Location
+            EnvironmentSKU = $environment.EnvironmentType
+            Ensure         = 'Present'
+            Credential     = $Credential
         }
     }
     catch
@@ -118,7 +118,7 @@ function Set-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        [ValidateSet('Production', 'Standard', 'Trial', 'Sandbox')]
+        [ValidateSet('Production', 'Standard', 'Trial', 'Sandbox', 'SubscriptionBasedTrial', 'Teams')]
         $EnvironmentSKU,
 
         [Parameter()]
@@ -150,7 +150,7 @@ function Set-TargetResource
 
     #region Telemetry
     $ResourceName = $MyInvocation.MyCommand.ModuleName -replace "MSFT_", ""
-    $CommandName  = $MyInvocation.MyCommand
+    $CommandName = $MyInvocation.MyCommand
     $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
         -CommandName $CommandName `
         -Parameters $PSBoundParameters
@@ -205,7 +205,7 @@ function Test-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        [ValidateSet('Production', 'Standard', 'Trial', 'Sandbox')]
+        [ValidateSet('Production', 'Standard', 'Trial', 'Sandbox', 'SubscriptionBasedTrial', 'Teams')]
         $EnvironmentSKU,
 
         [Parameter()]
@@ -234,7 +234,7 @@ function Test-TargetResource
 
     #region Telemetry
     $ResourceName = $MyInvocation.MyCommand.ModuleName -replace "MSFT_", ""
-    $CommandName  = $MyInvocation.MyCommand
+    $CommandName = $MyInvocation.MyCommand
     $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
         -CommandName $CommandName `
         -Parameters $PSBoundParameters
@@ -289,7 +289,7 @@ function Export-TargetResource
 
     #region Telemetry
     $ResourceName = $MyInvocation.MyCommand.ModuleName -replace "MSFT_", ""
-    $CommandName  = $MyInvocation.MyCommand
+    $CommandName = $MyInvocation.MyCommand
     $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
         -CommandName $CommandName `
         -Parameters $PSBoundParameters
@@ -305,13 +305,13 @@ function Export-TargetResource
         foreach ($environment in $environments)
         {
             Write-Host "    |---[$i/$($environments.Count)] $($environment.DisplayName)" -NoNewline
-            if ($environment.EnvironmentType -ne 'Default')
+            if ($environment.EnvironmentType -ne 'Default' -and $environment.EnvironmentType -ne 'NotSpecified' -and $environment.EnvironmentType -ne 'Developer')
             {
                 $Params = @{
                     DisplayName           = $environment.DisplayName
                     Location              = $environment.Location
                     EnvironmentSku        = $environment.EnvironmentType
-                    Credential    = $Credential
+                    Credential            = $Credential
                     ApplicationId         = $ApplicationId
                     TenantId              = $TenantId
                     CertificateThumbprint = $CertificateThumbprint
@@ -327,7 +327,7 @@ function Export-TargetResource
                 $dscContent += $currentDSCBlock
 
                 Save-M365DSCPartialExport -Content $currentDSCBlock `
-                            -FileName $Global:PartialExportFileName
+                    -FileName $Global:PartialExportFileName
             }
             Write-Host $Global:M365DSCEmojiGreenCheckMark
             $i++

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.psm1
@@ -328,8 +328,13 @@ function Export-TargetResource
 
                 Save-M365DSCPartialExport -Content $currentDSCBlock `
                     -FileName $Global:PartialExportFileName
+                Write-Host $Global:M365DSCEmojiGreenCheckMark
             }
-            Write-Host $Global:M365DSCEmojiGreenCheckMark
+            else
+            {
+                Write-Host "`r`n    |---Skipping $($environment.DisplayName) because of environment sku $($environment.EnvironmentType) " -NoNewline
+                Write-Host $Global:M365DSCEmojiRedX
+            }
             $i++
         }
         return $dscContent

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.schema.mof
@@ -3,7 +3,7 @@ class MSFT_PPPowerAppsEnvironment : OMI_BaseResource
 {
     [Key, Description("Display name for the PowerApps environment")] String DisplayName;
     [Required, Description("Location of the PowerApps environment."), ValueMap{"canada","unitedstates","europe","asia","australia","india","japan","unitedkingdom","unitedstatesfirstrelease","southamerica","france","usgov"}, Values{"canada","unitedstates","europe","asia","australia","india","japan","unitedkingdom","unitedstatesfirstrelease","southamerica","france","usgov"}] string Location;
-    [Required, Description("Environment type."), ValueMap{"Production","Standard","Trial","Sandbox"}, Values{"Production","Standard","Trial","Sandbox"}] String EnvironmentSKU;
+    [Required, Description("Environment type."), ValueMap{"Production","Standard","Trial","Sandbox",'SubscriptionBasedTrial', 'Teams'}, Values{"Production","Standard","Trial","Sandbox",'SubscriptionBasedTrial', 'Teams'}] String EnvironmentSKU;
     [Write, Description("Only accepted value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Credentials of the Power Platform Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.schema.mof
@@ -3,7 +3,7 @@ class MSFT_PPPowerAppsEnvironment : OMI_BaseResource
 {
     [Key, Description("Display name for the PowerApps environment")] String DisplayName;
     [Required, Description("Location of the PowerApps environment."), ValueMap{"canada","unitedstates","europe","asia","australia","india","japan","unitedkingdom","unitedstatesfirstrelease","southamerica","france","usgov"}, Values{"canada","unitedstates","europe","asia","australia","india","japan","unitedkingdom","unitedstatesfirstrelease","southamerica","france","usgov"}] string Location;
-    [Required, Description("Environment type."), ValueMap{"Production","Standard","Trial","Sandbox",'SubscriptionBasedTrial', 'Teams'}, Values{"Production","Standard","Trial","Sandbox",'SubscriptionBasedTrial', 'Teams'}] String EnvironmentSKU;
+    [Required, Description("Environment type."), ValueMap{"Production","Standard","Trial","Sandbox","SubscriptionBasedTrial", "Teams"}, Values{"Production","Standard","Trial","Sandbox","SubscriptionBasedTrial", "Teams"}] String EnvironmentSKU;
     [Write, Description("Only accepted value is 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Credentials of the Power Platform Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;


### PR DESCRIPTION
Fixed issue with exporting of Power Platform admin center by excluding EnvironmentTypes not available to create via New-AdminPowerAppEnvironment. Updated validation set of EnvironmentTypes to match New-AdminPowerAppEnvironment