### PR TITLE
FIX #2710

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@
     FIXES [#2719](https://github.com/microsoft/Microsoft365DSC/issues/2719)
 * TeamsEmergencyCallingPolicy
   * Fixes issue where CertificateThumbprint wasn't working because Credential was set to mandatory by the Test-TargetResource function.
-    FIXES [#2709](https://github.com/microsoft/Microsoft365DSC/issues/2709)
+    FIXES [#2710](https://github.com/microsoft/Microsoft365DSC/issues/2710)
 * TeamsEmergencyCallingRoutingPolicy
   * Fixes issue where CertificateThumbprint wasn't working because Credential was set to mandatory by the Test-TargetResource function.
-    FIXES [#2709](https://github.com/microsoft/Microsoft365DSC/issues/2709)
+    FIXES [#2710](https://github.com/microsoft/Microsoft365DSC/issues/2710)
 * TeamsIPPhonePolicy
   * Added descriptions to the resource parameters
   * Limited possible parameter values where required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 * SCRetentionCompliancePolicy
   * Forces changes to existing policies to be applied.
     FIXES [#2719](https://github.com/microsoft/Microsoft365DSC/issues/2719)
+* TeamsEmergencyCallingPolicy
+  * Fixes issue where CertificateThumbprint wasn't working because Credential was set to mandatory by the Test-TargetResource function.
+    FIXES [#2709](https://github.com/microsoft/Microsoft365DSC/issues/2709)
+* TeamsEmergencyCallingRoutingPolicy
+  * Fixes issue where CertificateThumbprint wasn't working because Credential was set to mandatory by the Test-TargetResource function.
+    FIXES [#2709](https://github.com/microsoft/Microsoft365DSC/issues/2709)
 * TeamsIPPhonePolicy
   * Added descriptions to the resource parameters
   * Limited possible parameter values where required

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallRoutingPolicy/MSFT_TeamsEmergencyCallRoutingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallRoutingPolicy/MSFT_TeamsEmergencyCallRoutingPolicy.psm1
@@ -261,7 +261,7 @@ function Test-TargetResource
         [System.String]
         $Ensure = 'Present',
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallingPolicy/MSFT_TeamsEmergencyCallingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallingPolicy/MSFT_TeamsEmergencyCallingPolicy.psm1
@@ -283,7 +283,7 @@ function Test-TargetResource
         [System.String]
         $Ensure = 'Present',
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 


### PR DESCRIPTION
#### Pull Request (PR) description
* TeamsEmergencyCallingPolicy
  * Fixes issue where CertificateThumbprint wasn't working because Credential was set to mandatory by the Test-TargetResource function.
* TeamsEmergencyCallingRoutingPolicy
  * Fixes issue where CertificateThumbprint wasn't working because Credential was set to mandatory by the Test-TargetResource function.

#### This Pull Request (PR) fixes the following issues
* FIXES #2710
