### PR TITLE
Compare-M365DSCConfigurations: Fix typo in var name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 # UNRELEASED
 
-* EXORemoteDomain 
+* EXORemoteDomain
   * Implemented a wait/retry mecanism between the New-RemoteDomain and Set-RemoteDomain to avoid timeout.
   FIXES [#3628](https://github.com/microsoft/Microsoft365DSC/issues/3628)
 * DEPENDENCIES
   * Updated Install-M365DSCDevBranch, Update-M365DSCDependencies and Update-M365DSCModule to be usable with -Scope, allowing the user to install/update the module dependencies without admin rights, using current user scope. Confirm-M365DSCDependencies error message changed to reflect this change.
     FIXES [#3621](https://github.com/microsoft/Microsoft365DSC/issues/3621)
+* MISC
+  * M365DscReport: Fix typo in var name in Compare-M365DSCConfigurations cmdlet
+    FIXES [#3632](https://github.com/microsoft/Microsoft365DSC/issues/3632)
 
 # 1.23.830.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -885,7 +885,7 @@ function Compare-M365DSCConfigurations
                                         {
                                             foreach ($property in $instance.Keys)
                                             {
-                                                if ($null -eq $sourceRsourceInstance."$property" -or $null -ne (Compare-Object -ReferenceObject ($instance."$property")`
+                                                if ($null -eq $sourceResourceInstance."$property" -or $null -ne (Compare-Object -ReferenceObject ($instance."$property")`
                                                     -DifferenceObject ($sourceResourceInstance."$property")))
                                                 {
                                                     # Make sure we haven't already added this drift in the delta return object to prevent duplicates.


### PR DESCRIPTION
#### Pull Request (PR) description

Fix typo in var name in cmdlet *Compare-M365DSCConfigurations* introduced in PR #3526

#### This Pull Request (PR) fixes the following issues

- Fixes #3632 
