### PR TITLE
#3629 Fix AADGroup properties not set on creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
+
 * AADGroup
   * Fixed Get-TargetResource not to use the paramaters that should be set, preventing an empty delta on Set-TargetResource
     FIXES [#3629](https://github.com/microsoft/Microsoft365DSC/issues/3629)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # UNRELEASED
 
 * AADGroup
-  * Fixed Get-TargetResource not to use the paramaters that should be set, preventing an empty delta on Set-TargetResource
+  * Fixed Get-TargetResource not to use the parameters that should be set, preventing an empty delta on Set-TargetResource
     FIXES [#3629](https://github.com/microsoft/Microsoft365DSC/issues/3629)
 
 # 1.23.830.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+* AADGroup
+  * Fixed Get-TargetResource not to use the paramaters that should be set, preventing an empty delta on Set-TargetResource
+    FIXES [#3629](https://github.com/microsoft/Microsoft365DSC/issues/3629)
+
 # 1.23.830.1
 
 * O365SearchAndintelligenceConfigurations

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -118,6 +118,10 @@ function Get-TargetResource
 
     $nullReturn = $PSBoundParameters
     $nullReturn.Ensure = 'Absent'
+    $nullReturn.Owners = @()
+    $nullReturn.Members = @()
+    $nullReturn.MemberOf = @()
+    $nullReturn.AssignedToRole = @()
     try
     {
         if ($PSBoundParameters.ContainsKey('Id'))


### PR DESCRIPTION
#### Pull Request (PR) description
Fixed Get-TargetResource not to use the parameters that should be set, preventing an empty delta on Set-TargetResource

#### This Pull Request (PR) fixes the following issues
- Fixes #3629 


Co-authored-by: Thomas Subotitsch @tbone4711