### PR TITLE
Added missing params on PP-resources

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.psm1
@@ -333,6 +333,7 @@ function Export-TargetResource
                     ApplicationId         = $ApplicationId
                     TenantId              = $TenantId
                     CertificateThumbprint = $CertificateThumbprint
+                    ApplicationSecret     = $ApplicationSecret
                 }
                 $Results = Get-TargetResource @Params
                 $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPTenantIsolationSettings/MSFT_PPTenantIsolationSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPTenantIsolationSettings/MSFT_PPTenantIsolationSettings.psm1
@@ -650,6 +650,10 @@ function Export-TargetResource
         $Params = @{
             IsSingleInstance      = 'Yes'
             Credential            = $Credential
+            ApplicationId         = $ApplicationId
+            TenantId              = $TenantId
+            CertificateThumbprint = $CertificateThumbprint
+            ApplicationSecret     = $ApplicationSecret
         }
 
         $Results = Get-TargetResource @Params

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPTenantSettings/MSFT_PPTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPTenantSettings/MSFT_PPTenantSettings.psm1
@@ -429,8 +429,12 @@ function Export-TargetResource
         $dscContent = ''
 
         $Params = @{
-            IsSingleInstance = 'Yes'
-            Credential       = $Credential
+            IsSingleInstance      = 'Yes'
+            Credential            = $Credential
+            ApplicationId         = $ApplicationId
+            TenantId              = $TenantId
+            CertificateThumbprint = $CertificateThumbprint
+            ApplicationSecret     = $ApplicationSecret
         }
         $Results = Get-TargetResource @Params
         $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `


### PR DESCRIPTION
#### Pull Request (PR) description
On PP-resources, params for ApplicationId, TenantId, CertificateThumbprint and ApplicationSecret have been added do the params block on all functions, but Export-TargetResource did not call Get-TargetResource with those params, it only called the Get-TargetResource with $Credential. 

#### This Pull Request (PR) fixes the following issues
- Fixes #2782 

