### PR TITLE
Power Platform: "germany" is missing as location for environments

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.psm1
@@ -9,7 +9,7 @@ function Get-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        [ValidateSet('canada', 'unitedstates', 'europe', 'asia', 'australia', 'india', 'japan', 'unitedkingdom', 'unitedstatesfirstrelease', 'southamerica', 'france', 'usgov')]
+        [ValidateSet('canada', 'unitedstates', 'europe', 'asia', 'australia', 'india', 'japan', 'unitedkingdom', 'unitedstatesfirstrelease', 'southamerica', 'france', 'usgov', 'germany')]
         $Location,
 
         [Parameter(Mandatory = $true)]
@@ -112,7 +112,7 @@ function Set-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        [ValidateSet('canada', 'unitedstates', 'europe', 'asia', 'australia', 'india', 'japan', 'unitedkingdom', 'unitedstatesfirstrelease', 'southamerica', 'france', 'usgov')]
+        [ValidateSet('canada', 'unitedstates', 'europe', 'asia', 'australia', 'india', 'japan', 'unitedkingdom', 'unitedstatesfirstrelease', 'southamerica', 'france', 'usgov', 'germany')]
         $Location,
 
         [Parameter(Mandatory = $true)]
@@ -207,7 +207,7 @@ function Test-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        [ValidateSet('canada', 'unitedstates', 'europe', 'asia', 'australia', 'india', 'japan', 'unitedkingdom', 'unitedstatesfirstrelease', 'southamerica', 'france', 'usgov')]
+        [ValidateSet('canada', 'unitedstates', 'europe', 'asia', 'australia', 'india', 'japan', 'unitedkingdom', 'unitedstatesfirstrelease', 'southamerica', 'france', 'usgov', 'germany')]
         $Location,
 
         [Parameter(Mandatory = $true)]


### PR DESCRIPTION
I tried in my tenant with environment in region "germany": Export-M365DSCConfiguration -Components @("PPPowerAppsEnvironment", "PPTenantIsolationSettings", "PPTenantSettings") -Credential $Credential

Error: 
[2023/02/15 05:56:14]
{InvalidData}
System.Management.Automation.ParameterBindingValidationException: Cannot validate argument on parameter 'Location'. The argument "germany" does not belong to the set "canada,unitedstates,europe,asia,australia,india,japan,unitedkingdom,unitedstatesfirstrelease,southamerica,france,usgov" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.
 ---> System.Management.Automation.ValidationMetadataException: The argument "germany" does not belong to the set "canada,unitedstates,europe,asia,australia,india,japan,unitedkingdom,unitedstatesfirstrelease,southamerica,france,usgov" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.
   at System.Management.Automation.ValidateSetAttribute.ValidateElement(Object element)
   at System.Management.Automation.ParameterBinderBase.BindParameter(CommandParameterInternal parameter, CompiledCommandParameter parameterMetadata, ParameterBindingFlags flags)
   --- End of inner exception stack trace ---
   at System.Management.Automation.ExceptionHandlingOps.CheckActionPreference(FunctionContext funcContext, Exception exception)
   at System.Management.Automation.Interpreter.ActionCallInstruction`2.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
"Error during Export:"
at Export-TargetResource, C:\Program Files\WindowsPowerShell\Modules\Microsoft365DSC\1.23.208.1\DSCResources\MSFT_PPPowerAppsEnvironment\MSFT_PPPowerAppsEnvironment.psm1: line 348 at Start-M365DSCConfigurationExtract, C:\Program Files\WindowsPowerShell\Modules\Microsoft365DSC\1.23.208.1\modules\M365DSCReverse.psm1: line 615 at Export-M365DSCConfiguration, C:\Program Files\WindowsPowerShell\Modules\Microsoft365DSC\1.23.208.1\modules\M365DSCUtil.psm1: line 1193 at <ScriptBlock>, <No file>: line 1
admin@xxx.onmicrosoft.com
TenantId: xxx.onmicrosoft.com

Resolution:
Add "germany" to the ValidateSets in this script.

#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
