### PR TITLE
Don't call Get-MgSubscribedSku on 2 loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   * Initial release.
 * DEPENDENCIES
   * Updated MicrosoftTeams to version 4.6.0.
+* O365User
+  * Optimize, call Get-MgSubscribedSku only once instead of inside of two loops per each user/license.
 
 # 1.22.727.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
@@ -417,11 +417,12 @@ function Set-TargetResource
 
         $licenses = @{}
 
+        $SubscribedSku = Get-MgSubscribedSku
         foreach ($licenseSkuPart in $LicenseAssignment)
         {
             Write-Verbose -Message "Adding License {$licenseSkuPart} to the Queue"
             $license = @{
-                SkuId = (Get-MgSubscribedSku | Where-Object -Property SkuPartNumber -Value $licenseSkuPart -EQ).SkuID
+                SkuId = ($SubscribedSku | Where-Object -Property SkuPartNumber -Value $licenseSkuPart -EQ).SkuID
             }
 
             # Set the Office license as the license we want to add in the $licenses object
@@ -441,7 +442,7 @@ function Set-TargetResource
             {
                 Write-Verbose -Message "Removing {$currentLicense} from user {$UserPrincipalName}"
                 $license = @{
-                    SkuId = (Get-MgSubscribedSku | Where-Object -Property SkuPartNumber -Value $currentLicense -EQ).SkuID
+                    SkuId = ($SubscribedSku | Where-Object -Property SkuPartNumber -Value $currentLicense -EQ).SkuID
                 }
                 if ( $licenses.Keys -NotContains "AddLicenses")
                 {


### PR DESCRIPTION
Optimize 2 loops by not having to call Get-MgSubscribedSku on every single license assignment user has to be added and/or removed, just call it once out of those loops.