### PR TITLE
Fixes #2615

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* AADServicePrincipal
+  * Fixes an issue where the service principals weren't created or updated when using ApplicationSecret to authenticate.
+    FIXES [#2615](https://github.com/microsoft/Microsoft365DSC/issues/2615)
 * PlannerBucket & PlannerPlan
   * Changed invalid permissions in the setting.json files
     FIXES [#2629](https://github.com/microsoft/Microsoft365DSC/issues/2629)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
@@ -299,6 +299,7 @@ function Set-TargetResource
     $currentParameters.Remove('Credential') | Out-Null
     $currentParameters.Remove('Ensure') | Out-Null
     $currentParameters.Remove('ObjectID') | Out-Null
+    $currentParameters.Remove('ApplicationSecret') | Out-Null
 
     # ServicePrincipal should exist but it doesn't
     if ($Ensure -eq 'Present' -and $currentAADServicePrincipal.Ensure -eq 'Absent')


### PR DESCRIPTION
#### Pull Request (PR) description
* AADServicePrincipal
  * Fixes an issue where the service principals weren't created or updated when using ApplicationSecret to authenticate.
 
#### This Pull Request (PR) fixes the following issues
* FIXES #2615 
