### PR TITLE
IntuneSettingCatalogCustomPolicyWindows10: Add missing properties to schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* IntuneSettingCatalogCustomPolicyWindows10
+  * Add missing properties to schema
+    FIXES [#3300](https://github.com/microsoft/Microsoft365DSC/issues/3300)
 * MISC
   * Major performance improvements for the New-M365DSCDeltaReport cmdlet.
     FIXES [#3016](https://github.com/microsoft/Microsoft365DSC/issues/3016)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogCustomPolicyWindows10/MSFT_IntuneSettingCatalogCustomPolicyWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogCustomPolicyWindows10/MSFT_IntuneSettingCatalogCustomPolicyWindows10.schema.mof
@@ -51,6 +51,8 @@ class MSFT_MicrosoftGraphDeviceManagementConfigurationChoiceSettingValue
 [ClassVersion("1.0.0")]
 class MSFT_MicrosoftGraphDeviceManagementConfigurationSettingValueTemplateReference
 {
+    [Write, Description("Setting value template id")] String settingValueTemplateId;
+    [Write, Description("Indicates whether to update policy setting value to match template setting default value")] Boolean useTemplateDefault;
 };
 [ClassVersion("1.0.0")]
 class MSFT_MicrosoftGraphDeviceManagementConfigurationGroupSettingValue
@@ -88,5 +90,5 @@ class MSFT_IntuneSettingCatalogCustomPolicyWindows10 : OMI_BaseResource
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
     [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
     [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
-	[Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
 };


### PR DESCRIPTION
#### Pull Request (PR) description

As explained in #3300 the resource IntuneSettingCatalogCustomPolicyWindows10 is failing to generate its documentation because one of its CIMInstances in the schema is empty and then when running cmdlet Update-M365DSCResourceDocumentationPage this makes it fail to generate the doc, this PR fixes this by adding missing properties to that empty CIMInstance.

#### This Pull Request (PR) fixes the following issues

- Fixes #3300