### PR TITLE
O365SearchAndIntelligenceConfigurations - Removes SPN Auth support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+* O365SearchAndintelligenceConfigurations
+  * Removed support for Service Principal Auth, which the cmdlet never supported.
 * DEPENDENCIES
   * Updated Microsoft.Graph to version 2.4.0.
   * Updated ReverseDSC to version 2.0.0.18

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
@@ -66,7 +66,7 @@
                         "name": "OrgSettings-DynamicsVoice.Read.All"
                     },
                     {
-                        "name": "Tasks.ReadWrite.All"
+                        "name": "Tasks.Read.All"
                     }
                 ],
                 "update": [
@@ -92,7 +92,7 @@
                         "name": "OrgSettings-DynamicsVoice.ReadWrite.All"
                     },
                     {
-                        "name": "Tasks.Read.All"
+                        "name": "Tasks.ReadWrite.All"
                     }
                 ]
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365SearchAndIntelligenceConfigurations/MSFT_O365SearchAndIntelligenceConfigurations.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365SearchAndIntelligenceConfigurations/MSFT_O365SearchAndIntelligenceConfigurations.psm1
@@ -27,27 +27,7 @@ function Get-TargetResource
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
-        $Credential,
-
-        [Parameter()]
-        [System.String]
-        $ApplicationId,
-
-        [Parameter()]
-        [System.String]
-        $TenantId,
-
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        $ApplicationSecret,
-
-        [Parameter()]
-        [System.String]
-        $CertificateThumbprint,
-
-        [Parameter()]
-        [Switch]
-        $ManagedIdentity
+        $Credential
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
@@ -99,11 +79,6 @@ function Get-TargetResource
             PersonInsightsIsEnabledInOrganization = $PersonInsights.IsEnabledInOrganization
             PersonInsightsDisabledForGroup        = $PersonInsightsDisabledForGroupValue
             Credential                            = $Credential
-            ApplicationId                         = $ApplicationId
-            TenantId                              = $TenantId
-            ApplicationSecret                     = $ApplicationSecret
-            CertificateThumbprint                 = $CertificateThumbprint
-            ManagedIdentity                       = $ManagedIdentity.IsPresent
         }
     }
     catch
@@ -146,27 +121,7 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
-        $Credential,
-
-        [Parameter()]
-        [System.String]
-        $ApplicationId,
-
-        [Parameter()]
-        [System.String]
-        $TenantId,
-
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        $ApplicationSecret,
-
-        [Parameter()]
-        [System.String]
-        $CertificateThumbprint,
-
-        [Parameter()]
-        [Switch]
-        $ManagedIdentity
+        $Credential
     )
 
     #Ensure the proper dependencies are installed in the current environment.
@@ -275,27 +230,7 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
-        $Credential,
-
-        [Parameter()]
-        [System.String]
-        $ApplicationId,
-
-        [Parameter()]
-        [System.String]
-        $TenantId,
-
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        $ApplicationSecret,
-
-        [Parameter()]
-        [System.String]
-        $CertificateThumbprint,
-
-        [Parameter()]
-        [Switch]
-        $ManagedIdentity
+        $Credential
     )
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
@@ -335,27 +270,7 @@ function Export-TargetResource
     (
         [Parameter()]
         [System.Management.Automation.PSCredential]
-        $Credential,
-
-        [Parameter()]
-        [System.String]
-        $ApplicationId,
-
-        [Parameter()]
-        [System.String]
-        $TenantId,
-
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        $ApplicationSecret,
-
-        [Parameter()]
-        [System.String]
-        $CertificateThumbprint,
-
-        [Parameter()]
-        [Switch]
-        $ManagedIdentity
+        $Credential
     )
     $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
         -InboundParameters $PSBoundParameters
@@ -377,11 +292,6 @@ function Export-TargetResource
         $Params = @{
             IsSingleInstance      = 'Yes'
             Credential            = $Credential
-            ApplicationId         = $ApplicationId
-            TenantId              = $TenantId
-            ApplicationSecret     = $ApplicationSecret
-            CertificateThumbprint = $CertificateThumbprint
-            Managedidentity       = $ManagedIdentity.IsPresent
         }
 
         $Results = Get-TargetResource @Params
@@ -408,7 +318,7 @@ function Export-TargetResource
     catch
     {
         Write-Host $Global:M365DSCEmojiRedX
-
+        $TenantId = $Credential.UserName.Split('@')[1]
         New-M365DSCLogEntry -Message 'Error during Export:' `
             -Exception $_ `
             -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365SearchAndIntelligenceConfigurations/MSFT_O365SearchAndIntelligenceConfigurations.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365SearchAndIntelligenceConfigurations/MSFT_O365SearchAndIntelligenceConfigurations.schema.mof
@@ -7,9 +7,4 @@ class MSFT_O365SearchAndIntelligenceConfigurations : OMI_BaseResource
     [Write, Description("Specifies whether or not Person Insights should be available for the organization.")] Boolean PersonInsightsIsEnabledInOrganization;
     [Write, Description("Specifies a single Azure AD Group for which Person Insights needs to be disabled.")] String PersonInsightsDisabledForGroup;
     [Write, Description("Credentials of the Global Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
-    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
-    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
-    [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
-    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
-    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
 };


### PR DESCRIPTION
#### Pull Request (PR) description
* O365SearchAndintelligenceConfigurations
  * Removed support for Service Principal Auth, which the cmdlet never supported.

#### This Pull Request (PR) fixes the following issues
* N/A
