### PR TITLE
SCLabelPolicy: If label policy is set to None don't get its label display name since it's not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* SCLabelPolicy
+  * If label policy is set to None don't get its label display name since it's not required
+    FIXES [#3104](https://github.com/microsoft/Microsoft365DSC/issues/3104)
+
 # 1.23.412.1
 
 * AADUser

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCLabelPolicy/MSFT_SCLabelPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCLabelPolicy/MSFT_SCLabelPolicy.psm1
@@ -866,7 +866,8 @@ function Convert-StringToAdvancedSettings
 
             if ($settingKey -like '*defaultlabel*')
             {
-                if ($values -ne "None") {
+                if ($values -ne "None")
+                {
                     $label = Get-Label -Identity $values
                     $values = $label.DisplayName
                 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCLabelPolicy/MSFT_SCLabelPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCLabelPolicy/MSFT_SCLabelPolicy.psm1
@@ -866,8 +866,10 @@ function Convert-StringToAdvancedSettings
 
             if ($settingKey -like '*defaultlabel*')
             {
-                $label = Get-Label -Identity $values
-                $values = $label.DisplayName
+                if ($values -ne "None") {
+                    $label = Get-Label -Identity $values
+                    $values = $label.DisplayName
+                }
             }
 
             $entry = @{

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCLabelPolicy/MSFT_SCLabelPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCLabelPolicy/MSFT_SCLabelPolicy.psm1
@@ -901,8 +901,15 @@ function Convert-CIMToAdvancedSettings
         $settingsValues = ''
         if ($obj.Key -like '*defaultlabel*')
         {
-            $label = Get-Label | Where-Object -FilterScript { $_.DisplayName -eq $obj.Value }
-            $settingsValues = $label.ImmutableId.ToString()
+            if ($obj.Value -ne "None")
+            {
+                $label = Get-Label | Where-Object -FilterScript { $_.DisplayName -eq $obj.Value }
+                $settingsValues = $label.ImmutableId.ToString()
+            }
+            else
+            {
+                $settingsValues = "None"
+            }
         }
         else
         {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCLabelPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCLabelPolicy.Tests.ps1
@@ -70,10 +70,16 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Name             = 'TestLabelPolicy'
                     Comment          = 'This is a test label policy'
                     Labels           = @('Personal', 'General')
-                    AdvancedSettings = (New-CimInstance -ClassName MSFT_SCLabelSetting -Property @{
+                    AdvancedSettings = @(
+                        (New-CimInstance -ClassName MSFT_SCLabelSetting -Property @{
                             Key   = 'LabelStatus'
                             Value = 'Enabled'
+                        } -ClientOnly),
+                        (New-CimInstance -ClassName MSFT_SCLabelSetting -Property @{
+                            Key   = 'DefaultLabelStatus'
+                            Value = 'None'
                         } -ClientOnly)
+                    )
                     Credential       = $Credential
                     Ensure           = 'Present'
                 }


### PR DESCRIPTION
#### Pull Request (PR) description
SCLabelPolicy: If label policy is set to None don't get its label display name since it's not required. This solves an issue when for instance a label policy has outlookdefaultlabel set to None, there is no label with such name and therefore Get-Label fails.

#### This Pull Request (PR) fixes the following issues
- Fixes #3104
