### PR TITLE
ConfigurationData.psd1 not generated with ManagedIdentity

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -761,7 +761,7 @@ function Start-M365DSCConfigurationExtract
         }
         $DSCContent.ToString() | Out-File $outputDSCFile
 
-        if (!$AzureAutomation -and !$ManagedIdentity.IsPresent)
+        if (!$AzureAutomation)
         {
             if (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
             {


### PR DESCRIPTION
#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
-->
Test at line 764 for `!$AzureAutomation -and !$ManagedIdentity.IsPresent` results in no ConfigurationData.psd1 being generated due to output generation lines wrapped inside block with certificate generation.  This PR removes the test, allowing output to be generated.
#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
Fixes #2508