### PR TITLE
Fix: Start-M365DSCConfigurationExtract broken for Service Principal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 1.22.1012.1
 
+* EXOManagementRoleAssignment
+  * Initial Release
+  FIXES [#2355](https://github.com/microsoft/Microsoft365DSC/issues/2355)
+  FIXES [#2356](https://github.com/microsoft/Microsoft365DSC/issues/2356)
 * SCRetentionCompliancePolicy
   * Fixed issue where the locations weren't properly returned.
   FIXES [#2338](https://github.com/microsoft/Microsoft365DSC/issues/2338)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   * Fixed issue where the locations weren't properly returned.
   FIXES [#2338](https://github.com/microsoft/Microsoft365DSC/issues/2338)
   FIXES [#2339](https://github.com/microsoft/Microsoft365DSC/issues/2339)
+* MISC
+  * Fixed an issue in in Export-M365DSCConfiguration when used with Service Principal
 
 # 1.22.1005.1
 
@@ -22,7 +24,7 @@
   Implements [#2301](https://github.com/microsoft/Microsoft365DSC/issues/2301)
 * AADTenantDetails
   * Fixed an issue where ApplicationSecret was send to Update-MgOrganization
-* FIXES [[#2340](https://github.com/microsoft/Microsoft365DSC/issues/2340)]
+    FIXES [[#2340](https://github.com/microsoft/Microsoft365DSC/issues/2340)]
 * EXOATPPolicyForO365
   * [BREAKING] Removed the deprecated BlockURLs, AllowClickThrough, EnableSafeLinksForO365Clients and TrackClicks parameters.
 * EXOMailContact
@@ -439,7 +441,7 @@
 # 1.22.511.1
 
 * AADNamedLocationPolicy
- * Added error handling in the Get-TargetResource function.
+* Added error handling in the Get-TargetResource function.
 * EXOIRMConfiguration
   * Initial release.
 * EXOMessageClassification
@@ -831,7 +833,7 @@ MISC
 
 # 1.21.1013.1
 
-  * Obfuscating Authentication Secrets from the Verbose output;
+* Obfuscating Authentication Secrets from the Verbose output;
 
 # 1.21.1006.3
 
@@ -1056,7 +1058,7 @@ MISC
 # 1.21.526.2
 
 *  EXOSafeAttachmentRule
-  * Fixed issue #1213 Policy X already has rule Y associated with it
+* Fixed issue #1213 Policy X already has rule Y associated with it
     if rule exists already
 * MSFT_IntuneDeviceCompliancePolicyAndroid
   * New resource
@@ -1085,7 +1087,7 @@ MISC
   * Forces a Global load of the new MicrosoftTeams module for
     Teams resources;
 
-#1.21.519.1
+# 1.21.519.1
 
 * TeamsClientConfiguration
   * Fixed an issue where the RestrictedSenderList was not properly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@
 * AADUser
   * Renamed from O365User
   * Added support for Roles.
-  FIXES [#2288](https://github.com/microsoft/Microsoft365DSC/issues/2288)
+    FIXES [#2288](https://github.com/microsoft/Microsoft365DSC/issues/2288)
 * AADGroup
   * Added properties MemberOf and AssignedToRole
-  Implements [#2301](https://github.com/microsoft/Microsoft365DSC/issues/2301)
+    Implements [#2301](https://github.com/microsoft/Microsoft365DSC/issues/2301)
 * AADTenantDetails
   * Fixed an issue where ApplicationSecret was send to Update-MgOrganization
     FIXES [[#2340](https://github.com/microsoft/Microsoft365DSC/issues/2340)]
@@ -31,13 +31,13 @@
   * Initial Release.
 * EXOMailTips
   * Fixes an issue where MailTips weren't extracted when using CertificateThumbprint to authenticate.
-  FIXES [#2235](https://github.com/microsoft/Microsoft365DSC/issues/2235)
+    FIXES [#2235](https://github.com/microsoft/Microsoft365DSC/issues/2235)
 * O365User
   * [BREAKING] Resource was renamed to AADUser.
-  FIXES [#2204](https://github.com/microsoft/Microsoft365DSC/issues/2204)
+    FIXES [#2204](https://github.com/microsoft/Microsoft365DSC/issues/2204)
 * IntuneDeviceConfigurationPolicyiOS
   * [Breaking] Changed all the MediaContentRating properties to be CIMInstances.
-  FIXES [#1871](https://github.com/microsoft/Microsoft365DSC/issues/1871)
+    FIXES [#1871](https://github.com/microsoft/Microsoft365DSC/issues/1871)
 * SCSensitivityLabel
   [BREAKING] Changed Setting attribute in MSFT_SCLabelLocaleSettings to LabelSetting since its resevered word and breaking reporting.
   FIXES #2314
@@ -62,7 +62,7 @@
     FIXES [#2283](https://github.com/microsoft/Microsoft365DSC/issues/2283)
 * AADConditionalAccessPolicy
   * Added support for the CustomAuthenticationFactors parameter.
-  FIXES [#2292](https://github.com/microsoft/Microsoft365DSC/issues/2292)
+    FIXES [#2292](https://github.com/microsoft/Microsoft365DSC/issues/2292)
 * O365User
   * Improved extraction performance by leveraging StringBuilder instead of re-assigning string.
 * SCAutoSensitivityLabelPolicy
@@ -98,7 +98,7 @@
     and TeamsChannelLocationException properties were not properly set on Update.
     FIXES #2173
 * SCRetentionComplianceRule
-  * Fixes an issue when trying to create new compliancerule for Teams based policies where invalid
+  * Fixes an issue when trying to create new compliance rule for Teams based policies where invalid
     parameters were passed.
     FIXES #2181
 * DEPENDENCIES
@@ -114,7 +114,7 @@
   * Ignore precanned filters if recipient filter is used. Precanned filters and recipient filter cannot be used at the same time.
     FIXES [#2194](https://github.com/microsoft/Microsoft365DSC/issues/2194)
 * EXOSafeLinksPolicy
-  * Add Suport for EnableSafeLinksForEmail and DisableUrlRewrite
+  * Add Support for EnableSafeLinksForEmail and DisableUrlRewrite
 * EXOInboundConnector
   * Add support for different syntax of SenderDomains parameter
   FIXES [#2180](https://github.com/microsoft/Microsoft365DSC/issues/2180)
@@ -314,17 +314,17 @@
 * EXOSafeLinksPolicy
   * Deprecated properties DoNotAllowClickThrough, DoNotTrackUserClicks & IsEnabled.
 * IntuneAppProtectionPolicyiOS
-   * Fixed issue with creation a new policies where it was complaining about invalid minimum versions.
-   * Fixed issues where creating new policies threw an error complaining about an invalid duration format.
+  * Fixed issue with creation a new policies where it was complaining about invalid minimum versions.
+  * Fixed issues where creating new policies threw an error complaining about an invalid duration format.
      FIXES [#2019](https://github.com/microsoft/Microsoft365DSC/issues/2019)
-   * Added the CustomBrowserProtocol paramters.
+  * Added the CustomBrowserProtocol paramters.
      FIXES [#2009](https://github.com/microsoft/Microsoft365DSC/issues/2009)
 * IntuneDeviceAndAppManagementAssignmentFilter
   * Initial release.
 * SCComplianceTag
   * Fixed issue where FilePlanProperty was not properly applied unless another child property was also modified.
 * SPOSharingSettings
-    * Updated code to remove None as valid value for DefaultLinkPermission. If value is set to None default to Edit.
+  * Updated code to remove None as valid value for DefaultLinkPermission. If value is set to None default to Edit.
 * DEPENDENCIES
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.150.
   * Updated MSCloudLoginAssistant to version 1.0.87.
@@ -366,7 +366,7 @@
 # 1.22.622.1
 
 * TeamsMessagingPolicy
-    * Removed the -force deprecated parameter on New/Set/Remove
+  * Removed the -force deprecated parameter on New/Set/Remove
 * MISC
   * Modified the dependency installation functions to for the AllUsers scope.
 
@@ -1057,8 +1057,8 @@ MISC
 
 # 1.21.526.2
 
-*  EXOSafeAttachmentRule
-* Fixed issue #1213 Policy X already has rule Y associated with it
+* EXOSafeAttachmentRule
+  * Fixed issue #1213 Policy X already has rule Y associated with it
     if rule exists already
 * MSFT_IntuneDeviceCompliancePolicyAndroid
   * New resource
@@ -1098,7 +1098,7 @@ MISC
 
 # 1.21.512.1
 
-* EXOOfflineAddresBook
+* EXOOfflineAddressBook
   * Fixed issue in Set-TargetResource where ConfiguredAttributes
     was passed and resulted in an error.
 * SCDLPComplianceRule
@@ -1110,7 +1110,7 @@ MISC
 * EXOTransportRule
   * Adding ExceptIfSCLOver and SCLOver.
   * Fixes SubjectOrBodyContainsWords parameter not being an array.
-  * Fixes DateTime formating on ExpiryDate and ActivationDate
+  * Fixes DateTime formatting on ExpiryDate and ActivationDate
 
 # 1.21.428.2
 
@@ -1201,7 +1201,7 @@ MISC
 * SPOSiteDesign
   * Added support for GrouplessTeamSite web template.
 * SPOSiteScript
-  * Fixed issue where an existin site script could not be updated.
+  * Fixed issue where an existing site script could not be updated.
   * Made parameter GlobalAdminAccount in Get-TargetResource
     optional.
 * SPOTheme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# 1.22.1012.1
+
+* SCRetentionCompliancePolicy
+  * Fixed issue where the locations weren't properly returned.
+  FIXES [#2338](https://github.com/microsoft/Microsoft365DSC/issues/2338)
+  FIXES [#2339](https://github.com/microsoft/Microsoft365DSC/issues/2339)
+
 # 1.22.1005.1
 
 * AADUser

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/MSFT_EXOManagementRoleAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/MSFT_EXOManagementRoleAssignment.psm1
@@ -1,0 +1,567 @@
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateLength(1, 64)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Role,
+
+        [Parameter()]
+        [System.String]
+        $App,
+
+        [Parameter()]
+        [System.String]
+        $Policy,
+
+        [Parameter()]
+        [System.String]
+        $SecurityGroup,
+
+        [Parameter()]
+        [System.String]
+        $User,
+
+        [Parameter()]
+        [System.String]
+        $CustomRecipientWriteScope,
+
+        [Parameter()]
+        [System.String]
+        $CustomResourceScope,
+
+        [Parameter()]
+        [System.String]
+        $ExclusiveRecipientWriteScope,
+
+        [Parameter()]
+        [System.String]
+        $RecipientAdministrativeUnitScope,
+
+        [Parameter()]
+        [System.String]
+        $RecipientOrganizationalUnitScope,
+
+        [Parameter()]
+        [System.String]
+        $RecipientRelativeWriteScope,
+
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [System.String]
+        $CertificatePath,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $CertificatePassword
+    )
+
+    Write-Verbose -Message "Getting Management Role Assignment for $Name"
+    if ($Global:CurrentModeIsExport)
+    {
+        $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
+            -InboundParameters $PSBoundParameters `
+            -SkipModuleReload $true
+    }
+    else
+    {
+        $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
+            -InboundParameters $PSBoundParameters
+    }
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName -replace "MSFT_", ""
+    $CommandName  = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    $nullReturn = $PSBoundParameters
+    $nullReturn.Ensure = "Absent"
+
+    try
+    {
+        $roleAssignment = Get-ManagementRoleAssignment -Identity $Name -ErrorAction Stop
+
+        if ($null -eq $roleAssignment)
+        {
+            Write-Verbose -Message "Management Role Assignment $($Name) does not exist."
+            return $nullReturn
+        }
+        else
+        {
+            $result = @{
+                Name                             = $roleAssignment.Name
+                CustomRecipientWriteScope        = $roleAssignment.CustomRecipientWriteScope
+                CustomResourceScope              = $roleAssignment.CustomResourceScope
+                ExclusiveRecipientWriteScope     = $roleAssignment.ExclusiveRecipientWriteScope
+                RecipientAdministrativeUnitScope = $roleAssignment.RecipientAdministrativeUnitScope
+                RecipientOrganizationalUnitScope = $roleAssignment.RecipientOrganizationalUnitScope
+                RecipientRelativeWriteScope      = $roleAssignment.RecipientRelativeWriteScope
+                Role                             = $roleAssignment.Role
+                Ensure                           = 'Present'
+                Credential                       = $Credential
+                ApplicationId                    = $ApplicationId
+                CertificateThumbprint            = $CertificateThumbprint
+                CertificatePath                  = $CertificatePath
+                CertificatePassword              = $CertificatePassword
+                TenantId                         = $TenantId
+            }
+
+            if ($roleAssignment.RoleAssigneeType -eq 'SecurityGroup')
+            {
+                $result.Add("SecurityGroup", $roleAssignment.RoleAssignee)
+            }
+            elseif ($roleAssignment.RoleAssigneeType -eq 'RoleAssignmentPolicy')
+            {
+                $result.Add("Policy", $roleAssignment.RoleAssignee)
+            }
+            elseif ($roleAssignment.RoleAssigneeType -eq 'ServicePrincipal')
+            {
+                $result.Add("App", $roleAssignment.RoleAssignee)
+            }
+            elseif ($roleAssignment.RoleAssigneeType -eq 'User')
+            {
+                $result.Add("User", $roleAssignment.RoleAssignee)
+            }
+
+            Write-Verbose -Message "Found Management Role Assignment $($Name)"
+            return $result
+        }
+    }
+    catch
+    {
+        try
+        {
+            Write-Verbose -Message $_
+            $tenantIdValue = ""
+            if (-not [System.String]::IsNullOrEmpty($TenantId))
+            {
+                $tenantIdValue = $TenantId
+            }
+            elseif ($null -ne $Credential)
+            {
+                $tenantIdValue = $Credential.UserName.Split('@')[1]
+            }
+            Add-M365DSCEvent -Message $_ -EntryType 'Error' `
+                -EventID 1 -Source $($MyInvocation.MyCommand.Source) `
+                -TenantId $tenantIdValue
+        }
+        catch
+        {
+            Write-Verbose -Message $_
+        }
+        return $nullReturn
+    }
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateLength(1, 64)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Role,
+
+        [Parameter()]
+        [System.String]
+        $App,
+
+        [Parameter()]
+        [System.String]
+        $Policy,
+
+        [Parameter()]
+        [System.String]
+        $SecurityGroup,
+
+        [Parameter()]
+        [System.String]
+        $User,
+
+        [Parameter()]
+        [System.String]
+        $CustomRecipientWriteScope,
+
+        [Parameter()]
+        [System.String]
+        $CustomResourceScope,
+
+        [Parameter()]
+        [System.String]
+        $ExclusiveRecipientWriteScope,
+
+        [Parameter()]
+        [System.String]
+        $RecipientAdministrativeUnitScope,
+
+        [Parameter()]
+        [System.String]
+        $RecipientOrganizationalUnitScope,
+
+        [Parameter()]
+        [System.String]
+        $RecipientRelativeWriteScope,
+
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [System.String]
+        $CertificatePath,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $CertificatePassword
+    )
+
+    Write-Verbose -Message "Setting Management Role Assignment for $Name"
+
+    $currentManagementRoleConfig = Get-TargetResource @PSBoundParameters
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName -replace "MSFT_", ""
+    $CommandName  = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
+        -InboundParameters $PSBoundParameters
+
+    $NewManagementRoleParams = $PSBoundParameters
+    $NewManagementRoleParams.Remove("Ensure") | Out-Null
+    $NewManagementRoleParams.Remove("Credential") | Out-Null
+    $NewManagementRoleParams.Remove("ApplicationId") | Out-Null
+    $NewManagementRoleParams.Remove("TenantId") | Out-Null
+    $NewManagementRoleParams.Remove("CertificateThumbprint") | Out-Null
+    $NewManagementRoleParams.Remove("CertificatePath") | Out-Null
+    $NewManagementRoleParams.Remove("CertificatePassword") | Out-Null
+
+    # CASE: Management Role doesn't exist but should;
+    if ($Ensure -eq "Present" -and $currentManagementRoleConfig.Ensure -eq "Absent")
+    {
+        Write-Verbose -Message "Management Role Assignment'$($Name)' does not exist but it should. Create and configure it."
+        # Create Management Role
+        New-ManagementRoleAssignment @NewManagementRoleParams
+
+    }
+    # CASE: Management Role exists but it shouldn't;
+    elseif ($Ensure -eq "Absent" -and $currentManagementRoleConfig.Ensure -eq "Present")
+    {
+        Write-Verbose -Message "Management Role Assignment'$($Name)' exists but it shouldn't. Remove it."
+        Remove-ManagementRoleAssignment -Identity $Name -Confirm:$false -Force
+    }
+    # CASE: Management Role exists and it should, but has different values than the desired ones
+    elseif ($Ensure -eq "Present" -and $currentManagementRoleConfig.Ensure -eq "Present")
+    {
+        Write-Verbose -Message "Management Role Assignment'$($Name)' already exists, but needs updating."
+        $NewManagementRoleParams.Add("Identity", $Name)
+        $NewManagementRoleParams.Remove("Name") | Out-Null
+        Set-ManagementRoleAssignment @NewManagementRoleParams
+    }
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateLength(1, 64)]
+        [System.String]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Role,
+
+        [Parameter()]
+        [System.String]
+        $App,
+
+        [Parameter()]
+        [System.String]
+        $Policy,
+
+        [Parameter()]
+        [System.String]
+        $SecurityGroup,
+
+        [Parameter()]
+        [System.String]
+        $User,
+
+        [Parameter()]
+        [System.String]
+        $CustomRecipientWriteScope,
+
+        [Parameter()]
+        [System.String]
+        $CustomResourceScope,
+
+        [Parameter()]
+        [System.String]
+        $ExclusiveRecipientWriteScope,
+
+        [Parameter()]
+        [System.String]
+        $RecipientAdministrativeUnitScope,
+
+        [Parameter()]
+        [System.String]
+        $RecipientOrganizationalUnitScope,
+
+        [Parameter()]
+        [System.String]
+        $RecipientRelativeWriteScope,
+
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [System.String]
+        $CertificatePath,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $CertificatePassword
+    )
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName -replace "MSFT_", ""
+    $CommandName  = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    Write-Verbose -Message "Testing Management Role Assignment for $Name"
+
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
+    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
+
+    $ValuesToCheck = $PSBoundParameters
+    $ValuesToCheck.Remove('Credential') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('CertificateThumbprint') | Out-Null
+    $ValuesToCheck.Remove('CertificatePath') | Out-Null
+    $ValuesToCheck.Remove('CertificatePassword') | Out-Null
+
+    $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
+        -Source $($MyInvocation.MyCommand.Source) `
+        -DesiredValues $PSBoundParameters `
+        -ValuesToCheck $ValuesToCheck.Keys
+
+    Write-Verbose -Message "Test-TargetResource returned $TestResult"
+
+    return $TestResult
+}
+
+function Export-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [System.String]
+        $CertificatePath,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $CertificatePassword
+    )
+    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
+        -InboundParameters $PSBoundParameters `
+        -SkipModuleReload $true
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName -replace "MSFT_", ""
+    $CommandName  = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    try
+    {
+        [array]$roleAssignments = Get-ManagementRoleAssignment | Where-Object -FilterScript {$_.RoleAssigneeType -eq 'ServicePrincipal' -or `
+            $_.RoleAssigneeType -eq 'User' -or $_.RoleAssigneeType -eq 'RoleAssignmentPolicy' -or $_.RoleAssigneeType -eq 'SecurityGroup'}
+
+        $dscContent = ""
+
+        if ($roleAssignments.Length -eq 0)
+        {
+            Write-Host $Global:M365DSCEmojiGreenCheckMark
+        }
+        else
+        {
+            Write-Host "`r`n" -NoNewline
+        }
+        $i = 1
+        foreach ($assignment in $roleAssignments)
+        {
+            Write-Host "    |---[$i/$($roleAssignments.Count)] $($assignment.Name)" -NoNewline
+
+            $Params = @{
+                Name                  = $assignment.Name
+                Role                  = $assignment.Role
+                Credential            = $Credential
+                ApplicationId         = $ApplicationId
+                TenantId              = $TenantId
+                CertificateThumbprint = $CertificateThumbprint
+                CertificatePassword   = $CertificatePassword
+                CertificatePath       = $CertificatePath
+            }
+            $Results = Get-TargetResource @Params
+            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
+                -Results $Results
+            $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
+                -ConnectionMode $ConnectionMode `
+                -ModulePath $PSScriptRoot `
+                -Results $Results `
+                -Credential $Credential
+            $dscContent += $currentDSCBlock
+            Save-M365DSCPartialExport -Content $currentDSCBlock `
+                -FileName $Global:PartialExportFileName
+            Write-Host $Global:M365DSCEmojiGreenCheckMark
+            $i++
+        }
+        return $dscContent
+    }
+    catch
+    {
+        try
+        {
+            Write-Host $Global:M365DSCEmojiRedX
+            Write-Verbose -Message $_
+            $tenantIdValue = ""
+            if (-not [System.String]::IsNullOrEmpty($TenantId))
+            {
+                $tenantIdValue = $TenantId
+            }
+            elseif ($null -ne $Credential)
+            {
+                $tenantIdValue = $Credential.UserName.Split('@')[1]
+            }
+            Add-M365DSCEvent -Message $_ -EntryType 'Error' `
+                -EventID 1 -Source $($MyInvocation.MyCommand.Source) `
+                -TenantId $tenantIdValue
+        }
+        catch
+        {
+            Write-Verbose -Message $_
+        }
+        return ""
+    }
+}
+
+Export-ModuleMember -Function *-TargetResource
+

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/MSFT_EXOManagementRoleAssignment.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/MSFT_EXOManagementRoleAssignment.schema.mof
@@ -1,0 +1,23 @@
+[ClassVersion("1.0.0.0"), FriendlyName("EXOManagementRoleAssignment")]
+class MSFT_EXOManagementRoleAssignment : OMI_BaseResource
+{
+    [Key, Description("The Name parameter specifies a name for the new management role assignment. The maximum length of the name is 64 characters.")] String Name;
+    [Key, Description("The Role parameter specifies the existing role to assign. You can use any value that uniquely identifies the role.")] String Role;
+    [Write, Description("The App parameter specifies the service principal to assign the management role to. Specifically, the ServiceId GUID value from the output of the Get-ServicePrincipal cmdlet (for example, 6233fba6-0198-4277-892f-9275bf728bcc).")] String App;
+    [Write, Description("The Policy parameter specifies the name of the management role assignment policy to assign the management role to.")] String Policy;
+    [Write, Description("The SecurityGroup parameter specifies the name of the management role group or mail-enabled universal security group to assign the management role to.")] String SecurityGroup;
+    [Write, Description("The User parameter specifies the name or alias of the user to assign the management role to.")] String User;
+    [Write, Description("The CustomRecipientWriteScope parameter specifies the existing recipient-based management scope to associate with this management role assignment.")] String CustomRecipientWriteScope;
+    [Write, Description("The CustomResourceScope parameter specifies the custom management scope to associate with this management role assignment. You can use any value that uniquely identifies the management scope.")] String CustomResourceScope;
+    [Write, Description("The ExclusiveConfigWriteScope parameter specifies the exclusive configuration-based management scope to associate with the new role assignment.")] String ExclusiveRecipientWriteScope;
+    [Write, Description("The RecipientAdministrativeUnitScope parameter specifies the administrative unit to scope the new role assignment to.")] String RecipientAdministrativeUnitScope;
+    [Write, Description("The RecipientOrganizationalUnitScope parameter specifies the OU to scope the new role assignment to. If you use the RecipientOrganizationalUnitScope parameter, you can't use the CustomRecipientWriteScope or ExclusiveRecipientWriteScope parameters.")] String RecipientOrganizationalUnitScope;
+    [Write, Description("The RecipientRelativeWriteScope parameter specifies the type of restriction to apply to a recipient scope. The available types are None, Organization, MyGAL, Self, and MyDistributionGroups. The RecipientRelativeWriteScope parameter is automatically set when the CustomRecipientWriteScope or RecipientOrganizationalUnitScope parameters are used.")] String RecipientRelativeWriteScope;
+    [Write, Description("Specify if the Management Role Assignment should exist or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Credentials of the Exchange Global Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
+    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
+    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
+    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
+    [Write, Description("Username can be made up to anything but password will be used for CertificatePassword"), EmbeddedInstance("MSFT_Credential")] String CertificatePassword;
+    [Write, Description("Path to certificate used in service principal usually a PFX file.")] String CertificatePath;
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/readme.md
@@ -1,0 +1,5 @@
+# EXOManagementRole
+
+## Description
+
+This resource configures RBAC Management Roles in Exchange Online.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/settings.json
@@ -1,0 +1,23 @@
+﻿{
+    "resourceName": "EXOManagementRole",
+    "description": "",
+    "permissions": {
+        "graph": {
+            "delegated": {
+                "read": [],
+                "update": []
+            },
+            "application": {
+                "read": [],
+                "update": []
+            }
+        },
+        "exchange": {
+            "requiredroles": [
+                "Role Management",
+                "View-Only Configuration"
+            ],
+            "requiredrolegroups": "Organization Management"
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionCompliancePolicy/MSFT_SCRetentionCompliancePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionCompliancePolicy/MSFT_SCRetentionCompliancePolicy.psm1
@@ -123,7 +123,7 @@ function Get-TargetResource
     $nullReturn.Ensure = 'Absent'
     try
     {
-        $PolicyObject = Get-RetentionCompliancePolicy $Name -ErrorAction SilentlyContinue
+        $PolicyObject = Get-RetentionCompliancePolicy $Name -DistributionDetail -ErrorAction SilentlyContinue
 
         if ($null -eq $PolicyObject)
         {
@@ -146,7 +146,7 @@ function Get-TargetResource
                     TeamsChannelLocationException = $PolicyObject.TeamsChannelLocationException
                     TeamsChatLocation             = [array]$PolicyObject.TeamsChatLocation
                     TeamsChatLocationException    = $PolicyObject.TeamsChatLocationException
-                    Credential            = $Credential
+                    Credential                    = $Credential
                 }
             }
             else

--- a/Modules/Microsoft365DSC/Examples/Resources/EXOManagementRoleAssignment/1-NewManagementRoleAssignment.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/EXOManagementRoleAssignment/1-NewManagementRoleAssignment.ps1
@@ -1,0 +1,26 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $credsCredential
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        EXOManagementRoleAssignment 'AssignManagementRole'
+        {
+            Credential           = $credsCredential;
+            Ensure               = "Present";
+            Name                 = "MyManagementRoleAssignment";
+            Role                 = "UserApplication";
+            User                 = "John.Smith";
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -11,7 +11,7 @@
     # RootModule = ''
 
     # Version number of this module.
-    ModuleVersion     = '1.22.921.1'
+    ModuleVersion     = '1.22.1005.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -235,7 +235,11 @@ function Start-M365DSCConfigurationExtract
                 $AuthMethods -contains 'ApplicationWithSecret')
         {
             $organization = Get-M365DSCTenantDomain -ApplicationId $ApplicationId `
-                -TenantId $TenantId
+                -TenantId $TenantId `
+                -CertificateThumbprint $CertificateThumbprint `
+                -ApplicationSecret $ApplicationSecret `
+                -CertificatePath $CertificatePath
+
         }
         elseif ($AuthMethods -Contains 'Credentials')
         {
@@ -253,7 +257,7 @@ function Start-M365DSCConfigurationExtract
         $AzureAutomation = $false
         if ($organization.IndexOf('.') -gt 0)
         {
-            $principal = $organization.Split('.')[0]
+            $organization = $organization.Split('.')[0]
         }
 
         [array] $version = Get-Module 'Microsoft365DSC'

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOManagementRoleAssignment.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOManagementRoleAssignment.Tests.ps1
@@ -1,0 +1,220 @@
+[CmdletBinding()]
+param(
+)
+$M365DSCTestFolder = Join-Path -Path $PSScriptRoot `
+                        -ChildPath "..\..\Unit" `
+                        -Resolve
+$CmdletModule = (Join-Path -Path $M365DSCTestFolder `
+            -ChildPath "\Stubs\Microsoft365.psm1" `
+            -Resolve)
+$GenericStubPath = (Join-Path -Path $M365DSCTestFolder `
+    -ChildPath "\Stubs\Generic.psm1" `
+    -Resolve)
+Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath "\UnitTestHelper.psm1" `
+        -Resolve)
+
+$Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
+    -DscResource "EXOManagementRoleAssignment" -GenericStubModule $GenericStubPath
+Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
+
+        BeforeAll {
+            $secpasswd = ConvertTo-SecureString "test@password1" -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ("tenantadmin", $secpasswd)
+
+            $Global:PartialExportFileName = "c:\TestPath"
+            Mock -CommandName Update-M365DSCExportAuthenticationResults -MockWith {
+                return @{}
+            }
+
+            Mock -CommandName Get-M365DSCExportContentForResource -MockWith {
+                return "FakeDSCContent"
+            }
+            Mock -CommandName Save-M365DSCPartialExport -MockWith {
+            }
+
+            Mock -CommandName New-M365DSCConnection -MockWith {
+                return "Credentials"
+            }
+
+            Mock -CommandName Get-PSSession -MockWith {
+
+            }
+
+            Mock -CommandName New-ManagementRoleAssignment -MockWith {
+
+            }
+
+            Mock -CommandName Set-ManagementRoleAssignment -MockWith {
+
+            }
+
+            Mock -CommandName Remove-ManagementRoleAssignment -MockWith {
+
+            }
+
+            Mock -CommandName Remove-PSSession -MockWith {
+
+            }
+        }
+
+        # Test contexts
+        Context -Name "Management Role Assignment should exist, but it is not." -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Name               = "Contoso Management Role"
+                    Role               = "MyRole"
+                    User               = "John.Smith"
+                    Ensure             = 'Present'
+                    Credential         = $Credential
+                }
+
+                Mock -CommandName Get-ManagementRoleAssignment -MockWith {
+                    return $null
+                }
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It "Should call the Set method" {
+                Set-TargetResource @testParams
+                Assert-MockCalled -CommandName New-ManagementRoleAssignment -Exactly 1
+            }
+
+            It "Should return Absent from the Get method" {
+                (Get-TargetResource @testParams).Ensure | Should -Be "Absent"
+            }
+        }
+
+        Context -Name "Management Role Assignment exists and is in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Name               = "Contoso Management Role"
+                    Role               = "MyRole"
+                    User               = "John.Smith"
+                    Ensure             = 'Present'
+                    Credential         = $Credential
+                }
+
+                Mock -CommandName Get-ManagementRoleAssignment -MockWith {
+                    return @{
+                        Name             = "Contoso Management Role"
+                        Role             = "MyRole"
+                        RoleAssignee     = "John.Smith"
+                        RoleAssigneeType = "User"
+                    }
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+
+            It 'Should return Present from the Get Method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be "Present"
+            }
+        }
+
+        Context -Name "Management Role Assignment exists and is NOT the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Name                             = "Contoso Management Role"
+                    Role                             = "MyRole"
+                    User                             = "Bob.Houle"
+                    RecipientOrganizationalUnitScope = "contoso.com/Legal/Users"
+                    Ensure                           = 'Present'
+                    Credential                       = $Credential
+                }
+
+                Mock -CommandName Get-ManagementRoleAssignment -MockWith {
+                    return @{
+                        Name                             = "Contoso Management Role"
+                        Role                             = "MyRole"
+                        RecipientOrganizationalUnitScope = "contoso.com/Drift/Users"
+                        RoleAssignee                     = "Bob.Houle"
+                        RoleAssigneeType                 = "User"
+                    }
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should return Present from the Get Method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be "Present"
+            }
+
+            It "Should call the Set method" {
+                Set-TargetResource @testParams
+                Assert-MockCalled -CommandName Set-ManagementRoleAssignment -Exactly 1
+            }
+        }
+
+        Context -Name "Management Role Assignment exists and it SHOULD NOT." -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Name               = "Contoso Management Role"
+                    Role               = "MyRole"
+                    Ensure             = 'Absent'
+                    Credential         = $Credential
+                }
+
+                Mock -CommandName Get-ManagementRoleAssignment -MockWith {
+                    return @{
+                        Name             = "Contoso Management Role"
+                        Role             = "MyRole"
+                        RoleAssignee     = "Bob.Houle"
+                        RoleAssigneeType = "User"
+                    }
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should return Present from the Get Method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be "Present"
+            }
+
+            It "Should call the Set method" {
+                Set-TargetResource @testParams
+                Assert-MockCalled -CommandName Remove-ManagementRoleAssignment -Exactly 1
+            }
+        }
+
+        Context -Name "ReverseDSC Tests" -Fixture {
+            BeforeAll {
+                $Global:CurrentModeIsExport = $true
+                $testParams = @{
+                    Credential = $Credential
+                }
+
+                $ManagementRole = @{
+                    Name        = "Contoso Management Role Assignment"
+                    Parent      = "MyRole"
+                }
+
+                Mock -CommandName Get-ManagementRoleAssignment -MockWith {
+                    return @{
+                        Name             = "Contoso Management Role"
+                        Role             = "MyRole"
+                        RoleAssignee     = "Bob.Houle"
+                        RoleAssigneeType = "User"
+                    }
+                }
+            }
+
+            It "Should Reverse Engineer resource from the Export method when single" {
+                Export-TargetResource @testParams
+            }
+        }
+    }
+}
+
+Invoke-Command -ScriptBlock $Global:DscHelper.CleanupScript -NoNewScope

--- a/Tests/Unit/Stubs/Microsoft365.psm1
+++ b/Tests/Unit/Stubs/Microsoft365.psm1
@@ -763,6 +763,75 @@ function Get-ManagementRole
         $GetChildren
     )
 }
+function Get-ManagementRoleAssignment
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.Object]
+        $RoleAssigneeType,
+
+        [Parameter()]
+        [System.Object]
+        $CustomRecipientWriteScope,
+
+        [Parameter()]
+        [System.Object]
+        $Identity,
+
+        [Parameter()]
+        [System.Boolean]
+        $Enabled,
+
+        [Parameter()]
+        [System.Object]
+        $RecipientWriteScope,
+
+        [Parameter()]
+        [System.Object]
+        $WritableRecipient,
+
+        [Parameter()]
+        [System.Object]
+        $ConfigWriteScope,
+
+        [Parameter()]
+        [System.Object]
+        $RoleAssignee,
+
+        [Parameter()]
+        [System.Boolean]
+        $Delegating,
+
+        [Parameter()]
+        [System.Boolean]
+        $Exclusive,
+
+        [Parameter()]
+        [System.Object[]]
+        $AssignmentMethod,
+
+        [Parameter()]
+        [System.Object]
+        $Role,
+
+        [Parameter()]
+        [System.Object]
+        $RecipientAdministrativeUnitScope,
+
+        [Parameter()]
+        [System.Object]
+        $ExclusiveRecipientWriteScope,
+
+        [Parameter()]
+        [System.Object]
+        $RecipientOrganizationalUnitScope,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $GetEffectiveUsers
+    )
+}
 function Get-MessageClassification
 {
     [CmdletBinding()]
@@ -1009,6 +1078,19 @@ function Get-SafeLinksRule
         [Parameter()]
         [System.Object]
         $State
+    )
+}
+function Get-ServicePrincipal
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.Object]
+        $Identity,
+
+        [Parameter()]
+        [System.Object]
+        $Organization
     )
 }
 function Get-SharingPolicy
@@ -7826,6 +7908,59 @@ function Set-MalwareFilterRule
         $ExceptIfSentToMemberOf
     )
 }
+function Set-ManagementRoleAssignment
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Force,
+
+        [Parameter()]
+        [System.Object]
+        $CustomRecipientWriteScope,
+
+        [Parameter()]
+        [System.String]
+        $User,
+
+        [Parameter()]
+        [System.String]
+        $Role,
+
+        [Parameter()]
+        [System.Object]
+        $RecipientAdministrativeUnitScope,
+
+        [Parameter()]
+        [System.Object]
+        $ExclusiveRecipientWriteScope,
+
+        [Parameter()]
+        [System.Object]
+        $CustomResourceScope,
+
+        [Parameter()]
+        [System.Object]
+        $Identity,
+
+        [Parameter()]
+        [System.Boolean]
+        $Enabled,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
+
+        [Parameter()]
+        [System.Object]
+        $RecipientRelativeWriteScope,
+
+        [Parameter()]
+        [System.Object]
+        $RecipientOrganizationalUnitScope
+    )
+}
 function Set-MessageClassification
 {
     [CmdletBinding()]
@@ -10990,6 +11125,10 @@ function Get-MgApplicationOwner
         $Sort,
 
         [Parameter()]
+        [System.String]
+        $ConsistencyLevel,
+
+        [Parameter()]
         [System.Management.Automation.SwitchParameter]
         $All,
 
@@ -11116,6 +11255,10 @@ function Get-MgServicePrincipalAppRoleAssignment
         $ProxyUseDefaultCredentials,
 
         [Parameter()]
+        [System.String]
+        $AppRoleAssignmentId,
+
+        [Parameter()]
         [System.Int32]
         $PageSize,
 
@@ -11149,7 +11292,7 @@ function Get-MgServicePrincipalAppRoleAssignment
 
         [Parameter()]
         [System.String]
-        $AppRoleAssignmentId,
+        $ConsistencyLevel,
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
@@ -13036,10 +13179,6 @@ function New-MgDeviceManagementDeviceConfiguration
         $AdditionalProperties,
 
         [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $SupportsScopeTags,
-
-        [Parameter()]
         [PSObject]
         $DeviceManagementApplicabilityRuleOSVersion,
 
@@ -13058,6 +13197,10 @@ function New-MgDeviceManagementDeviceConfiguration
         [Parameter()]
         [System.Int32]
         $Version,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
 
         [Parameter()]
         [PSObject]
@@ -13090,10 +13233,6 @@ function New-MgDeviceManagementDeviceConfiguration
         [Parameter()]
         [System.Management.Automation.PSCredential]
         $ProxyCredential,
-
-        [Parameter()]
-        [System.String[]]
-        $RoleScopeTagIds,
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
@@ -13281,10 +13420,6 @@ function Update-MgDeviceManagement
 
         [Parameter()]
         [PSObject]
-        $TroubleshootingEvents,
-
-        [Parameter()]
-        [PSObject]
         $BodyParameter,
 
         [Parameter()]
@@ -13310,6 +13445,10 @@ function Update-MgDeviceManagement
         [Parameter()]
         [PSObject]
         $ZebraFotaConnector,
+
+        [Parameter()]
+        [PSObject]
+        $UserExperienceAnalyticsDevicesWithoutCloudIdentity,
 
         [Parameter()]
         [PSObject]
@@ -13389,11 +13528,11 @@ function Update-MgDeviceManagement
 
         [Parameter()]
         [PSObject]
-        $DeviceConfigurations,
+        $MobileThreatDefenseConnectors,
 
         [Parameter()]
         [PSObject]
-        $NotificationMessageTemplates,
+        $ImportedWindowsAutopilotDeviceIdentities,
 
         [Parameter()]
         [PSObject]
@@ -13413,15 +13552,7 @@ function Update-MgDeviceManagement
 
         [Parameter()]
         [PSObject]
-        $UserExperienceAnalyticsDevicePerformance,
-
-        [Parameter()]
-        [PSObject]
         $RoleAssignments,
-
-        [Parameter()]
-        [System.DateTime]
-        $LastReportAggregationDateTime,
 
         [Parameter()]
         [PSObject]
@@ -13489,6 +13620,10 @@ function Update-MgDeviceManagement
 
         [Parameter()]
         [PSObject]
+        $DeviceConfigurations,
+
+        [Parameter()]
+        [PSObject]
         $RemoteAssistanceSettings,
 
         [Parameter()]
@@ -13502,10 +13637,6 @@ function Update-MgDeviceManagement
         [Parameter()]
         [PSObject]
         $GroupPolicyConfigurations,
-
-        [Parameter()]
-        [PSObject]
-        $DeviceCategories,
 
         [Parameter()]
         [System.Collections.Hashtable]
@@ -13533,7 +13664,7 @@ function Update-MgDeviceManagement
 
         [Parameter()]
         [PSObject]
-        $ApplePushNotificationCertificate,
+        $DeviceShellScripts,
 
         [Parameter()]
         [PSObject]
@@ -13557,15 +13688,15 @@ function Update-MgDeviceManagement
 
         [Parameter()]
         [PSObject]
-        $UserExperienceAnalyticsDevicesWithoutCloudIdentity,
-
-        [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $Confirm,
+        $TroubleshootingEvents,
 
         [Parameter()]
         [PSObject]
         $UserExperienceAnalyticsBatteryHealthCapacityDetails,
+
+        [Parameter()]
+        [PSObject]
+        $ManagedDeviceOverview,
 
         [Parameter()]
         [PSObject]
@@ -13594,6 +13725,10 @@ function Update-MgDeviceManagement
         [Parameter()]
         [PSObject]
         $ComplianceCategories,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
 
         [Parameter()]
         [PSObject]
@@ -13658,10 +13793,6 @@ function Update-MgDeviceManagement
         [Parameter()]
         [PSObject]
         $IosUpdateStatuses,
-
-        [Parameter()]
-        [System.DateTime]
-        $DeviceComplianceReportSummarizationDateTime,
 
         [Parameter()]
         [PSObject]
@@ -13756,10 +13887,6 @@ function Update-MgDeviceManagement
         $HttpPipelinePrepend,
 
         [Parameter()]
-        [PSObject]
-        $Settings,
-
-        [Parameter()]
         [System.Management.Automation.PSCredential]
         $ProxyCredential,
 
@@ -13797,11 +13924,11 @@ function Update-MgDeviceManagement
 
         [Parameter()]
         [PSObject]
-        $DeviceShellScripts,
+        $ApplePushNotificationCertificate,
 
         [Parameter()]
         [PSObject]
-        $ImportedWindowsAutopilotDeviceIdentities,
+        $DeviceCategories,
 
         [Parameter()]
         [PSObject]
@@ -13829,7 +13956,7 @@ function Update-MgDeviceManagement
 
         [Parameter()]
         [PSObject]
-        $ManagedDeviceOverview,
+        $NotificationMessageTemplates,
 
         [Parameter()]
         [PSObject]
@@ -13864,10 +13991,6 @@ function Update-MgDeviceManagement
         $Monitoring,
 
         [Parameter()]
-        [PSObject]
-        $MobileThreatDefenseConnectors,
-
-        [Parameter()]
         [System.Management.Automation.SwitchParameter]
         $Break,
 
@@ -13882,10 +14005,6 @@ function Update-MgDeviceManagement
         [Parameter()]
         [PSObject]
         $GroupPolicyCategories,
-
-        [Parameter()]
-        [PSObject]
-        $AssignmentFilters,
 
         [Parameter()]
         [PSObject]
@@ -13932,8 +14051,8 @@ function Update-MgDeviceManagement
         $WindowsQualityUpdateProfiles,
 
         [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $UnlicensedAdminstratorsEnabled,
+        [PSObject]
+        $AssignmentFilters,
 
         [Parameter()]
         [PSObject]
@@ -13942,6 +14061,10 @@ function Update-MgDeviceManagement
         [Parameter()]
         [PSObject]
         $MicrosoftTunnelServerLogCollectionResponses,
+
+        [Parameter()]
+        [PSObject]
+        $Settings,
 
         [Parameter()]
         [PSObject]
@@ -13984,8 +14107,8 @@ function Update-MgDeviceManagement
         $Proxy,
 
         [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $LegacyPcManangementEnabled,
+        [PSObject]
+        $UserExperienceAnalyticsDevicePerformance,
 
         [Parameter()]
         [PSObject]
@@ -14228,7 +14351,7 @@ function Update-MgDeviceManagementDeviceConfiguration
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
-        $SupportsScopeTags,
+        $ProxyUseDefaultCredentials,
 
         [Parameter()]
         [PSObject]
@@ -14297,10 +14420,6 @@ function Update-MgDeviceManagementDeviceConfiguration
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
         $Break,
-
-        [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $ProxyUseDefaultCredentials,
 
         [Parameter()]
         [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
@@ -15029,10 +15148,6 @@ function New-MgDeviceManagementConfigurationPolicy
         $CreatedDateTime,
 
         [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $Confirm,
-
-        [Parameter()]
         [PSObject]
         $Settings,
 
@@ -15077,8 +15192,8 @@ function New-MgDeviceManagementConfigurationPolicy
         $Proxy,
 
         [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $IsAssigned,
+        [PSObject]
+        $BodyParameter,
 
         [Parameter()]
         [System.String]
@@ -15089,8 +15204,8 @@ function New-MgDeviceManagementConfigurationPolicy
         $CreationSource,
 
         [Parameter()]
-        [PSObject]
-        $BodyParameter,
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -15459,10 +15574,6 @@ function Update-MgDeviceManagementConfigurationPolicy
         $CreatedDateTime,
 
         [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $Confirm,
-
-        [Parameter()]
         [PSObject]
         $Settings,
 
@@ -15503,8 +15614,8 @@ function Update-MgDeviceManagementConfigurationPolicy
         $Proxy,
 
         [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $IsAssigned,
+        [PSObject]
+        $BodyParameter,
 
         [Parameter()]
         [Microsoft.Graph.PowerShell.Support.DeviceManagementConfigurationPlatforms]
@@ -15519,8 +15630,8 @@ function Update-MgDeviceManagementConfigurationPolicy
         $CreationSource,
 
         [Parameter()]
-        [PSObject]
-        $BodyParameter,
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
@@ -15957,6 +16068,83 @@ function Get-MgRoleManagementDirectory
         $Break
     )
 }
+function Get-MgRoleManagementDirectoryRoleAssignment
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.String]
+        $UnifiedRoleAssignmentId,
+
+        [Parameter()]
+        [System.String[]]
+        $Property,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Int32]
+        $PageSize,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Int32]
+        $Skip,
+
+        [Parameter()]
+        [System.Int32]
+        $Top,
+
+        [Parameter()]
+        [System.String]
+        $CountVariable,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.String[]]
+        $Sort,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $All,
+
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.String]
+        $Search,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.String[]]
+        $ExpandProperty,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelineAppend
+    )
+}
 function Get-MgRoleManagementDirectoryRoleDefinition
 {
     [CmdletBinding()]
@@ -16105,6 +16293,95 @@ function New-MgDeviceManagementDeviceEnrollmentConfiguration
         [Parameter()]
         [Microsoft.Graph.PowerShell.Support.DeviceEnrollmentConfigurationType]
         $DeviceEnrollmentConfigurationType,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelineAppend
+    )
+}
+function New-MgRoleManagementDirectoryRoleAssignment
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [PSObject]
+        $Principal,
+
+        [Parameter()]
+        [System.String]
+        $ResourceScope,
+
+        [Parameter()]
+        [System.Collections.Hashtable]
+        $AdditionalProperties,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [PSObject]
+        $DirectoryScope,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.String]
+        $PrincipalId,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [PSObject]
+        $BodyParameter,
+
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [System.String]
+        $Condition,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
+
+        [Parameter()]
+        [System.String]
+        $RoleDefinitionId,
+
+        [Parameter()]
+        [PSObject]
+        $RoleDefinition,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [PSObject]
+        $AppScope,
+
+        [Parameter()]
+        [System.String]
+        $DirectoryScopeId,
+
+        [Parameter()]
+        [System.String]
+        $PrincipalOrganizationId,
+
+        [Parameter()]
+        [System.String]
+        $AppScopeId,
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
@@ -16268,6 +16545,55 @@ function Remove-MgRoleManagementDirectory
         [Parameter()]
         [System.String]
         $IfMatch,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelineAppend
+    )
+}
+function Remove-MgRoleManagementDirectoryRoleAssignment
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $PassThru,
+
+        [Parameter()]
+        [System.String]
+        $UnifiedRoleAssignmentId,
+
+        [Parameter()]
+        [System.String]
+        $IfMatch,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
@@ -18837,6 +19163,10 @@ function Get-MgGroupMember
         $Sort,
 
         [Parameter()]
+        [System.String]
+        $ConsistencyLevel,
+
+        [Parameter()]
         [System.Management.Automation.SwitchParameter]
         $All,
 
@@ -18851,6 +19181,91 @@ function Get-MgGroupMember
         [Parameter()]
         [System.String]
         $Search,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.String[]]
+        $ExpandProperty,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelineAppend
+    )
+}
+function Get-MgGroupMemberOf
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.String[]]
+        $Property,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Int32]
+        $PageSize,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Int32]
+        $Skip,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [System.Int32]
+        $Top,
+
+        [Parameter()]
+        [System.String]
+        $CountVariable,
+
+        [Parameter()]
+        [System.String]
+        $GroupId,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.String[]]
+        $Sort,
+
+        [Parameter()]
+        [System.String]
+        $ConsistencyLevel,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $All,
+
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.String]
+        $Search,
+
+        [Parameter()]
+        [System.String]
+        $DirectoryObjectId,
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
@@ -18908,6 +19323,10 @@ function Get-MgGroupOwner
         [Parameter()]
         [System.String[]]
         $Sort,
+
+        [Parameter()]
+        [System.String]
+        $ConsistencyLevel,
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
@@ -20904,6 +21323,132 @@ function New-MgDevice
         $Kind
     )
 }
+function New-MgDirectoryRole
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [System.String]
+        $RoleTemplateId,
+
+        [Parameter()]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.Collections.Hashtable]
+        $AdditionalProperties,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [PSObject]
+        $ScopedMembers,
+
+        [Parameter()]
+        [PSObject]
+        $Members,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [PSObject]
+        $BodyParameter,
+
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.DateTime]
+        $DeletedDateTime,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelineAppend
+    )
+}
+function New-MgDirectoryRoleMemberByRef
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [PSObject]
+        $BodyParameter,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $PassThru,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [System.String]
+        $DirectoryRoleId,
+
+        [Parameter()]
+        [System.String]
+        $OdataId,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
+
+        [Parameter()]
+        [System.Collections.Hashtable]
+        $AdditionalProperties,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break
+    )
+}
 function Remove-MgDevice
 {
     [CmdletBinding()]
@@ -20951,6 +21496,112 @@ function Remove-MgDevice
         [Parameter()]
         [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
         $HttpPipelineAppend
+    )
+}
+function Remove-MgDirectoryRole
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $PassThru,
+
+        [Parameter()]
+        [System.String]
+        $IfMatch,
+
+        [Parameter()]
+        [System.String]
+        $DirectoryRoleId,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break
+    )
+}
+function Remove-MgDirectoryRoleMemberByRef
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $PassThru,
+
+        [Parameter()]
+        [System.String]
+        $IfMatch,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [System.String]
+        $DirectoryRoleId,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
+
+        [Parameter()]
+        [Microsoft.Graph.PowerShell.Runtime.SendAsyncStep[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.String]
+        $DirectoryObjectId,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break
     )
 }
 function Update-MgDevice
@@ -25464,10 +26115,6 @@ function Update-MgUser
         $AppConsentRequestsForApproval,
 
         [Parameter()]
-        [System.String]
-        $UserType,
-
-        [Parameter()]
         [PSObject]
         $TransitiveMemberOf,
 
@@ -25592,6 +26239,10 @@ function Update-MgUser
         $EmployeeId,
 
         [Parameter()]
+        [System.String]
+        $PostalCode,
+
+        [Parameter()]
         [PSObject]
         $AssignedLicenses,
 
@@ -25689,7 +26340,7 @@ function Update-MgUser
 
         [Parameter()]
         [System.String]
-        $PostalCode,
+        $UserType,
 
         [Parameter()]
         [System.String]
@@ -25742,7 +26393,7 @@ function Get-AutoSensitivityLabelPolicy
     [CmdletBinding()]
     param(
         [Parameter()]
-        [System.Object]
+        [System.Management.Automation.SwitchParameter]
         $ForceValidate,
 
         [Parameter()]
@@ -25770,6 +26421,10 @@ function Get-AutoSensitivityLabelRule
 {
     [CmdletBinding()]
     param(
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ForceValidate,
+
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
         $Confirm,
@@ -26030,7 +26685,7 @@ function Get-DlpCompliancePolicy
         $Summary,
 
         [Parameter()]
-        [System.Object]
+        [System.Management.Automation.SwitchParameter]
         $ForceValidate,
 
         [Parameter()]
@@ -26179,7 +26834,7 @@ function Get-LabelPolicy
     [CmdletBinding()]
     param(
         [Parameter()]
-        [System.Object]
+        [System.Management.Automation.SwitchParameter]
         $ForceValidate,
 
         [Parameter()]
@@ -26247,6 +26902,10 @@ function Get-RetentionCompliancePolicy
         [Parameter()]
         [System.Object]
         $Identity,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ErrorPolicyOnly,
 
         [Parameter()]
         [System.Management.Automation.SwitchParameter]
@@ -27049,6 +27708,10 @@ function New-ComplianceTag
         $Regulatory,
 
         [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
+
+        [Parameter()]
         [System.Object]
         $Name,
 
@@ -27066,15 +27729,15 @@ function New-ComplianceTag
 
         [Parameter()]
         [System.Object]
+        $FlowId,
+
+        [Parameter()]
+        [System.Object]
         $IsRecordUnlockedAsDefault,
 
         [Parameter()]
         [System.Object]
         $ComplianceTagForNextStage,
-
-        [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $Confirm,
 
         [Parameter()]
         [System.Object]
@@ -29771,11 +30434,15 @@ function Set-ComplianceTag
 
         [Parameter()]
         [System.Object]
-        $EventType,
+        $FlowId,
 
         [Parameter()]
         [System.Object]
         $ReviewerEmail,
+
+        [Parameter()]
+        [System.Object]
+        $EventType,
 
         [Parameter()]
         [System.Object]

--- a/docs/docs/resources/exchange/EXOManagementRoleAssignment.md
+++ b/docs/docs/resources/exchange/EXOManagementRoleAssignment.md
@@ -1,0 +1,63 @@
+﻿# EXOManagementRoleAssignment
+
+## Parameters
+
+| Parameter | Attribute | DataType | Description | Allowed Values |
+| --- | --- | --- | --- | --- |
+| **Name** | Key | String | The Name parameter specifies a name for the new management role assignment. The maximum length of the name is 64 characters. ||
+| **Role** | Key | String | The Role parameter specifies the existing role to assign. You can use any value that uniquely identifies the role. ||
+| **App** | Write | String | The App parameter specifies the service principal to assign the management role to. Specifically, the ServiceId GUID value from the output of the Get-ServicePrincipal cmdlet (for example, 6233fba6-0198-4277-892f-9275bf728bcc). ||
+| **Policy** | Write | String | The Policy parameter specifies the name of the management role assignment policy to assign the management role to. ||
+| **SecurityGroup** | Write | String | The SecurityGroup parameter specifies the name of the management role group or mail-enabled universal security group to assign the management role to. ||
+| **User** | Write | String | The User parameter specifies the name or alias of the user to assign the management role to. ||
+| **CustomRecipientWriteScope** | Write | String | The CustomRecipientWriteScope parameter specifies the existing recipient-based management scope to associate with this management role assignment. ||
+| **CustomResourceScope** | Write | String | The CustomResourceScope parameter specifies the custom management scope to associate with this management role assignment. You can use any value that uniquely identifies the management scope. ||
+| **ExclusiveRecipientWriteScope** | Write | String | The ExclusiveConfigWriteScope parameter specifies the exclusive configuration-based management scope to associate with the new role assignment. ||
+| **RecipientAdministrativeUnitScope** | Write | String | The RecipientAdministrativeUnitScope parameter specifies the administrative unit to scope the new role assignment to. ||
+| **RecipientOrganizationalUnitScope** | Write | String | The RecipientOrganizationalUnitScope parameter specifies the OU to scope the new role assignment to. If you use the RecipientOrganizationalUnitScope parameter, you can't use the CustomRecipientWriteScope or ExclusiveRecipientWriteScope parameters. ||
+| **RecipientRelativeWriteScope** | Write | String | The RecipientRelativeWriteScope parameter specifies the type of restriction to apply to a recipient scope. The available types are None, Organization, MyGAL, Self, and MyDistributionGroups. The RecipientRelativeWriteScope parameter is automatically set when the CustomRecipientWriteScope or RecipientOrganizationalUnitScope parameters are used. ||
+| **Ensure** | Write | String | Specify if the Management Role Assignment should exist or not. |Present, Absent|
+| **Credential** | Write | PSCredential | Credentials of the Exchange Global Admin ||
+| **ApplicationId** | Write | String | Id of the Azure Active Directory application to authenticate with. ||
+| **TenantId** | Write | String | Id of the Azure Active Directory tenant used for authentication. ||
+| **CertificateThumbprint** | Write | String | Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication. ||
+| **CertificatePassword** | Write | PSCredential | Username can be made up to anything but password will be used for CertificatePassword ||
+| **CertificatePath** | Write | String | Path to certificate used in service principal usually a PFX file. ||
+
+# EXOManagementRole
+
+### Description
+
+This resource configures RBAC Management Roles in Exchange Online.
+
+## Examples
+
+### Example 1
+
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+
+```powershell
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $credsCredential
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        EXOManagementRoleAssignment 'AssignManagementRole'
+        {
+            Credential           = $credsCredential;
+            Ensure               = "Present";
+            Name                 = "MyManagementRoleAssignment";
+            Role                 = "UserApplication";
+            User                 = "John.Smith";
+        }
+    }
+}
+```
+


### PR DESCRIPTION
- Fixes #2374

Additional: Reassigned unused variable.
