### PR TITLE
2 SCRetentionCompliance related fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* SCRetentionCompliancePolicy
+  * Fixes an issue where the TeamsChatLocation, TeamsChatLocationException, TeamsChannelLocation
+    and TeamsChannelLocationException properties were not properly set on Update.
+    FIXES #2173
+* SCRetentionComplianceRule
+  * Fixes an issue when trying to create new compliancerule for Teams based policies where invalid
+    parameters were passed.
+    FIXES #2181
+
 # 1.22.831.1
 
 * EXOAddressList

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionCompliancePolicy/MSFT_SCRetentionCompliancePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionCompliancePolicy/MSFT_SCRetentionCompliancePolicy.psm1
@@ -593,6 +593,103 @@ function Set-TargetResource
             TeamsChatLocation             = $TeamsChatLocation
             TeamsChatLocationException    = $TeamsChatLocationException
         }
+
+        # Teams Chat Location is specified or already existing, we need to determine
+        # the delta.
+        if ($null -ne $CurrentPolicy.TeamsChatLocation -or `
+                $null -ne $TeamsChatLocation)
+        {
+            $ToBeRemoved = $CurrentPolicy.TeamsChatLocation | `
+                Where-Object { $TeamsChatLocation -NotContains $_ }
+            if ($null -ne $ToBeRemoved)
+            {
+                Write-Verbose -Message "Adding the RemoveTeamsChatLocation property."
+                $CreationParams.Add("RemoveTeamsChatLocation", $ToBeRemoved)
+            }
+
+            $ToBeAdded = $TeamsChatLocation | `
+                Where-Object { $CurrentPolicy.TeamsChatLocation -NotContains $_ }
+            if ($null -ne $ToBeAdded)
+            {
+                Write-Verbose -Message "Adding the AddTeamsChatLocation property."
+                $CreationParams.Add("AddTeamsChatLocation", $ToBeAdded)
+            }
+            Write-Verbose -Message "Removing the TeamsChatLocation property."
+            $CreationParams.Remove("TeamsChatLocation")
+        }
+
+        # Teams Chat Location Exception is specified or already existing, we need to determine
+        # the delta.
+        if ($null -ne $CurrentPolicy.TeamsChatLocationException -or `
+                $null -ne $TeamsChatLocationException)
+        {
+            $ToBeRemoved = $CurrentPolicy.TeamsChatLocationException | `
+                Where-Object { $TeamsChatLocationException -NotContains $_ }
+            if ($null -ne $ToBeRemoved)
+            {
+                Write-Verbose -Message "Adding the RemoveTeamsChatLocationException property."
+                $CreationParams.Add("RemoveTeamsChatLocationException", $ToBeRemoved)
+            }
+
+            $ToBeAdded = $TeamsChatLocationException | `
+                Where-Object { $CurrentPolicy.TeamsChatLocationException -NotContains $_ }
+            if ($null -ne $ToBeAdded)
+            {
+                Write-Verbose -Message "Adding the AddTeamsChatLocationException property."
+                $CreationParams.Add("AddTeamsChatLocationException", $ToBeAdded)
+            }
+            Write-Verbose -Message "Removing the TeamsChatLocationException property."
+            $CreationParams.Remove("TeamsChatLocationException")
+        }
+
+        # Teams Channel Location is specified or already existing, we need to determine
+        # the delta.
+        if ($null -ne $CurrentPolicy.TeamsChannelLocation -or `
+                $null -ne $TeamsChannelLocation)
+        {
+            $ToBeRemoved = $CurrentPolicy.TeamsChannelLocation | `
+                Where-Object { $TeamsChannelLocation -NotContains $_ }
+            if ($null -ne $ToBeRemoved)
+            {
+                Write-Verbose -Message "Adding the RemoveTeamsChannelLocation property."
+                $CreationParams.Add("RemoveTeamsChannelLocation", $ToBeRemoved)
+            }
+
+            $ToBeAdded = $TeamsChannelLocation | `
+                Where-Object { $CurrentPolicy.TeamsChannelLocation -NotContains $_ }
+            if ($null -ne $ToBeAdded)
+            {
+                Write-Verbose -Message "Adding the AddTeamsChannelLocation property."
+                $CreationParams.Add("AddTeamsChannelLocation", $ToBeAdded)
+            }
+            Write-Verbose -Message "Removing the TeamsChannelLocation property."
+            $CreationParams.Remove("TeamsChannelLocation")
+        }
+
+        # Teams Channel Location Exception is specified or already existing, we need to determine
+        # the delta.
+        if ($null -ne $CurrentPolicy.TeamsChannelLocationException -or `
+                $null -ne $TeamsChannelLocationException)
+        {
+            $ToBeRemoved = $CurrentPolicy.TeamsChannelChannelLocationException | `
+                Where-Object { $TeamsChannelLocationException -NotContains $_ }
+            if ($null -ne $ToBeRemoved)
+            {
+                Write-Verbose -Message "Adding the RemoveTeamsChannelLocationException property."
+                $CreationParams.Add("RemoveTeamsChannelLocationException", $ToBeRemoved)
+            }
+
+            $ToBeAdded = $TeamsChannelLocationException | `
+                Where-Object { $CurrentPolicy.TeamsChannelLocationException -NotContains $_ }
+            if ($null -ne $ToBeAdded)
+            {
+                Write-Verbose -Message "Adding the AddTeamsChannelLocationException property."
+                $CreationParams.Add("AddTeamsChannelLocationException", $ToBeAdded)
+            }
+            Write-Verbose -Message "Removing the TeamsChannelLocationException property."
+            $CreationParams.Remove("TeamsChannelLocationException")
+        }
+        $CreationParams.Remove("RestrictiveRetention") | Out-Null
     }
     if (('Present' -eq $Ensure) -and ('Absent' -eq $CurrentPolicy.Ensure))
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionComplianceRule/MSFT_SCRetentionComplianceRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionComplianceRule/MSFT_SCRetentionComplianceRule.psm1
@@ -104,14 +104,17 @@ function Get-TargetResource
                 Name                         = $RuleObject.Name
                 Comment                      = $RuleObject.Comment
                 Policy                       = $AssociatedPolicy.Name
-                ExcludedItemClasses          = $RuleObject.ExcludedItemClasses
                 RetentionDuration            = $RuleObject.RetentionDuration
-                RetentionDurationDisplayHint = $RuleObject.RetentionDurationDisplayHint
-                ContentMatchQuery            = $RuleObject.ContentMatchQuery
-                ExpirationDateOption         = $RuleObject.ExpirationDateOption
                 RetentionComplianceAction    = $RetentionComplianceActionValue
                 Credential                   = $Credential
                 Ensure                       = 'Present'
+            }
+            if (-not $associatedPolicy.TeamsPolicy)
+            {
+                $result.Add('ExpirationDateOption', $RuleObject.ExpirationDateOption)
+                $result.Add('ExcludedItemClasses', $RuleObject.ExcludedItemClasses)
+                $result.Add('RetentionDurationDisplayHint', $RuleObject.RetentionDurationDisplayHint)
+                $result.Add('ContentMatchQuery', $RuleObject.ContentMatchQuery)
             }
 
             Write-Verbose -Message "Found RetentionComplianceRule $($Name)"
@@ -223,6 +226,45 @@ function Set-TargetResource
         $CreationParams = $PSBoundParameters
         $CreationParams.Remove("Credential")
         $CreationParams.Remove("Ensure")
+
+        Write-Verbose -Message "Checking to see if the policy is a Teams based one."
+        $RuleObject = Get-RetentionComplianceRule -Identity $Name `
+            -ErrorAction SilentlyContinue
+        $AssociatedPolicy = Get-RetentionCompliancePolicy $RuleObject.Policy
+
+        if ($AssociatedPolicy.TeamsPolicy)
+        {
+            Write-Verbose -Message "The current policy is a Teams based one, removing invalid parameters."
+            if ($CreationParams.ContainsKey('ApplyComplianceTag'))
+            {
+                $CreationParams.Remove("ApplyComplianceTag") | Out-Null
+            }
+            if ($CreationParams.ContainsKey('ContentContainsSensitiveInformation'))
+            {
+                $CreationParams.Remove("ContentContainsSensitiveInformation") | Out-Null
+            }
+            if ($CreationParams.ContainsKey('ContentMatchQuery'))
+            {
+                $CreationParams.Remove("ContentMatchQuery") | Out-Null
+            }
+            if ($CreationParams.ContainsKey('ExcludedItemClasses'))
+            {
+                $CreationParams.Remove("ExcludedItemClasses") | Out-Null
+            }
+            if ($CreationParams.ContainsKey('ExpirationDateOption'))
+            {
+                $CreationParams.Remove("ExpirationDateOption") | Out-Null
+            }
+            if ($CreationParams.ContainsKey('PublishComplianceTag'))
+            {
+                $CreationParams.Remove("PublishComplianceTag") | Out-Null
+            }
+            if ($CreationParams.ContainsKey('RetentionDurationDisplayHint'))
+            {
+                $CreationParams.Remove("RetentionDurationDisplayHint") | Out-Null
+            }
+        }
+
         New-RetentionComplianceRule @CreationParams
     }
     elseif (('Present' -eq $Ensure) -and ('Present' -eq $CurrentRule.Ensure))
@@ -233,6 +275,45 @@ function Set-TargetResource
         $CreationParams.Remove("Name")
         $CreationParams.Add("Identity", $Name)
         $CreationParams.Remove("Policy")
+
+        Write-Verbose -Message "Checking to see if the policy is a Teams based one."
+        $RuleObject = Get-RetentionComplianceRule -Identity $Name `
+            -ErrorAction SilentlyContinue
+        $AssociatedPolicy = Get-RetentionCompliancePolicy $RuleObject.Policy
+
+        if ($AssociatedPolicy.TeamsPolicy)
+        {
+            Write-Verbose -Message "The current policy is a Teams based one, removing invalid parameters."
+
+            if ($CreationParams.ContainsKey('ApplyComplianceTag'))
+            {
+                $CreationParams.Remove("ApplyComplianceTag") | Out-Null
+            }
+            if ($CreationParams.ContainsKey('ContentContainsSensitiveInformation'))
+            {
+                $CreationParams.Remove("ContentContainsSensitiveInformation") | Out-Null
+            }
+            if ($CreationParams.ContainsKey('ContentMatchQuery'))
+            {
+                $CreationParams.Remove("ContentMatchQuery") | Out-Null
+            }
+            if ($CreationParams.ContainsKey('ExcludedItemClasses'))
+            {
+                $CreationParams.Remove("ExcludedItemClasses") | Out-Null
+            }
+            if ($CreationParams.ContainsKey('ExpirationDateOption'))
+            {
+                $CreationParams.Remove("ExpirationDateOption") | Out-Null
+            }
+            if ($CreationParams.ContainsKey('PublishComplianceTag'))
+            {
+                $CreationParams.Remove("PublishComplianceTag") | Out-Null
+            }
+            if ($CreationParams.ContainsKey('RetentionDurationDisplayHint'))
+            {
+                $CreationParams.Remove("RetentionDurationDisplayHint") | Out-Null
+            }
+        }
 
         Set-RetentionComplianceRule @CreationParams
     }


### PR DESCRIPTION
#### Pull Request (PR) description
* SCRetentionCompliancePolicy
  * Fixes an issue where the TeamsChatLocation, TeamsChatLocationException, TeamsChannelLocation
    and TeamsChannelLocationException properties were not properly set on Update.
* SCRetentionComplianceRule
  * Fixes an issue when trying to create new compliancerule for Teams based policies where invalid
    parameters were passed.

#### This Pull Request (PR) fixes the following issues
* Fixes #2173 
* Fixes #2181 
