### PR TITLE
MSFT_ODSettings - DomainGuids fix for #2021

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
@@ -348,16 +348,12 @@ function Set-TargetResource
         $Options.Add("BlockMacSync", $CurrentParameters.BlockMacSync)
         $CurrentParameters.Remove("BlockMacSync") | Out-Null
     }
-
-
+    # set the TenantRestrictionEnabled and DomainGuids values to avoid invalid configurations
     if ($TenantRestrictionEnabled -eq $true)
     {
-        # specified true so we need to ensure guids are valid`
-        # this should check there is a domainguids value, it isn't an empty array and it isn't an array with an empty string
         if (!($CurrentParameters.ContainsKey("DomainGuids") -and ($CurrentParameters.DomainGuids.count -gt 0) -and ($CurrentParameters.DomainGuids[0] -ne '') ))
         {
             Write-Verbose -Message "Invalid configuration specified: TenantRestrictionEnabled is True but No DomainGuids Specified, this option will not be enabled"
-            # wipe settings
             $TenantRestrictionEnabled = $false
             $DomainGuids = @()
 
@@ -366,10 +362,8 @@ function Set-TargetResource
     }
     else
     {
-        # have we specified false or omitted?
         if ($CurrentParameters.ContainsKey("TenantRestrictionEnabled"))
         {
-            # specified false, so we will ignore guids
             if ($CurrentParameters.ContainsKey("DomainGuids") -and ($CurrentParameters.DomainGuids.count -gt 0) -and ($CurrentParameters.DomainGuids[0] -ne '') )
             {
                 Write-Verbose -Message "DomainGuids have been Specified but TenantRestrictionEnabled is set to False, DomainGuids value will be ignored"
@@ -383,11 +377,9 @@ function Set-TargetResource
                 $DomainGuids = @()
             }
             $CurrentParameters.Remove("TenantRestrictionEnabled") | Out-Null
-
         }
         else
         {
-            #value not specified, so we need to figure out what is wanted
             if ($CurrentParameters.ContainsKey("DomainGuids") -and ($CurrentParameters.DomainGuids.count -gt 0) -and ($CurrentParameters.DomainGuids[0] -ne '') )
             {
                 Write-Verbose -Message "TenantRestrictionEnabled value not specified but a valid DomainGuids value is present - TenantRestrictionEnabled will be set to true"
@@ -404,8 +396,8 @@ function Set-TargetResource
     }
 
     if ($CurrentParameters.ContainsKey("DomainGuids")) { $CurrentParameters.Remove("DomainGuids") | Out-Null }
-    # add the values we've set
-    $Options.Add("DomainGuids", $DomainGuids)
+
+    $Options.Add("DomainGuids", [System.Guid[]]$DomainGuids)
     $Options.Add("Enable", $TenantRestrictionEnabled)
 
     if ($CurrentParameters.ContainsKey("DisableReportProblemDialog"))
@@ -440,10 +432,10 @@ function Set-TargetResource
     ## Configure Sync Client restrictions
     ## Set-SPOTenantSyncClientRestriction has different parameter sets and they cannot be combined see article:
     ## https://docs.microsoft.com/en-us/powershell/module/sharepoint-online/set-spotenantsyncclientrestriction?view=sharepoint-ps
-    Write-Verbose -Message "Setting other configuration parameters"
+    Write-Verbose -Message "Setting other configuration parameters2"
     Write-Verbose -Message ($Options | Out-String)
 
-    Set-PnPTenantSyncClientRestriction @Options # -Enable:$TenantRestrictionEnabled
+    Set-PnPTenantSyncClientRestriction @Options
 
 }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
@@ -432,7 +432,7 @@ function Set-TargetResource
     ## Configure Sync Client restrictions
     ## Set-SPOTenantSyncClientRestriction has different parameter sets and they cannot be combined see article:
     ## https://docs.microsoft.com/en-us/powershell/module/sharepoint-online/set-spotenantsyncclientrestriction?view=sharepoint-ps
-    Write-Verbose -Message "Setting other configuration parameters2"
+    Write-Verbose -Message "Setting other configuration parameters"
     Write-Verbose -Message ($Options | Out-String)
 
     Set-PnPTenantSyncClientRestriction @Options

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
@@ -48,6 +48,10 @@ function Get-TargetResource
         $DisableReportProblemDialog,
 
         [Parameter()]
+        [System.Boolean]
+        $TenantRestrictionEnabled,
+
+        [Parameter()]
         [System.String[]]
         $DomainGuids,
 
@@ -264,6 +268,10 @@ function Set-TargetResource
         $DisableReportProblemDialog,
 
         [Parameter()]
+        [System.Boolean]
+        $TenantRestrictionEnabled,
+
+        [Parameter()]
         [System.String[]]
         $DomainGuids,
 
@@ -443,6 +451,10 @@ function Test-TargetResource
         [Parameter()]
         [System.Boolean]
         $DisableReportProblemDialog,
+
+        [Parameter()]
+        [System.Boolean]
+        $TenantRestrictionEnabled,
 
         [Parameter()]
         [System.String[]]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
@@ -568,6 +568,7 @@ function Test-TargetResource
             "ExcludedFileExtensions", `
             "DisableReportProblemDialog", `
             "GrooveBlockOption", `
+            "TenantRestrictionEnabled", `
             "DomainGuids", `
             "OneDriveStorageQuota", `
             "OrphanedPersonalSitesRetentionPeriod", `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
@@ -329,6 +329,7 @@ function Set-TargetResource
     $CurrentParameters = $PSBoundParameters
     $CurrentParameters.Remove("Credential") | Out-Null
     $Options = @{}
+    $TenantRestrictionEnabled = $false
 
     if ($CurrentParameters.ContainsKey("Ensure"))
     {
@@ -341,6 +342,17 @@ function Set-TargetResource
     }
     if ($CurrentParameters.ContainsKey("DomainGuids"))
     {
+        if ($CurrentParameters.DomainGuids.count -gt 0)
+        {
+            Write-Verbose -Message "Updating DomainGuids"
+            $TenantRestrictionEnabled = $true
+        }
+        else
+        {
+            Write-Verbose -Message "No DomainGuids Specified - TenantRestrictionEnabled will be set to False"
+        }
+        # think we need to add a blank value in here even if we'#ve omitted domainguids...
+        #gui wipes out the value but cmdlet doesn't and it alters what we get as exports
         $Options.Add("DomainGuids", [System.Guid[]]$CurrentParameters.DomainGuids)
         $CurrentParameters.Remove("DomainGuids") | Out-Null
     }
@@ -379,15 +391,8 @@ function Set-TargetResource
     Write-Verbose -Message "Setting other configuration parameters"
     Write-Verbose -Message ($Options | Out-String)
 
-    if ($Options.ContainsKey("DomainGuids"))
-    {
-        Write-Verbose -Message "Updating DomainGuids"
-        Set-PnPTenantSyncClientRestriction @Options -Enable:$true
-    }
-    else
-    {
-        Set-PnPTenantSyncClientRestriction @Options
-    }
+    Set-PnPTenantSyncClientRestriction @Options -Enable:$TenantRestrictionEnabled
+
 }
 
 function Test-TargetResource

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
@@ -130,7 +130,7 @@ function Get-TargetResource
 
         if ($null -eq $tenantRestrictions)
         {
-            Write-Verbose -Message "Failed to get Tenant client synce settings!"
+            Write-Verbose -Message "Failed to get Tenant client sync settings!"
             return $nullReturn
         }
 
@@ -174,6 +174,7 @@ function Get-TargetResource
             IsSingleInstance                          = "Yes"
             BlockMacSync                              = $tenantRestrictions.BlockMacSync
             DisableReportProblemDialog                = $tenantRestrictions.DisableReportProblemDialog
+            TenantRestrictionEnabled                  = $tenantRestrictions.TenantRestrictionEnabled
             DomainGuids                               = $FixedAllowedDomainList
             ExcludedFileExtensions                    = $FixedExcludedFileExtensions
             GrooveBlockOption                         = $GrooveOption

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.schema.mof
@@ -11,7 +11,7 @@ class MSFT_ODSettings : OMI_BaseResource
     [Write, Description("Lets administrators set policy on access requests and requests to share in OneDrive for Business"),ValueMap{"On","Off","Unspecified"},Values{"On","Off","Unspecified"}] String ODBAccessRequests;
     [Write, Description("Block sync client on Mac")] Boolean BlockMacSync;
     [Write, Description("Disable dialog box")] Boolean DisableReportProblemDialog;
-    [Write, Description("enable/disable Safe domain List - if disabled overrides DomainGuids value")] Boolean TenantRestrictionEnabled;
+    [Write, Description("Enable/disable Safe domain List - if disabled overrides DomainGuids value")] Boolean TenantRestrictionEnabled;
     [Write, Description("Safe domain list")] String DomainGuids[];
     [Write, Description("Exclude files from being synced to OneDrive")] String ExcludedFileExtensions[];
     [Write, Description("Groove block options"),ValueMap{"OptOut","HardOptIn","SoftOptIn"},Values{"OptOut","HardOptIn","SoftOptIn"}] String GrooveBlockOption;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.schema.mof
@@ -11,6 +11,7 @@ class MSFT_ODSettings : OMI_BaseResource
     [Write, Description("Lets administrators set policy on access requests and requests to share in OneDrive for Business"),ValueMap{"On","Off","Unspecified"},Values{"On","Off","Unspecified"}] String ODBAccessRequests;
     [Write, Description("Block sync client on Mac")] Boolean BlockMacSync;
     [Write, Description("Disable dialog box")] Boolean DisableReportProblemDialog;
+    [Write, Description("enable/disable Safe domain List - if disabled overrides DomainGuids value")] Boolean TenantRestrictionEnabled;
     [Write, Description("Safe domain list")] String DomainGuids[];
     [Write, Description("Exclude files from being synced to OneDrive")] String ExcludedFileExtensions[];
     [Write, Description("Groove block options"),ValueMap{"OptOut","HardOptIn","SoftOptIn"},Values{"OptOut","HardOptIn","SoftOptIn"}] String GrooveBlockOption;

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.ODSettings.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.ODSettings.Tests.ps1
@@ -86,6 +86,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ODBAccessRequests                         = "On"
                     BlockMacSync                              = $true
                     DisableReportProblemDialog                = $true
+                    TenantRestrictionEnabled                  = $true
                     DomainGuids                               = @(New-Guid)
                     ExcludedFileExtensions                    = @(".asmx")
                     GrooveBlockOption                         = "HardOptIn"


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
Changes to the MSFT_ODSettings configuration to address #2021

I have added in parameter TenantRestrictionEnabled and this setting, if specified, takes precedence over the DomainGuids value

I've tried to get the module to behave the same way as changing the settings in the GUI would.  so if you disable TenantRestrictionEnabled it will also clear the value of DomainGuids.

I have also tried to ensure that existing configuration files won't fail if values are omitted.

If you omit the TenantRestrictionEnabled the module will set the value based on whether a valid DomainGuids entry is present flag up that it has set this based on other values.

If you omit DomainGuids, or if DomainGuids is not a valid value, the module will set TenantRestrictionEnabled to false to avoid invalid configurations being set and flag this up.


#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
Fixes #2021
