### PR TITLE
fixes for issue #2423

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -62,7 +62,7 @@ function Start-M365DSCConfigurationExtract
         $ApplicationId,
 
         [Parameter()]
-        [System.String]
+        [System.Management.Automation.PSCredential]
         $ApplicationSecret,
 
         [Parameter()]
@@ -381,7 +381,7 @@ function Start-M365DSCConfigurationExtract
             {
                 Add-ConfigurationDataEntry -Node 'NonNodeData' `
                     -Key 'ApplicationSecret' `
-                    -Value $ApplicationSecret `
+                    -Value ($ApplicationSecret.GetNetworkCredential().Password) `
                     -Description 'Azure AD Application Secret for Authentication'
             }
             'Credentials'
@@ -525,8 +525,7 @@ function Start-M365DSCConfigurationExtract
                 }
                 'ApplicationSecret'
                 {
-                    $applicationSecretValue = New-Object System.Management.Automation.PSCredential ('ApplicationSecret', (ConvertTo-SecureString $ApplicationSecret -AsPlainText -Force));
-                    $parameters.Add('ApplicationSecret', $applicationSecretValue)
+                    $parameters.Add('ApplicationSecret', $ApplicationSecret)
                 }
                 'Credentials'
                 {

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1026,7 +1026,7 @@ function Export-M365DSCConfiguration
         $TenantId,
 
         [Parameter()]
-        [System.String]
+        [System.Management.Automation.PSCredential]
         $ApplicationSecret,
 
         [Parameter()]
@@ -1376,7 +1376,7 @@ function Get-M365DSCTenantDomain
         $TenantId,
 
         [Parameter(ParameterSetName = 'AppId')]
-        [System.String]
+        [System.Management.Automation.PSCredential]
         $ApplicationSecret,
 
         [Parameter(ParameterSetName = 'AppId')]


### PR DESCRIPTION
changed ApplicationSecret variable from string to PSCredential in functions  Start-M365DSCConfigurationExtract,  Export-M365DSCConfiguration, and Get-M365DSCTenantDomain. Removed line converting the string to  a pscredential as it is no longer required, added a line to convert back to string for final output

#### Pull Request (PR) description
Since The updates to require ApplicationSecret to be in the form of a PSCredential I have had errors when exporting previous configurations.
I think the cause is a few functions which are still expecting ApplicationSecret to be passed as a string.  I've amended these functions to use the PSCredential.  There are also a couple of changes where the new type needs to be accounted for. I've tested it exporting the Intune workload and the IntuneAppProtectionPolicyAndroid component with no errors,
I believe All the configurations were updated at the same time to require the ApplicationSecret to be a PSCredential but I haven't tested any other configurations

#### This Pull Request (PR) fixes the following issues
Fixes #2423
