### PR TITLE
Remove GroupTypes defaulting to Unified - fixes #3073

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 * AADGroup
   * Changed the SecurityEnabled and MailEnabled parameters to become mandatory.
     FIXES [#3072](https://github.com/microsoft/Microsoft365DSC/issues/3072)
+  * Stopped GroupTypes defaulting to 'Unified' to allow creation of Security groups.
+    FIXES [#3073](https://github.com/microsoft/Microsoft365DSC/issues/3073)
 * AADUser
   * [BREAKING CHANGE] Remove deprecated parameter PreferredDataLocation* EXOAntiPhishPolicy
   * [BREAKING CHANGE] Remove deprecated parameters EnableAntispoofEnforcement and

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -34,7 +34,7 @@ function Get-TargetResource
 
         [Parameter()]
         [System.String[]]
-        $GroupTypes = @('Unified'),
+        $GroupTypes,
 
         [Parameter()]
         [System.String]
@@ -401,10 +401,6 @@ function Set-TargetResource
     {
         Write-Verbose -Message 'Cannot set mailenabled to false if GroupTypes is set to Unified when creating group.'
         throw 'Cannot set mailenabled to false if GroupTypes is set to Unified when creating a group.'
-    }
-    if (-not $GroupTypes -and $currentParameters.GroupTypes -eq $null)
-    {
-        $currentParameters.Add('GroupTypes', @('Unified'))
     }
 
     $currentValuesToCheck = @()


### PR DESCRIPTION
#### Pull Request (PR) description
Remove GroupTypes code defaulting to Unified. This means that it can be left to $null allowing the [creation of security groups](https://learn.microsoft.com/en-us/graph/api/group-post-groups?view=graph-rest-1.0&tabs=http#example-2-create-a-group-with-owners-and-members).

Why was this code here? Looking at blame it appears to have a bit of history:
-  It was originally inserted to fix #850 - a failure in Set-TargetResource. The original code was checking $GroupTypes.Contains("Unified") but didn't check if $GroupTypes was $null first. The author of the fix may not have realised that when creating security groups, $GroupTypes *needs* to be null, so 'fixed' it by defaulting group types to Unified if nothing is specified. However the side effect is that security groups can no longer be created.
- Since then there's been [another fix](https://github.com/microsoft/Microsoft365DSC/commit/970073f82fdc6cb7f0edfe9393ddd037fd6c5dcf) which resolves issue #850 with checking $GroupTypes.Contains("Unified") the correct way - by preceding it with a check for '$null -ne $GroupTypes' before it goes ahead.

Therefore the original problem is now resolved, so hopefully if we remove the final check, everything works OK!

Happy to comment/discuss if you think I'm wrong.

#### This Pull Request (PR) fixes the following issues
Fixes #3073
