### PR TITLE
Remove support for importing/exporting app owners for now since it's not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 * AADApplication
   * Fixed issue where Update-MgApplication could be called with parameter ReplyURLs which is invalid.
-  * Added support to export/import app owners.
 * EXOTransportRule
   * Fix issue setting IncidentReportContent
   FIXES [#2196](https://github.com/microsoft/Microsoft365DSC/issues/2196)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.schema.mof
@@ -22,7 +22,6 @@ class MSFT_AADApplication : OMI_BaseResource
     [Write, Description("Set this to true if an Oauth2 post response is required.")] Boolean Oauth2RequirePostResponse;
     [Write, Description("Specifies whether this application is a public client (such as an installed application running on a mobile device). Default is false.")] Boolean PublicClient;
     [Write, Description("Specifies the URLs that user tokens are sent to for sign in, or the redirect URIs that OAuth 2.0 authorization codes and access tokens are sent to.")] String ReplyURLs[];
-    [Write, Description("UPN or ObjectID values of the app's owners.")] String Owners[];
     [Write, Description("Specify if the Azure AD App should exist or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Credentials for the Microsoft Graph delegated permissions."), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;


### PR DESCRIPTION
Remove support for importing/exporting application owners on AADApplication resource, at least for now, since currently the backend is failing with "The request is currently not supported" on both adding and removing owners.

Not only the cmdlet New-MgApplicationOwnerByRef lost the param BodyParameter, the whole backend is responding "The request is currently not supported" with anything app owner related even manually sending the requests towards Graph.