### PR TITLE
M365DSCUtil (Convert-M365DscHashtableToString): Fix typo in order to obfuscate cert thumbprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * MISC
   * Major performance improvements for the New-M365DSCDeltaReport cmdlet.
     FIXES [#3016](https://github.com/microsoft/Microsoft365DSC/issues/3016)
+  * M365DSCUtil: Fix typo in order to obfuscate cert thumbprint
 
 # 1.23.510.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -126,7 +126,7 @@ function Convert-M365DscHashtableToString
     )
 
     $values = @()
-    $parametersToObfuscate = @('ApplicationId', 'ApplicationSecret', 'TenantId', 'CertificateThumnbprint', 'CertificatePath', 'CertificatePassword', 'Credential')
+    $parametersToObfuscate = @('ApplicationId', 'ApplicationSecret', 'TenantId', 'CertificateThumbprint', 'CertificatePath', 'CertificatePassword', 'Credential')
     foreach ($pair in $Hashtable.GetEnumerator())
     {
         try

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -111,7 +111,7 @@ function Get-TeamByName
 
 <#
 .Description
-This function converts a parameter hastable to a string, for outputting to screen
+This function converts a parameter hashtable to a string, for outputting to screen
 
 .Functionality
 Internal


### PR DESCRIPTION
#### Pull Request (PR) description

If function Convert-M365DscHashtableToString finds any of the authentication methods available as a property it obfuscates it, nevertheless this is not happening with Certificate Thumbprint due to a typo, after fixing the typo the parameter is now being properly obfuscated.