### PR TITLE
PR: update Intune assignment logic - Fixes 3892 and 3921

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCDRGUtil
+  * Added ConvertFrom-IntunePolicyAssignment and ConvertTo-IntunePolicyAssignment
+  FIXES [#3892](https://github.com/microsoft/Microsoft365DSC/issues/3892)
+* IntuneWindowsAutopilotDeploymentProfileAzureADJoined
+  * Modified assigned to use sdk instead of API call and added logic to use groupDisplayName in assignment
+  FIXES [#3892](https://github.com/microsoft/Microsoft365DSC/issues/3892)
+* IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined
+  * Modified assigned to use sdk instead of API call and added logic to use groupDisplayName in assignment
+  FIXES [#3892](https://github.com/microsoft/Microsoft365DSC/issues/3892)
+* IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10
+  * Modified assigned to use sdk instead of API call and added logic to use groupDisplayName in assignment
+  FIXES [#3892](https://github.com/microsoft/Microsoft365DSC/issues/3892)
+* IntuneDeviceConfigurationPolicyWindows10
+  * Modified assigned to use sdk instead of API call and added logic to use groupDisplayName in assignment
+  FIXES [#3921](https://github.com/microsoft/Microsoft365DSC/issues/3921)
+
 # 1.23.1122.1
 
 * SPOSharingSettings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * IntuneDeviceConfigurationPolicyWindows10
   * Modified assigned to use sdk instead of API call and added logic to use groupDisplayName in assignment
   FIXES [#3921](https://github.com/microsoft/Microsoft365DSC/issues/3921)
+* IntuneDeviceEnrollmentStatusPageWindows10
+  * Fixed assignments using API call
+  FIXES [#3921](https://github.com/microsoft/Microsoft365DSC/issues/3921)
 
 # 1.23.1122.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationPolicyWindows10.psm1
@@ -1976,35 +1976,13 @@ function Get-TargetResource
             Managedidentity                                       = $ManagedIdentity.IsPresent
             #endregion
         }
-        $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
+
+        $rawAssignments = @()
+        $rawAssignments =  Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id -All
         $assignmentResult = @()
-        foreach ($assignmentEntry in $AssignmentsValues)
+        if($null -ne $rawAssignments -and $rawAssignments.count -gt 0)
         {
-            $DataType = $assignmentEntry.Target.AdditionalProperties.'@odata.type'
-            $GroupId = $assignmentEntry.Target.AdditionalProperties.groupId
-            $GroupDisplayName = $null
-
-            if ($DataType -eq "#microsoft.graph.groupAssignmentTarget" -or `
-                $DataType -eq "#microsoft.graph.exclusionGroupAssignmentTarget") {
-                $Group = Get-MgGroup -GroupId $GroupId -ErrorAction SilentlyContinue
-                if ($Group.Count -eq 1)
-                {
-                    $GroupDisplayName = $Group.DisplayName
-                    $GroupId = $null
-                }
-            }
-
-            $assignmentValue = @{
-                dataType                                   = $DataType
-                deviceAndAppManagementAssignmentFilterType = $(if ($null -ne $assignmentEntry.Target.DeviceAndAppManagementAssignmentFilterType)
-                    {
-                        $assignmentEntry.Target.DeviceAndAppManagementAssignmentFilterType.ToString()
-                    })
-                deviceAndAppManagementAssignmentFilterId   = $assignmentEntry.Target.DeviceAndAppManagementAssignmentFilterId
-                groupId                                    = $GroupId
-                groupDisplayName                           = $GroupDisplayName
-            }
-            $assignmentResult += $assignmentValue
+            $assignmentResult += ConvertFrom-IntunePolicyAssignment -Assignments $rawAssignments
         }
         $results.Add('Assignments', $assignmentResult)
 
@@ -3300,17 +3278,17 @@ function Set-TargetResource
         #region resource generator code
         $CreateParameters.Add("@odata.type", "#microsoft.graph.windows10GeneralConfiguration")
         $policy = New-MgBetaDeviceManagementDeviceConfiguration -BodyParameter $CreateParameters
-        $assignmentsHash = @()
-        foreach ($assignment in $Assignments)
-        {
-            $assignmentsHash += Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $Assignment
-        }
-
+        #endregion
+        #region new Intune assignment management
         if ($policy.id)
         {
-            Update-DeviceConfigurationPolicyAssignment -DeviceConfigurationPolicyId $policy.id `
-                -Targets $assignmentsHash `
-                -Repository 'deviceManagement/deviceConfigurations'
+            $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+            foreach ($assignment in $intuneAssignments)
+            {
+                New-MgBetaDeviceManagementDeviceConfigurationAssignment `
+                    -DeviceConfigurationId $policy.id `
+                    -BodyParameter $assignment
+            }
         }
         #endregion
     }
@@ -3337,74 +3315,34 @@ function Set-TargetResource
         Update-MgBetaDeviceManagementDeviceConfiguration  `
             -DeviceConfigurationId $currentInstance.Id `
             -BodyParameter $UpdateParameters
-        $assignmentsHash = @()
-        foreach ($assignment in $Assignments)
+        #endregion
+        #region new Intune assignment management
+        $currentAssignments = @()
+        $currentAssignments += Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $currentInstance.id
+
+        $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        foreach ($assignment in $intuneAssignments)
         {
-            if ($Assignment.dataType -eq "#microsoft.graph.groupAssignmentTarget" -or `
-                $Assignment.dataType -eq "#microsoft.graph.exclusionGroupAssignmentTarget")
+            if ( $null -eq ($currentAssignments | Where-Object { $_.Target.AdditionalProperties.groupId -eq $assignment.Target.groupId -and $_.Target.AdditionalProperties."@odata.type" -eq $assignment.Target.'@odata.type' }))
             {
-                if (![string]::IsNullOrEmpty($Assignment.groupId))
-                {
-                    $Group = Get-MgGroup -GroupId $Assignment.groupId -ErrorAction SilentlyContinue
-                    $GroupId = $Assignment.groupId
-                }
-                else
-                {
-                    $Group = $null
-                    $GroupId = "null"
-                }
-
-                if ($Group.Count -eq 0)
-                {
-                    $Message = "Could not find assignment group with id {0}, trying with display name" -f $GroupId
-                    Write-Verbose -Message $Message
-
-                    if (![string]::IsNullOrEmpty($Assignment.groupDisplayName))
-                    {
-                        $Message = "Checking for the assignment group '{0}'" -f $Assignment.groupDisplayName
-                        Write-Verbose -Message $Message
-
-                        $Filter = "displayName eq '{0}'" -f $Assignment.groupDisplayName
-                        $Group = Get-MgGroup -Filter $Filter -ErrorAction SilentlyContinue
-                        if ($Group.Count -eq 1)
-                        {
-                            $Message = "Found assignment group '{0}' with id '{1}'" -f $Group.DisplayName, $Group.Id
-                            Write-Verbose -Message $Message
-
-                            $Assignment.groupId = $Group.Id
-                        }
-                        else
-                        {
-                            if ([string]::IsNullOrEmpty($Assignment.groupId))
-                            {
-                                $Message = "Could not find assignment group, skipping"
-                                continue
-                            }
-
-                            $Message = "Could not find assignment group '{0}', instead use group with id '{1}'" -f $Assignment.groupDisplayName, $Assignment.groupId
-                            Write-Verbose -Message $Message
-                        }
-                    }
-                    else
-                    {
-                        $Message = "Could not find assignment group, skipping"
-                        Write-Verbose -Message $Message
-                        continue
-                    }
-                }
+                New-MgBetaDeviceManagementDeviceConfigurationAssignment `
+                    -DeviceConfigurationId $currentInstance.id `
+                    -BodyParameter $assignment
             }
-
-            $assignmentHash = Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $Assignment
-            if (![string]::IsNullOrEmpty($Assignment.groupDisplayName))
+            else
             {
-                $assignmentHash.Remove("groupDisplayName") | Out-Null
+                $currentAssignments = $currentAssignments | Where-Object { -not ($_.Target.AdditionalProperties.groupId -eq $assignment.Target.groupId -and $_.Target.AdditionalProperties."@odata.type" -eq $assignment.Target.'@odata.type') }
             }
-            $assignmentsHash += $assignmentHash
         }
-        Update-DeviceConfigurationPolicyAssignment `
-            -DeviceConfigurationPolicyId $currentInstance.id `
-            -Targets $assignmentsHash `
-            -Repository 'deviceManagement/deviceConfigurations'
+        if($currentAssignments.count -gt 0)
+        {
+            foreach ($assignment in $currentAssignments)
+            {
+                Remove-MgBetaDeviceManagementDeviceConfigurationAssignment `
+                    -DeviceConfigurationId $currentInstance.Id `
+                    -DeviceConfigurationAssignmentId $assignment.Id
+            }
+        }
         #endregion
     }
     elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
@@ -4690,11 +4628,34 @@ function Test-TargetResource
                 -Source ($source) `
                 -Target ($target)
 
-            if (-Not $testResult)
+            if( $key -eq "Assignments")
             {
-                $testResult = $false
-                break
+                $testResult = $source.count -eq $target.count
+                if (-Not $testResult) { break }
+                foreach ($assignment in $source)
+                {
+                    if ($assignment.dataType -like '*GroupAssignmentTarget')
+                    {
+                        $testResult = $null -ne ($target | Where-Object {$_.dataType -eq $assignment.DataType -and $_.groupId -eq $assignment.groupId})
+                        #Using assignment groupDisplayName only if the groupId is not found in the directory otherwise groupId should be the key
+                        if (-not $testResult)
+                        {
+                            $groupNotFound =  $null -eq (Get-MgGroup -GroupId ($assignment.groupId) -ErrorAction SilentlyContinue)
+                        }
+                        if (-not $testResult -and $groupNotFound)
+                        {
+                            $testResult = $null -ne ($target | Where-Object {$_.dataType -eq $assignment.DataType -and $_.groupDisplayName -eq $assignment.groupDisplayName})
+                        }
+                    }
+                    else
+                    {
+                        $testResult = $null -ne ($target | Where-Object {$_.dataType -eq $assignment.DataType})
+                    }
+                    if (-Not $testResult) { break }
+                }
+                if (-Not $testResult) { break }
             }
+            if (-Not $testResult) { break }
 
             $ValuesToCheck.Remove($key) | Out-Null
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationPolicyWindows10.psm1
@@ -3282,7 +3282,11 @@ function Set-TargetResource
         #region new Intune assignment management
         if ($policy.id)
         {
-            $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+            $intuneAssignments = @()
+            if($null -ne $Assignments -and $Assignments.count -gt 0)
+            {
+                $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+            }
             foreach ($assignment in $intuneAssignments)
             {
                 New-MgBetaDeviceManagementDeviceConfigurationAssignment `
@@ -3320,7 +3324,11 @@ function Set-TargetResource
         $currentAssignments = @()
         $currentAssignments += Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $currentInstance.id
 
-        $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        $intuneAssignments = @()
+        if($null -ne $Assignments -and $Assignments.count -gt 0)
+        {
+            $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        }
         foreach ($assignment in $intuneAssignments)
         {
             if ( $null -eq ($currentAssignments | Where-Object { $_.Target.AdditionalProperties.groupId -eq $assignment.Target.groupId -and $_.Target.AdditionalProperties."@odata.type" -eq $assignment.Target.'@odata.type' }))

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1
@@ -377,13 +377,11 @@ function Set-TargetResource
         $CreateParameters.Add('@odata.type', '#microsoft.graph.windows10EnrollmentCompletionPageConfiguration')
         $policy = New-MgBetaDeviceManagementDeviceEnrollmentConfiguration -BodyParameter $CreateParameters
 
-        foreach ($assignment in $Assignments)
-        {
-            $assignmentsHash += Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $Assignment
-        }
-        Update-DeviceConfigurationPolicyAssignment -DeviceConfigurationPolicyId  $policy.id `
-            -Targets $assignmentsHash `
-            -Repository 'deviceManagement/deviceEnrollmentConfigurations'
+        $intuneAssignments = @()
+        $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        $body = @{'enrollmentConfigurationAssignments' = $intuneAssignments} | ConvertTo-Json -Depth 100
+        $Uri = "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations/$($policy.Id)/assign"
+        Invoke-MgGraphRequest -Method POST -Uri $Uri -Body $body -ErrorAction Stop
 
         Update-DeviceEnrollmentConfigurationPriority `
             -DeviceEnrollmentConfigurationId $policy.id `
@@ -414,14 +412,11 @@ function Set-TargetResource
 
         if ($currentInstance.Id -notlike '*_DefaultWindows10EnrollmentCompletionPageConfiguration')
         {
-            foreach ($assignment in $Assignments)
-            {
-                $assignmentsHash += Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $Assignment
-            }
-
-            Update-DeviceConfigurationPolicyAssignment -DeviceConfigurationPolicyId  $currentInstance.id `
-                -Targets $assignmentsHash `
-                -Repository 'deviceManagement/deviceEnrollmentConfigurations'
+            $intuneAssignments = @()
+            $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+            $body = @{'enrollmentConfigurationAssignments' = $intuneAssignments} | ConvertTo-Json -Depth 100
+            $Uri = "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations/$($currentInstance.Id)/assign"
+            Invoke-MgGraphRequest -Method POST -Uri $Uri -Body $body -ErrorAction Stop
 
             Update-DeviceEnrollmentConfigurationPriority `
                 -DeviceEnrollmentConfigurationId $currentInstance.id `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1
@@ -378,7 +378,10 @@ function Set-TargetResource
         $policy = New-MgBetaDeviceManagementDeviceEnrollmentConfiguration -BodyParameter $CreateParameters
 
         $intuneAssignments = @()
-        $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        if($null -ne $Assignments -and $Assignments.count -gt 0)
+        {
+            $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        }
         $body = @{'enrollmentConfigurationAssignments' = $intuneAssignments} | ConvertTo-Json -Depth 100
         $Uri = "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations/$($policy.Id)/assign"
         Invoke-MgGraphRequest -Method POST -Uri $Uri -Body $body -ErrorAction Stop
@@ -413,7 +416,10 @@ function Set-TargetResource
         if ($currentInstance.Id -notlike '*_DefaultWindows10EnrollmentCompletionPageConfiguration')
         {
             $intuneAssignments = @()
-            $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+            if($null -ne $Assignments -and $Assignments.count -gt 0)
+            {
+                $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+            }
             $body = @{'enrollmentConfigurationAssignments' = $intuneAssignments} | ConvertTo-Json -Depth 100
             $Uri = "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations/$($currentInstance.Id)/assign"
             Invoke-MgGraphRequest -Method POST -Uri $Uri -Body $body -ErrorAction Stop

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined.psm1
@@ -354,7 +354,11 @@ function Set-TargetResource
         $policy = New-MgBetaDeviceManagementWindowsAutopilotDeploymentProfile -BodyParameter $CreateParameters
         #endregion
         #region new Intune assignment management
-        $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        $intuneAssignments = @()
+        if($null -ne $Assignments -and $Assignments.count -gt 0)
+        {
+            $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        }
         foreach ($assignment in $intuneAssignments)
         {
             New-MgBetaDeviceManagementWindowsAutopilotDeploymentProfileAssignment `
@@ -390,8 +394,11 @@ function Set-TargetResource
         #region new Intune assignment management
         $currentAssignments = @()
         $currentAssignments += Get-MgBetaDeviceManagementWindowsAutopilotDeploymentProfileAssignment -WindowsAutopilotDeploymentProfileId $currentInstance.id
-
-        $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        $intuneAssignments = @()
+        if($null -ne $Assignments -and $Assignments.count -gt 0)
+        {
+            $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        }
         foreach ($assignment in $intuneAssignments)
         {
             if ( $null -eq ($currentAssignments | Where-Object { $_.Target.AdditionalProperties.groupId -eq $assignment.Target.groupId -and $_.Target.AdditionalProperties."@odata.type" -eq $assignment.Target.'@odata.type' }))

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined.psm1
@@ -353,7 +353,11 @@ function Set-TargetResource
         #endregion
 
         #region new Intune assignment management
-        $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        $intuneAssignments = @()
+        if($null -ne $Assignments -and $Assignments.count -gt 0)
+        {
+            $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        }
         foreach ($assignment in $intuneAssignments)
         {
             New-MgBetaDeviceManagementWindowsAutopilotDeploymentProfileAssignment `
@@ -391,7 +395,11 @@ function Set-TargetResource
         $currentAssignments = @()
         $currentAssignments += Get-MgBetaDeviceManagementWindowsAutopilotDeploymentProfileAssignment -WindowsAutopilotDeploymentProfileId $currentInstance.id
 
-        $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        $intuneAssignments = @()
+        if($null -ne $Assignments -and $Assignments.count -gt 0)
+        {
+            $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        }
         foreach ($assignment in $intuneAssignments)
         {
             if ( $null -eq ($currentAssignments | Where-Object { $_.Target.AdditionalProperties.groupId -eq $assignment.Target.groupId -and $_.Target.AdditionalProperties."@odata.type" -eq $assignment.Target.'@odata.type' }))

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10.psm1
@@ -677,7 +677,11 @@ function Set-TargetResource
         $policy = New-MgBetaDeviceManagementDeviceConfiguration -BodyParameter $CreateParameters
         #endregion
         #region new Intune assignment management
-        $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        $intuneAssignments = @()
+        if($null -ne $Assignments -and $Assignments.count -gt 0)
+        {
+            $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        }
         foreach ($assignment in $intuneAssignments)
         {
             New-MgBetaDeviceManagementDeviceConfigurationAssignmentAssignment `
@@ -714,7 +718,11 @@ function Set-TargetResource
         $currentAssignments = @()
         $currentAssignments += Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $currentInstance.id
 
-        $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        $intuneAssignments = @()
+        if($null -ne $Assignments -and $Assignments.count -gt 0)
+        {
+            $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        }
         foreach ($assignment in $intuneAssignments)
         {
             if ( $null -eq ($currentAssignments | Where-Object { $_.Target.AdditionalProperties.groupId -eq $assignment.Target.groupId -and $_.Target.AdditionalProperties."@odata.type" -eq $assignment.Target.'@odata.type' }))

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10.psm1
@@ -411,23 +411,15 @@ function Get-TargetResource
             Managedidentity                         = $ManagedIdentity.IsPresent
             #endregion
         }
-        $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
+
+        $rawAssignments = @()
+        $rawAssignments =  Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id -All
         $assignmentResult = @()
-        foreach ($assignmentEntry in $AssignmentsValues)
+        if($null -ne $rawAssignments -and $rawAssignments.count -gt 0)
         {
-            $assignmentValue = @{
-                dataType                                   = $assignmentEntry.Target.AdditionalProperties.'@odata.type'
-                deviceAndAppManagementAssignmentFilterType = $(if ($null -ne $assignmentEntry.Target.DeviceAndAppManagementAssignmentFilterType)
-                    {
-                        $assignmentEntry.Target.DeviceAndAppManagementAssignmentFilterType.ToString()
-                    })
-                deviceAndAppManagementAssignmentFilterId   = $assignmentEntry.Target.DeviceAndAppManagementAssignmentFilterId
-                groupId                                    = $assignmentEntry.Target.AdditionalProperties.groupId
-            }
-            $assignmentResult += $assignmentValue
+            $assignmentResult += ConvertFrom-IntunePolicyAssignment -Assignments $rawAssignments
         }
         $results.Add('Assignments', $assignmentResult)
-
         return [System.Collections.Hashtable] $results
     }
     catch
@@ -683,17 +675,14 @@ function Set-TargetResource
         #region resource generator code
         $CreateParameters.Add("@odata.type", "#microsoft.graph.windowsUpdateForBusinessConfiguration")
         $policy = New-MgBetaDeviceManagementDeviceConfiguration -BodyParameter $CreateParameters
-        $assignmentsHash=@()
-        foreach($assignment in $Assignments)
+        #endregion
+        #region new Intune assignment management
+        $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        foreach ($assignment in $intuneAssignments)
         {
-            $assignmentsHash += Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $Assignment
-        }
-
-        if ($policy.id)
-        {
-            Update-DeviceConfigurationPolicyAssignment -DeviceConfigurationPolicyId $policy.id `
-                -Targets $assignmentsHash `
-                -Repository 'deviceManagement/deviceConfigurations'
+            New-MgBetaDeviceManagementDeviceConfigurationAssignmentAssignment `
+                -DeviceConfigurationAssignmentId $policy.id `
+                -BodyParameter $assignment
         }
         #endregion
     }
@@ -720,11 +709,34 @@ function Set-TargetResource
         Update-MgBetaDeviceManagementDeviceConfiguration  `
             -DeviceConfigurationId $currentInstance.id `
             -BodyParameter $UpdateParameters
+        #endregion
+        #region new Intune assignment management
+        $currentAssignments = @()
+        $currentAssignments += Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $currentInstance.id
 
-        $assignmentsHash = @()
-        Update-DeviceConfigurationPolicyAssignment -DeviceConfigurationPolicyId $currentInstance.id `
-            -Targets $assignmentsHash `
-            -Repository 'deviceManagement/deviceConfigurations'
+        $intuneAssignments = ConvertTo-IntunePolicyAssignment -Assignments $Assignments
+        foreach ($assignment in $intuneAssignments)
+        {
+            if ( $null -eq ($currentAssignments | Where-Object { $_.Target.AdditionalProperties.groupId -eq $assignment.Target.groupId -and $_.Target.AdditionalProperties."@odata.type" -eq $assignment.Target.'@odata.type' }))
+            {
+                New-MgBetaDeviceManagementDeviceConfigurationAssignment `
+                    -DeviceConfigurationId $currentInstance.id `
+                    -BodyParameter $assignment
+            }
+            else
+            {
+                $currentAssignments = $currentAssignments | Where-Object { -not($_.Target.AdditionalProperties.groupId -eq $assignment.Target.groupId -and $_.Target.AdditionalProperties."@odata.type" -eq $assignment.Target.'@odata.type') }
+            }
+        }
+        if($currentAssignments.count -gt 0)
+        {
+            foreach ($assignment in $currentAssignments)
+            {
+                Remove-MgBetaDeviceManagementDeviceConfigurationAssignment `
+                    -DeviceConfigurationId $currentInstance.Id `
+                    -DeviceConfigurationAssignmentId $assignment.Id
+            }
+        }
         #endregion
     }
     elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
@@ -971,11 +983,34 @@ function Test-TargetResource
                 -Source ($source) `
                 -Target ($target)
 
-            if (-Not $testResult)
+            if( $key -eq "Assignments")
             {
-                $testResult = $false
-                break
+                $testResult = $source.count -eq $target.count
+                if (-Not $testResult) { break }
+                foreach ($assignment in $source)
+                {
+                    if ($assignment.dataType -like '*GroupAssignmentTarget')
+                    {
+                        $testResult = $null -ne ($target | Where-Object {$_.dataType -eq $assignment.DataType -and $_.groupId -eq $assignment.groupId})
+                        #Using assignment groupDisplayName only if the groupId is not found in the directory otherwise groupId should be the key
+                        if (-not $testResult)
+                        {
+                            $groupNotFound =  $null -eq (Get-MgGroup -GroupId ($assignment.groupId) -ErrorAction SilentlyContinue)
+                        }
+                        if (-not $testResult -and $groupNotFound)
+                        {
+                            $testResult = $null -ne ($target | Where-Object {$_.dataType -eq $assignment.DataType -and $_.groupDisplayName -eq $assignment.groupDisplayName})
+                        }
+                    }
+                    else
+                    {
+                        $testResult = $null -ne ($target | Where-Object {$_.dataType -eq $assignment.DataType})
+                    }
+                    if (-Not $testResult) { break }
+                }
+                if (-Not $testResult) { break }
             }
+            if (-Not $testResult) { break }
 
             $ValuesToCheck.Remove($key) | Out-Null
         }

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1272,7 +1272,7 @@ function Update-DeviceConfigurationPolicyAssignment
             $deviceManagementPolicyAssignments += @{'target' = $formattedTarget}
         }
         $body = @{'assignments' = $deviceManagementPolicyAssignments} | ConvertTo-Json -Depth 20
-        write-verbose -Message $body
+        #write-verbose -Message $body
         Invoke-MgGraphRequest -Method POST -Uri $Uri -Body $body -ErrorAction Stop
     }
     catch

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1109,7 +1109,119 @@ function Update-IntuneSettingCatalogPolicy
         return $null
     }
 }
+function ConvertFrom-IntunePolicyAssignment
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable[]])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Array]
+        $Assignments,
+        [Parameter()]
+        [System.Boolean]
+        $IncludeDeviceFilter = $true
+    )
 
+    $assignmentResult = @()
+    foreach ($assignment in $Assignments)
+    {
+        $hashAssignment = @{}
+        $dataType = $assignment.Target.AdditionalProperties."@odata.type"
+        $groupId = $assignment.Target.AdditionalProperties.groupId
+
+        $hashAssignment.add('dataType',$dataType)
+        if (-not [string]::IsNullOrEmpty($groupId))
+        {
+            $hashAssignment.add('groupId', $groupId)
+
+            $group = Get-MgGroup -GroupId ($groupId) -ErrorAction SilentlyContinue
+            if ($null -ne $group)
+            {
+                $hashAssignment.add('groupDisplayName', $group.DisplayName)
+            }
+        }
+        if ($IncludeDeviceFilter)
+        {
+            if ($null -ne $assignment.Target.DeviceAndAppManagementAssignmentFilterType)
+            {
+                $hashAssignment.add('deviceAndAppManagementAssignmentFilterType', $assignment.Target.DeviceAndAppManagementAssignmentFilterType.ToString())
+            }
+            if ($null -ne $assignment.Target.DeviceAndAppManagementAssignmentFilterId)
+            {
+                $hashAssignment.add('deviceAndAppManagementAssignmentFilterId', $assignment.Target.DeviceAndAppManagementAssignmentFilterId)
+            }
+        }
+
+        $assignmentResult += $hashAssignment
+    }
+
+    return $assignmentResult
+}
+
+function ConvertTo-IntunePolicyAssignment
+{
+    [CmdletBinding()]
+    [OutputType([Hashtable[]])]
+    param (
+        [Parameter(Mandatory = $true)]
+        $Assignments,
+        [Parameter()]
+        [System.Boolean]
+        $IncludeDeviceFilter = $true
+    )
+
+    $assignmentResult = @()
+    foreach ($assignment in $Assignments)
+    {
+        $target = @{"@odata.type" = $assignment.dataType}
+        if ($IncludeDeviceFilter)
+        {
+            if ($null -ne $assignment.DeviceAndAppManagementAssignmentFilterId)
+            {
+                $target.add('deviceAndAppManagementAssignmentFilterId', $assignment.DeviceAndAppManagementAssignmentFilterId)
+            }
+            if ($null -ne $assignment.DeviceAndAppManagementAssignmentFilterType)
+            {
+                $target.add('deviceAndAppManagementAssignmentFilterType',$assignment.DeviceAndAppManagementAssignmentFilterType)
+            }
+        }
+        if ($assignment.dataType -like '*GroupAssignmentTarget')
+        {
+            $group = Get-MgGroup -GroupId ($assignment.groupId) -ErrorAction SilentlyContinue
+            if ($null -eq $group)
+            {
+                $group = Get-MgGroup -Filter "DisplayName eq '$($assignment.groupDisplayName)'" -ErrorAction SilentlyContinue
+                if ($null -eq $group)
+                {
+                    $message = "Skipping assignment for the group with DisplayName {$($assignment.groupDisplayName)} as it could not be found in the directory.`r`n"
+                    $message += "Please update your DSC resource extract with the correct groupId or groupDisplayName."
+                    write-verbose -Message $message
+                    $target = $null
+                }
+                if ($group -and $group.count -gt 1)
+                {
+                    $message = "Skipping assignment for the group with DisplayName {$($assignment.groupDisplayName)} as it is not unique in the directory.`r`n"
+                    $message += "Please update your DSC resource extract with the correct groupId or a unique group DisplayName."
+                    write-verbose -Message $message
+                    $group = $null
+                    $target = $null
+                }
+            }
+            #Skipping assignment if group not found from either groupId or groupDisplayName
+            if ($null -ne $group)
+            {
+                $target.add('groupId',$group.Id)
+            }
+        }
+
+        if ($target)
+        {
+            $assignmentResult += @{Target = $target}
+        }
+    }
+
+    return $assignmentResult
+}
 function Update-DeviceConfigurationPolicyAssignment
 {
     [CmdletBinding()]
@@ -1160,7 +1272,7 @@ function Update-DeviceConfigurationPolicyAssignment
             $deviceManagementPolicyAssignments += @{'target' = $formattedTarget}
         }
         $body = @{'assignments' = $deviceManagementPolicyAssignments} | ConvertTo-Json -Depth 20
-        #write-verbose -Message $body
+        write-verbose -Message $body
         Invoke-MgGraphRequest -Method POST -Uri $Uri -Body $body -ErrorAction Stop
     }
     catch

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1216,7 +1216,7 @@ function ConvertTo-IntunePolicyAssignment
 
         if ($target)
         {
-            $assignmentResult += @{Target = $target}
+            $assignmentResult += @{target = $target}
         }
     }
 


### PR DESCRIPTION
#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
* M365DSCDRGUtil
  * Added ConvertFrom-IntunePolicyAssignment and ConvertTo-IntunePolicyAssignment
  FIXES [#3892](https://github.com/microsoft/Microsoft365DSC/issues/3892)
* IntuneWindowsAutopilotDeploymentProfileAzureADJoined
  * Modified assigned to use sdk instead of API call and added logic to use groupDisplayName in assignment
  FIXES [#3892](https://github.com/microsoft/Microsoft365DSC/issues/3892)
* IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined
  * Modified assigned to use sdk instead of API call and added logic to use groupDisplayName in assignment
  FIXES [#3892](https://github.com/microsoft/Microsoft365DSC/issues/3892)
* IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10
  * Modified assigned to use sdk instead of API call and added logic to use groupDisplayName in assignment
  FIXES [#3892](https://github.com/microsoft/Microsoft365DSC/issues/3892)
* IntuneDeviceConfigurationPolicyWindows10
  * Modified assigned to use sdk instead of API call and added logic to use groupDisplayName in assignment
  FIXES [#3921](https://github.com/microsoft/Microsoft365DSC/issues/3921)
* IntuneDeviceEnrollmentStatusPageWindows10
  * Fixed assignments using API call
  FIXES [#3921](https://github.com/microsoft/Microsoft365DSC/issues/3921)