### PR TITLE
fix: Progress bar "Scanning dependencies" stays on screen sometimes. …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
   * Added a QA check to test for the presence of a Key parameter and fixes
     resources where this was not the case.
     FIXES [#2925](https://github.com/microsoft/Microsoft365DSC/issues/2925)
+  * Added a fix making sure that the progress bar "Scanning dependencies" is no longer displayed after the operation is completed.
 
 # 1.23.322.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2592,7 +2592,6 @@ function Test-M365DSCDependenciesForNewVersions
 
     foreach ($dependency in $dependencies)
     {
-        
         Write-Progress -Activity 'Scanning Dependencies' -PercentComplete ($i / $dependencies.Count * 100)
         try
         {

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2593,7 +2593,7 @@ function Test-M365DSCDependenciesForNewVersions
     foreach ($dependency in $dependencies)
     {
         
-        -Activity 'Scanning Dependencies' -PercentComplete ($i / $dependencies.Count * 100)
+        Write-Progress -Activity 'Scanning Dependencies' -PercentComplete ($i / $dependencies.Count * 100)
         try
         {
             $moduleInGallery = Find-Module $dependency.ModuleName

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2592,7 +2592,8 @@ function Test-M365DSCDependenciesForNewVersions
 
     foreach ($dependency in $dependencies)
     {
-        Write-Progress -Activity 'Scanning Dependencies' -PercentComplete ($i / $dependencies.Count * 100)
+        
+        -Activity 'Scanning Dependencies' -PercentComplete ($i / $dependencies.Count * 100)
         try
         {
             $moduleInGallery = Find-Module $dependency.ModuleName
@@ -2614,6 +2615,9 @@ function Test-M365DSCDependenciesForNewVersions
         }
         $i++
     }
+    
+    # The progress bar seems to hang sometimes. Make sure it is no longer displayed.
+    Write-Progress -Activity 'Scanning Dependencies' -Completed
 }
 
 <#
@@ -2688,6 +2692,9 @@ function Update-M365DSCDependencies
         }
         $i++
     }
+    
+    # The progress bar seems to hang sometimes. Make sure it is no longer displayed.
+    Write-Progress -Activity 'Scanning Dependencies' -Completed
 
     if ($ValidateOnly)
     {


### PR DESCRIPTION
…Make sure it is no longer displayed.

#### Pull Request (PR) description
fix: Progress bar "Scanning dependencies" stays on screen sometimes. Make sure it is no longer displayed.

#### This Pull Request (PR) fixes the following issues
fix: Progress bar "Scanning dependencies" stays on screen sometimes. Make sure it is no longer displayed.