### PR TITLE
EXOAddressList: Fix precanned filters issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* EXOAddressList
+  * Ignore precanned filters if recipient filter is used. Precanned filters and recipient filter cannot be used at the same time.
+    FIXES [#2194](https://github.com/microsoft/Microsoft365DSC/issues/2194)
 * EXOSafeLinksPolicy
   * Add Suport for EnableSafeLinksForEmail and DisableUrlRewrite
 * EXOInboundConnector

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressList/MSFT_EXOAddressList.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressList/MSFT_EXOAddressList.psm1
@@ -395,6 +395,7 @@ function Set-TargetResource
 
     if ($RecipientFilter)
     {
+        Write-Verbose -Message "You can't use RecipientFilter and precanned filters at the same time. All precanned filters will be ignored."
         $NewAddressListParams = @{
             Name            = $Name
             RecipientFilter = $RecipientFilter
@@ -429,31 +430,44 @@ function Set-TargetResource
         }
     }
 
-    $SetAddressListParams = @{
-        Identity                     = $Name
-        Name                         = $Name
-        ConditionalCompany           = $ConditionalCompany
-        ConditionalCustomAttribute1  = $ConditionalCustomAttribute1
-        ConditionalCustomAttribute10 = $ConditionalCustomAttribute10
-        ConditionalCustomAttribute11 = $ConditionalCustomAttribute11
-        ConditionalCustomAttribute12 = $ConditionalCustomAttribute12
-        ConditionalCustomAttribute13 = $ConditionalCustomAttribute13
-        ConditionalCustomAttribute14 = $ConditionalCustomAttribute14
-        ConditionalCustomAttribute15 = $ConditionalCustomAttribute15
-        ConditionalCustomAttribute2  = $ConditionalCustomAttribute2
-        ConditionalCustomAttribute3  = $ConditionalCustomAttribute3
-        ConditionalCustomAttribute4  = $ConditionalCustomAttribute4
-        ConditionalCustomAttribute5  = $ConditionalCustomAttribute5
-        ConditionalCustomAttribute6  = $ConditionalCustomAttribute6
-        ConditionalCustomAttribute7  = $ConditionalCustomAttribute7
-        ConditionalCustomAttribute8  = $ConditionalCustomAttribute8
-        ConditionalCustomAttribute9  = $ConditionalCustomAttribute9
-        ConditionalDepartment        = $ConditionalDepartment
-        ConditionalStateOrProvince   = $ConditionalStateOrProvince
-        DisplayName                  = $DisplayName
-        IncludedRecipients           = $IncludedRecipients
-        RecipientFilter              = $RecipientFilter
-        Confirm                      = $false
+    if ($RecipientFilter)
+    {
+        Write-Verbose -Message "You can't use RecipientFilter and precanned filters at the same time. All precanned filters will be ignored."
+        $SetAddressListParams = @{
+            Identity        = $Name
+            Name            = $Name
+            RecipientFilter = $RecipientFilter
+            Confirm         = $false
+        }
+    }
+    else
+    {
+        $SetAddressListParams = @{
+            Identity                     = $Name
+            Name                         = $Name
+            ConditionalCompany           = $ConditionalCompany
+            ConditionalCustomAttribute1  = $ConditionalCustomAttribute1
+            ConditionalCustomAttribute10 = $ConditionalCustomAttribute10
+            ConditionalCustomAttribute11 = $ConditionalCustomAttribute11
+            ConditionalCustomAttribute12 = $ConditionalCustomAttribute12
+            ConditionalCustomAttribute13 = $ConditionalCustomAttribute13
+            ConditionalCustomAttribute14 = $ConditionalCustomAttribute14
+            ConditionalCustomAttribute15 = $ConditionalCustomAttribute15
+            ConditionalCustomAttribute2  = $ConditionalCustomAttribute2
+            ConditionalCustomAttribute3  = $ConditionalCustomAttribute3
+            ConditionalCustomAttribute4  = $ConditionalCustomAttribute4
+            ConditionalCustomAttribute5  = $ConditionalCustomAttribute5
+            ConditionalCustomAttribute6  = $ConditionalCustomAttribute6
+            ConditionalCustomAttribute7  = $ConditionalCustomAttribute7
+            ConditionalCustomAttribute8  = $ConditionalCustomAttribute8
+            ConditionalCustomAttribute9  = $ConditionalCustomAttribute9
+            ConditionalDepartment        = $ConditionalDepartment
+            ConditionalStateOrProvince   = $ConditionalStateOrProvince
+            DisplayName                  = $DisplayName
+            IncludedRecipients           = $IncludedRecipients
+            RecipientFilter              = $RecipientFilter
+            Confirm                      = $false
+        }
     }
 
     #Address List doesn't exist but it should


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes an issue if recipient filter and precanned filters were used at the same time. This was already implemented for New-* cmdlet. Added the same logic for Set-* cmdlet.

#### This Pull Request (PR) fixes the following issues
- Fixes #2194 
