### PR TITLE
Fix json, remove extra trailing commas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* IntuneDeviceEnrollmentConfigurationWindows10
+  * Fix settings.json
+    FIXES [#2930](https://github.com/microsoft/Microsoft365DSC/issues/2930)
 * TeamsOnlineVoiceUser
   * Fix issue where the cmdlet Get-CsOnlineVoiceUser is now deprecated.
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentConfigurationWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentConfigurationWindows10/settings.json
@@ -10,7 +10,7 @@
                     },
                     {
                         "name": "DeviceManagementServiceConfig.Read.All"
-                    },
+                    }
                 ],
                 "update": [
                     {
@@ -28,7 +28,7 @@
                     },
                     {
                         "name": "DeviceManagementServiceConfig.Read.All"
-                    },
+                    }
                 ],
                 "update": [
                     {


### PR DESCRIPTION
#### Pull Request (PR) description
Update-M365DSCResourceDocumentationPage is not working because one of the new settings.json file is not correct then ConvertFrom-Json errors out and cannot generate the documentation. Fix this by removing two extra trailing commas from this JSON file

#### This Pull Request (PR) fixes the following issues
- Fixes #2930 
