### PR TITLE
SPOSharingSettings: Amend SharingCapability description in MOF

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSharingSettings/MSFT_SPOSharingSettings.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSharingSettings/MSFT_SPOSharingSettings.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_SPOSharingSettings : OMI_BaseResource
 {
     [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'"),ValueMap{"Yes"},Values{"Yes"}] String IsSingleInstance;
-    [Write, Description("Configures anonymous link types for folders"),ValueMap{"ExistingExternalUserSharingOnly","ExternalUserAndGuestSharing","Disabled","ExternalUserSharingOnly"},Values{"ExistingExternalUserSharingOnly","ExternalUserAndGuestSharing","Disabled","ExternalUserSharingOnly"}] string SharingCapability;
+    [Write, Description("Configures sharing capability for SharePoint"),ValueMap{"ExistingExternalUserSharingOnly","ExternalUserAndGuestSharing","Disabled","ExternalUserSharingOnly"},Values{"ExistingExternalUserSharingOnly","ExternalUserAndGuestSharing","Disabled","ExternalUserSharingOnly"}] string SharingCapability;
     [Write, Description("Configures sharing capability for mysite (onedrive)"),ValueMap{"ExistingExternalUserSharingOnly","ExternalUserAndGuestSharing","Disabled","ExternalUserSharingOnly"},Values{"ExistingExternalUserSharingOnly","ExternalUserAndGuestSharing","Disabled","ExternalUserSharingOnly"}] string MySiteSharingCapability;
     [Write, Description("Enables the administrator to hide the Everyone claim in the People Picker.")] boolean ShowEveryoneClaim;
     [Write, Description("Enables the administrator to hide the All Users claim groups in People Picker.")] boolean ShowAllUsersClaim;


### PR DESCRIPTION
#### Pull Request (PR) description
SharingCapability property currently has a wrong description which was copy-pasted from FolderAnonymousLinkType, this change corrects it.

#### This Pull Request (PR) fixes the following issues
None
