### PR TITLE
TeamsMessagingPolicy: Add new parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,8 @@
 
 # UNRELEASED
 
- * IntuneSettingCatalogCustomPolicyWindows10
+* AADAuthenticationStrengthPolicy
   * Initial release
-  FIXES [#2692](https://github.com/microsoft/Microsoft365DSC/issues/2692),
-  FIXES [#2976](https://github.com/microsoft/Microsoft365DSC/issues/2976),
-  FIXES [#3070](https://github.com/microsoft/Microsoft365DSC/issues/3070),
-  FIXES [#3071](https://github.com/microsoft/Microsoft365DSC/issues/3071),
-  FIXES [#3156](https://github.com/microsoft/Microsoft365DSC/issues/3156)
 * AADCrossTenantAccessPolicy
   * Initial release
     FIXES [#3251](https://github.com/microsoft/Microsoft365DSC/issues/3251)
@@ -20,6 +15,13 @@
     FIXES [#3253](https://github.com/microsoft/Microsoft365DSC/issues/3253)
 * TeamsMessagingPolicy
   * Add support for new parameters: AllowSmartCompose, AllowSmartReply, AllowUserDeleteChat
+ * IntuneSettingCatalogCustomPolicyWindows10
+  * Initial release
+  FIXES [#2692](https://github.com/microsoft/Microsoft365DSC/issues/2692),
+  FIXES [#2976](https://github.com/microsoft/Microsoft365DSC/issues/2976),
+  FIXES [#3070](https://github.com/microsoft/Microsoft365DSC/issues/3070),
+  FIXES [#3071](https://github.com/microsoft/Microsoft365DSC/issues/3071),
+  FIXES [#3156](https://github.com/microsoft/Microsoft365DSC/issues/3156)
 * DEPENDENCIES
   * Updated DSCParser to version 1.0.8.
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.162.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * AADCrossTenantAccessPolicyConfigurationPartner
   * Initial release
     FIXES [#3253](https://github.com/microsoft/Microsoft365DSC/issues/3253)
+* TeamsMessagingPolicy
+  * Add support for new parameters: AllowSmartCompose, AllowSmartReply, AllowUserDeleteChat
 * DEPENDENCIES
   * Updated DSCParser to version 1.0.8.
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.162.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.psm1
@@ -42,6 +42,14 @@ function Get-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $AllowSmartCompose,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowSmartReply,
+
+        [Parameter()]
+        [System.Boolean]
         $AllowUserTranslation,
 
         [Parameter()]
@@ -55,6 +63,10 @@ function Get-TargetResource
         [Parameter()]
         [System.Boolean]
         $AllowPriorityMessages,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowUserDeleteChat,
 
         [Parameter()]
         [System.String]
@@ -152,12 +164,15 @@ function Get-TargetResource
                 AllowUserChat                 = $policy.AllowUserChat
                 AllowUserDeleteMessage        = $policy.AllowUserDeleteMessage
                 AllowUserEditMessage          = $policy.AllowUserEditMessage
+                AllowSmartCompose             = $policy.AllowSmartCompose
+                AllowSmartReply               = $policy.AllowSmartReply
                 AllowUserTranslation          = $policy.AllowUserTranslation
                 GiphyRatingType               = $policy.GiphyRatingType
                 ReadReceiptsEnabledType       = $policy.ReadReceiptsEnabledType
                 AllowImmersiveReader          = $policy.AllowImmersiveReader
                 AllowRemoveUser               = $policy.AllowRemoveUser
                 AllowPriorityMessages         = $policy.AllowPriorityMessages
+                AllowUserDeleteChat           = $policy.AllowUserDeleteChat
                 ChannelsInChatListEnabledType = $policy.ChannelsInChatListEnabledType
                 AudioMessageEnabledType       = $policy.AudioMessageEnabledType
                 Description                   = $policy.Description
@@ -225,6 +240,14 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $AllowSmartCompose,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowSmartReply,
+
+        [Parameter()]
+        [System.Boolean]
         $AllowUserTranslation,
 
         [Parameter()]
@@ -238,6 +261,10 @@ function Set-TargetResource
         [Parameter()]
         [System.Boolean]
         $AllowPriorityMessages,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowUserDeleteChat,
 
         [Parameter()]
         [System.String]
@@ -373,6 +400,14 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $AllowSmartCompose,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowSmartReply,
+
+        [Parameter()]
+        [System.Boolean]
         $AllowUserTranslation,
 
         [Parameter()]
@@ -386,6 +421,10 @@ function Test-TargetResource
         [Parameter()]
         [System.Boolean]
         $AllowPriorityMessages,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowUserDeleteChat,
 
         [Parameter()]
         [System.String]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.schema.mof
@@ -6,6 +6,8 @@ class MSFT_TeamsMessagingPolicy : OMI_BaseResource
     [Write, Description("Determines whether a user is allowed to access and post memes. Set this to TRUE to allow. Set this FALSE to prohibit.")] boolean AllowMemes;
     [Write, Description("Determines whether owners are allowed to delete all the messages in their team. Set this to TRUE to allow. Set this to FALSE to prohibit.")] boolean AllowOwnerDeleteMessage;
     [Write, Description("Determines whether a user is allowed to edit their own messages. Set this to TRUE to allow. Set this to FALSE to prohibit.")] boolean AllowUserEditMessage;
+    [Write, Description("Turn on this setting to let a user get text predictions for chat messages.")] boolean AllowSmartCompose;
+    [Write, Description("Turn this setting on to enable suggested replies for chat messages. Set this to TRUE to allow. Set this to FALSE to prohibit.")] boolean AllowSmartReply;
     [Write, Description("Determines whether a user is allowed to access and post stickers. Set this to TRUE to allow. Set this FALSE to prohibit.")] boolean AllowStickers;
     [Write, Description("Use this setting to turn automatic URL previewing on or off in messages. Set this to TRUE to turn on. Set this to FALSE to turn off.")] boolean AllowUrlPreviews;
     [Write, Description("Determines whether a user is allowed to chat. Set this to TRUE to allow a user to chat across private chat, group chat and in meetings. Set this to FALSE to prohibit all chat.")] boolean AllowUserChat;
@@ -14,6 +16,7 @@ class MSFT_TeamsMessagingPolicy : OMI_BaseResource
     [Write, Description("Determines whether a user is allowed to use Immersive Reader for reading conversation messages. Set this to TRUE to allow. Set this FALSE to prohibit.")] boolean AllowImmersiveReader;
     [Write, Description("Determines whether a user is allowed to remove a user from a conversation. Set this to TRUE to allow. Set this FALSE to prohibit.")] boolean AllowRemoveUser;
     [Write, Description("Determines whether a user is allowed to send priorities messages. Set this to TRUE to allow. Set this FALSE to prohibit.")] boolean AllowPriorityMessages;
+    [Write, Description("Turn this setting on to allow users to permanently delete their 1:1, group chat, and meeting chat as participants (this deletes the chat only for them, not other users in the chat).")] boolean AllowUserDeleteChat;
     [Write, Description("Provide a description of your policy to identify purpose of creating it.")] string Description;
     [Write, Description("Determines the Giphy content restrictions applicable to a user. Set this to STRICT, MODERATE or NORESTRICTION."),ValueMap{"STRICT","MODERATE","NORESTRICTION"}, Values{"STRICT","MODERATE","NORESTRICTION"}] string GiphyRatingType;
     [Write, Description("Use this setting to specify whether read receipts are user controlled, enabled for everyone, or disabled. Set this to UserPreference, Everyone or None."),ValueMap{"UserPreference","Everyone","None"}, Values{"UserPreference","Everyone","None"}] string ReadReceiptsEnabledType;


### PR DESCRIPTION
#### Pull Request (PR) description
Add new parameters to TeamsMessagingPolicy:

- AllowSmartCompose
- AllowSmartReply
- AllowUserDeleteChat

#### This Pull Request (PR) fixes the following issues
None
