### PR TITLE
AADAdministrativeUnit : Updated schema wrt Identity and ScopedRoleMembership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
+* AADAdministrativeUnit
+  * Updated validation of properties in schema to assist usage
 
 * AADAdministrativeUnit
   * Fixed general issues caused by improper handling of nested CIMInstances

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.schema.mof
@@ -2,12 +2,12 @@
 class MSFT_MicrosoftGraphIdentity
 {
     [Write, Description("Identity of member. For users, specify a UserPrincipalName. For groups and devices, specify DisplayName")] String Identity;
-    [Write, Description("Specify User, Group or Device to interpret the identity. Can be Principal in ScopedRoleMembers")] String Type;
+    [Write, Description("Specify User, Group or Device to interpret the identity. Can be ServicePrincipal in ScopedRoleMembers"), ValueMap{"User", "Group", "Device", "ServicePrincipal"}, Values{"User", "Group", "Device", "ServicePrincipal"}] String Type;
 };
 [ClassVersion("1.0.0")]
 class MSFT_MicrosoftGraphScopedRoleMembership
 {
-    [Write, Description("Name of the Azure AD Role that is assigned")] String RoleName;
+    [Write, Description("Name of the Azure AD Role that is assigned. See https://learn.microsoft.com/en-us/azure/active-directory/roles/admin-units-assign-roles#roles-that-can-be-assigned-with-administrative-unit-scope")] String RoleName;
     [Write, Description("Member that is assigned the scoped role"), EmbeddedInstance("MSFT_MicrosoftGraphIdentity")] String RoleMemberInfo;
     // [Write, Description("Identity of member. For users, specify a UserPrincipalName. For groups and SPNs, specify the DisplayName")] String Identity;
     // [Write, Description("Specify User, Group or ServicePrincipal to interpret the Identity")] String Type;


### PR DESCRIPTION
#### Pull Request (PR) description
Updated schema-property Type for CIMInstance MSFT_MicrosoftGraphIdentity used in AADAdministrativeUnit to enable validation of content while editing a configuration. Also, for clarity, added link to show available roles in description of property RoleName for CIMInstance MSFT_MicrosoftGraphScopedRoleMembership

#### This Pull Request (PR) fixes the following issues
None