### PR TITLE
Use New-MgGroup{Owner,Member} instead of New-MgGroup{Owner,Member}ByRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   * Updated MicrosoftTeams to version 4.6.0.
 * O365User
   * Optimize, call Get-MgSubscribedSku only once instead of inside of two loops per each user/license.
+* AADGroup
+  * Use New-MgGroupOwner and New-MgGroupMember instead of their ByRef counterparts
+  FIXES [#2203](https://github.com/microsoft/Microsoft365DSC/issues/2203)
 
 # 1.22.727.1
 

--- a/Modules/Microsoft365DSC/Dependencies/GraphCmdletPermissions.csv
+++ b/Modules/Microsoft365DSC/Dependencies/GraphCmdletPermissions.csv
@@ -25,6 +25,7 @@ New-MgDirectorySetting,Directory.ReadWrite.All,Directory.ReadWrite.All
 New-MgGroup,Group.ReadWrite.All,Group.ReadWrite.All
 New-MgGroupLifecyclePolicy,Directory.ReadWrite.All,Directory.ReadWrite.All
 New-MgGroupMember,Group.ReadWrite.All,Group.ReadWrite.All
+New-MgGroupOwner,Group.ReadWrite.All,Group.ReadWrite.All
 New-MgGroupOwnerByRef,Group.ReadWrite.All,Group.ReadWrite.All
 New-MgIdentityConditionalAccessPolicy,Policy.Read.All/Policy.ReadWrite.ConditionalAccess,Policy.Read.All/Policy.ReadWrite.ConditionalAccess
 New-MgPlannerBucket,Tasks.ReadWrite,NotSupported


### PR DESCRIPTION
With new version v1.11.0 of MSGraph SDK the cmdlets New-MgGroup{Owner,Member}ByRef lost the param BodyParameter therefore calling them this way stopped working. Instead use their counterparts New-MgGroup{Owner,Member} with parameter DirectoryObjectId. While here check if user exists before trying to add/remove as member, and/or owner, and enclose all these cmdlets within exceptions.

Fixes #2203