### PR TITLE
Update-M365DSCAllowedGraphScopes: Fixed handling of Graph connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * DEPENDENCIES
   * Updated Microsoft.Graph to version 2.6.1.
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.117.
+* MISC
+  * Fixed handling of Graph connection in Update-M365DSCAllowedGraphScopes
 
 # 1.23.920.2
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCPermissions.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCPermissions.psm1
@@ -406,7 +406,7 @@ function Update-M365DSCAllowedGraphScopes
 
     Write-Verbose -Message 'Connecting to MS Graph to update permissions'
     $result = Connect-MgGraph @params -Environment $Environment
-    if ($result -eq 'Welcome To Microsoft Graph!')
+    if ($result -like '*Welcome To Microsoft Graph!*')
     {
         Write-Output 'Allowed Graph scopes updated!'
     }


### PR DESCRIPTION
#### Pull Request (PR) description
Fixed handling of Graph connection in Update-M365DSCAllowedGraphScopes

Output of Connect-Graph is now more than "Welcome to Microsoft Graph!":

Welcome to Microsoft Graph!
 
Connected via delegated access using 14d82eec-2xxxxx
Readme: https://aka.ms/graph/sdk/powershell
SDK Docs: https://aka.ms/graph/sdk/powershell/docs
API Docs: https://aka.ms/graph/docs
 
NOTE: You can use the -NoWelcome parameter to suppress this message.

#### This Pull Request (PR) fixes the following issues
None