### PR TITLE
ConfigurationData.psd1 not generated due to generation inside AzureAutomation/ManagedIdentity test block

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -761,7 +761,7 @@ function Start-M365DSCConfigurationExtract
         }
         $DSCContent.ToString() | Out-File $outputDSCFile
 
-        if (!$AzureAutomation)
+        if (!$AzureAutomation -and !$ManagedIdentity.IsPresent)
         {
             if (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
             {
@@ -796,10 +796,9 @@ function Start-M365DSCConfigurationExtract
                 Write-Host "Cannot export Local Configuration Manager settings. This process isn't executed with Administrative Privileges!" -NoNewline -ForegroundColor DarkCyan
                 Write-Host '}'
             }
-            $outputConfigurationData = $OutputDSCPath + 'ConfigurationData.psd1'
-            New-ConfigurationDataDocument -Path $outputConfigurationData
         }
-
+        $outputConfigurationData = $OutputDSCPath + 'ConfigurationData.psd1'
+        New-ConfigurationDataDocument -Path $outputConfigurationData
         if ($shouldOpenOutputDirectory)
         {
             try

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -761,7 +761,7 @@ function Start-M365DSCConfigurationExtract
         }
         $DSCContent.ToString() | Out-File $outputDSCFile
 
-        if (!$AzureAutomation -and !$ManagedIdentity.IsPresent)
+        if (!$AzureAutomation)
         {
             if (([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
             {


### PR DESCRIPTION
#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
-->
Generation of ConfigurationData.psd1 is inside test block (line 764) where encryption certificate is generated.  Move generation outside as not tied to certificate generation.
#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
