### PR TITLE
fixes bug #2672 and enhancement #2673

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailContact/MSFT_EXOMailContact.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailContact/MSFT_EXOMailContact.psm1
@@ -135,8 +135,7 @@ function Get-TargetResource
 
     try
     {
-        $contactList = Get-MailContact -ErrorAction Stop
-        $contact = $contactList | Where-Object -FilterScript { $_.Name -eq $Name }
+        $contact = Get-MailContact -Identity $Name -ErrorAction Continue
 
         if ($null -eq $contact)
         {
@@ -549,7 +548,7 @@ function Export-TargetResource
     try
     {
         $dscContent = [System.Text.StringBuilder]::new()
-        [array]$contactList = Get-MailContact -ErrorAction Stop
+        [array]$contactList = Get-MailContact -ResultSize 'Unlimited' -ErrorAction Stop
         if ($contactList.Length -eq 0)
         {
             Write-Host $Global:M365DSCEmojiGreenCheckMark


### PR DESCRIPTION
#### Pull Request (PR) description
 - Issue 2673: 
The following is inefficient (and contains the bug of only getting 1000 elements since `-ResultSize 'Unlimited'` is missing) since it gets the full contact list (or rather the 1000 first) in order to get a single contact:  
```powershell
# line 138
$contactList = Get-MailContact -ErrorAction Stop
$contact = $contactList | Where-Object -FilterScript { $_.Name -eq $Name }
```
Replacing it with the following makes it more efficient: 
```powershell
$contact = Get-MailContact -Identity $Name -ErrorAction Continue
```
The `-ErrorAction Continue` is to allow reaching the test below it; `if ($null -eq $contact) { ...`

- Issue 2672:
The following only get's the first 1000 contacts: 
```powershell
# line 552
[array]$contactList = Get-MailContact -ErrorAction Stop
```
Adding the `-ResultSize 'Unlimited'` ensures all contacts are fetched: 
```powershell
# line 552
[array]$contactList = Get-MailContact -ResultSize 'Unlimited' -ErrorAction Stop
```

#### This Pull Request (PR) fixes the following issues
- Fixes #2672
- Fixes #2673

