### PR TITLE
M365DSCUtil: Fix problem naming similar resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 * DEPENDENCIES
   * Updated MicrosoftTeams to version 5.6.0.
     FIXES [#3671](https://github.com/microsoft/Microsoft365DSC/issues/3671)
+* MISC
+  * M365DSCUtil: Fix problem naming similar resources
+    FIXES [#3700](https://github.com/microsoft/Microsoft365DSC/issues/3700)
 
 # 1.23.913.2
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -3301,7 +3301,7 @@ function Get-M365DSCExportContentForResource
         $i++
     }
     $instanceName = $tempName
-    $Global:M365DSCExportedResourceInstancesNames += $tempName
+    [string[]]$Global:M365DSCExportedResourceInstancesNames += $tempName
 
     $content = [System.Text.StringBuilder]::New()
     [void]$content.Append("        $ResourceName `"$instanceName`"`r`n")


### PR DESCRIPTION
#### Pull Request (PR) description

Fix problem naming similar resources (generating ResourceInstanceName) on cmdlet *Get-M365DSCExportContentForResource*

#### This Pull Request (PR) fixes the following issues

- Fixes #3700 
