### PR TITLE
Fix #3656: AADNamedLocationPolicy: Add default CountryLookupMethod and reorganise IsTrusted assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+* AADNamedLocationPolicy
+  * Set default value for CountryLookupMethod and removed unwanted properties
+    FIXES [#3656](https://github.com/microsoft/Microsoft365DSC/issues/3656)
+
 # 1.23.906.1
 
 * AADAuthenticationMethodPolicyAuthenticator

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
@@ -248,7 +248,6 @@ function Set-TargetResource
     $desiredValues = @{
         '@odata.type' = $OdataType
         displayName   = $DisplayName
-        isTrusted     = $IsTrusted
     }
     if ($OdataType -eq '#microsoft.graph.ipNamedLocation')
     {
@@ -274,7 +273,6 @@ function Set-TargetResource
     {
         $desiredValues.Add('includeUnknownCountriesAndRegions', $IncludeUnknownCountriesAndRegions)
         $desiredValues.Add('countriesAndRegions', $CountriesAndRegions)
-        $desiredValues.Add('countryLookupMethod', $CountryLookupMethod)
     }
 
     # Named Location should exist but it doesn't
@@ -291,8 +289,7 @@ function Set-TargetResource
     }
     # Named Location should exist and will be configured to desired state
     elseif ($Ensure -eq 'Present' -and $CurrentAADNamedLocation.Ensure -eq 'Present')
-    {
-        $desiredValues.Add('NamedLocationId', $currentAADNamedLocation.Id) | Out-Null
+    {   
         $VerboseAttributes = ($desiredValues | Out-String)
         Write-Verbose -Message "Updating existing AAD Named Location {$Displayname)} with attributes: $VerboseAttributes"
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
@@ -193,7 +193,7 @@ function Set-TargetResource
         [Parameter()]
         [System.String]
         [ValidateSet('clientIpAddress','authenticatorAppGps')]
-        $CountryLookupMethod,
+        $CountryLookupMethod = 'clientIpAddress',
 
         [Parameter()]
         [System.Boolean]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
@@ -251,6 +251,7 @@ function Set-TargetResource
     }
     if ($OdataType -eq '#microsoft.graph.ipNamedLocation')
     {
+        $desiredValues.Add('isTrusted', $IsTrusted)
         $IpRangesValue = @()
         foreach ($IpRange in $IpRanges)
         {
@@ -273,6 +274,7 @@ function Set-TargetResource
     {
         $desiredValues.Add('includeUnknownCountriesAndRegions', $IncludeUnknownCountriesAndRegions)
         $desiredValues.Add('countriesAndRegions', $CountriesAndRegions)
+        $desiredValues.Add('countryLookupMethod', $CountryLookupMethod)
     }
 
     # Named Location should exist but it doesn't

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.schema.mof
@@ -5,7 +5,7 @@ class MSFT_AADNamedLocationPolicy : OMI_BaseResource
     [Write, Description("Specifies the ID of a Named Location in Azure Active Directory.")] String Id;
     [Key, Description("Specifies the Display Name of a Named Location in Azure Active Directory")] string DisplayName;
     [Write, Description("Specifies the IP ranges of the Named Location in Azure Active Directory")] String IpRanges[];
-    [Write, Description("Specifies the isTrusted value for the Named Location in Azure Active Directory")] Boolean IsTrusted;
+    [Write, Description("Specifies the isTrusted value for the Named Location (IP ranges only) in Azure Active Directory")] Boolean IsTrusted;
     [Write, Description("Specifies the countries and regions for the Named Location in Azure Active Directory")] String CountriesAndRegions[];
     [Write, Description("Determines what method is used to decide which country the user is located in. Possible values are clientIpAddress(default) and authenticatorAppGps."), ValueMap{"clientIpAddress","authenticatorAppGps"}, Values{"clientIpAddress","authenticatorAppGps"}] String CountryLookupMethod;
     [Write, Description("Specifies the includeUnknownCountriesAndRegions value for the Named Location in Azure Active Directory")] Boolean IncludeUnknownCountriesAndRegions;


### PR DESCRIPTION
#### Pull Request (PR) description
- Removes the `NamedLocationId` property from the JSON map as it is not used
- Sets the default property for `CountryLookupMethod` to `'clientIpAddress'` as graph request fails if empty
- Sets `IsTrusted` to only apply to `IP Ranges` as this is not supported for Countries

#### This Pull Request (PR) fixes the following issues
- Fixes #3656 
