### PR TITLE
Update M365DSCUtil.psm1

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2308,6 +2308,12 @@ function Assert-M365DSCBlueprint
                 $ResourcesInBluePrint += $resource.ResourceName
             }
         }
+
+        if (!$ResourcesInBluePrint) {
+            Write-Host "Malformed BluePrint, aborting"
+            break
+        }
+
         Write-Host "Selected BluePrint contains ($($ResourcesInBluePrint.Length)) components to assess."
 
         # Call the Export-M365DSCConfiguration cmdlet to extract only the resource


### PR DESCRIPTION
If you pass a malformed BluePrint into Assert-M365DSCBlueprint it will then try to call Export-M365DSCConfiguration with Components set to an empty array which in turn means it will try to export ALL components, and if you don't have permissions to the different workloads it starts giving out access denied messages just as mentioned at the bottom.

In order to fix this just bail out early as soon as we detect that there were no resources found in the BluePrint.

PS C:\Dsc> Assert-M365DSCBlueprint -BluePrintUrl .\M365TenantConfig.m365 -OutputReportPath .\Report.html -Credentials $Credentials
Selected BluePrint contains (0) components to assess.
Initiating the Export of those (0) components from the tenant...
[WARNING] Based on the provided Authentication parameters, the following resources cannot be extracted:
PlannerBucket PlannerPlan TeamsChannelTab
Connecting to {ExchangeOnline}...
[outlook.office365.com] Connecting to remote server outlook.office365.com failed with the following error message : Access is denied. For more information, see the about_Remote_Troubleshooting Help topic.
Partial Export file was saved at: C:\Users\\[redacted]\AppData\Local\Temp\378e16c5-f8bf-4094-b4ea-24ebec780500.partial.ps1

New-M365DSCDeltaReport : Cannot find file specified in parameter Source:
C:\Users\\[redacted]\AppData\Local\Temp\db29a6ba-2554-4ec4-af88-bfb6aeed2c6a.ps1. Please make sure the file exists!
At C:\Program Files\WindowsPowerShell\Modules\Microsoft365DSC\1.22.720.1\modules\M365DSCUtil.psm1:2312 char:9
[+]         New-M365DSCDeltaReport -Source $ExportPath `
[+]         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	[+] CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
	[+] FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,New-M365DSCDeltaReport