### PR TITLE
Fixes #2190 and #2191

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+* AADGroup
+  * Changed behavior where if a group has a dynamic membership rule that is active,
+    we no longer process members from the export, Get and Set functions.
+    FIXES [#2190](https://github.com/microsoft/Microsoft365DSC/issues/2190)
 * AADRoleSetting
   * Fixed an issue where the export wasn't properly passing credential to the Get function.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   * Changed behavior where if a group has a dynamic membership rule that is active,
     we no longer process members from the export, Get and Set functions.
     FIXES [#2190](https://github.com/microsoft/Microsoft365DSC/issues/2190)
+  * Fixed an issue where if the licenses parameter was omitted and another parameter caused
+    a drift, that the licenses would get stripped from the group.
+    FIXES [#2191](https://github.com/microsoft/Microsoft365DSC/issues/2191)
 * AADRoleSetting
   * Fixed an issue where the export wasn't properly passing credential to the Get function.
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -464,7 +464,7 @@ function Set-TargetResource
                 Update-MgGroup @currentParameters | Out-Null
             }
 
-            if ($licensesToAdd.Length -gt 0 -or $licensesToRemove.Length -gt 0)
+            if (($licensesToAdd.Length -gt 0 -or $licensesToRemove.Length -gt 0) -and $AssignedLicenses -ne $null)
             {
                 try
                 {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -156,14 +156,18 @@ function Get-TargetResource
                 }
             }
 
-            # Members
-            [Array]$members = Get-MgGroupMember -GroupId $Group.Id -All:$true
-            $MembersValues = @()
-            foreach ($member in $members)
+            $MembersValues = $null
+            if ($Group.MembershipRuleProcessingState -ne 'On')
             {
-                if ($member.AdditionalProperties.userPrincipalName -ne $null)
+                # Members
+                [Array]$members = Get-MgGroupMember -GroupId $Group.Id -All:$true
+                $MembersValues = @()
+                foreach ($member in $members)
                 {
-                    $MembersValues += $member.AdditionalProperties.userPrincipalName
+                    if ($member.AdditionalProperties.userPrincipalName -ne $null)
+                    {
+                        $MembersValues += $member.AdditionalProperties.userPrincipalName
+                    }
                 }
             }
 
@@ -553,38 +557,45 @@ function Set-TargetResource
         }
 
         #Members
-        $currentMembersValue = @()
-        if ($currentParameters.Members.Length -ne 0)
+        if ($MembershipRuleProcessingState -ne 'On')
         {
-            $currentMembersValue = $backCurrentMembers
-        }
-        $desiredMembersValue = @()
-        if ($Members.Length -ne 0)
-        {
-            $desiredMembersValue = $Members
-        }
-        if ($backCurrentMembers -eq $null)
-        {
-            $backCurrentMembers = @()
-        }
-        $membersDiff = Compare-Object -ReferenceObject $backCurrentMembers -DifferenceObject $desiredMembersValue
-        foreach ($diff in $membersDiff)
-        {
-            $user = Get-MgUser -UserId $diff.InputObject
+            $currentMembersValue = @()
+            if ($currentParameters.Members.Length -ne 0)
+            {
+                $currentMembersValue = $backCurrentMembers
+            }
+            $desiredMembersValue = @()
+            if ($Members.Length -ne 0)
+            {
+                $desiredMembersValue = $Members
+            }
+            if ($backCurrentMembers -eq $null)
+            {
+                $backCurrentMembers = @()
+            }
+            $membersDiff = Compare-Object -ReferenceObject $backCurrentMembers -DifferenceObject $desiredMembersValue
+            foreach ($diff in $membersDiff)
+            {
+                $user = Get-MgUser -UserId $diff.InputObject
 
-            if ($diff.SideIndicator -eq '=>')
-            {
-                Write-Verbose -Message "Adding new member {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
-                $memberObject = @{
-                    "@odata.id"= "https://graph.microsoft.com/v1.0/users/{$($user.Id)}"
+                if ($diff.SideIndicator -eq '=>')
+                {
+                    Write-Verbose -Message "Adding new member {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
+                    $memberObject = @{
+                        "@odata.id"= "https://graph.microsoft.com/v1.0/users/{$($user.Id)}"
+                    }
+                    New-MgGroupMemberByRef -GroupId ($currentGroup.Id) -BodyParameter $memberObject | Out-Null
                 }
-                New-MgGroupMemberByRef -GroupId ($currentGroup.Id) -BodyParameter $memberObject | Out-Null
+                elseif ($diff.SideIndicator -eq '<=')
+                {
+                    Write-Verbose -Message "Removing new member {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
+                    Remove-MgGroupMemberByRef -GroupId ($currentGroup.Id) -DirectoryObjectId ($user.Id) | Out-Null
+                }
             }
-            elseif ($diff.SideIndicator -eq '<=')
-            {
-                Write-Verbose -Message "Removing new member {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
-                Remove-MgGroupMemberByRef -GroupId ($currentGroup.Id) -DirectoryObjectId ($user.Id) | Out-Null
-            }
+        }
+        else
+        {
+            Write-Verbose -Message "Ignoring membership since this is a dynamic group."
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
* AADGroup
  * Changed behavior where if a group has a dynamic membership rule that is active, we no longer process members from the export, Get and Set functions.
    FIXES [#2190](https://github.com/microsoft/Microsoft365DSC/issues/2190)
  * Fixed an issue where if the licenses parameter was omitted and another parameter caused
    a drift, that the licenses would get stripped from the group.
    FIXES [#2191](https://github.com/microsoft/Microsoft365DSC/issues/2191)

#### This Pull Request (PR) fixes the following issues
* FIXES #2190 
* FIXES #2191 
