### PR TITLE
TeamsTeam: Fix group creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
   * Add support for AllowUserDeleteChat parameter
 * TeamsGuestMeetingConfiguration
   * Add support for LiveCaptionsEnabledType parameter
+* TeamsTeam
+  * Fix group creation
 * DEPENDENCIES
   * Updated DSCParser to version 1.0.9.
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.162.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -412,7 +412,7 @@ function Set-TargetResource
         {
             $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
                 -InboundParameters $PSBoundParameters
-            $group = New-MgSGroup -DisplayName $DisplayName -GroupTypes 'Unified' -MailEnabled $true -SecurityEnabled $true -MailNickname $MailNickName
+            $group = New-MgGroup -DisplayName $DisplayName -GroupTypes 'Unified' -MailEnabled $true -SecurityEnabled $true -MailNickname $MailNickName
             $currentOwner = (($CurrentParameters.Owner)[0])
 
             Write-Verbose -Message "Retrieving Group Owner {$currentOwner}"


### PR DESCRIPTION
#### Pull Request (PR) description

There is a typo in the cmdlet to create a group, before creating the team associated with that group, and therefore it doesn't get created, this PR just fixes that typo.