### PR TITLE
Bug fix new value for new teams client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * EXODistributionGroup
   * Fixes the export of group membership to use Identity.
+* TeamsUpdateManagementPolicy
+  * Add support for the new acceptable value for UseNewTeamsClient ( NewTeamsAsDefault )
 
 # 1.23.1004.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpdateManagementPolicy/MSFT_TeamsUpdateManagementPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpdateManagementPolicy/MSFT_TeamsUpdateManagementPolicy.psm1
@@ -39,7 +39,7 @@ function Get-TargetResource
         $UpdateTimeOfDay,
 
         [Parameter()]
-        [ValidateSet('UserChoice', 'MicrosoftChoice', 'AdminDisabled')]
+        [ValidateSet('UserChoice', 'MicrosoftChoice', 'AdminDisabled', 'NewTeamsAsDefault')]
         [System.String]
         $UseNewTeamsClient,
 
@@ -169,7 +169,7 @@ function Set-TargetResource
         $UpdateTimeOfDay,
 
         [Parameter()]
-        [ValidateSet('UserChoice', 'MicrosoftChoice', 'AdminDisabled')]
+        [ValidateSet('UserChoice', 'MicrosoftChoice', 'AdminDisabled', 'NewTeamsAsDefault')]
         [System.String]
         $UseNewTeamsClient,
 
@@ -286,7 +286,7 @@ function Test-TargetResource
         $UpdateTimeOfDay,
 
         [Parameter()]
-        [ValidateSet('UserChoice', 'MicrosoftChoice', 'AdminDisabled')]
+        [ValidateSet('UserChoice', 'MicrosoftChoice', 'AdminDisabled', 'NewTeamsAsDefault')]
         [System.String]
         $UseNewTeamsClient,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpdateManagementPolicy/MSFT_TeamsUpdateManagementPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpdateManagementPolicy/MSFT_TeamsUpdateManagementPolicy.schema.mof
@@ -9,7 +9,7 @@ class MSFT_TeamsUpdateManagementPolicy : OMI_BaseResource
     [Write, Description("Determines the day of week to perform the updates. Value shoud be between 0 and 6.")] UInt32 UpdateDayOfWeek;
     [Write, Description("Determines the time of day to perform the updates. Must be a valid HH:MM format string with leading 0. For instance 08:30.")] String UpdateTime;
     [Write, Description("Determines the time of day to perform the updates. Accepts a DateTime as string. Only the time will be considered.")] String UpdateTimeOfDay;
-    [Write, Description("Determines whether or not users will use the new Teams client."), ValueMap{"UserChoice","MicrosoftChoice","AdminDisabled"}, Values{"UserChoice","MicrosoftChoice","AdminDisabled"}] String UseNewTeamsClient;
+    [Write, Description("Determines whether or not users will use the new Teams client."), ValueMap{"NewTeamsAsDefault","UserChoice","MicrosoftChoice","AdminDisabled"}, Values{"NewTeamsAsDefault","UserChoice","MicrosoftChoice","AdminDisabled"}] String UseNewTeamsClient;
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Credentials of the Teams Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;


### PR DESCRIPTION
#### Pull Request (PR) description
There is a new acceptable value for $UseNewTeamsClient
<img width="326" alt="image" src="https://github.com/microsoft/Microsoft365DSC/assets/338699/b2306604-a45b-44d9-812c-8b208947e5d8">


#### This Pull Request (PR) fixes the following issues
None