### PR TITLE
SPOTenantCdnPolicy: Policies can be null, check before split string

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantCdnPolicy/MSFT_SPOTenantCdnPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantCdnPolicy/MSFT_SPOTenantCdnPolicy.psm1
@@ -64,11 +64,23 @@ function Get-TargetResource
     try
     {
         $Policies = Get-PnPTenantCdnPolicies -CdnType $CDNType -ErrorAction Stop
+        if ($null -ne $Policies['ExcludeRestrictedSiteClassifications']) {
+            $ExcludeRestrictedSiteClassifications = `
+                $Policies['ExcludeRestrictedSiteClassifications'].Split(',')
+        } else {
+            $ExcludeRestrictedSiteClassifications = $null
+        }
+        if ($null -ne $Policies['IncludeFileExtensions']) {
+            $IncludeFileExtensions = `
+                $Policies['IncludeFileExtensions'].Split(',')
+        } else {
+            $IncludeFileExtensions = $null
+        }
 
         return @{
             CDNType                              = $CDNType
-            ExcludeRestrictedSiteClassifications = $Policies['ExcludeRestrictedSiteClassifications'].Split(',')
-            IncludeFileExtensions                = $Policies['IncludeFileExtensions'].Split(',')
+            ExcludeRestrictedSiteClassifications = $ExcludeRestrictedSiteClassifications
+            IncludeFileExtensions                = $IncludeFileExtensions
             Credential                           = $Credential
             ApplicationId                        = $ApplicationId
             TenantId                             = $TenantId


### PR DESCRIPTION
- Both ExcludeRestrictedSiteClassifications and IncludeFileExtensions policies can be null, make a check if they are or not before trying to split the strings otherwise if they are indeed null an exception will occur.
- Fixes #2434 