### PR TITLE
Fix  Wrong attribute name in class causes error displayed during dsc operation #3843 

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementConnectedOrganization/MSFT_AADEntitlementManagementConnectedOrganization.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementConnectedOrganization/MSFT_AADEntitlementManagementConnectedOrganization.psm1
@@ -147,7 +147,7 @@ function Get-TargetResource
 
                 if (-not [String]::IsNullOrEmpty($source.AdditionalProperties.tenantId))
                 {
-                    $formattedSource.Add('ExternalTenantId', $source.AdditionalProperties.tenantId)
+                    $formattedSource.Add('tenantId', $source.AdditionalProperties.tenantId)
                 }
 
                 if (-not [String]::IsNullOrEmpty($source.AdditionalProperties.cloudInstance))
@@ -313,7 +313,7 @@ function Set-TargetResource
                 $CreateParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $CreateParameters.$key
             }
         }
-        $TenantId = $CreateParameters.IdentitySources.ExternalTenantId
+        $TenantId = $CreateParameters.IdentitySources.tenantId
         $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/tenantRelationships/microsoft.graph.findTenantInformationByTenantId(tenantId='$tenantid')"
         $DomainName = (Invoke-MgGraphRequest -Method 'GET' -Uri $url).defaultDomainName
         $newConnectedOrganization = New-MgBetaEntitlementManagementConnectedOrganization -Description $CreateParameters.Description -DisplayName $CreateParameters.DisplayName -State $CreateParameters.State -DomainName $DomainName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementConnectedOrganization/MSFT_AADEntitlementManagementConnectedOrganization.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementConnectedOrganization/MSFT_AADEntitlementManagementConnectedOrganization.schema.mof
@@ -4,7 +4,7 @@ class MSFT_AADEntitlementManagementConnectedOrganizationIdentitySource
 {
     [Write, Description("Type of the identity source."), ValueMap{"#microsoft.graph.azureActiveDirectoryTenant","#microsoft.graph.crossCloudAzureActiveDirectoryTenant","#microsoft.graph.domainIdentitySource","#microsoft.graph.externalDomainFederation"}, Values{"#microsoft.graph.azureActiveDirectoryTenant","#microsoft.graph.crossCloudAzureActiveDirectoryTenant","#microsoft.graph.domainIdentitySource","#microsoft.graph.externalDomainFederation"}] String odataType;
     [Write, Description("The name of the Azure Active Directory tenant.")] String DisplayName;
-    [Write, Description("The ID of the Azure Active Directory tenant.")] String ExternalTenantId;
+    [Write, Description("The ID of the Azure Active Directory tenant.")] String tenantId;
     [Write, Description("The ID of the cloud where the tenant is located, one of microsoftonline.com, microsoftonline.us or partner.microsoftonline.cn.")] String CloudInstance;
     [Write, Description("The domain name.")] String DomainName;
     [Write, Description("The issuerURI of the incoming federation.")] String IssuerUri;

--- a/Modules/Microsoft365DSC/Examples/Resources/AADEntitlementManagementConnectedOrganization/Configure_ConnectedOrganization.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/AADEntitlementManagementConnectedOrganization/Configure_ConnectedOrganization.ps1
@@ -22,7 +22,7 @@ Configuration Example
             Id                    = "12345678-1234-1234-1234-123456789012";
             IdentitySources       = @(
                 MSFT_AADEntitlementManagementConnectedOrganizationIdentitySource{
-                    ExternalTenantId = "12345678-1234-1234-1234-123456789012"
+                    tenantId = "12345678-1234-1234-1234-123456789012"
                     DisplayName = 'Contoso'
                     odataType = '#microsoft.graph.azureActiveDirectoryTenant'
                 }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADEntitlementManagementConnectedOrganization.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADEntitlementManagementConnectedOrganization.Tests.ps1
@@ -72,7 +72,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Id               = 'ConnectedOrganization_Id'
                     IdentitySources  = @(
                             (New-CimInstance -ClassName MSFT_AADEntitlementManagementConnectedOrganizationIdentitySource -Property @{
-                            ExternalTenantId = 'IdentitySource_TenantId'
+                            tenantId = 'IdentitySource_TenantId'
                             odataType        = '#microsoft.graph.azureActiveDirectoryTenant'
                             displayName      = 'IdentitySource_DisplayName'
                         } -ClientOnly)
@@ -130,7 +130,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Id               = 'ConnectedOrganization_Id'
                     IdentitySources  = @(
                         (New-CimInstance -ClassName MSFT_AADEntitlementManagementConnectedOrganizationIdentitySource -Property @{
-                            ExternalTenantId = 'IdentitySource_TenantId'
+                            tenantId = 'IdentitySource_TenantId'
                             odataType        = '#microsoft.graph.azureActiveDirectoryTenant'
                             displayName      = 'IdentitySource_DisplayName'
                         } -ClientOnly)
@@ -197,7 +197,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Id               = '12345678-1234-1234-1234-123456789012'
                     IdentitySources  = @(
                         (New-CimInstance -ClassName MSFT_AADEntitlementManagementConnectedOrganizationIdentitySource -Property @{
-                            ExternalTenantId = 'IdentitySource_TenantId'
+                            tenantId = 'IdentitySource_TenantId'
                             odataType        = '#microsoft.graph.azureActiveDirectoryTenant'
                             displayName      = 'IdentitySource_DisplayName'
                         } -ClientOnly)
@@ -254,7 +254,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Id               = '12345678-1234-1234-1234-123456789012'
                     IdentitySources  = @(
                         (New-CimInstance -ClassName MSFT_AADEntitlementManagementConnectedOrganizationIdentitySource -Property @{
-                            ExternalTenantId = 'IdentitySource_TenantId'
+                            tenantId = 'IdentitySource_TenantId'
                             odataType        = '#microsoft.graph.azureActiveDirectoryTenant'
                             displayName      = 'IdentitySource_DisplayName'
                         } -ClientOnly)


### PR DESCRIPTION
… 'DifferenceObject' because it is null #3478

#### Pull Request (PR) description
Fix #3843 Wrong attribute name in class causes error displayed during dsc operation

#### This Pull Request (PR) fixes the following issues
    - Fixes #3843 

