### PR TITLE
PlannerPlan: fix hard-coded authentication with credential in Export-TargetResource

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerPlan/MSFT_PlannerPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerPlan/MSFT_PlannerPlan.psm1
@@ -360,8 +360,7 @@ function Export-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    $ConnectionMode = 'Credentials'
-    $null = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
         -InboundParameters $PSBoundParameters
 
     try


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes hard coded `$CredentialMode = 'Credential'` in PlannerPlan's Export-TargetResource. 

#### This Pull Request (PR) fixes the following issues
- Fixes #2769 

