### PR TITLE
O365 org setting workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
-
+* O365OrgSettings
+  * Introduced a workaround to fix an issue with the ExchangeOnlineManagement module where if connected to Security and Compliance center
+    an error about an invalid token would get thrown when calling the Get-DefaultTenantMyAnalyticsFeatureConfig cmdlet.
 * SPOApp
   * Fixes an issue where the extraction was complaining about op_addition failing.
 * DRG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
+
+* IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator
+  * Fixes an issue where the Get-TargetResource function was defining the parameter as Identity and all othe methods and schema had it defined to Id.
 * O365OrgSettings
   * Introduced a workaround to fix an issue with the ExchangeOnlineManagement module where if connected to Security and Compliance center
     an error about an invalid token would get thrown when calling the Get-DefaultTenantMyAnalyticsFeatureConfig cmdlet.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator.psm1
@@ -7,7 +7,7 @@ function Get-TargetResource
         #region resource generator code
         [Parameter(Mandatory = $true)]
         [System.String]
-        $Identity,
+        $Id,
 
         [Parameter(Mandatory = $true)]
         [System.String]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
@@ -156,6 +156,14 @@ function Get-TargetResource
     $ConnectionModeTasks = New-M365DSCConnection -Workload 'Tasks' `
         -InboundParameters $PSBoundParameters
 
+    # Workaround for issue when if connected to S+C prior to calling cmdlet, an error about an invalid token is thrown.
+    # If connected to S+C, then we need to re-initialize the connection to EXO.
+    if ($Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Connected -and `
+        $Global:MSCloudLoginConnectionProfile.ExchangeOnline.Connected)
+    {
+        $Global:MSCloudLoginConnectionProfile.ExchangeOnline.Disconnect()
+        $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Connected = $false
+    }
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
         -InboundParameters $PSBoundParameters
 
@@ -210,7 +218,7 @@ function Get-TargetResource
             }
         }
 
-        # Viva Insightss settings
+        # Viva Insights settings
         $currentVivaInsightsSettings = Get-DefaultTenantMyAnalyticsFeatureConfig
         $MRODeviceManagerService = 'ebe0c285-db95-403f-a1a3-a793bd6d7767'
         try


### PR DESCRIPTION
#### Pull Request (PR) description
* O365OrgSettings
  * Introduced a workaround to fix an issue with the ExchangeOnlineManagement module where if connected to Security and Compliance center
    an error about an invalid token would get thrown when calling the Get-DefaultTenantMyAnalyticsFeatureConfig cmdlet.

#### This Pull Request (PR) fixes the following issues
* N/A
