### PR TITLE
Don't export all policies if none match the type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 * EXOInboundConnector
   * Add support for different syntax of SenderDomains parameter
   FIXES [#2180](https://github.com/microsoft/Microsoft365DSC/issues/2180)
+* IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator
+  * Don't export all policies if none match the type
+* IntuneDeviceConfigurationPolicyAndroidOpenSourceProject
+  * Don't export all policies if none match the type
+  FIXES [#2228](https://github.com/microsoft/Microsoft365DSC/issues/2228)
 
 # 1.22.824.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator.psm1
@@ -1256,12 +1256,6 @@ function Export-TargetResource
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidGeneralDeviceConfiguration'  `
             }
-
-        if (-not $getValue)
-        {
-            [array]$getValue = Get-MgDeviceManagementDeviceConfiguration `
-                -ErrorAction Stop
-        }
         #endregion
 
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject.psm1
@@ -764,12 +764,6 @@ function Export-TargetResource
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.aospDeviceOwnerDeviceConfiguration'  `
             }
-
-        if (-not $getValue)
-        {
-            [array]$getValue = Get-MgDeviceManagementDeviceConfiguration `
-                -ErrorAction Stop
-        }
         #endregion
 
 


### PR DESCRIPTION
#### Pull Request (PR) description
If there are no policies that match type then it shouldn't try to export all of them instead. This is the same fix as applied on IntuneDeviceConfigurationPolicyMacOS on PR #2214.

#### This Pull Request (PR) fixes the following issues
Fixes #2228