### PR TITLE
Fixes #2587

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # UNRELEASED
 
-*AADGroup
+* AADGroup
   * Extraction not longer exports Distribution List or mail enabled security list since these are not supported by the Microsoft Graph API.
     FIXES [#2587](https://github.com/microsoft/Microsoft365DSC/issues/2587)
 * EXOMailContact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # UNRELEASED
 
 * AADGroup
-  * Extraction not longer exports Distribution List or mail enabled security list since these are not supported by the Microsoft Graph API.
+  * Extraction no longer exports Distribution List or mail enabled security list since these are not supported by the Microsoft Graph API.
     FIXES [#2587](https://github.com/microsoft/Microsoft365DSC/issues/2587)
 * EXOMailContact
   * Ensures all results are returned from the Export scenario. Currently limited at 1,000 results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+*AADGroup
+  * Extraction not longer exports Distribution List or mail enabled security list since these are not supported by the Microsoft Graph API.
+    FIXES [#2587](https://github.com/microsoft/Microsoft365DSC/issues/2587)
 * EXOMailContact
   * Ensures all results are returned from the Export scenario. Currently limited at 1,000 results.
     FIXES [#2672](https://github.com/microsoft/Microsoft365DSC/issues/2672)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -649,7 +649,7 @@ function Set-TargetResource
                 }
             }
         }
-        else
+        elseif ($MembershipRuleProcessingState -ne 'On')
         {
             Write-Verbose -Message 'Ignoring membership since this is a dynamic group.'
         }
@@ -1016,6 +1016,8 @@ function Export-TargetResource
     try
     {
         [array] $groups = Get-MgGroup -Filter $Filter -All:$true -ErrorAction Stop
+        $groups = $groups | Where-Object -FilterScript {-not ($_.MailEnabled -and ($null -eq $_.GroupTypes -or $_.GroupTypes.Length -eq 0)) -and
+                                                        -not ($_.MailEnabled -and $_.SecurityEnabled)}
         $i = 1
         $dscContent = ''
         Write-Host "`r`n" -NoNewline

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/Readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/Readme.md
@@ -2,4 +2,4 @@
 
 ## Description
 
-This resource configures an Azure Active Directory group.
+This resource configures an Azure Active Directory group. IMPORTANT: It does not support mail enabled security groups or mail enabled groups that are not unified or dynamic groups.


### PR DESCRIPTION
#### Pull Request (PR) description
* AADGroup
  * Extraction no longer exports Distribution List or mail enabled security list since these are not supported by the Microsoft Graph API. Where are now filtering out groups that are not of type unified or Dynamic and which have the MailEnabled property set to true or Groups that are both security and mail enabled.

#### This Pull Request (PR) fixes the following issues
* Fixes #2587 