### PR TITLE
Abort extraction if all components are invalid or if resource files were not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   * Initial release.
 * DEPENDENCIES
   * Updated MicrosoftTeams to version 4.6.0.
+* MISC
+  * Fixed issue with Export-M365DSCConfiguration if all components were invalid or if resource files were not found.
 
 # 1.22.727.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -148,6 +148,11 @@ function Start-M365DSCConfigurationExtract
         -ChildPath "..\DSCResources\" `
         -Resolve
         $AllResources = Get-ChildItem $ResourcesPath -Recurse | Where-Object { $_.Name -like 'MSFT_*.psm1' }
+        if (!$AllResources)
+        {
+            Write-Host "Resource files were not found, aborting"
+            break
+        }
 
         $i = 1
         $ResourcesToExport = @()
@@ -171,6 +176,11 @@ function Start-M365DSCConfigurationExtract
             {
                 New-M365DSCLogEntry -Error $_ -Message $ResourceModule.Name -Source "[M365DSCReverse]$($ResourceModule.Name)"
             }
+        }
+        if (!$ResourcesToExport)
+        {
+            Write-Host "There are no valid resources to export, aborting"
+            break
         }
 
         $allSupportedResources = Get-M365DSCComponentsForAuthenticationType -AuthenticationMethod $AuthMethods `


### PR DESCRIPTION
When calling Export-M365DSCConfiguration, only with a list of invalid components (see at the bottom), then Start-M365DSCConfigurationExtract is called internally without validating that list. This means it tries to export as much as it can and depending on the accesses required may start giving access denied error messages. Fix is to just stop early if all components are invalid.

Additionally also be careful to not proceed with extraction if in the meantime user deletes all resource files, this should not happen but it doesn't hurt to have the check.

e.g.:

Export-M365DSCConfiguration \`
    -Components This, Is, An, Invalid, List, Of, Components \`
    -Path C:\Dsc \`
    -ApplicationId $ApplicationId \`
    -ApplicationSecret $ApplicationSecret \`
    -TenantId $TenantId