### PR TITLE
Improve performance when exporting mutliple DSC resources.

### DIFF
--- a/Modules/Microsoft365DSC/Modules/EncodingHelpers/M365DSCStringEncoding.psm1
+++ b/Modules/Microsoft365DSC/Modules/EncodingHelpers/M365DSCStringEncoding.psm1
@@ -40,8 +40,22 @@ function Format-M365DSCString
         }
     )
 
-    $DSCResource = Get-DscResource -Module 'Microsoft365DSC' `
-        -Name $ResourceName
+    # Cache the DSC resource to a global variable.
+    # This avoids fetching the definition multiple times for the same resource, thus increasing overall speed.
+    try
+    {
+        if (-not($Global:DSCResources.ContainsKey($ResourceName)))
+        {
+            $DSCResource = $Global:DSCResources[$ResourceName]
+        }
+    }
+    catch
+    {
+        $Global:DSCResources = @{
+            $ResourceName = Get-DscResource -Module 'Microsoft365DSC' -Name $ResourceName
+        }
+        $DSCResource = $Global:DSCResources[$ResourceName]
+    }
 
     # For each invalid character, look for an instance in the string,
     # if an instance is found,

--- a/Modules/Microsoft365DSC/Modules/EncodingHelpers/M365DSCStringEncoding.psm1
+++ b/Modules/Microsoft365DSC/Modules/EncodingHelpers/M365DSCStringEncoding.psm1
@@ -44,17 +44,17 @@ function Format-M365DSCString
     # This avoids fetching the definition multiple times for the same resource, thus increasing overall speed.
     try
     {
-        if (-not($Global:DSCResources.ContainsKey($ResourceName)))
+        if (-not($Script:DSCResources.ContainsKey($ResourceName)))
         {
-            $DSCResource = $Global:DSCResources[$ResourceName]
+            $DSCResource = $Script:DSCResources[$ResourceName]
         }
     }
     catch
     {
-        $Global:DSCResources = @{
+        $Script:DSCResources = @{
             $ResourceName = Get-DscResource -Module 'Microsoft365DSC' -Name $ResourceName
         }
-        $DSCResource = $Global:DSCResources[$ResourceName]
+        $DSCResource = $Script:DSCResources[$ResourceName]
     }
 
     # For each invalid character, look for an instance in the string,


### PR DESCRIPTION
#### Pull Request (PR) description

Improve performance when exporting mutliple DSC resources by caching the DSC resource definition to a variable in $Global -scope.

#### This Pull Request (PR) fixes the following issues

-Fixes #2686
