### PR TITLE
Remove ValidateScript from param Credential in Export-M365DSCConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
       FIXES [#3068](https://github.com/microsoft/Microsoft365DSC/issues/3068)
 * TeamsUpdateManagementPolicy
   * Added support for the Forced value for the AllowPublicPreview property.
+* MODULES
+  * M365DSCUtil: Fixed an issue when calling Assert-M365DSCBlueprint with App credentials
+    FIXES [#3153](https://github.com/microsoft/Microsoft365DSC/issues/3153)
 
 # 1.23.405.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1095,7 +1095,7 @@ function Export-M365DSCConfiguration
                 }
                 else
                 {
-                    Write-Warning -Message "We recommend providing the TenantId property in the format of <tenant>.onmicrosoft.*"
+                    Write-Host -Object "[WARNING] We recommend providing the TenantId property in the format of <tenant>.onmicrosoft.*" -ForegroundColor Yellow
                 }
             }
             return $true
@@ -1112,18 +1112,6 @@ function Export-M365DSCConfiguration
         $CertificateThumbprint,
 
         [Parameter(ParameterSetName = 'Export')]
-        [ValidateScript({
-            $invalid = $_.Username -notmatch ".onmicrosoft."
-            if (-not $invalid)
-            {
-                return $true
-            }
-            else
-            {
-                Write-Warning -Message "We recommend providing the username in the format of <tenant>.onmicrosoft.* for the Credential property."
-            }
-            return $true
-        })]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -1155,6 +1143,15 @@ function Export-M365DSCConfiguration
     $Global:WarningPreference = 'SilentlyContinue'
 
     ##### FIRST CHECK AUTH PARAMETERS
+    if ($PSBoundParameters.ContainsKey('Credential') -eq $true -and `
+        -not [System.String]::IsNullOrEmpty($Credential))
+    {
+        if ($Credential.Username -notmatch ".onmicrosoft.")
+        {
+            Write-Host -Object "[WARNING] We recommend providing the username in the format of <tenant>.onmicrosoft.* for the Credential property." -ForegroundColor Yellow
+        }
+    }
+
     if ($PSBoundParameters.ContainsKey('CertificatePath') -eq $true -and `
             $PSBoundParameters.ContainsKey('CertificatePassword') -eq $false)
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Remove ValidateScript from param Credential, in function Export-M365DSCConfiguration, since it may be null when using App creds, and validation will throw an error, instead do the validation afterwards in the body of the function itself.

#### This Pull Request (PR) fixes the following issues
- Fixes #3153
