### PR TITLE
Add function Test-M365DSCModuleValidity

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -3526,14 +3526,16 @@ function Test-M365DSCModuleValidity
     if ($latestVersion -gt $localVersion)
     {
         Write-Host "There is a newer version of the 'Microsoft365DSC' module available on the gallery."
-        if(!( $UpdateConsent = Read-Host -Prompt "Do you wish to update the M365DSC module and it's dependencies? (Y/N) [Default: 'Y']")) { $UpdateConsent = 'Y' }
-        if(!( $UpdateConsent -eq 'Y' -or $UpdateConsent -eq 'y' )) { return }
-        Write-Host "Updating the M365DSC module..." -ForegroundColor Yellow
-        Update-Module -Name 'Microsoft365DSC' -Force
-        Write-Host "Updating dependencies..." -ForegroundColor Yellow
-        Update-M365DSCDependencies -Force
-        Write-Host "uninstalling outdated installations..." -ForegroundColor Yellow
-        Uninstall-M365DSCOutdatedDependencies
+        Write-Host "To update the module and it's dependencies, run the following commands:"
+        Write-Host "Update-Module -Name 'Microsoft365DSC' -Force`nUpdate-M365DSCDependencies -Force`nUninstall-M365DSCOutdatedDependencies" -ForegroundColor Blue
+        # if(!( $UpdateConsent = Read-Host -Prompt "Do you wish to update the M365DSC module and it's dependencies? (Y/N) [Default: 'Y']")) { $UpdateConsent = 'Y' }
+        # if(!( $UpdateConsent -eq 'Y' -or $UpdateConsent -eq 'y' )) { return }
+        # Write-Host "Updating the M365DSC module..." -ForegroundColor Yellow
+        # Update-Module -Name 'Microsoft365DSC' -Force
+        # Write-Host "Updating dependencies..." -ForegroundColor Yellow
+        #Update-M365DSCDependencies -Force
+        # Write-Host "uninstalling outdated installations..." -ForegroundColor Yellow
+        # Uninstall-M365DSCOutdatedDependencies
     }
 }
 Export-ModuleMember -Function @(


### PR DESCRIPTION
This cmdlet checks whether or not the Microsoft365DSC Module is up2date and suggests the user to update the module and its dependencies if it isnt.

<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please make sure you have read the [Contribution Guidelines](https://github.com/PowerShell/SharePointDsc/wiki/Contributing%20to%20SharePointDsc).

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
