### PR TITLE
Fixes extraction of the ScopedRoleMembers property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * AADAdministrativeUnit
   * [BREAKING CHANGE] Setting Id as Key parameter and DisplayName as Required
   * Fixes extraction of the Members property.
+  * Fixes extraction of the ScopedRoleMembers property.
 * AADApplication
   * [BREAKING CHANGE] Remove deprecated parameter Oauth2RequirePostResponse
 * AADConditionalAccessPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
@@ -984,7 +984,7 @@ function Export-TargetResource
                 $complexMapping = @(
                     @{
                         Name            = 'RoleMemberInfo'
-                        CimInstanceName = 'MicrosoftGraphIdentity'
+                        CimInstanceName = 'MicrosoftGraphMember'
                     }
                 )
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject ([Array]$Results.ScopedRoleMembers) `


### PR DESCRIPTION
#### Pull Request (PR) description

Commit f60f2b9434db70f86374f9f2b22c612dc96549d8 solved the extraction for the Members property, but ScopedRoleMembers was not changed, this fixes it by using the correct CIM instance name.

#### This Pull Request (PR) fixes the following issues
