### PR TITLE
Dedup some code and fix typo in variable on O365SiteGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   * DEPRECATED then IncludeDevices and ExcludeDevices parameters.
   * Fixed issue extracting a policy that had invalid users or groups (deleted from AAD).
   FIXES [#2151](https://github.com/microsoft/Microsoft365DSC/issues/2151)
+* SPOSiteGroup
+  * Avoid redefining $SiteGroupSettings always to the same value, just define it once, and call it as is on Set-PnPGroup.
+  * To keep the same order of updating the group and then its permissions check on which conditions it needs to be updated and at the end call Set-PnPGroup then Set-PnPGroupPermissions.
+  * Fix typo in variable, not an issue right now but the group would always be updated even if name and owner were already correct.
 * TeamsEventsPolicy
   * Initial release.
 * DEPENDENCIES

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteGroup/MSFT_SPOSiteGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteGroup/MSFT_SPOSiteGroup.psm1
@@ -327,7 +327,9 @@ function Set-TargetResource
     {
         Write-Verbose -Message "Removing Group $Identity"
         Write-Verbose "Removing SPOSiteGroup $Identity"
-        $SiteGroupSettings.Remove("Owner")
+        $SiteGroupSettings = @{
+            Identity = $Identity
+        }
         Remove-PnPGroup @SiteGroupSettings
     }
 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteGroup/MSFT_SPOSiteGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteGroup/MSFT_SPOSiteGroup.psm1
@@ -282,11 +282,12 @@ function Set-TargetResource
             Identity = $Identity
         }
 
-        $UpdateGroupPermissions = $false
+        $NeedsToUpdateGroup = $true
+        $NeedsToUpdateGroupPermissions = $false
         if ($PermissionLevelsToAdd.Count -eq 0 -and $PermissionLevelsToRemove.Count -ne 0)
         {
             Write-Verbose -Message "Need to remove Permissions $PermissionLevelsToRemove"
-            $UpdateGroupPermissions = $true
+            $NeedsToUpdateGroupPermissions = $true
             $GroupPermissionsParameters.Add("RemoveRole", $PermissionLevelsToRemove)
         }
         elseif ($PermissionLevelsToRemove.Count -eq 0 -and $PermissionLevelsToAdd.Count -ne 0)
@@ -294,14 +295,15 @@ function Set-TargetResource
             Write-Verbose -Message "Need to add Permissions $PermissionLevelsToAdd"
             Write-Verbose -Message "Setting PnP Group with Identity {$Identity} and Owner {$Owner}"
             Write-Verbose -Message "Setting PnP Group Permissions Identity {$Identity} AddRole {$PermissionLevelsToAdd}"
-            $UpdateGroupPermissions = $true
+            $NeedsToUpdateGroupPermissions = $true
             $GroupPermissionsParameters.Add("AddRole", $PermissionLevelsToAdd)
         }
         elseif ($PermissionLevelsToAdd.Count -eq 0 -and $PermissionLevelsToRemove.Count -eq 0)
         {
-            if (($Identity -eq $currentValues.Identity) -and ($Owner -eq $currentlValues.Owner))
+            if (($Identity -eq $currentValues.Identity) -and ($Owner -eq $currentValues.Owner))
             {
                 Write-Verbose -Message "All values are configured as desired"
+                $NeedsToUpdateGroup = $false
             }
             else
             {
@@ -311,10 +313,12 @@ function Set-TargetResource
         else
         {
             Write-Verbose -Message "Updating Group Permissions Add {$PermissionLevelsToAdd} Remove {$PermissionLevelsToRemove}"
-            $UpdateGroupPermissions = $true
+            $NeedsToUpdateGroupPermissions = $true
             $GroupPermissionsParameters.Add("AddRole", $PermissionLevelsToAdd)
         }
-        Set-PnPGroup @SiteGroupSettings
+        if ($NeedsToUpdateGroup) {
+            Set-PnPGroup @SiteGroupSettings
+        }
         if ($UpdateGroupPermissions) {
             Set-PnPGroupPermissions @GroupPermissionsParameters
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteGroup/MSFT_SPOSiteGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteGroup/MSFT_SPOSiteGroup.psm1
@@ -319,7 +319,7 @@ function Set-TargetResource
         if ($NeedsToUpdateGroup) {
             Set-PnPGroup @SiteGroupSettings
         }
-        if ($UpdateGroupPermissions) {
+        if ($NeedsToUpdateGroupPermissions) {
             Set-PnPGroupPermissions @GroupPermissionsParameters
         }
     }


### PR DESCRIPTION
Avoid redefining $SiteGroupSettings always to the same value, just define it once, and call it as is on Set-PnPGroup, except if it's to be used on remove the SiteGroup, in this case just remove the Owner key/value. Additionally to keep the order of setting the group owner first, and then the group permissions add a new object ($GroupPermissionsParameters) to keep track of which parameters are required and then finally call Set-PnPGroup/Set-PnPGroupPermissions in the right order. Note that if the order of calling both cmdlets is not important then of course the diff would be even smaller since the calls to Set-PnPGroupPermissions could be kept as is.

While here fix typo in variable, currently this is only a nuisance since even if Identity and Owner of SiteGroup are the same as $currentValues it tries to update the group anyway to those same values, but if not noticed and code inside condition is altered then it could cause problems, so make it clear that if they are the same then calling Set-PnPGroup is not required and it can just be skipped.