### PR TITLE
Update M365DSCDRGUtil.psm1 to support Multiple Clouds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * O365OrgSettings
   * Changes to how ToDo discrepencies are being fixed in the SET method.
 * M365DSCDRGUtil
-  * Added support for ntune URIs to be dynamic based on user 
+  * Added support for Intune URIs to be dynamic based on user 
     cloud (Commercial, GCC-H..etc) 
 * DEPENDENCIES
   * Updated Microsoft.Graph to version 2.6.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   * Improvements to how rules are evaluated and how drifts are logged.
 * O365OrgSettings
   * Changes to how ToDo discrepencies are being fixed in the SET method.
+* M365DSCDRGUtil
+  * Added support for ntune URIs to be dynamic based on user 
+    cloud (Commercial, GCC-H..etc) 
 * DEPENDENCIES
   * Updated Microsoft.Graph to version 2.6.1.
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.117.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 * O365OrgSettings
   * Changes to how ToDo discrepencies are being fixed in the SET method.
 * M365DSCDRGUtil
-  * Added support for Intune URIs to be dynamic based on user 
-    cloud (Commercial, GCC-H..etc) 
+  * Added support for Intune URIs to be dynamic based on target 
+    cloud instance (Commercial, GCC-H..etc) 
 * DEPENDENCIES
   * Updated Microsoft.Graph to version 2.6.1.
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.117.

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -400,7 +400,7 @@ function Get-M365DSCDRGComplexTypeToString
                 $currentValue = $ComplexObject[$key]
                 if ($currentValue.GetType().Name -eq 'String')
                 {
-                    $currentValue = $ComplexObject[$key].Replace("'", "''").Replace(" ", "''")
+                     $currentValue = $ComplexObject[$key].Replace("'", "''").Replace("�", "''")
                 }
                 $currentProperty += Get-M365DSCDRGSimpleObjectTypeToString -Key $key -Value $currentValue -Space ($indent)
             }

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1011,7 +1011,7 @@ function New-IntuneSettingCatalogPolicy
     try
     {
 	$BaseUrl = $Global:MSCloudLoginConnectionProfile.Intune.GraphBaseUrl
-        $Uri = "$($BaseUrl)/beta/deviceManagement/configurationPolicies'
+        $Uri = '$($BaseUrl)/beta/deviceManagement/configurationPolicies'
 
         $policy = @{
             'name'              = $Name

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -400,7 +400,7 @@ function Get-M365DSCDRGComplexTypeToString
                 $currentValue = $ComplexObject[$key]
                 if ($currentValue.GetType().Name -eq 'String')
                 {
-                    $currentValue = $ComplexObject[$key].Replace("'", "''").Replace("�", "''")
+                    $currentValue = $ComplexObject[$key].Replace("'", "''").Replace(" ", "''")
                 }
                 $currentProperty += Get-M365DSCDRGSimpleObjectTypeToString -Key $key -Value $currentValue -Space ($indent)
             }
@@ -1010,7 +1010,8 @@ function New-IntuneSettingCatalogPolicy
 
     try
     {
-        $Uri = 'https://graph.microsoft.com/beta/deviceManagement/configurationPolicies'
+	$BaseUrl = $Global:MSCloudLoginConnectionProfile.Intune.GraphBaseUrl
+        $Uri = '$($BaseUrl)/beta/deviceManagement/configurationPolicies'
 
         $policy = @{
             'name'              = $Name
@@ -1073,7 +1074,8 @@ function Update-IntuneSettingCatalogPolicy
 
     try
     {
-        $Uri = "https://graph.microsoft.com/beta/deviceManagement/configurationPolicies/$DeviceConfigurationPolicyId"
+        $BaseUrl = $Global:MSCloudLoginConnectionProfile.Intune.GraphBaseUrl
+        $Uri = '$($BaseUrl)/beta/deviceManagement/configurationPolicies/$DeviceConfigurationPolicyId"
 
         $policy = @{
             'name'              = $Name
@@ -1124,7 +1126,8 @@ function Update-DeviceConfigurationPolicyAssignment
     try
     {
         $deviceManagementPolicyAssignments = @()
-        $Uri = "https://graph.microsoft.com/$APIVersion/$Repository/$DeviceConfigurationPolicyId/assign"
+        $BaseUrl = $Global:MSCloudLoginConnectionProfile.Intune.GraphBaseUrl
+        $Uri = '$($BaseUrl)/$APIVersion/$Repository/$DeviceConfigurationPolicyId/assign"
 
         foreach ($target in $targets)
         {

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1011,7 +1011,7 @@ function New-IntuneSettingCatalogPolicy
     try
     {
 	$BaseUrl = $Global:MSCloudLoginConnectionProfile.Intune.GraphBaseUrl
-        $Uri = '$($BaseUrl)/beta/deviceManagement/configurationPolicies'
+        $Uri = "$($BaseUrl)/beta/deviceManagement/configurationPolicies'
 
         $policy = @{
             'name'              = $Name
@@ -1075,7 +1075,7 @@ function Update-IntuneSettingCatalogPolicy
     try
     {
         $BaseUrl = $Global:MSCloudLoginConnectionProfile.Intune.GraphBaseUrl
-        $Uri = '$($BaseUrl)/beta/deviceManagement/configurationPolicies/$DeviceConfigurationPolicyId"
+        $Uri = "$($BaseUrl)/beta/deviceManagement/configurationPolicies/$DeviceConfigurationPolicyId"
 
         $policy = @{
             'name'              = $Name
@@ -1127,7 +1127,7 @@ function Update-DeviceConfigurationPolicyAssignment
     {
         $deviceManagementPolicyAssignments = @()
         $BaseUrl = $Global:MSCloudLoginConnectionProfile.Intune.GraphBaseUrl
-        $Uri = '$($BaseUrl)/$APIVersion/$Repository/$DeviceConfigurationPolicyId/assign"
+        $Uri = "$($BaseUrl)/$APIVersion/$Repository/$DeviceConfigurationPolicyId/assign"
 
         foreach ($target in $targets)
         {


### PR DESCRIPTION
Intune endpoints were all hardcoded for graph.microsoft.com -- rendering the intune pull useless for GCC-H and DoD Cloud -- updated to pull the Graph Base URL from the existing  $Global:MSCloudLoginConnectionProfile.Intune.GraphBaseUrl variable

#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
-->

#### This Pull Request (PR) fixes the following issues
<!--
 None
-->
