### PR TITLE
Add -TenantId param to MI connection to support correct environment retrieval

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -246,7 +246,7 @@ function Start-M365DSCConfigurationExtract
         }
         elseif ($AuthMethods -contains 'ManagedIdentity')
         {
-            $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' -InboundParameters @{'ManagedIdentity' = $true }
+            $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' -InboundParameters @{'ManagedIdentity' = $true; 'TenantId' = $TenantId }
             $TenantId = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.TenantId
             $organization = $TenantId
         }
@@ -483,7 +483,7 @@ function Start-M365DSCConfigurationExtract
             }
 
             if (-not [System.String]::IsNullOrEmpty($ApplicationSecret))
-            {=======
+            { =======
                 $ConnectionParams.Add('ApplicationSecret', (New-Object System.Management.Automation.PSCredential ('ApplicationSecret', (ConvertTo-SecureString $ApplicationSecret -AsPlainText -Force))))
             }
 
@@ -553,11 +553,11 @@ function Start-M365DSCConfigurationExtract
 
             if ($ComponentsToSkip -notcontains $resourceName)
             {
-                Write-Host "[$i/$($ResourcesToExport.Length)] Extracting [" -NoNewLine
-                Write-Host $resourceName -ForegroundColor Green -NoNewLine
-                Write-Host "] using {" -NoNewLine
+                Write-Host "[$i/$($ResourcesToExport.Length)] Extracting [" -NoNewline
+                Write-Host $resourceName -ForegroundColor Green -NoNewline
+                Write-Host '] using {' -NoNewline
                 Write-Host $mostSecureAuthMethod -ForegroundColor Cyan -NoNewline
-                Write-Host "}..." -NoNewline
+                Write-Host '}...' -NoNewline
                 $exportString = [System.Text.StringBuilder]::New()
                 if ($GenerateInfo)
                 {

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1838,6 +1838,7 @@ function New-M365DSCConnection
         Write-Verbose -Message 'Connecting via managed identity'
         Connect-M365Tenant -Workload $Workload `
             -Identity `
+            -TenantId $InboundParameters.TenantId `
             -SkipModuleReload $Global:CurrentModeIsExport `
             -ProfileName $ProfileName
 
@@ -3776,7 +3777,7 @@ function Test-M365DSCModuleValidity
     {
         Write-Host "There is a newer version of the 'Microsoft365DSC' module available on the gallery."
         Write-Host "To update the module and it's dependencies, run the following command:"
-        Write-Host "Update-M365DSCModule" -ForegroundColor Blue
+        Write-Host 'Update-M365DSCModule' -ForegroundColor Blue
     }
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
<!--
Add -TenantId param to MI connection requests.  Change required based on change in MSCloudLoginAssistant MI token retrieval method.  Get-AzAccessToken returned tenantId as part of token package, REST call does not so need to include TenantId  specifier to allow supporting MSCloudLoginAssistant methods  to retrieve environment settings.
-->

#### This Pull Request (PR) fixes the following issues
<!--
 None
-->
