### PR TITLE
Fixes wrong api permissions on PlannerBucket and PlannerPlan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
   * Fixes #2819
 * DEPENDENCIES
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.155.
+* Planner
+  * Fixed api-permissions on PlannerBucket and PlannerPlan.
+    FIXES [#2843](https://github.com/microsoft/Microsoft365DSC/issues/2843)
 
 # 1.23.118.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerBucket/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerBucket/settings.json
@@ -6,12 +6,12 @@
             "delegated": {
                 "read": [
                     {
-                        "name": "Tasks.Read"
+                        "name": "Tasks.Read.All"
                     }
                 ],
                 "update": [
                     {
-                        "name": "Tasks.ReadWrite"
+                        "name": "Tasks.ReadWrite.All"
                     }
                 ]
             },

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerPlan/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerPlan/settings.json
@@ -9,7 +9,7 @@
                         "name": "Group.Read.All"
                     },
                     {
-                        "name": "Tasks.Read"
+                        "name": "Tasks.Read.All"
                     }
                 ],
                 "update": [
@@ -17,10 +17,10 @@
                         "name": "Group.Read.All"
                     },
                     {
-                        "name": "Tasks.Read"
+                        "name": "Tasks.Read.All"
                     },
                     {
-                        "name": "Tasks.ReadWrite"
+                        "name": "Tasks.ReadWrite.All"
                     }
                 ]
             },

--- a/Modules/Microsoft365DSC/Modules/M365DSCPermissions.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCPermissions.psm1
@@ -1508,7 +1508,7 @@ function Update-M365DSCAzureAdApplication
                     $_ -is [Microsoft.Azure.PowerShell.Cmdlets.Resources.MSGraph.Models.ApiV10.MicrosoftGraphKeyCredential]
                 }
 
-                if ($PSBoundParameters.ContainsKey('CertificatePath'))
+                if (($PSBoundParameters.ContainsKey('CertificatePath') -and (-not $CreateSelfSignedCertificate)))
                 {
                     $cerCert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 -ArgumentList $CertificatePath
                 }

--- a/docs/docs/resources/planner/PlannerBucket.md
+++ b/docs/docs/resources/planner/PlannerBucket.md
@@ -32,11 +32,11 @@ To authenticate with the Microsoft Graph API, this resource required the followi
 
 - **Read**
 
-    - Tasks.Read
+    - Tasks.Read.All
 
 - **Update**
 
-    - Tasks.ReadWrite
+    - Tasks.ReadWrite.All
 
 #### Application permissions
 

--- a/docs/docs/resources/planner/PlannerPlan.md
+++ b/docs/docs/resources/planner/PlannerPlan.md
@@ -31,11 +31,11 @@ To authenticate with the Microsoft Graph API, this resource required the followi
 
 - **Read**
 
-    - Group.Read.All, Tasks.Read
+    - Group.Read.All, Tasks.Read.All
 
 - **Update**
 
-    - Group.Read.All, Tasks.Read, Tasks.ReadWrite
+    - Group.Read.All, Tasks.Read.All, Tasks.ReadWrite.All
 
 #### Application permissions
 


### PR DESCRIPTION
#### Pull Request (PR) description
1. Fixes the wrong names on api permissions for PlannerBucket and PlannerPlan:

The api permissions `Tasks.Read` and `Tasks.ReadWrite` does not exist. 
The correct api permissions are `Tasks.Read.All` and `Tasks.ReadWrite.All`. 

2. Also fixes #2850 allthough totally unrelated. 

#### This Pull Request (PR) fixes the following issues
- Fixes #2843 
- Fixes #2850 
 


