### PR TITLE
Fix: Remove redundant initialization of reactPlugin

### DIFF
--- a/generator/src/services/TelemetryService.ts
+++ b/generator/src/services/TelemetryService.ts
@@ -25,8 +25,6 @@ const createTelemetryService = () => {
             throw new Error('Instrumentation key not provided in ./src/telemetry-provider.jsx')
         }
 
-        reactPlugin = new ReactPlugin();
-
         appInsights = new ApplicationInsights({
             config: {
                 instrumentationKey: instrumentationKey,


### PR DESCRIPTION
The variable 'reactPlugin' was being redundantly initialized twice in the code. This commit removes the redundant assignment inside the 'createTelemetryService' function, as the variable is already initialized at the beginning of the file. The code now runs efficiently without any redundancy.

#### Pull Request (PR) description
This pull request removes the redundant initialization of the 'reactPlugin' variable in the telemetry service code.

#### This Pull Request (PR) fixes the following issues
- This PR removes the redundant assignment inside the 'createTelemetryService' function, as the variable is already initialized earlier in the file.
- After this change, the code runs more efficiently without any redundant operations and maintains the intended functionality.
