### PR TITLE
EXODistributionGroup: Fix warning issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* EXODistributionGroup
+  * Fixes warning issue regarding OrganizationalUnit property
+    FIXES [#2252]
 * SCRetentionCompliancePolicy
   * Fixes an issue where the TeamsChatLocation, TeamsChatLocationException, TeamsChannelLocation
     and TeamsChannelLocationException properties were not properly set on Update.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/MSFT_EXODistributionGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/MSFT_EXODistributionGroup.psm1
@@ -398,7 +398,7 @@ function Set-TargetResource
         Write-Verbose -Message "The Distribution Group {$Name} already exists. Updating settings"
         Write-Verbose -Message "Setting Distribution Group {$Name} with values: $(Convert-M365DscHashtableToString -Hashtable $currentParameters)"
 
-        if ($currentDistributionGroup.OrganizationalUnit -ne $OrganizationalUnit)
+        if ($null -ne $OrganizationalUnit -and $currentDistributionGroup.OrganizationalUnit -ne $OrganizationalUnit)
         {
             Write-Warning -Message "Desired and current OrganizationalUnit values differ. This property cannot be updated once the distribution group has been created. Delete and recreate the distribution group to update the value."
         }
@@ -546,6 +546,11 @@ function Test-TargetResource
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters
+
+    if (!$ValuesToCheck.OrganizationalUnit)
+    {
+        $ValuesToCheck.Remove("OrganizationalUnit") | Out-Null
+    }
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `


### PR DESCRIPTION
#### Pull Request (PR) description
The OrganizationalUnit property is not very useful for distribution groups in EXO. However, it is supported for the New-DistributionGroup cmdlet. I assume, that this property is rarely set, but it is never empty. 
With this PR the property is skipped in the Test-TargetResource function if no value is provided.

#### This Pull Request (PR) fixes the following issues
- Fixes #2252 
