### PR TITLE
Unconditionally remove ReplyURLs (and friends) from $currentParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+* AADApplication
+  * Fixed issue where Update-MgApplication could be called with parameter $ReplyURLs which is invalid.
 * AADConditionalAccessPolicy
   * DEPRECATED then IncludeDevices and ExcludeDevices parameters.
   * Fixed issue extracting a policy that had invalid users or groups (deleted from AAD).

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -381,10 +381,10 @@ function Set-TargetResource
         }
 
         $currentParameters.Add("web", $webValue)
-        $currentParameters.Remove("ReplyURLs") | Out-Null
-        $currentParameters.Remove("LogoutURL") | Out-Null
-        $currentParameters.Remove("Homepage") | Out-Null
     }
+    $currentParameters.Remove("ReplyURLs") | Out-Null
+    $currentParameters.Remove("LogoutURL") | Out-Null
+    $currentParameters.Remove("Homepage") | Out-Null
 
     if ($Ensure -eq "Present" -and $currentAADApp.Ensure -eq "Absent")
     {


### PR DESCRIPTION
Whenever an application is both present in the tenant and in the DSC side then "Update-MgApplication @currentParameters" is always called but if $ReplyURLs is empty then it errors out because it will try to use it as parameter for Update-MgApplication which doesn't exist. To fix this just remove $ReplyURLs and friends from $currentParameters. Note that this same problem will happen if app is not present and needs to be recreated with New-MgApplication.

Error below:

VERBOSE: [redacted]:[[AADApplication][redacted]] Updating existing AzureAD Application {[redacted]} with values:

Key            Value
---            -----
DisplayName    [redacted]
IdentifierUris {}
ApplicationId  [redacted]
ReplyURLs      {}
SignInAudience AzureADMyOrg
Verbose        True

A parameter cannot be found that matches parameter name 'ReplyURLs'.
    [+] CategoryInfo          : InvalidArgument: (:) [], CimException
    [+] FullyQualifiedErrorId : NamedParameterNotFound,Update-MgApplication
    [+] PSComputerName        : localhost