### PR TITLE
TeamsVoiceRoutingPolicy: Remove unsupported Confirm parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for Microsoft365DSC
 
+# UNBRELEASED
+* TeamsVoiceRoutingPolicy
+  * Remove unsupported Confirm parameter from Remove-CsOnlineVoiceRoutingPolicy cmdlet (Confirm parameter is no longer available for MicrosoftTeams PowerShell module 4.4.1+).
+    FIXES #2055
 # 1.22.629.1
 
 * EXOMalwareFilterPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoutingPolicy/MSFT_TeamsVoiceRoutingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoutingPolicy/MSFT_TeamsVoiceRoutingPolicy.psm1
@@ -175,7 +175,7 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Absent' -and $CurrentValues.Ensure -eq 'Present')
     {
         Write-Verbose -Message "Removing existing Voice Routing Policy {$Identity}"
-        Remove-CsOnlineVoiceRoutingPolicy -Identity $Identity -Confirm:$false
+        Remove-CsOnlineVoiceRoutingPolicy -Identity $Identity
     }
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Remove unsupported Confirm parameter from Remove-CsOnlineVoiceRoutingPolicy cmdlet (Confirm parameter is no longer available for MicrosoftTeams PowerShell module 4.4.1+).

#### This Pull Request (PR) fixes the following issues
- Fixes #2055 
