### PR TITLE
Fix #2321

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.psm1
@@ -353,6 +353,7 @@ function Get-TargetResource
             EligibleAssignmentAssigneeNotificationOnlyCritical        = $EligibleAssignmentAssigneeNotificationOnlyCritical
             Ensure                                                    = 'Present'
             Managedidentity                                           = $ManagedIdentity.IsPresent
+            TenantId                                                  = $TenantId
         }
         Write-Verbose -Message "Get-TargetResource Result: `n $(Convert-M365DscHashtableToString -Hashtable $result)"
         return $result

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.psm1
@@ -165,6 +165,11 @@ function Get-TargetResource
         $EligibleAssignmentAssigneeNotificationOnlyCritical,
 
         [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -219,18 +224,25 @@ function Get-TargetResource
     $Filter = "scopeId eq '/' and scopeType eq 'DirectoryRole' and RoleDefinitionId eq '" + $Id + "'"
     #$Policy = Get-MgPolicyRoleManagementPolicyAssignment -Filter $Filter
 
-    try{
+    try
+    {
         $Policy = Get-MgPolicyRoleManagementPolicyAssignment -Filter $Filter -ErrorAction Stop
     }
-    catch{
-        if($_ -match "The tenant needs an AAD Premium 2 license"){
+    catch
+    {
+        if ($_ -match "The tenant needs an AAD Premium 2 license")
+        {
             Write-Warning -Message "WARNING: AAD Premium License is required to get the role"
             return $nullReturn
         }
     }
 
-
+    if ($null -eq $Policy)
+    {
+        return $nullReturn
+    }
     $RoleDefinition = Get-MgRoleManagementDirectoryRoleDefinition -UnifiedRoleDefinitionId $Id
+
     #get Policyrule
     $role = Get-MgPolicyRoleManagementPolicyRule -UnifiedRoleManagementPolicyId $Policy.Policyid
 
@@ -244,16 +256,20 @@ function Get-TargetResource
     [string[]]$ActivateApprover = @()
     foreach ($Item in $ActivateApprovers.id)
     {
-        try{
+        try
+        {
             $user = Get-MgUser -UserId $Item -ErrorAction Stop
             $ActivateApprover += $user.UserPrincipalName
         }
-        catch{
-            try{
-                $group = get-mggroup -GroupId $Item -ErrorAction stop
+        catch
+        {
+            try
+            {
+                $group = Get-MgGroup -GroupId $Item -ErrorAction stop
                 $ActivateApprover += $group.DisplayName
             }
-            catch{
+            catch
+            {
                 Write-Verbose -Message "Error: $($Error[0])"
             }
         }
@@ -335,6 +351,7 @@ function Get-TargetResource
             EligibleAssignmentAssigneeNotificationDefaultRecipient    = $EligibleAssignmentAssigneeNotificationDefaultRecipient
             EligibleAssignmentAssigneeNotificationAdditionalRecipient = [System.String[]]$EligibleAssignmentAssigneeNotificationAdditionalRecipient
             EligibleAssignmentAssigneeNotificationOnlyCritical        = $EligibleAssignmentAssigneeNotificationOnlyCritical
+            Ensure                                                    = 'Present'
         }
         Write-Verbose -Message "Get-TargetResource Result: `n $(Convert-M365DscHashtableToString -Hashtable $result)"
         return $result
@@ -525,6 +542,11 @@ function Set-TargetResource
         [Parameter()]
         [System.Boolean]
         $EligibleAssignmentAssigneeNotificationOnlyCritical,
+
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -872,32 +894,40 @@ function Set-TargetResource
                 if ($ActivateApprover.count -gt 0)
                 {
                     $primaryApprovers = @()
-                    foreach ($item in $ActivateApprover){
+                    foreach ($item in $ActivateApprover)
+                    {
                         #is not a guid try with user
                         $Filter = "UserPrincipalName eq '" + $item + "'"
-                        try{
+                        try
+                        {
                             $user = Get-MgUser -Filter $Filter -ErrorAction Stop
                         }
-                        catch{
+                        catch
+                        {
                             Write-Verbose -Message "User not found, try with group"
                         }
-                        if($user.length -gt 0){
+                        if ($user.length -gt 0)
+                        {
                             $ActivateApprovers = @{}
                             $ActivateApprovers.Add("@odata.type", "#microsoft.graph.singleUser")
                             $ActivateApprovers.Add("userId", $user.Id)
                             $primaryApprovers += $ActivateApprovers
                             $user = $null
                         }
-                        else{
+                        else
+                        {
                             #try with group
                             $Filter = "Displayname eq '" + $item + "'"
-                            try{
+                            try
+                            {
                                 $group = Get-MgGroup -Filter $Filter -ErrorAction Stop
                             }
-                            catch{
+                            catch
+                            {
                                 Write-Verbose -Message "Group not found"
                             }
-                            if($group.length -gt 0){
+                            if ($group.length -gt 0)
+                            {
                                 $ActivateApprovers = @{}
                                 $ActivateApprovers.Add("@odata.type", "#microsoft.graph.groupMembers")
                                 $ActivateApprovers.Add("groupId", $group.Id)
@@ -1216,6 +1246,11 @@ function Test-TargetResource
         $EligibleAssignmentAssigneeNotificationOnlyCritical,
 
         [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -1263,6 +1298,7 @@ function Test-TargetResource
     $ValuesToCheck.Remove('TenantId') | Out-Null
     $ValuesToCheck.Remove('ApplicationSecret') | Out-Null
     $ValuesToCheck.Remove('Id') | Out-Null
+    $ValuesToCheck.Remove('ManagedIdentity') | Out-Null
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `
@@ -1328,11 +1364,14 @@ function Export-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    try{
-        Get-MgPolicyRoleManagementPolicyAssignment -Filter "scopeId eq '/' and scopeType eq 'DirectoryRole'" -ErrorAction Stop
+    try
+    {
+        Get-MgPolicyRoleManagementPolicyAssignment -Filter "scopeId eq '/' and scopeType eq 'DirectoryRole'" -ErrorAction Stop | Out-Null
     }
-    catch{
-        if($_ -match "The tenant needs an AAD Premium 2 license"){
+    catch
+    {
+        if ($_ -match "The tenant needs an AAD Premium 2 license")
+        {
             Write-Host -Message "`nWARNING: AAD Premium License is required to get the role" -ForegroundColor Yellow
             continue
         }
@@ -1354,18 +1393,22 @@ function Export-TargetResource
                 Managedidentity       = $ManagedIdentity.IsPresent
                 Credential            = $Credential
             }
-            $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-            $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
-                -ConnectionMode $ConnectionMode `
-                -ModulePath $PSScriptRoot `
-                -Results $Results `
-                -Credential $Credential
-            $dscContent += $currentDSCBlock
-            Save-M365DSCPartialExport -Content $currentDSCBlock `
-                -FileName $Global:PartialExportFileName
 
+            $Results = Get-TargetResource @Params
+
+            if ($Results.Ensure -eq 'Present')
+            {
+                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
+                    -Results $Results
+                $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
+                    -ConnectionMode $ConnectionMode `
+                    -ModulePath $PSScriptRoot `
+                    -Results $Results `
+                    -Credential $Credential
+                $dscContent += $currentDSCBlock
+                Save-M365DSCPartialExport -Content $currentDSCBlock `
+                    -FileName $Global:PartialExportFileName
+            }
             Write-Host $Global:M365DSCEmojiGreenCheckMark
             $i++
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.psm1
@@ -217,7 +217,7 @@ function Get-TargetResource
     #endregion
 
     $nullReturn = $PSBoundParameters
-    $nullReturn.Ensure = "Absent"
+    $nullReturn.Ensure = 'Absent'
 
     #get role
     [string]$Filter = $null
@@ -230,9 +230,9 @@ function Get-TargetResource
     }
     catch
     {
-        if ($_ -match "The tenant needs an AAD Premium 2 license")
+        if ($_ -match 'The tenant needs an AAD Premium 2 license')
         {
-            Write-Warning -Message "WARNING: AAD Premium License is required to get the role"
+            Write-Warning -Message 'WARNING: AAD Premium License is required to get the role'
             return $nullReturn
         }
     }
@@ -352,6 +352,7 @@ function Get-TargetResource
             EligibleAssignmentAssigneeNotificationAdditionalRecipient = [System.String[]]$EligibleAssignmentAssigneeNotificationAdditionalRecipient
             EligibleAssignmentAssigneeNotificationOnlyCritical        = $EligibleAssignmentAssigneeNotificationOnlyCritical
             Ensure                                                    = 'Present'
+            Managedidentity                                           = $ManagedIdentity.IsPresent
         }
         Write-Verbose -Message "Get-TargetResource Result: `n $(Convert-M365DscHashtableToString -Hashtable $result)"
         return $result
@@ -904,13 +905,13 @@ function Set-TargetResource
                         }
                         catch
                         {
-                            Write-Verbose -Message "User not found, try with group"
+                            Write-Verbose -Message 'User not found, try with group'
                         }
                         if ($user.length -gt 0)
                         {
                             $ActivateApprovers = @{}
-                            $ActivateApprovers.Add("@odata.type", "#microsoft.graph.singleUser")
-                            $ActivateApprovers.Add("userId", $user.Id)
+                            $ActivateApprovers.Add('@odata.type', '#microsoft.graph.singleUser')
+                            $ActivateApprovers.Add('userId', $user.Id)
                             $primaryApprovers += $ActivateApprovers
                             $user = $null
                         }
@@ -924,13 +925,13 @@ function Set-TargetResource
                             }
                             catch
                             {
-                                Write-Verbose -Message "Group not found"
+                                Write-Verbose -Message 'Group not found'
                             }
                             if ($group.length -gt 0)
                             {
                                 $ActivateApprovers = @{}
-                                $ActivateApprovers.Add("@odata.type", "#microsoft.graph.groupMembers")
-                                $ActivateApprovers.Add("groupId", $group.Id)
+                                $ActivateApprovers.Add('@odata.type', '#microsoft.graph.groupMembers')
+                                $ActivateApprovers.Add('groupId', $group.Id)
                                 $primaryApprovers += $ActivateApprovers
                                 $group = $null
                             }
@@ -1370,7 +1371,7 @@ function Export-TargetResource
     }
     catch
     {
-        if ($_ -match "The tenant needs an AAD Premium 2 license")
+        if ($_ -match 'The tenant needs an AAD Premium 2 license')
         {
             Write-Host -Message "`nWARNING: AAD Premium License is required to get the role" -ForegroundColor Yellow
             continue

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.schema.mof
@@ -41,7 +41,7 @@ class MSFT_AADRoleSetting : OMI_BaseResource
     [Write, Description("Send notifications when eligible members activate this role: Notification to activated user (requestor), default recipient (True/False)")] Boolean EligibleAssignmentAssigneeNotificationDefaultRecipient;
     [Write, Description("Send notifications when eligible members activate this role: Notification to activated user (requestor), additional recipient (UPN)")] String EligibleAssignmentAssigneeNotificationAdditionalRecipient[];
     [Write, Description("Send notifications when eligible members activate this role: Notification to activated user (requestor), only critical Email (True/False)")] Boolean EligibleAssignmentAssigneeNotificationOnlyCritical;
-    [Write, Description("Specify if the Azure AD CA Policy should exist or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Specify if the Azure AD role setting should exist or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Credentials for the Microsoft Graph delegated permissions."), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.schema.mof
@@ -41,6 +41,7 @@ class MSFT_AADRoleSetting : OMI_BaseResource
     [Write, Description("Send notifications when eligible members activate this role: Notification to activated user (requestor), default recipient (True/False)")] Boolean EligibleAssignmentAssigneeNotificationDefaultRecipient;
     [Write, Description("Send notifications when eligible members activate this role: Notification to activated user (requestor), additional recipient (UPN)")] String EligibleAssignmentAssigneeNotificationAdditionalRecipient[];
     [Write, Description("Send notifications when eligible members activate this role: Notification to activated user (requestor), only critical Email (True/False)")] Boolean EligibleAssignmentAssigneeNotificationOnlyCritical;
+    [Write, Description("Specify if the Azure AD CA Policy should exist or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Credentials for the Microsoft Graph delegated permissions."), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;


### PR DESCRIPTION
#### Pull Request (PR) description
Test for P2 using Get-MgPolicyRoleManagementPolicyAssignment was leaving return values on the stack.  Appended `| Out-Null` to drain results.

Add Ensure handling - was added in Get-TargetResource for null entry but was not present as parameter for Test-TargetResource or schema resulting in failed compilation.

#### This Pull Request (PR) fixes the following issues
Fixes #2321
