### PR TITLE
M365DSCDRGUtil: Write properties properly indented and in new line in blueprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* MISC
+  * M365DSCDRGUtil: Write properties properly indented and in new line
+    FIXES [#3634](https://github.com/microsoft/Microsoft365DSC/issues/3634)
+
 # 1.23.920.1
 
 * O365OrgSettings

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -400,7 +400,7 @@ function Get-M365DSCDRGComplexTypeToString
                 $currentValue = $ComplexObject[$key]
                 if ($currentValue.GetType().Name -eq 'String')
                 {
-                    $currentValue = $ComplexObject[$key].Replace("'", "''").Replace("’", "''")
+                    $currentValue = $ComplexObject[$key].Replace("'", "''").Replace("ï¿½", "''")
                 }
                 $currentProperty += Get-M365DSCDRGSimpleObjectTypeToString -Key $key -Value $currentValue -Space ($indent)
             }
@@ -430,17 +430,17 @@ function Get-M365DSCDRGComplexTypeToString
     }
 
     $currentProperty += "$indent}"
-    #if ($isArray -or $IndentLevel -gt 4)
-    #{
-        #$currentProperty += "`r`n"
-    #}
+    if ($isArray -or $IndentLevel -gt 4)
+    {
+        $currentProperty += "`r`n"
+    }
 
     #Indenting last parenthese when the cim instance is an array
-    <#if ($IndentLevel -eq 5)
+    if ($IndentLevel -eq 5)
     {
         $indent = '    ' * ($IndentLevel -2)
         $currentProperty += $indent
-    }#>
+    }
 
     $emptyCIM = $currentProperty.replace(' ', '').replace("`r`n", '')
     if ($emptyCIM -eq "MSFT_$CIMInstanceName{}")

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -435,7 +435,7 @@ function Get-M365DSCDRGComplexTypeToString
         $currentProperty += "`r`n"
     }
 
-    #Indenting last parenthese when the cim instance is an array
+    #Indenting last parenthesis when the cim instance is an array
     if ($IndentLevel -eq 5)
     {
         $indent = '    ' * ($IndentLevel -2)


### PR DESCRIPTION
#### Pull Request (PR) description

Write properties properly indented and in new line in blueprints.

Currently some resources, such as *IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10*, with deeply nested properties are not being written correctly in the blueprints, instead they are written in the same line of previous property which makes the blueprint unable to be compiled to MOF.

This is a partial revert of commit https://github.com/microsoft/Microsoft365DSC/commit/61260b5fc3b6bb8bb7ec72cf227011f0becc9140

#### This Pull Request (PR) fixes the following issues

- Fixes #3634 
- Possibly fixes #3693