### PR TITLE
fix: Update documentation for authentication

### DIFF
--- a/docs/docs/user-guide/get-started/authentication-and-permissions.md
+++ b/docs/docs/user-guide/get-started/authentication-and-permissions.md
@@ -106,7 +106,7 @@ Doing so will return an object with two properties. The **ReadPermissions** prop
 By default, this cmdlet outputs the permissions required for Delegated permissions. To output the Application permissions, use the PermissionsType parameter
 
 ```PowerShell
-Get-M365DSCCompiledPermissionList -ResourceNameList @('AADUser', 'AADApplication') -Source 'Graph' -PermissionsType 'Application'
+Get-M365DSCCompiledPermissionList -ResourceNameList @('AADUser', 'AADApplication') -PermissionsType 'Application'
 ```
 
 If you are trying to interact with all available components in Microsoft365DSC, you can get a complete picture of all permissions required across all resources by running the following line of PowerShell.
@@ -193,7 +193,7 @@ For the Exchange Online resources, the service account needs certain permissions
 To request the permissions,
 
 ```PowerShell
-Get-M365DSCCompiledPermissionList -ResourceNameList @('EXOAcceptedDomain') -Source 'Exchange'
+Get-M365DSCCompiledPermissionList -ResourceNameList @('EXOAcceptedDomain')
 ```
 
 <figure markdown>


### PR DESCRIPTION
#### Pull Request (PR) description

Reflect the change to ``Get-M365DSCCompiledPermissionList``  where "-Source" switch has been dropped for some time.

#### This Pull Request (PR) fixes the following issues

If we have working examples in the getting started documentation users are
more likely to get this module up and running with less obstacles to bump into.

It looks like this parameter was dropped quite some time ago in 9a7434de13ca193cdb1764d38b4d3886a0d095e4.