### PR TITLE
AADRoleDefinition: The cmdlet Get-MgRoleManagementDirectoryRoleDefinition is called with parameter -Id which does not exist

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleDefinition/MSFT_AADRoleDefinition.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleDefinition/MSFT_AADRoleDefinition.psm1
@@ -91,9 +91,9 @@ function Get-TargetResource
     {
         try
         {
-            if ($null -ne $Id -or $Id -ne '')
+            if (($null -ne $Id) -and ($Id -ne ''))
             {
-                $AADRoleDefinition = Get-MgRoleManagementDirectoryRoleDefinition -Id $Id
+                $AADRoleDefinition = Get-MgRoleManagementDirectoryRoleDefinition -Filter "Id eq '$($Id)'"
             }
         }
         catch


### PR DESCRIPTION
#### Pull Request (PR) description
'Id' is not a parameter to the function. Also function the if-statement that was always true. 

#### This Pull Request (PR) fixes the following issues
- Fixes #2698


