### PR TITLE
Fixed various permissions within settings.json and .csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# 1.23.215.2
+
+* MISC
+  * Updated Tasks.Read and Tasks.ReadWrite Permissions for Planner Plans and Planner Buckets
+    FIXES [#2866](https://github.com/microsoft/Microsoft365DSC/issues/2866)
+
 # 1.23.215.1
 
 * EXOIRMConfiguration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * MISC
   * Updated Tasks.Read and Tasks.ReadWrite Permissions for Planner Plans and Planner Buckets
     FIXES [#2866](https://github.com/microsoft/Microsoft365DSC/issues/2866)
+  * Fixed Permissions Scopes for AADAuthorizationPolicy and AADSecurityDefaults
 
 # 1.23.215.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log for Microsoft365DSC
 
-# 1.23.215.2
+# UNRELEASED
 
 * MISC
   * Updated Tasks.Read and Tasks.ReadWrite Permissions for Planner Plans and Planner Buckets

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthorizationPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthorizationPolicy/settings.json
@@ -11,7 +11,7 @@
                 ],
                 "update": [
                     {
-                        "name": "Policy.ReadWrite.All"
+                        "name": "Policy.ReadWrite.Authorization"
                     }
                 ]
             },
@@ -23,7 +23,7 @@
                 ],
                 "update": [
                     {
-                        "name": "Policy.ReadWrite.All"
+                        "name": "Policy.ReadWrite.Authorization"
                     }
                 ]
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADSecurityDefaults/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADSecurityDefaults/settings.json
@@ -11,7 +11,7 @@
                 ],
                 "update": [
                     {
-                        "name": "Policy.ReadWrite.All"
+                        "name": "Policy.ReadWrite.ConditionalAccess"
                     }
                 ]
             },
@@ -23,7 +23,7 @@
                 ],
                 "update": [
                     {
-                        "name": "Policy.ReadWrite.All"
+                        "name": "Policy.ReadWrite.ConditionalAccess"
                     }
                 ]
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerBucket/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerBucket/settings.json
@@ -6,24 +6,24 @@
             "delegated": {
                 "read": [
                     {
-                        "name": "Tasks.Read.All"
+                        "name": "Tasks.Read"
                     }
                 ],
                 "update": [
                     {
-                        "name": "Tasks.ReadWrite.All"
+                        "name": "Tasks.ReadWrite"
                     }
                 ]
             },
             "application": {
                 "read": [
                     {
-                        "name": "Tasks.Read.All"
+                        "name": "Tasks.Read"
                     }
                 ],
                 "update": [
                     {
-                        "name": "Tasks.ReadWrite.All"
+                        "name": "Tasks.ReadWrite"
                     }
                 ]
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerPlan/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerPlan/settings.json
@@ -9,7 +9,7 @@
                         "name": "Group.Read.All"
                     },
                     {
-                        "name": "Tasks.Read.All"
+                        "name": "Tasks.Read"
                     }
                 ],
                 "update": [
@@ -17,10 +17,10 @@
                         "name": "Group.Read.All"
                     },
                     {
-                        "name": "Tasks.Read.All"
+                        "name": "Tasks.Read"
                     },
                     {
-                        "name": "Tasks.ReadWrite.All"
+                        "name": "Tasks.ReadWrite"
                     }
                 ]
             },
@@ -30,7 +30,7 @@
                         "name": "Group.Read.All"
                     },
                     {
-                        "name": "Tasks.Read.All"
+                        "name": "Tasks.Read"
                     }
                 ],
                 "update": [
@@ -38,10 +38,10 @@
                         "name": "Group.Read.All"
                     },
                     {
-                        "name": "Tasks.Read.All"
+                        "name": "Tasks.Read"
                     },
                     {
-                        "name": "Tasks.ReadWrite.All"
+                        "name": "Tasks.ReadWrite"
                     }
                 ]
             }

--- a/Modules/Microsoft365DSC/Dependencies/GraphCmdletPermissions.csv
+++ b/Modules/Microsoft365DSC/Dependencies/GraphCmdletPermissions.csv
@@ -22,11 +22,11 @@ Get-MgGroupLifecyclePolicy,Directory.Read.All,Directory.Read.All
 Get-MgGroupMember,Group.Read.All,Group.Read.All
 Get-MgGroupMemberOf,Group.Read.All,Group.Read.All
 Get-MgGroupOwner,Group.Read.All,Group.Read.All
-Get-MgGroupPlannerPlan,Tasks.Read.All,Tasks.Read.All
+Get-MgGroupPlannerPlan,Tasks.Read,Tasks.Read
 Get-MgIdentityConditionalAccessNamedLocation,Policy.Read.All,Policy.Read.All
 Get-MgIdentityConditionalAccessPolicy,Policy.Read.All,Policy.Read.All
 Get-MgOrganization,Organization.Read.All,Organization.Read.All
-Get-MgPlannerPlanBucket,Tasks.Read.All,Tasks.Read.All
+Get-MgPlannerPlanBucket,Tasks.Read,Tasks.Read
 Get-MgPlannerTask,Group.Read.All,Group.Read.All
 Get-MgPlannerTaskDetail,Group.Read.All,Group.Read.All
 Get-MgPolicyAuthorizationPolicy,Policy.Read.All,Policy.Read.All
@@ -61,8 +61,8 @@ New-MgGroupMember,Group.ReadWrite.All,Group.ReadWrite.All
 New-MgGroupMemberByRef,Group.ReadWrite.All,Group.ReadWrite.All
 New-MgGroupOwnerByRef,Group.ReadWrite.All,Group.ReadWrite.All
 New-MgIdentityConditionalAccessPolicy,Policy.Read.All/Policy.ReadWrite.ConditionalAccess,Policy.Read.All/Policy.ReadWrite.ConditionalAccess
-New-MgPlannerBucket,Tasks.ReadWrite.All,Tasks.ReadWrite.All
-New-MgPlannerPlan,Tasks.ReadWrite.All,Tasks.ReadWrite.All
+New-MgPlannerBucket,Tasks.ReadWrite,Tasks.ReadWrite
+New-MgPlannerPlan,Tasks.ReadWrite,Tasks.ReadWrite
 New-MgPlannerTask,Group.ReadWrite.All,Group.ReadWrite.All
 New-MgPolicyTokenLifetimePolicy,Policy.ReadWrite.ApplicationConfiguration,Policy.ReadWrite.ApplicationConfiguration
 New-MgRoleManagementDirectoryRoleAssignment,RoleManagement.ReadWrite.Directory,RoleManagement.ReadWrite.Directory
@@ -109,7 +109,7 @@ Update-MgGroup,Group.ReadWrite.All,Group.ReadWrite.All
 Update-MgGroupLifecyclePolicy,Directory.ReadWrite.All,Directory.ReadWrite.All
 Update-MgIdentityConditionalAccessPolicy,Policy.Read.All/Policy.ReadWrite.ConditionalAccess,Policy.Read.All/Policy.ReadWrite.ConditionalAccess
 Update-MgOrganization,Organization.ReadWrite.All,Organization.ReadWrite.All
-Update-MgPlannerPlan,Tasks.ReadWrite.All,Tasks.ReadWrite.All
+Update-MgPlannerPlan,Tasks.ReadWrite,Tasks.ReadWrite
 Update-MgPolicyAuthorizationPolicy,Policy.ReadWrite.All,Policy.ReadWrite.All
 Update-MgPolicyIdentitySecurityDefaultEnforcementPolicy,Policy.ReadWrite.All,Policy.ReadWrite.All
 Update-MgPolicyRoleManagementPolicyRule,RoleManagementPolicy.Read.Directory,RoleManagementPolicy.Read.Directory

--- a/Modules/Microsoft365DSC/Dependencies/GraphCmdletPermissions.csv
+++ b/Modules/Microsoft365DSC/Dependencies/GraphCmdletPermissions.csv
@@ -110,8 +110,8 @@ Update-MgGroupLifecyclePolicy,Directory.ReadWrite.All,Directory.ReadWrite.All
 Update-MgIdentityConditionalAccessPolicy,Policy.Read.All/Policy.ReadWrite.ConditionalAccess,Policy.Read.All/Policy.ReadWrite.ConditionalAccess
 Update-MgOrganization,Organization.ReadWrite.All,Organization.ReadWrite.All
 Update-MgPlannerPlan,Tasks.ReadWrite,Tasks.ReadWrite
-Update-MgPolicyAuthorizationPolicy,Policy.ReadWrite.All,Policy.ReadWrite.All
-Update-MgPolicyIdentitySecurityDefaultEnforcementPolicy,Policy.ReadWrite.All,Policy.ReadWrite.All
+Update-MgPolicyAuthorizationPolicy,Policy.ReadWrite.Authorization,Policy.ReadWrite.Authorization
+Update-MgPolicyIdentitySecurityDefaultEnforcementPolicy,Policy.ReadWrite.ConditionalAccess,Policy.ReadWrite.ConditionalAccess
 Update-MgPolicyRoleManagementPolicyRule,RoleManagementPolicy.Read.Directory,RoleManagementPolicy.Read.Directory
 Update-MgPolicyTokenLifetimePolicy,Policy.ReadWrite.ApplicationConfiguration,Policy.ReadWrite.ApplicationConfiguration
 Update-MgRoleManagementDirectoryRoleDefinition,RoleManagement.ReadWrite.Directory,RoleManagement.ReadWrite.Directory

--- a/docs/docs/resources/azure-ad/AADAuthorizationPolicy.md
+++ b/docs/docs/resources/azure-ad/AADAuthorizationPolicy.md
@@ -58,7 +58,7 @@ To authenticate with the Microsoft Graph API, this resource required the followi
 
 - **Update**
 
-    - Policy.ReadWrite.All
+    - Policy.ReadWrite.Authorization
 
 #### Application permissions
 
@@ -68,7 +68,7 @@ To authenticate with the Microsoft Graph API, this resource required the followi
 
 - **Update**
 
-    - Policy.ReadWrite.All
+    - Policy.ReadWrite.Authorization
 
 ## Examples
 

--- a/docs/docs/resources/azure-ad/AADSecurityDefaults.md
+++ b/docs/docs/resources/azure-ad/AADSecurityDefaults.md
@@ -34,7 +34,7 @@ To authenticate with the Microsoft Graph API, this resource required the followi
 
 - **Update**
 
-    - Policy.ReadWrite.All
+    - Policy.ReadWrite.ConditionalAccess
 
 #### Application permissions
 
@@ -44,7 +44,7 @@ To authenticate with the Microsoft Graph API, this resource required the followi
 
 - **Update**
 
-    - Policy.ReadWrite.All
+    - Policy.ReadWrite.ConditionalAccess
 
 ## Examples
 

--- a/docs/docs/resources/planner/PlannerBucket.md
+++ b/docs/docs/resources/planner/PlannerBucket.md
@@ -32,21 +32,21 @@ To authenticate with the Microsoft Graph API, this resource required the followi
 
 - **Read**
 
-    - Tasks.Read.All
+    - Tasks.Read
 
 - **Update**
 
-    - Tasks.ReadWrite.All
+    - Tasks.ReadWrite
 
 #### Application permissions
 
 - **Read**
 
-    - Tasks.Read.All
+    - Tasks.Read
 
 - **Update**
 
-    - Tasks.ReadWrite.All
+    - Tasks.ReadWrite
 
 ## Examples
 

--- a/docs/docs/resources/planner/PlannerPlan.md
+++ b/docs/docs/resources/planner/PlannerPlan.md
@@ -31,21 +31,21 @@ To authenticate with the Microsoft Graph API, this resource required the followi
 
 - **Read**
 
-    - Group.Read.All, Tasks.Read.All
+    - Group.Read.All, Tasks.Read
 
 - **Update**
 
-    - Group.Read.All, Tasks.Read.All, Tasks.ReadWrite.All
+    - Group.Read.All, Tasks.Read, Tasks.ReadWrite
 
 #### Application permissions
 
 - **Read**
 
-    - Group.Read.All, Tasks.Read.All
+    - Group.Read.All, Tasks.Read
 
 - **Update**
 
-    - Group.Read.All, Tasks.Read.All, Tasks.ReadWrite.All
+    - Group.Read.All, Tasks.Read, Tasks.ReadWrite
 
 ## Examples
 


### PR DESCRIPTION
- This will fix the last remaining wrong scopes for Planner Plans and Planner Buckets
  - renaming of Tasks.Read.All to Tasks.Read and Tasks.ReadWrite.All to Tasks.ReadWrite


- Fixed Permissions Scopes for AADAuthorizationPolicy and AADSecurityDefaults