### PR TITLE
SCAutoSensitivityLabelRule fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Performance improvements.
 * O365OrgSettings
   * Added support for the AdminCenterReportDisplayConcealedNames property.
+* SCAutoSensitivityLabelRule
+  * Fixes an issue with the HeaderMatchesPatterns property not compiling when empty.
 * TeamsOrgWideAppSettings
   * Initial release.
 * DEPENDENCIES

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCAutoSensitivityLabelRule/MSFT_SCAutoSensitivityLabelRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCAutoSensitivityLabelRule/MSFT_SCAutoSensitivityLabelRule.psm1
@@ -149,7 +149,7 @@ function Get-TargetResource
         $FromAddressMatchesPatterns,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
+        [Microsoft.Management.Infrastructure.CimInstance]
         $HeaderMatchesPatterns,
 
         [Parameter()]
@@ -277,9 +277,9 @@ function Get-TargetResource
             {
                 $ExceptIfContentExtensionMatchesWords = $PolicyRule.ExceptIfContentExtensionMatchesWords.Replace(' ', '').Split(',')
             }
-            $HeaderMatchesPatternsValue = @{}
             if ($null -ne $HeaderMatchesPatterns -and $null -ne $HeaderMatchesPatterns.Name)
             {
+                $HeaderMatchesPatternsValue = @{}
                 foreach ($value in $HeaderMatchesPatterns[($HeaderMatchesPatterns.Name)])
                 {
                     if ($HeaderMatchesPatternsValue.ContainsKey($HeaderMatchesPatterns.Name))
@@ -534,7 +534,7 @@ function Set-TargetResource
         $FromAddressMatchesPatterns,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
+        [Microsoft.Management.Infrastructure.CimInstance]
         $HeaderMatchesPatterns,
 
         [Parameter()]
@@ -919,7 +919,7 @@ function Test-TargetResource
         $FromAddressMatchesPatterns,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
+        [Microsoft.Management.Infrastructure.CimInstance]
         $HeaderMatchesPatterns,
 
         [Parameter()]


### PR DESCRIPTION
#### Pull Request (PR) description
* SCAutoSensitivityLabelRule
  * Fixes an issue with the HeaderMatchesPatterns property not compiling when empty.

#### This Pull Request (PR) fixes the following issues
* N/A