### PR TITLE
Ignore Write-Host warning in ScriptAnalyzerSettings.psd1

### DIFF
--- a/.vscode/ScriptAnalyzerSettings.psd1
+++ b/.vscode/ScriptAnalyzerSettings.psd1
@@ -1,7 +1,8 @@
 @{
-    Severity = @('Error',
-                 'Warning')
+    Severity     = @('Error',
+        'Warning')
     ExcludeRules = @('PSMissingModuleManifestField',
-                     'PSUseShouldProcessForStateChangingFunctions',
-                     'PSAvoidGlobalVars')
+        'PSUseShouldProcessForStateChangingFunctions',
+        'PSAvoidGlobalVars',
+        'PSAvoidUsingWriteHost')
 }


### PR DESCRIPTION
#### Pull Request (PR) description

Add PSAvoidUsingWriteHost to stop emitting warnings for Write-Host.  Write-Host is used throughout and is needed for colorization and formatting of output


#### This Pull Request (PR) fixes the following issues

Partial fix for  https://github.com/microsoft/Microsoft365DSC/issues/2326

