### PR TITLE
Filter on planner

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerBucket/MSFT_PlannerBucket.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerBucket/MSFT_PlannerBucket.psm1
@@ -286,6 +286,10 @@ function Export-TargetResource
     param
     (
         [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -326,7 +330,7 @@ function Export-TargetResource
 
     try
     {
-        [array]$groups = Get-MgGroup -All:$true -ErrorAction Stop
+        [array]$groups = Get-MgGroup -All:$true -ErrorAction Stop -Filter $filter
 
         $i = 1
         $dscContent = ''

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerPlan/MSFT_PlannerPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerPlan/MSFT_PlannerPlan.psm1
@@ -360,8 +360,7 @@ function Export-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    $ConnectionMode = 'Credentials'
-    $null = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
         -InboundParameters $PSBoundParameters
 
     try

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerPlan/MSFT_PlannerPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerPlan/MSFT_PlannerPlan.psm1
@@ -325,6 +325,10 @@ function Export-TargetResource
     param
     (
         [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -365,7 +369,7 @@ function Export-TargetResource
 
     try
     {
-        [array]$groups = Get-MgGroup -All:$true -ErrorAction Stop
+        [array]$groups = Get-MgGroup -All:$true -ErrorAction Stop -Filter $filter
 
         $i = 1
         $dscContent = ''
@@ -377,7 +381,6 @@ function Export-TargetResource
             {
                 [Array]$plans = Get-MgGroupPlannerPlan -GroupId $group.Id `
                     -All:$true `
-                    -Filter $Filter `
                     -ErrorAction 'SilentlyContinue'
 
                 $j = 1

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerTask/MSFT_PlannerTask.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerTask/MSFT_PlannerTask.psm1
@@ -582,6 +582,10 @@ function Export-TargetResource
     param
     (
         [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -622,7 +626,7 @@ function Export-TargetResource
         $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
             -InboundParameters $PSBoundParameters
 
-        [array]$groups = Get-MgGroup -All:$true
+        [array]$groups = Get-MgGroup -All:$true -ErrorAction Stop -Filter $filter
 
         $i = 1
         $dscContent = ''


### PR DESCRIPTION
#### Pull Request (PR) description
As discussed in #2772 , PlannerBucket, PlannerPlan and Plannertask do not support filters. The following PR is an implementation in which the `$Filter` parameter is added to each of the resource's `Export-TargetResource` function, and used on Groups: 
```powershell
[array]$groups = Get-MgGroup -All:$true -ErrorAction Stop -Filter $filter
```

#### This Pull Request (PR) fixes the following issues
- Fixes #2772

