### PR TITLE
Removed -froce parm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# Unreleased changes
+
+* TeamsMessagingPolicy
+    * Removed the -force deprecated parameter on New/Set/Remove
+
 # 1.22.615.1
 
 * EXODataClassification

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.psm1
@@ -301,15 +301,15 @@ function Set-TargetResource
 
     if ($curPolicy.Ensure -eq "Absent" -and "Present" -eq $Ensure )
     {
-        New-CsTeamsMessagingPolicy @SetParams -force:$True
+        New-CsTeamsMessagingPolicy @SetParams
     }
     elseif (($curPolicy.Ensure -eq "Present" -and "Present" -eq $Ensure))
     {
-        Set-CsTeamsMessagingPolicy @SetParams -force:$True
+        Set-CsTeamsMessagingPolicy @SetParams
     }
     elseif (($Ensure -eq "Absent" -and $curPolicy.Ensure -eq "Present"))
     {
-        Remove-CsTeamsMessagingPolicy -identity $curPolicy.Identity -force:$True
+        Remove-CsTeamsMessagingPolicy -identity $curPolicy.Identity
     }
 }
 


### PR DESCRIPTION
Removed force parameter
#### Pull Request (PR) description
Removed the force parameters as it's no longer a parameter on latest Teams cmdlet for New-CsTeamsMessagingPolicy, Set-CsTeamsMessagingPolicy and Remove-CsTeamsMessagingPolicy
