### PR TITLE
AADConditionalAccessPolicy: Object should be identified by its Id and not DisplayName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * DEPRECATED then IncludeDevices and ExcludeDevices parameters.
   * Fixed issue extracting a policy that had invalid users or groups (deleted from AAD).
   FIXES [#2151](https://github.com/microsoft/Microsoft365DSC/issues/2151)
+  * Fixed issue compiling to MOF if objects had the same DisplayName (just identify them by their Id instead)
+  FIXES [#2184](https://github.com/microsoft/Microsoft365DSC/issues/2184)
 * TeamsEventsPolicy
   * Initial release.
 * DEPENDENCIES

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.schema.mof
@@ -1,8 +1,8 @@
 [ClassVersion("1.0.0.0"), FriendlyName("AADConditionalAccessPolicy")]
 class MSFT_AADConditionalAccessPolicy : OMI_BaseResource
 {
-    [Key, Description("DisplayName of the AAD CA Policy")] String DisplayName;
-    [Write, Description("Specifies the GUID for the Policy.")] String Id;
+    [Key, Description("Specifies the GUID for the Policy.")] String Id;
+    [Write, Description("DisplayName of the AAD CA Policy")] String DisplayName;
     [Write, Description("Specifies the State of the Policy."), ValueMap{"disabled","enabled","enabledForReportingButNotEnforced"}, Values{"disabled","enabled","enabledForReportingButNotEnforced"}] String State;
     [Write, Description("Cloud Apps in scope of the Policy.")] String IncludeApplications[];
     [Write, Description("Cloud Apps out of scope of the Policy.")] String ExcludeApplications[];


### PR DESCRIPTION
Tenants may have several AADConditionalAccessPolicy objects created with the same DisplayName therefore they need to be identified by their Id instead.

Fixes #2184