### PR TITLE
Fixes #2439 - Remove duplicate code and incorrect bracing

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -135,10 +135,17 @@ function Start-M365DSCConfigurationExtract
 
         Write-Host -Object ' '
         Write-Host -Object 'Authentication methods specified:'
-        if ($null -ne $Credential)
+        if ($null -ne $Credential -and `
+                [System.String]::IsNullOrEmpty($ApplicationId) )
         {
             Write-Host -Object '- Credentials'
             $AuthMethods += 'Credentials'
+        }
+        if ($null -ne $Credential -and `
+                -not [System.String]::IsNullOrEmpty($ApplicationId))
+        {
+            Write-Host -Object '- CredentialsWithApplicationId'
+            $AuthMethods += 'CredentialsWithApplicationId'
         }
         if (-not [System.String]::IsNullOrEmpty($CertificateThumbprint))
         {
@@ -234,7 +241,6 @@ function Start-M365DSCConfigurationExtract
                 $AuthMethods -contains 'CertificatePath' -or `
                 $AuthMethods -contains 'ApplicationWithSecret')
         {
-            $AppSecretAsPSCredential = $null
             if (-not [System.String]::IsNullOrEmpty($ApplicationSecret))
             {
                 [SecureString]$secStringPassword = ConvertTo-SecureString $ApplicationSecret -AsPlainText -Force
@@ -247,7 +253,8 @@ function Start-M365DSCConfigurationExtract
                 -ApplicationSecret $AppSecretAsPSCredential `
                 -CertificatePath $CertificatePath
         }
-        elseif ($AuthMethods -Contains 'Credentials')
+        elseif ($AuthMethods -Contains 'Credentials' -or `
+                $AuthMethods -Contains 'CredentialsWithApplicationId')
         {
             if ($null -ne $Credential -and $Credential.UserName.Contains('@'))
             {
@@ -391,7 +398,7 @@ function Start-M365DSCConfigurationExtract
                     -Value $ApplicationSecret `
                     -Description 'Azure AD Application Secret for Authentication'
             }
-            'Credentials'
+            { $_ -in 'Credentials', 'CredentialsWithApplicationId' }
             {
                 if ($newline)
                 {
@@ -535,8 +542,12 @@ function Start-M365DSCConfigurationExtract
                     $applicationSecretValue = New-Object System.Management.Automation.PSCredential ('ApplicationSecret', (ConvertTo-SecureString $ApplicationSecret -AsPlainText -Force));
                     $parameters.Add('ApplicationSecret', $applicationSecretValue)
                 }
-                'Credentials'
+                { $_ -in 'Credentials', 'CredentialsWithApplicationId' }
                 {
+                    if ($AuthMethods -contains 'CredentialsWithApplicationId')
+                    {
+                        $parameters.Add('ApplicationId', $ApplicationId)
+                    }
                     $parameters.Add('Credential', $Credential)
                 }
                 'ManagedIdentity'
@@ -616,7 +627,7 @@ function Start-M365DSCConfigurationExtract
                 $DSCContent = $DSCContent.Insert($startPosition, $credsContent)
                 $launchCommand += " -CertificatePassword `$CertificatePassword"
             }
-            'Credentials'
+            { $_ -in 'Credentials', 'CredentialsWithApplicationId' }
             {
                 #region Add the Prompt for Required Credentials at the top of the Configuration
                 $credsContent = ''
@@ -748,12 +759,13 @@ function Start-M365DSCConfigurationExtract
         }
         $DSCContent.ToString() | Out-File $outputDSCFile
 
-        if (!$AzureAutomation)
+        if (!$AzureAutomation -and `
+                !$ManagedIdentity.IsPresent)
         {
             if (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
             {
                 $LCMConfig = Get-DscLocalConfigurationManager
-                if ($null -ne $LCMConfig.CertificateID)
+                if ($null -eq $LCMConfig.CertificateID)
                 {
                     try
                     {
@@ -767,8 +779,11 @@ function Start-M365DSCConfigurationExtract
                     catch
                     {
                         Write-Verbose -Message $_
-                        Add-M365DSCEvent -Message $_ -EntryType 'Error' `
-                            -EventID 1 -Source $($MyInvocation.MyCommand.Source)
+                        if ($_ -notmatch 'The file exists')
+                        {
+                            Add-M365DSCEvent -Message $_ -EntryType 'Error' `
+                                -EventID 1 -Source $($MyInvocation.MyCommand.Source)
+                        }
                     }
 
                     Add-ConfigurationDataEntry -Node 'localhost' `
@@ -783,9 +798,10 @@ function Start-M365DSCConfigurationExtract
                 Write-Host "Cannot export Local Configuration Manager settings. This process isn't executed with Administrative Privileges!" -NoNewline -ForegroundColor DarkCyan
                 Write-Host '}'
             }
-            $outputConfigurationData = $OutputDSCPath + 'ConfigurationData.psd1'
-            New-ConfigurationDataDocument -Path $outputConfigurationData
         }
+
+        $outputConfigurationData = $OutputDSCPath + 'ConfigurationData.psd1'
+        New-ConfigurationDataDocument -Path $outputConfigurationData
 
         if ($shouldOpenOutputDirectory)
         {

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1080,6 +1080,7 @@ function Export-M365DSCConfiguration
     }
 
     if ($PSBoundParameters.ContainsKey('ApplicationId') -eq $true -and `
+            $PSBoundParameters.ContainsKey('Credential') -eq $false -and `
             $PSBoundParameters.ContainsKey('TenantId') -eq $false)
     {
         Write-Host -Object '[ERROR] You have to specify TenantId when you specify ApplicationId' -ForegroundColor Red
@@ -1096,7 +1097,8 @@ function Export-M365DSCConfiguration
 
     if ($PSBoundParameters.ContainsKey('ApplicationId') -eq $true -and `
             $PSBoundParameters.ContainsKey('TenantId') -eq $true -and `
-        ($PSBoundParameters.ContainsKey('CertificateThumbprint') -eq $false -and `
+        ($PSBoundParameters.ContainsKey('Credential') -eq $false -and `
+                $PSBoundParameters.ContainsKey('CertificateThumbprint') -eq $false -and `
                 $PSBoundParameters.ContainsKey('ApplicationSecret') -eq $false -and `
                 $PSBoundParameters.ContainsKey('CertificatePath') -eq $false))
     {
@@ -1540,8 +1542,7 @@ function New-M365DSCConnection
     elseif ($null -eq $InboundParameters.Credential -and `
             [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
             [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
-            [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint) -and `
-            -not $InboundParameters.ManagedIdentity)
+            [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint))
     {
         $message = 'No Authentication method was provided'
         Write-Verbose -Message $message
@@ -1566,228 +1567,44 @@ function New-M365DSCConnection
                 -Credential $InboundParameters.Credential `
                 -SkipModuleReload $Global:CurrentModeIsExport `
                 -ProfileName $ProfileName
-            $data.Add('ConnectionType', 'Credential')
-
-            try
-            {
-                $tenantId = $InboundParameters.Credential.Username.Split('@')[1]
-                $data.Add('Tenant', $tenantId)
-            }
-            catch
-            {
-                Write-Verbose $_
-            }
-
-            Add-M365DSCTelemetryEvent -Data $data -Type 'Connection'
-            return 'Credentials'
         }
-        if ($InboundParameters.ContainsKey('Credential') -and
-            $null -ne $InboundParameters.Credential)
+        else
         {
             Connect-M365Tenant -Workload $Workload `
                 -Credential $InboundParameters.Credential `
-                -Url $Url `
+                -ConnectionUrl $Url `
                 -SkipModuleReload $Global:CurrentModeIsExport `
                 -ProfileName $ProfileName
-            $data.Add('ConnectionType', 'Credential')
-
-            try
-            {
-                $tenantId = $InboundParameters.Credential.Username.Split('@')[1]
-                $data.Add('Tenant', $tenantId)
-            }
-            catch
-            {
-                Write-Verbose $_
-            }
-
-            Add-M365DSCTelemetryEvent -Data $data -Type 'Connection'
-            return 'Credentials'
         }
-        if ($InboundParameters.ContainsKey('ApplicationId') -and
-            -not [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId))
+        $data.Add('ConnectionType', 'Credential')
+        try
         {
-            Connect-M365Tenant -Workload $Workload `
-                -ApplicationId $InboundParameters.ApplicationId `
-                -Credential $InboundParameters.Credential `
-                -SkipModuleReload $Global:CurrentModeIsExport `
-                -ProfileName $ProfileName
-
-            $data.Add('ConnectionType', 'CredentialsWithApplicationId')
-
-            try
-            {
-                $tenantId = $InboundParameters.Credential.Username.Split('@')[1]
-                $data.Add('Tenant', $tenantId)
-            }
-            catch
-            {
-                Write-Verbose $_
-            }
-
-            Add-M365DSCTelemetryEvent -Data $data -Type 'Connection'
-            return 'CredentialsWithApplicationId'
+            $tenantId = $InboundParameters.Credential.Username.Split('@')[1]
+            $data.Add('Tenant', $tenantId)
         }
-        if ($InboundParameters.ContainsKey('ApplicationSecret') -and
-            -not [System.String]::IsNullOrEmpty($InboundParameters.ApplicationSecret))
+        catch
         {
-            Connect-M365Tenant -Workload $Workload `
-                -ApplicationId $InboundParameters.ApplicationId `
-                -ApplicationSecret $InboundParameters.ApplicationSecret `
-                -TenantId $InboundParameters.TenantId `
-                -Url $Url `
-                -SkipModuleReload $Global:CurrentModeIsExport `
-                -ProfileName $ProfileName
-
-            $data.Add('ConnectionType', 'ServicePrincipalWithSecret')
-            $data.Add('Tenant', $InboundParameters.TenantId)
-
-            Add-M365DSCTelemetryEvent -Data $data -Type 'Connection'
-            return 'ServicePrincipalWithSecret'
+            Write-Verbose $_
         }
-        if ($InboundParameters.ContainsKey('CertificatePath') -and
-            -not [System.String]::IsNullOrEmpty($InboundParameters.CertificatePath))
-        {
-            $data.Add('CertificatePath', 'Yes')
-        }
-        if ($InboundParameters.ContainsKey('CertificateThumbprint') -and
-            -not [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint))
-        {
-            Write-Verbose -Message 'ApplicationId, TenantId and CertificateThumprint were specified. Connecting via Service Principal'
-            Connect-M365Tenant -Workload $Workload `
-                -ApplicationId $InboundParameters.ApplicationId `
-                -TenantId $InboundParameters.TenantId `
-                -CertificateThumbprint $InboundParameters.CertificateThumbprint `
-                -SkipModuleReload $Global:CurrentModeIsExport `
-                -ProfileName $ProfileName
-
-            $data.Add('ConnectionType', 'ServicePrincipalWithThumbprint')
-            $data.Add('Tenant', $InboundParameters.TenantId)
-
-            Add-M365DSCTelemetryEvent -Data $data -Type 'Connection'
-            return 'ServicePrincipalWithThumbprint'
-        }
-        if ($InboundParameters.ContainsKey('CertificatePassword') -and
-            -not [System.String]::IsNullOrEmpty($InboundParameters.CertificatePassword))
-        {
-            Connect-M365Tenant -Workload $Workload `
-                -ApplicationId $InboundParameters.ApplicationId `
-                -TenantId $InboundParameters.TenantId `
-                -CertificatePassword $InboundParameters.CertificatePassword.Password `
-                -Url $Url `
-                -SkipModuleReload $Global:CurrentModeIsExport `
-                -ProfileName $ProfileName
-            return 'ServicePrincipalWithPath'
-        }
-        $data.Add('ConnectionType', 'ServicePrincipalWithPassword')
-        $data.Add('Tenant', $InboundParameters.TenantId)
         Add-M365DSCTelemetryEvent -Data $data -Type 'Connection'
-        return 'ServicePrincipalWithPassword'
+        return 'Credential'
     }
-    # Case only the ServicePrincipal with Thumbprint parameters are specified
-    elseif ($null -eq $InboundParameters.Credential -and `
+    # Case only the ApplicationID and Credentials parameters are specified
+    elseif ($null -ne $InboundParameters.Credential -and `
             -not [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
-            -not [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
-            -not [System.String]::IsNullOrEmpty($InboundParameters.CertificatePath) -and `
-            $null -ne $InboundParameters.CertificatePassword)
+            [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
+            [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint))
     {
-        if ([System.String]::IsNullOrEmpty($url))
-        {
-            Write-Verbose -Message 'ApplicationId, TenantId, CertificatePath & CertificatePassword were specified. Connecting via Service Principal'
-            Connect-M365Tenant -Workload $Workload `
-                -ApplicationId $InboundParameters.ApplicationId `
-                -TenantId $InboundParameters.TenantId `
-                -CertificatePassword $InboundParameters.CertificatePassword.Password `
-                -CertificatePath $InboundParameters.CertificatePath `
-                -SkipModuleReload $Global:CurrentModeIsExport `
-                -ProfileName $ProfileName
 
-            $data.Add('ConnectionType', 'ServicePrincipalWithPath')
-            $data.Add('Tenant', $InboundParameters.TenantId)
-            Add-M365DSCTelemetryEvent -Data $data -Type 'Connection'
-            return 'ServicePrincipalWithPath'
-        }
-        #endregion
+        Connect-M365Tenant -Workload $Workload `
+            -ApplicationId $InboundParameters.ApplicationId `
+            -TenantId $InboundParameters.TenantId `
+            -CertificatePassword $InboundParameters.CertificatePassword.Password `
+            -CertificatePath $InboundParameters.CertificatePath `
+            -Url $Url `
+            -SkipModuleReload $Global:CurrentModeIsExport `
+            -ProfileName $ProfileName
 
-        # Case both authentication methods are attempted
-        if ($null -ne $InboundParameters.Credential -and `
-            (-not [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -or `
-                    -not [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint)))
-        {
-            $message = 'Both Authentication methods are attempted'
-            Write-Verbose -Message $message
-            $data.Add('Event', 'Error')
-            $data.Add('Exception', $message)
-            $errorText = "You can't specify both the Credential and one of {TenantId, CertificateThumbprint}"
-            $data.Add('CustomMessage', $errorText)
-            Add-M365DSCTelemetryEvent -Type 'Error' -Data $data
-            throw $errorText
-        }
-        # Case no authentication method is specified
-        elseif ($null -eq $InboundParameters.Credential -and `
-                [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
-                [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
-                [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint))
-        {
-            $message = 'No Authentication method was provided'
-            Write-Verbose -Message $message
-            $message += "`r`nProvided Keys --> $($InboundParameters.Keys)"
-            $data.Add('Event', 'Error')
-            $data.Add('Exception', $message)
-            $errorText = 'You must specify either the Credential or ApplicationId, TenantId and CertificateThumbprint parameters.'
-            $data.Add('CustomMessage', $errorText)
-            Add-M365DSCTelemetryEvent -Type 'Error' -Data $data
-            throw $errorText
-        }
-        # Case only Credential is specified
-        elseif ($null -ne $InboundParameters.Credential -and `
-                [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
-                [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
-                [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint))
-        {
-            Write-Verbose -Message 'Credential was specified. Connecting via User Principal'
-            if ([System.String]::IsNullOrEmpty($Url))
-            {
-                Connect-M365Tenant -Platform $Platform `
-                    -Credential $InboundParameters.Credential `
-                    -SkipModuleReload $Global:CurrentModeIsExport `
-                    -ProfileName $ProfileName
-            }
-            else
-            {
-                Connect-M365Tenant -Platform $Platform `
-                    -Credential $InboundParameters.Credential `
-                    -ConnectionUrl $Url `
-                    -SkipModuleReload $Global:CurrentModeIsExport `
-                    -ProfileName $ProfileName
-            }
-            $data.Add('ConnectionType', 'Credential')
-            try
-            {
-                $tenantId = $InboundParameters.Credential.Username.Split('@')[1]
-                $data.Add('Tenant', $tenantId)
-            }
-            catch
-            {
-                Write-Verbose $_
-            }
-            Add-M365DSCTelemetryEvent -Data $data -Type 'Connection'
-            return 'Credential'
-        }
-        # Case only the ApplicationID and Credentials parameters are specified
-        elseif ($null -ne $InboundParameters.Credential -and `
-                -not [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId))
-        {
-
-            Connect-M365Tenant -Workload $Workload `
-                -ApplicationId $InboundParameters.ApplicationId `
-                -TenantId $InboundParameters.TenantId `
-                -CertificatePassword $InboundParameters.CertificatePassword.Password `
-                -CertificatePath $InboundParameters.CertificatePath `
-                -Url $Url `
-                -SkipModuleReload $Global:CurrentModeIsExport `
-                -ProfileName $ProfileName
-        }
         $data.Add('ConnectionType', 'ServicePrincipalWithPath')
         $data.Add('Tenant', $InboundParameters.TenantId)
         Add-M365DSCTelemetryEvent -Data $data -Type 'Connection'
@@ -1831,6 +1648,7 @@ function New-M365DSCConnection
             return 'ServicePrincipalWithSecret'
         }
     }
+    # Case only the CertificateThumbprint, ApplicationID and TenantId are specified
     elseif ($InboundParameters.CertificateThumbprint -and $InboundParameters.ApplicationId -and $InboundParameters.TenantId)
     {
         Write-Verbose -Message 'ApplicationId, TenantId, CertificateThumbprint were specified. Connecting via Service Principal'
@@ -1847,7 +1665,9 @@ function New-M365DSCConnection
         Add-M365DSCTelemetryEvent -Data $data -Type 'Connection'
         return 'ServicePrincipalWithThumbprint'
     }
-    elseif ($InboundParameters.ManagedIdentity)
+    # Case only Managed Identity and TenantId are specified
+    elseif ($InboundParameters.ManagedIdentity -and `
+            -not [System.String]::IsNullOrEmpty($InboundParameters.TenantId))
     {
         Write-Verbose -Message 'Connecting via managed identity'
         Connect-M365Tenant -Workload $Workload `
@@ -3067,7 +2887,7 @@ function Get-M365DSCComponentsWithMostSecureAuthenticationType
     param(
         [Parameter()]
         [System.String[]]
-        [ValidateSet('ApplicationWithSecret', 'CertificateThumbprint', 'CertificatePath', 'Credentials', 'ManagedIdentity')]
+        [ValidateSet('ApplicationWithSecret', 'CertificateThumbprint', 'CertificatePath', 'Credentials', 'CredentialsWithApplicationId', 'ManagedIdentity')]
         $AuthenticationMethod
     )
 
@@ -3078,8 +2898,17 @@ function Get-M365DSCComponentsWithMostSecureAuthenticationType
         Import-Module $resource.FullName -Force
         $parameters = (Get-Command 'Set-TargetResource').Parameters.Keys
 
+        # Case - Resource supports Managed Identity
+        if ($AuthenticationMethod.Contains('ManagedIdentity') -and `
+                $parameters.Contains('ManagedIdentity'))
+        {
+            $Components += @{
+                Resource   = $resource.Name -replace 'MSFT_', '' -replace '.psm1', ''
+                AuthMethod = 'ManagedIdentity'
+            }
+        }
         #Case - Resource supports CertificateThumbprint
-        if ($AuthenticationMethod.Contains('CertificateThumbprint') -and `
+        elseif ($AuthenticationMethod.Contains('CertificateThumbprint') -and `
                 $parameters.Contains('ApplicationId') -and `
                 $parameters.Contains('CertificateThumbprint') -and `
                 $parameters.Contains('TenantId'))
@@ -3113,7 +2942,14 @@ function Get-M365DSCComponentsWithMostSecureAuthenticationType
                 AuthMethod = 'ApplicationSecret'
             }
         }
-
+        elseif ($AuthenticationMethod.Contains('CredentialsWithApplicationId') -and `
+                $parameters.Contains('Credential'))
+        {
+            $Components += @{
+                Resource   = $resource.Name -replace 'MSFT_', '' -replace '.psm1', ''
+                AuthMethod = 'CredentialsWithApplicationId'
+            }
+        }
         # Case - Resource supports Credential
         elseif ($AuthenticationMethod.Contains('Credentials') -and `
                 $parameters.Contains('Credential'))
@@ -3121,14 +2957,6 @@ function Get-M365DSCComponentsWithMostSecureAuthenticationType
             $Components += @{
                 Resource   = $resource.Name -replace 'MSFT_', '' -replace '.psm1', ''
                 AuthMethod = 'Credentials'
-            }
-        }
-        elseif ($AuthenticationMethod.Contains('ManagedIdentity') -and `
-                $parameters.Contains('ManagedIdentity'))
-        {
-            $Components += @{
-                Resource   = $resource.Name -replace 'MSFT_', '' -replace '.psm1', ''
-                AuthMethod = 'ManagedIdentity'
             }
         }
     }


### PR DESCRIPTION
Primary:
- De-dup of partial duplicate code block in M365DSCUtil::New-M365DSCConnection
- Fix incorrect brace/block termination

Secondary:
- Move ManagedIdentity to top of Get-M365DSCComponentsWithMostSecureAuthenticationType eval
- Add missing support for CredentialsWithApplicationId
- Fix incorrect test for DSCLocalConfigurartionManager CertificateId when considering creation of self-signed certificate

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
Fixes #2439