### PR TITLE
TeamsComplianceRecordingPolicy: ComplianceRecordingApplications Ids are strings not objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@
   * Added a QA check to test if all used subclasses actually exist in the MOF schema.
 * DEPENDENCIES
   * Updated Microsoft. Graph dependencies to version 2.9.0.
+* TeamsTeam
+  * Fixes incompatible type for ComplianceRecordingApplications, expected string[] but receive object[]
+    FIXES: [#3890](https://github.com/microsoft/Microsoft365DSC/issues/3890)
 
 # 1.23.1108.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   * Updated DSCParser to version 1.4.0.1.
   * Updated Microsoft.Graph to version 2.10.0.
   * Updated MSCloudLoginAssistant to version 1.1.0.
+* TeamsTeam
+  * Fixes incompatible type for ComplianceRecordingApplications, expected string[] but receive object[]
+    FIXES: [#3890](https://github.com/microsoft/Microsoft365DSC/issues/3890)
 
 # 1.23.1122.1
 
@@ -74,9 +77,6 @@
   * Added a QA check to test if all used subclasses actually exist in the MOF schema.
 * DEPENDENCIES
   * Updated Microsoft. Graph dependencies to version 2.9.0.
-* TeamsTeam
-  * Fixes incompatible type for ComplianceRecordingApplications, expected string[] but receive object[]
-    FIXES: [#3890](https://github.com/microsoft/Microsoft365DSC/issues/3890)
 
 # 1.23.1108.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsComplianceRecordingPolicy/MSFT_TeamsComplianceRecordingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsComplianceRecordingPolicy/MSFT_TeamsComplianceRecordingPolicy.psm1
@@ -81,7 +81,7 @@ function Get-TargetResource
         }
         $recordApplicationIds = @()
         foreach ($app in $recordingApplications) {
-            $recordApplicationIds += @{Id=$app.Id}
+            $recordApplicationIds += $app.Id
         }
 
         Write-Verbose -Message "Found an instance with Identity {$Identity}"

--- a/Modules/Microsoft365DSC/Examples/Resources/TeamsComplianceRecordingPolicy/1-TeamsComplianceRecordingPolicy-Example.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/TeamsComplianceRecordingPolicy/1-TeamsComplianceRecordingPolicy-Example.ps1
@@ -16,7 +16,7 @@ Configuration Example
     {
         TeamsComplianceRecordingPolicy 'Example'
         {
-            ComplianceRecordingApplications                     = @();
+            ComplianceRecordingApplications                     = @('qwertzuio-abcd-abcd-abcd-qwertzuio');
             Credential                                          = $Credscredential;
             DisableComplianceRecordingAudioNotificationForCalls = $False;
             Enabled                                             = $False;

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsComplianceRecordingPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsComplianceRecordingPolicy.Tests.ps1
@@ -63,7 +63,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Description                                         = 'FakeStringValue'
                     Enabled                                             = $True
                     DisableComplianceRecordingAudioNotificationForCalls = $True
-                    ComplianceRecordingApplications                     = @(@{Id="123456"})
+                    ComplianceRecordingApplications                     = @("123456")
                     Identity                                            = 'FakeStringValue'
                     Ensure                                              = 'Present'
                     Credential                                          = $Credential
@@ -95,7 +95,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Description                                         = 'FakeStringValue'
                     Enabled                                             = $True
                     DisableComplianceRecordingAudioNotificationForCalls = $True
-                    ComplianceRecordingApplications                     = @(@{Id='123456'})
+                    ComplianceRecordingApplications                     = @('123456')
                     Identity                                            = 'FakeStringValue'
                     Ensure                                              = 'Absent'
                     Credential                                          = $Credential
@@ -147,7 +147,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Description                                         = 'FakeStringValue'
                     Enabled                                             = $True
                     DisableComplianceRecordingAudioNotificationForCalls = $True
-                    ComplianceRecordingApplications                     = @(@{Id='123456'})
+                    ComplianceRecordingApplications                     = @('123456')
                     Identity                                            = 'FakeStringValue'
                     Ensure                                              = 'Present'
                     Credential                                          = $Credential
@@ -184,7 +184,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Description                                         = 'FakeStringValue'
                     Enabled                                             = $True
                     DisableComplianceRecordingAudioNotificationForCalls = $True
-                    ComplianceRecordingApplications                     = @{Id='123456'}
+                    ComplianceRecordingApplications                     = @('123456')
                     Identity                                            = 'FakeStringValue'
                     Ensure                                              = 'Present'
                     Credential                                          = $Credential

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsComplianceRecordingPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsComplianceRecordingPolicy.Tests.ps1
@@ -124,7 +124,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Result = (Get-TargetResource @testParams)
                 $Result.Ensure | Should -Be 'Present'
                 $Result.ComplianceRecordingApplications.Length | Should -Be 1
-                $Result.ComplianceRecordingApplications[0].Id | Should -Be '123456'
+                $Result.ComplianceRecordingApplications[0] | Should -Be '123456'
                 Should -Invoke -CommandName Get-CsTeamsComplianceRecordingPolicy -Exactly 1
                 Should -Invoke -CommandName Get-CsTeamsComplianceRecordingApplication -ParameterFilter {$Filter -eq 'FakeStringValue/*'} -Exactly 1
 


### PR DESCRIPTION
#### Pull Request (PR) description
BigFix: TeamsComplianceRecordingPolicy, ComplianceRecordingApplications Ids are strings not objects


#### This Pull Request (PR) fixes the following issues
Fixes and Close #3890 
