### PR TITLE
Fix $OrganizationName replacement

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -330,6 +330,7 @@ function Start-M365DSCConfigurationExtract
             { $_ -in 'CertificateThumbprint', 'CertificatePath', 'ApplicationWithSecret' }
             {
                 $postParamContent.Append("    `$OrganizationName = `$ConfigurationData.NonNodeData.OrganizationName`r`n") | Out-Null
+                $postParamContent.Append("    `$TenantId = `$ConfigurationData.NonNodeData.TenantId`r`n") | Out-Null
 
                 Add-ConfigurationDataEntry -Node 'NonNodeData' `
                     -Key 'OrganizationName' `

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2969,14 +2969,7 @@ function Get-M365DSCExportContentForResource
     {
         $partialContent = $partialContent -ireplace [regex]::Escape($OrganizationName + ':'), "`$($OrganizationName):"
         $partialContent = $partialContent -ireplace [regex]::Escape($OrganizationName), "`$OrganizationName"
-        if ($OrganizationName -eq $TenantId)
-        {
-            $partialContent = $partialContent -ireplace [regex]::Escape('@' + $OrganizationName), "@`$TenantId"
-        }
-        else
-        {
-            $partialContent = $partialContent -ireplace [regex]::Escape('@' + $OrganizationName), "@`$OrganizationName"
-        }
+        $partialContent = $partialContent -ireplace [regex]::Escape('@' + $OrganizationName), "@`$TenantId"
     }
     $content += $partialContent
     $content += "        }`r`n"

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2968,8 +2968,8 @@ function Get-M365DSCExportContentForResource
     if ($partialContent.ToLower().IndexOf($OrganizationName.ToLower()) -gt 0)
     {
         $partialContent = $partialContent -ireplace [regex]::Escape($OrganizationName + ':'), "`$($OrganizationName):"
-        $partialContent = $partialContent -ireplace [regex]::Escape($OrganizationName), "`$OrganizationName"
         $partialContent = $partialContent -ireplace [regex]::Escape('@' + $OrganizationName), "@`$TenantId"
+        $partialContent = $partialContent -ireplace [regex]::Escape($OrganizationName), "`$OrganizationName"
     }
     $content += $partialContent
     $content += "        }`r`n"

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2969,7 +2969,14 @@ function Get-M365DSCExportContentForResource
     {
         $partialContent = $partialContent -ireplace [regex]::Escape($OrganizationName + ':'), "`$($OrganizationName):"
         $partialContent = $partialContent -ireplace [regex]::Escape($OrganizationName), "`$OrganizationName"
-        $partialContent = $partialContent -ireplace [regex]::Escape('@' + $OrganizationName), "@`$OrganizationName"
+        if ($OrganizationName -eq $TenantId)
+        {
+            $partialContent = $partialContent -ireplace [regex]::Escape('@' + $OrganizationName), "@`$TenantId"
+        }
+        else
+        {
+            $partialContent = $partialContent -ireplace [regex]::Escape('@' + $OrganizationName), "@`$OrganizationName"
+        }
     }
     $content += $partialContent
     $content += "        }`r`n"


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes a problem with the generalization of exported M365TenantConfig.ps1 files.
Wherever a supposed email address was replaced by @$OrganizationName, it is now replaced by @$TenantId.

Example (output shortened for better readability)
$OrganizationName = demotenant
$TenantId = demotenant.onmicrosoft.com

```
    $OrganizationName = $ConfigurationData.NonNodeData.OrganizationName

    Import-DscResource -ModuleName 'Microsoft365DSC' -ModuleVersion '1.22.1102.1'

    Node localhost
    {
        AADConditionalAccessPolicy f886acfa-a0b0-4b27-a336-bd8848616f1d
        {
            ApplicationEnforcedRestrictionsIsEnabled = $False;
            ApplicationId                            = $ConfigurationData.NonNodeData.ApplicationId;
            ApplicationSecret                        = New-Object System.Management.Automation.PSCredential ('ApplicationSecret', (ConvertTo-SecureString $ConfigurationData.NonNodeData.ApplicationSecret -AsPlainText -Force));
            BuiltInControls                          = @("mfa");
            ClientAppTypes                           = @("browser","mobileAppsAndDesktopClients");
            CloudAppSecurityIsEnabled                = $False;
            CloudAppSecurityType                     = "";
            CustomAuthenticationFactors              = @();
            DeviceFilterRule                         = "";
            DisplayName                              = "DemoPolicy";
            Ensure                                   = "Present";
			...
            ExcludeUsers                             = @("admin@$OrganizationName");
            GrantControlOperator                     = "OR";
            Id                                       = "8857d729-42c8-489b-9bee-a51abc27beed";
            IncludeApplications                      = @("All");
			...
            State                                    = "enabled";
            TenantId                                 = $ConfigurationData.NonNodeData.TenantId;
            UserRiskLevels                           = @();
        }
	}
```

When compiling this configuration the ExcludeUsers in the mof file will be displayed as

```
[...]
 ExcludeUsers = {
    "admin@demotenant"
};
[...]
```

With this fix the M365TenantConfig.ps1 will look like this:
```
    $OrganizationName = $ConfigurationData.NonNodeData.OrganizationName
    $TenantId = $ConfigurationData.NonNodeData.TenantId

    Import-DscResource -ModuleName 'Microsoft365DSC' -ModuleVersion '1.22.1102.1'

    Node localhost
    {
        AADConditionalAccessPolicy f886acfa-a0b0-4b27-a336-bd8848616f1d
        {
            ApplicationEnforcedRestrictionsIsEnabled = $False;
            ApplicationId                            = $ConfigurationData.NonNodeData.ApplicationId;
            ApplicationSecret                        = New-Object System.Management.Automation.PSCredential ('ApplicationSecret', (ConvertTo-SecureString $ConfigurationData.NonNodeData.ApplicationSecret -AsPlainText -Force));
            BuiltInControls                          = @("mfa");
            ClientAppTypes                           = @("browser","mobileAppsAndDesktopClients");
            CloudAppSecurityIsEnabled                = $False;
            CloudAppSecurityType                     = "";
            CustomAuthenticationFactors              = @();
            DeviceFilterRule                         = "";
            DisplayName                              = "DemoPolicy";
            Ensure                                   = "Present";
			...
            **ExcludeUsers                             = @("admin@$TenantId");**
            GrantControlOperator                     = "OR";
            Id                                       = "8857d729-42c8-489b-9bee-a51abc27beed";
            IncludeApplications                      = @("All");
			...
            State                                    = "enabled";
            TenantId                                 = $ConfigurationData.NonNodeData.TenantId;
            UserRiskLevels                           = @();
        }
	}
```

and the compiled mof file will look like this:

```
 ExcludeUsers = {
    "admin@demotenant.onmicrosoft.com"
};
```

#### This Pull Request (PR) fixes the following issues

- Fixes #2065 
- Fixes #2462 

