### PR TITLE
EXOSharedMailbox: Rename Aliases to EmailAddresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   * Parameters Action, EnableExternalSenderNotifications and EnableInternalSenderNotifications are deprecated and will be removed in future. These parameters are no longer available in EXO, only in onprem Exchange. Please remove these parameters from your configuration.
   FIXES #2025
   * Added support for FileTypeAction parameter.
+* EXOSharedMailbox
+  * Fix using umlauts in displayname by allowing to set alias
+    FIXES #1921
+  * Rename parameter Aliases to EmailAddresses. Aliases is now deprecated.
 * DEPENDENCIES
   * Updated Microsoft.Graph.* modules to version 1.10.0.
   * Updated MSCloudLoginAssistant to version 1.0.86.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharedMailbox/MSFT_EXOSharedMailbox.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharedMailbox/MSFT_EXOSharedMailbox.schema.mof
@@ -4,7 +4,8 @@ class MSFT_EXOSharedMailbox : OMI_BaseResource
     [Key, Description("The display name of the Shared Mailbox")] string DisplayName;
     [Write, Description("The primary email address of the Shared Mailbox")] string PrimarySMTPAddress;
     [Write, Description("The alias of the Shared Mailbox")] string Alias;
-    [Write, Description("Aliases for the Shared Mailbox")] string Aliases[];
+    [Write, Description("DEPRECATED")] string Aliases[];
+    [Write, Description("The EmailAddresses parameter specifies all the email addresses (proxy addresses) for the Shared Mailbox")] string EmailAddresses[];
     [Write, Description("Present ensures the group exists, absent ensures it is removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Exchange Global Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;

--- a/Modules/Microsoft365DSC/Examples/Resources/EXOSharedMailbox/1 - CreateSharedMailbox.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/EXOSharedMailbox/1 - CreateSharedMailbox.ps1
@@ -18,7 +18,7 @@ Configuration Example
         {
             DisplayName        = "Test"
             PrimarySMTPAddress = "Test@O365DSC1.onmicrosoft.com"
-            Aliases            = @("Joufflu@o365dsc1.onmicrosoft.com", "Gilles@O365dsc1.onmicrosoft.com")
+            EmailAddresses     = @("Joufflu@o365dsc1.onmicrosoft.com", "Gilles@O365dsc1.onmicrosoft.com")
             Ensure             = "Present"
             Credential         = $credsGlobalAdmin
         }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOSharedMailbox.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOSharedMailbox.Tests.ps1
@@ -107,13 +107,13 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     DisplayName        = "Test Shared Mailbox"
                     PrimarySMTPAddress = "Test@contoso.onmicrosoft.com"
-                    Aliases            = @("Test@contoso.onmicrosoft.com")
+                    EmailAddresses     = @("Test@contoso.onmicrosoft.com")
                     Ensure             = "Present"
                     Credential = $Credential
                 }
 
                 It "Should throw an error from the Set method" {
-                    { Set-TargetResource @testParams } | Should Throw "You cannot have the Aliases list contain the PrimarySMTPAddress"
+                    { Set-TargetResource @testParams } | Should Throw "You cannot have the EmailAddresses list contain the PrimarySMTPAddress"
                 }
             }
         }
@@ -123,7 +123,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     DisplayName        = "Test Shared Mailbox"
                     PrimarySMTPAddress = "Test@contoso.onmicrosoft.com"
-                    Aliases            = @("User1@contoso.onmicrosoft.com")
+                    EmailAddresses     = @("User1@contoso.onmicrosoft.com")
                     Ensure             = "Absent"
                     Credential = $Credential
                 }
@@ -149,12 +149,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
         }
 
-        Context -Name "Aliases are specified" -Fixture {
+        Context -Name "EmailAddresses are specified" -Fixture {
             BeforeAll {
                 $testParams = @{
                     DisplayName        = "Test Shared Mailbox"
                     PrimarySMTPAddress = "Test@contoso.onmicrosoft.com"
-                    Aliases            = @("User1@contoso.onmicrosoft.com")
+                    EmailAddresses     = @("User1@contoso.onmicrosoft.com")
                     Ensure             = "Present"
                     Credential = $Credential
                 }


### PR DESCRIPTION
#### Pull Request (PR) description
Rename parameter Aliases of EXOSharedMailbox to Emailaddresses as requested in PR 1922. Aliases is now deprecated but still working. A warning is printed out if Aliases is still used. 

#### This Pull Request (PR) fixes the following issues
None
