### PR TITLE
IntuneAppProtectionPolicyAndroid - amend configuration to use graph functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # 1.22.608.1
 
+* IntuneAppProtectionPolicyAndroid
+  * Amended to remove direct graph calls and instead use Graph module cmdlets
+  * Added AppGroupType parameter - this value takes precedence over apps specified in the 'apps' parameter
+  * Configuration will complete even if some parameters missing from config (existing values retained for updates)
+  * Timespans can be used for time periods rather than iso8601 string
+  * Removed unused parameters in function (fixes #1955)
 * AADConditionalAccessPolicy
   * Updated settings.json with missing permissions
 * DEPENDENCIES

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyAndroid/MSFT_IntuneAppProtectionPolicyAndroid.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyAndroid/MSFT_IntuneAppProtectionPolicyAndroid.schema.mof
@@ -25,6 +25,7 @@ class MSFT_IntuneAppProtectionPolicyAndroid : OMI_BaseResource
     [Write, Description("TimePeriod before the all-level pin must be reset if PinRequired is set to True.")] String PeriodBeforePinReset;
     [Write, Description("Indicates whether printing is allowed from managed apps.")] Boolean PrintBlocked;
     [Write, Description("Indicates whether use of the fingerprint reader is allowed in place of a pin if PinRequired is set to True.")] Boolean FingerprintBlocked;
+    [Write, Description("The apps controlled by this protection policy, overrides any values in Apps unless this value is 'selectedPublicApps'.")] String AppGroupType;
     [Write, Description("List of IDs representing the Android apps controlled by this protection policy.")] String Apps[];
     [Write, Description("List of IDs of the groups assigned to this Android Protection Policy.")] String Assignments[];
     [Write, Description("List of IDs of the groups that are excluded from this Android Protection Policy.")] String ExcludedGroups[];

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAppProtectionPolicyAndroid.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAppProtectionPolicyAndroid.Tests.ps1
@@ -63,6 +63,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     AllowedInboundDataTransferSources       = "managedApps";
                     AllowedOutboundClipboardSharingLevel    = "managedAppsWithPasteIn";
                     AllowedOutboundDataTransferDestinations = "managedApps";
+                    AppGroupType                            = "selectedPublicApps";
                     Apps                                    = @("com.cisco.im.intune.android", "com.penlink.penpoint.android", "com.slack.intune.android");
                     Assignments                             = @("6ee86c9f-2b3c-471d-ad38-ff4673ed723e");
                     ContactSyncBlocked                      = $False;
@@ -129,6 +130,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     AllowedInboundDataTransferSources       = "managedApps";
                     AllowedOutboundClipboardSharingLevel    = "managedAppsWithPasteIn";
                     AllowedOutboundDataTransferDestinations = "managedApps";
+                    AppGroupType                            = "selectedPublicApps";
                     Apps                                    = @("com.cisco.im.intune.android", "com.penlink.penpoint.android", "com.slack.intune.android");
                     Assignments                             = @("6ee86c9f-2b3c-471d-ad38-ff4673ed723e");
                     ContactSyncBlocked                      = $False;
@@ -171,6 +173,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         AllowedInboundDataTransferSources       = "managedApps";
                         AllowedOutboundClipboardSharingLevel    = "managedAppsWithPasteIn";
                         AllowedOutboundDataTransferDestinations = "managedApps";
+                        AppGroupType                            = "selectedPublicApps";
                         Apps                                    = @(
                             @{
                                 id                  = "com.cisco.im.intune.android.android"
@@ -254,6 +257,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     AllowedInboundDataTransferSources       = "managedApps";
                     AllowedOutboundClipboardSharingLevel    = "managedAppsWithPasteIn";
                     AllowedOutboundDataTransferDestinations = "managedApps";
+                    AppGroupType                            = "selectedPublicApps";
                     Apps                                    = @("com.cisco.im.intune.android", "com.penlink.penpoint.android", "com.slack.intune.android");
                     Assignments                             = @("6ee86c9f-2b3c-471d-ad38-ff4673ed723e");
                     ContactSyncBlocked                      = $False;
@@ -296,6 +300,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         AllowedInboundDataTransferSources       = "managedApps";
                         AllowedOutboundClipboardSharingLevel    = "managedAppsWithPasteIn";
                         AllowedOutboundDataTransferDestinations = "managedApps";
+                        AppGroupType                            = "selectedPublicApps";
                         Apps                                    = @(
                             @{
                                 id                  = "com.cisco.im.intune.android.android"
@@ -370,6 +375,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     AllowedInboundDataTransferSources       = "managedApps";
                     AllowedOutboundClipboardSharingLevel    = "managedAppsWithPasteIn";
                     AllowedOutboundDataTransferDestinations = "managedApps";
+                    AppGroupType                            = "selectedPublicApps";
                     Apps                                    = @("com.cisco.im.intune.android", "com.penlink.penpoint.android", "com.slack.intune.android");
                     Assignments                             = @("6ee86c9f-2b3c-471d-ad38-ff4673ed723e");
                     ContactSyncBlocked                      = $False;
@@ -412,6 +418,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         AllowedInboundDataTransferSources       = "managedApps";
                         AllowedOutboundClipboardSharingLevel    = "managedAppsWithPasteIn";
                         AllowedOutboundDataTransferDestinations = "managedApps";
+                        AppGroupType                            = "selectedPublicApps";
                         Apps                                    = @(
                             @{
                                 id                  = "com.cisco.im.intune.android.android"
@@ -509,6 +516,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         AllowedInboundDataTransferSources       = "managedApps";
                         AllowedOutboundClipboardSharingLevel    = "managedAppsWithPasteIn";
                         AllowedOutboundDataTransferDestinations = "managedApps";
+                        AppGroupType                            = "selectedPublicApps";
                         Apps                                    = @(
                             @{
                                 id                  = "com.cisco.im.intune.android.android"


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
This is an amendment to the IntuneAppProtectionPolicyAndroid configuration.  I submitted the initial configuration under #1901 as an amended version of the existing IOS config with the intention of converting it to use the MSGraph cmdlets rather than calling graph directly..

I felt that using the cmdlets would ease adding new parameters.  It has proven a little more complicated than I'd hoped but the further new parameters ought to be easier to add in now.

This is a huge change, pretty much a complete re-write of the configuration, so I'm not automatically expecting it to be accepted - All feedback is appreciated and I'll work towards correcting things (even if that feedback is that it is better off using the direct graph calls and avoiding the cmdlets).

This is purely the conversion to use the cmdlets, the only new parameter added is AppGroupType because it was necessary to correctly configure the applications.

Time period values can be input as timespans in the config document but iso8601 will still work.

Incomplete configuration documents will not fail with null errors as before - for a new policy omitted values are either not set or set to defaults - for existing policies the existing values are retained for the most part.

Some parameters behave differently if omitted because their value impacts other settings (Apps + assignments/excluded groups).  For these values the config document overrides existing settings and the verbose output will flag it up.

Although the configuration is quite new a problem has already been posted for this (#1955) where the code references some parameters which are not currently available, this update addresses that.


#### This Pull Request (PR) fixes the following issues
- Fixes #2002
- Fixes #1955
