### PR TITLE
Added Support for the AdminCenterReportDisplayConcealedNames property in O365OrgSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+* O365OrgSettings
+  * Added support for the AdminCenterReportDisplayConcealedNames property.
 * DEPENDENCIES
   * Updated MSCloudLoginAssistant to version 1.0.111
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/settings.json
@@ -7,6 +7,9 @@
                 "read": [
                     {
                         "name": "Group.Read.All"
+                    },
+                    {
+                        "name": "ReportSettings.Read.All"
                     }
                 ],
                 "update": [
@@ -27,6 +30,9 @@
                     },
                     {
                         "name": "User.Read.All"
+                    },
+                    {
+                        "name": "ReportSettings.ReadWrite.All"
                     }
                 ]
             },
@@ -34,6 +40,9 @@
                 "read": [
                     {
                         "name": "Group.Read.All"
+                    },
+                    {
+                        "name": "ReportSettings.Read.All"
                     }
                 ],
                 "update": [
@@ -54,6 +63,9 @@
                     },
                     {
                         "name": "User.Read.All"
+                    },
+                    {
+                        "name": "ReportSettings.ReadWrite.All"
                     }
                 ]
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.schema.mof
@@ -4,6 +4,7 @@ class MSFT_O365OrgSettings : OMI_BaseResource
     [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'"), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
     [Write, Description("Allow Cortana in windows 10 (version 1909 and earlier), and the Cortana app on iOS and Android, to access Microsoft-hosted data on behalf of people in your organization.")] Boolean CortanaEnabled;
     [Write, Description("Let users open files stored in third-party storage services in Microsoft 365 on the Web.")] Boolean M365WebEnableUsersToOpenFilesFrom3PStorage;
+    [Write, Description("Controls whether or not the Admin Center reports will conceale user, group and site names.")] Boolean AdminCenterReportDisplayConcealedNames;
     [Write, Description("Since there is only one setting available, this must be set to 'Present'"), ValueMap{"Present"}, Values{"Present"}] String Ensure;
     [Write, Description("Credentials of the Global Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;

--- a/Modules/Microsoft365DSC/Examples/Resources/O365OrgSettings/1-ConfigureOrgSettings.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/O365OrgSettings/1-ConfigureOrgSettings.ps1
@@ -17,6 +17,7 @@ Configuration Example
     {
         O365OrgSettings 'O365OrgSettings'
         {
+            AdminCenterReportDisplayConcealedNames     = $True;
             Credential                                 = $Credscredential;
             Ensure                                     = "Present";
             IsSingleInstance                           = "Yes";

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -565,7 +565,7 @@ function Test-M365DSCParameterState
         [System.String]
         $Tenant
     )
-    $verbosePreference = 'Continue'
+    $verbosePreference = 'SilentlyContinue'
     #region Telemetry
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
     $data.Add('Resource', "$Source")

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.O365OrgSettings.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.O365OrgSettings.Tests.ps1
@@ -38,12 +38,20 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             Mock -CommandName Get-MgServicePrincipal -MockWith {
             }
+
+            Mock -CommandName Invoke-MgGraphRequest -MockWith {
+                return @{
+                    "@odata.type"         = "#microsoft.graph.adminReportSettings"
+                    displayConcealedNames = $true
+                }
+            }
         }
 
         # Test contexts
         Context -Name 'When Org Settings are already in the Desired State' -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AdminCenterReportDisplayConcealedNames     = $True;
                     IsSingleInstance                           = 'Yes'
                     M365WebEnableUsersToOpenFilesFrom3PStorage = $False;
                     Ensure                                     = 'Present'
@@ -71,6 +79,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'When Org Settings NOT in the Desired State' -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AdminCenterReportDisplayConcealedNames     = $True;
                     IsSingleInstance                           = 'Yes'
                     M365WebEnableUsersToOpenFilesFrom3PStorage = $True;
                     Ensure                                     = 'Present'


### PR DESCRIPTION
#### Pull Request (PR) description
* O365OrgSettings
  * Added support for the AdminCenterReportDisplayConcealedNames property.

#### This Pull Request (PR) fixes the following issues
* N/A
