### PR TITLE
FIXES #2472

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # UNRELEASED
 
+* SCRetentionCompliancePolicy
+  * Fixes issue with the TeamsChannelLocation and TeamsChatsLocation parameters that were improperly returned by the Get- function.
+    FIXES [#2472](https://github.com/microsoft/Microsoft365DSC/issues/2472)
+* SCRetentionComplianceRule
+  * Fixes issue with Teams Policy where the RetentionDurationDisplayHint and ExpirationDateOption parameters weren't returned by the Get- function.
+    FIXES [#2472](https://github.com/microsoft/Microsoft365DSC/issues/2472)
 * DEPENDENCIES
   * Updated Microsoft.Graph.* to version 1.17.0;
   * Updated MSCloudLoginAssistant to version 1.0.98;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionCompliancePolicy/MSFT_SCRetentionCompliancePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionCompliancePolicy/MSFT_SCRetentionCompliancePolicy.psm1
@@ -142,9 +142,9 @@ function Get-TargetResource
                     Comment                       = $PolicyObject.Comment
                     Enabled                       = $PolicyObject.Enabled
                     RestrictiveRetention          = $PolicyObject.RestrictiveRetention
-                    TeamsChannelLocation          = [array]$PolicyObject.TeamsChannelLocation
+                    TeamsChannelLocation          = [array]$PolicyObject.TeamsChannelLocation.DisplayName
                     TeamsChannelLocationException = $PolicyObject.TeamsChannelLocationException
-                    TeamsChatLocation             = [array]$PolicyObject.TeamsChatLocation
+                    TeamsChatLocation             = [array]$PolicyObject.TeamsChatLocation.DisplayName
                     TeamsChatLocationException    = $PolicyObject.TeamsChatLocationException
                     Credential                    = $Credential
                 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionComplianceRule/MSFT_SCRetentionComplianceRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionComplianceRule/MSFT_SCRetentionComplianceRule.psm1
@@ -106,14 +106,14 @@ function Get-TargetResource
                 Policy                       = $AssociatedPolicy.Name
                 RetentionDuration            = $RuleObject.RetentionDuration
                 RetentionComplianceAction    = $RetentionComplianceActionValue
+                RetentionDurationDisplayHint = $RuleObject.RetentionDurationDisplayHint
+                ExpirationDateOption         = $RuleObject.ExpirationDateOption
                 Credential                   = $Credential
                 Ensure                       = 'Present'
             }
             if (-not $associatedPolicy.TeamsPolicy)
             {
-                $result.Add('ExpirationDateOption', $RuleObject.ExpirationDateOption)
                 $result.Add('ExcludedItemClasses', $RuleObject.ExcludedItemClasses)
-                $result.Add('RetentionDurationDisplayHint', $RuleObject.RetentionDurationDisplayHint)
                 $result.Add('ContentMatchQuery', $RuleObject.ContentMatchQuery)
             }
 


### PR DESCRIPTION
#### Pull Request (PR) description
* SCRetentionCompliancePolicy
  * Fixes issue with the TeamsChannelLocation and TeamsChatsLocation parameters that were improperly returned by the Get- function.
* SCRetentionComplianceRule
  * Fixes issue with Teams Policy where the RetentionDurationDisplayHint and ExpirationDateOption parameters weren't returned by the Get- function.

#### This Pull Request (PR) fixes the following issues
* FIXES #2472 
