### PR TITLE
Fix for usage of Test-M365DSCDependenciesForNewVersions in Export functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 * DEPENDENCIES
   * Updated Microsoft.Graph.* to version 1.17.0;
   * Updated MSCloudLoginAssistant to version 1.0.98;
+* MISC
+  * Removed Test-M365DSCDependenciesForNewVersions from export functions. This will improve export speed.
+  * New Parameter `ValidateOnly` for Update-M365DSCDependencies to check if all dependencies are installed.
+    FIXES [2519](https://github.com/microsoft/Microsoft365DSC/issues/2519)
+  * Fixed incorrect usage of Write-Information cmdLet
 
 # 1.22.1116.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1241,8 +1241,6 @@ function Confirm-M365DSCDependencies
     {
         Write-Verbose -Message 'Dependencies were not already validated.'
 
-        Update-M365DSCDependencies
-
         $result = Update-M365DSCDependencies -ValidateOnly
 
         if ($result.Length -gt 0)

--- a/docs/docs/user-guide/cmdlets/Test-M365DSCDependenciesForNewVersions.md
+++ b/docs/docs/user-guide/cmdlets/Test-M365DSCDependenciesForNewVersions.md
@@ -11,10 +11,9 @@ This function does not generate any output.
 ## Parameters
 
 This function does not have any input parameters.
+
 ## Examples
 
 -------------------------- EXAMPLE 1 --------------------------
 
 `Test-M365DSCDependenciesForNewVersions`
-
-


### PR DESCRIPTION
#### Pull Request (PR) description

* Removed Test-M365DSCDependenciesForNewVersions from export functions. This will improve export speed.
* New Parameter `ValidateOnly` for Update-M365DSCDependencies to check if all dependencies are installed.
* Fixed incorrect usage of Write-Information cmdLet

#### This Pull Request (PR) fixes the following issues
- FIXES #2519

