### PR TITLE
Fix Android Device Administrator Basic Wi-Fi Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneWiFiConfigurationPolicyAndroidDeviceAdministrator
+  * Renamed resource to IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic
+  * Updated properties
+  * Fixed import, update and test of the resource
+  FIXES [#3975](https://github.com/microsoft/Microsoft365DSC/issues/3975)
+
 # 1.23.1129.1
 
+* IntuneAntivirusPolicyWindows10SettingCatalog
+  * Skipped settingValueTemplateReference and settingInstanceTemplateReference for severethreats, highseveritythreats, moderateseveritythreats, lowseveritythreats as per API requirements observed in the Intune portal
+  FIXES [#3818](https://github.com/microsoft/Microsoft365DSC/issues/3818)
+  FIXES [#3955](https://github.com/microsoft/Microsoft365DSC/issues/3955)
 * AADRoleSetting
   * Export sorted by DisplayName for better comparison
   * Enable Filter property to be used on export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,6 @@
 
 # 1.23.1129.1
 
-* IntuneAntivirusPolicyWindows10SettingCatalog
-  * Skipped settingValueTemplateReference and settingInstanceTemplateReference for severethreats, highseveritythreats, moderateseveritythreats, lowseveritythreats as per API requirements observed in the Intune portal
-  FIXES [#3818](https://github.com/microsoft/Microsoft365DSC/issues/3818)
-  FIXES [#3955](https://github.com/microsoft/Microsoft365DSC/issues/3955)
 * AADRoleSetting
   * Export sorted by DisplayName for better comparison
   * Enable Filter property to be used on export

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministrator/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministrator/readme.md
@@ -1,6 +1,0 @@
-
-# IntuneWifiConfigurationPolicyAndroidDeviceAdministrator
-
-## Description
-
-This resource configures an Intune Wifi Configuration Policy Android Device Administrator Device.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.psm1
@@ -19,6 +19,10 @@ function Get-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $ConnectAutomatically,
+
+        [Parameter()]
+        [System.Boolean]
         $ConnectWhenNetworkNameIsHidden,
 
         [Parameter()]
@@ -120,6 +124,7 @@ function Get-TargetResource
             Id                             = $getValue.Id
             Description                    = $getValue.Description
             DisplayName                    = $getValue.DisplayName
+            ConnectAutomatically           = $getValue.AdditionalProperties.connectAutomatically
             ConnectWhenNetworkNameIsHidden = $getValue.AdditionalProperties.connectWhenNetworkNameIsHidden
             NetworkName                    = $getValue.AdditionalProperties.networkName
             Ssid                           = $getValue.AdditionalProperties.ssid
@@ -180,6 +185,10 @@ function Set-TargetResource
         [Parameter()]
         [System.String]
         $Description,
+
+        [Parameter()]
+        [System.Boolean]
+        $ConnectAutomatically,
 
         [Parameter()]
         [System.Boolean]
@@ -273,7 +282,6 @@ function Set-TargetResource
 
         $CreateParameters = ([Hashtable]$PSBoundParameters).clone()
         $CreateParameters = Rename-M365DSCCimInstanceParameter -Properties $CreateParameters
-        $CreateParameters.Add('ConnectAutomatically', $false)
 
         $AdditionalProperties = Get-M365DSCAdditionalProperties -Properties ($CreateParameters)
         foreach ($key in $AdditionalProperties.keys)
@@ -396,6 +404,10 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $ConnectAutomatically,
+
+        [Parameter()]
+        [System.Boolean]
         $ConnectWhenNetworkNameIsHidden,
 
         [Parameter()]
@@ -463,7 +475,7 @@ function Test-TargetResource
     $CurrentValues = Get-TargetResource @PSBoundParameters
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).clone()
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.psm1
@@ -19,10 +19,6 @@ function Get-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $ConnectAutomatically,
-
-        [Parameter()]
-        [System.Boolean]
         $ConnectWhenNetworkNameIsHidden,
 
         [Parameter()]
@@ -34,7 +30,7 @@ function Get-TargetResource
         $Ssid,
 
         [Parameter()]
-        [ValidateSet('open', 'wpaEnterprise', 'wpa2Enterprise')]
+        [ValidateSet('open')]
         [System.String]
         $WiFiSecurityType,
 
@@ -108,6 +104,7 @@ function Get-TargetResource
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidWiFiConfiguration' `
             }
+            $Id = $getValue.Id
         }
         #endregion
 
@@ -123,7 +120,6 @@ function Get-TargetResource
             Id                             = $getValue.Id
             Description                    = $getValue.Description
             DisplayName                    = $getValue.DisplayName
-            ConnectAutomatically           = $getValue.AdditionalProperties.connectAutomatically
             ConnectWhenNetworkNameIsHidden = $getValue.AdditionalProperties.connectWhenNetworkNameIsHidden
             NetworkName                    = $getValue.AdditionalProperties.networkName
             Ssid                           = $getValue.AdditionalProperties.ssid
@@ -187,10 +183,6 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $ConnectAutomatically,
-
-        [Parameter()]
-        [System.Boolean]
         $ConnectWhenNetworkNameIsHidden,
 
         [Parameter()]
@@ -202,7 +194,7 @@ function Set-TargetResource
         $Ssid,
 
         [Parameter()]
-        [ValidateSet('open', 'wpaEnterprise', 'wpa2Enterprise')]
+        [ValidateSet('open')]
         [System.String]
         $WiFiSecurityType,
 
@@ -281,6 +273,7 @@ function Set-TargetResource
 
         $CreateParameters = ([Hashtable]$PSBoundParameters).clone()
         $CreateParameters = Rename-M365DSCCimInstanceParameter -Properties $CreateParameters
+        $CreateParameters.Add('ConnectAutomatically', $false)
 
         $AdditionalProperties = Get-M365DSCAdditionalProperties -Properties ($CreateParameters)
         foreach ($key in $AdditionalProperties.keys)
@@ -403,10 +396,6 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $ConnectAutomatically,
-
-        [Parameter()]
-        [System.Boolean]
         $ConnectWhenNetworkNameIsHidden,
 
         [Parameter()]
@@ -418,7 +407,7 @@ function Test-TargetResource
         $Ssid,
 
         [Parameter()]
-        [ValidateSet('open', 'wpaEnterprise', 'wpa2Enterprise')]
+        [ValidateSet('open')]
         [System.String]
         $WiFiSecurityType,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.schema.mof
@@ -15,6 +15,7 @@ class MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic : OMI_Ba
     [Write, Description("Id of the Intune Policy.")] String Id;
     [Key, Description("Display name of the Intune Policy.")] String DisplayName;
     [Write, Description("Description of the Intune Policy.")] String Description;
+    [Write, Description("Connect automatically.")] Boolean ConnectAutomatically;
     [Write, Description("Connect if the network name is hidden.")] Boolean ConnectWhenNetworkNameIsHidden;
     [Write, Description("Network name.")] String NetworkName;
     [Write, Description("SSID.")] String Ssid;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.schema.mof
@@ -9,17 +9,16 @@ class MSFT_DeviceManagementConfigurationPolicyAssignments
     [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
 };
 
-[ClassVersion("1.0.0.0"), FriendlyName("IntuneWifiConfigurationPolicyAndroidDeviceAdministrator")]
-class MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministrator : OMI_BaseResource
+[ClassVersion("1.0.0.0"), FriendlyName("IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic")]
+class MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic : OMI_BaseResource
 {
     [Write, Description("Id of the Intune Policy.")] String Id;
     [Key, Description("Display name of the Intune Policy.")] String DisplayName;
     [Write, Description("Description of the Intune Policy.")] String Description;
-    [Write, Description("Connect automatically.")] Boolean ConnectAutomatically;
-    [Write, Description("Connect when network name is hidden.")] Boolean ConnectWhenNetworkNameIsHidden;
+    [Write, Description("Connect if the network name is hidden.")] Boolean ConnectWhenNetworkNameIsHidden;
     [Write, Description("Network name.")] String NetworkName;
     [Write, Description("SSID.")] String Ssid;
-    [Write, Description("Wi-Fi security type."), ValueMap{"open","wpaEnterprise","wpa2Enterprise"}, Values{"open","wpaEnterprise","wpa2Enterprise"}] String WiFiSecurityType;
+    [Write, Description("Wi-Fi security type."), ValueMap{"open"}, Values{"open"}] String WiFiSecurityType;
     [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Intune Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/readme.md
@@ -1,0 +1,6 @@
+
+# IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic
+
+## Description
+
+This resource configures an Intune Android Device Administrator Basic Wifi Configuration Policy.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/settings.json
@@ -1,6 +1,6 @@
 {
-    "resourceName": "IntuneWifiConfigurationPolicyAndroidDeviceAdministrator",
-    "description": "This resource configures an Intune Wifi Configuration Policy Android Device Administrator Device.",
+    "resourceName": "IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic",
+    "description": "This resource configures an Intune Android Device Administrator Basic Wifi Configuration Policy.",
     "permissions": {
         "graph": {
             "delegated": {

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/1-ConfigureIntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/1-ConfigureIntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.ps1
@@ -23,6 +23,7 @@ Configuration Example
                     dataType                                   = '#microsoft.graph.allDevicesAssignmentTarget'
                 }
             )
+            ConnectAutomatically           = $True
             ConnectWhenNetworkNameIsHidden = $True
             DisplayName                    = 'Android Device Admin Basic Wi-Fi Profile'
             NetworkName                    = 'b71f8c63-8140-4c7e-b818-f9b4aa98b79b'

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/1-ConfigureIntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic/1-ConfigureIntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.ps1
@@ -14,7 +14,7 @@ Configuration Example
 
     node localhost
     {
-        IntuneWiFiConfigurationPolicyAndroidDeviceAdministrator 'myWifiConfigAndroidDevicePolicy'
+        IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic 'myWifiConfigAndroidDevicePolicy'
         {
             Id                             = '41869a42-3217-4bfa-9929-92668fc674c5'
             Assignments                    = @(
@@ -23,12 +23,11 @@ Configuration Example
                     dataType                                   = '#microsoft.graph.allDevicesAssignmentTarget'
                 }
             )
-            ConnectAutomatically           = $False
             ConnectWhenNetworkNameIsHidden = $True
-            DisplayName                    = 'Wifi Configuration Androind Device'
+            DisplayName                    = 'Android Device Admin Basic Wi-Fi Profile'
             NetworkName                    = 'b71f8c63-8140-4c7e-b818-f9b4aa98b79b'
-            Ssid                           = 'sf'
-            WiFiSecurityType               = 'wpaEnterprise'
+            Ssid                           = 'ssid'
+            WiFiSecurityType               = 'open'
             Ensure                         = 'Present'
             Credential                     = $credsGlobalAdmin
         }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.Tests.ps1
@@ -24,7 +24,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             $secpasswd = ConvertTo-SecureString 'test@password1' -AsPlainText -Force
             $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
 
-
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
@@ -57,6 +56,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic should exist but it DOES NOT' -Fixture {
             BeforeAll {
                 $testParams = @{
+                    ConnectAutomatically           = $True
                     ConnectWhenNetworkNameIsHidden = $True
                     Description                    = 'FakeStringValue'
                     DisplayName                    = 'FakeStringValue'
@@ -87,6 +87,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic exists but it SHOULD NOT' -Fixture {
             BeforeAll {
                 $testParams = @{
+                    ConnectAutomatically           = $True
                     ConnectWhenNetworkNameIsHidden = $True
                     Description                    = 'FakeStringValue'
                     DisplayName                    = 'FakeStringValue'
@@ -134,6 +135,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic Exists and Values are already in the desired state' -Fixture {
             BeforeAll {
                 $testParams = @{
+                    ConnectAutomatically           = $True
                     ConnectWhenNetworkNameIsHidden = $True
                     Description                    = 'FakeStringValue'
                     DisplayName                    = 'FakeStringValue'
@@ -173,6 +175,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic exists and values are NOT in the desired state' -Fixture {
             BeforeAll {
                 $testParams = @{
+                    ConnectAutomatically           = $True
                     ConnectWhenNetworkNameIsHidden = $True
                     Description                    = 'FakeStringValue'
                     DisplayName                    = 'FakeStringValue'

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneWiFiConfigurationPolicyAndroidDeviceAdministratorBasic.Tests.ps1
@@ -15,7 +15,7 @@ Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
         -Resolve)
 
 $Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
-    -DscResource 'IntuneWifiConfigurationPolicyAndroidDeviceAdministrator' -GenericStubModule $GenericStubPath
+    -DscResource 'IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic' -GenericStubModule $GenericStubPath
 Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
     InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
         Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
@@ -54,10 +54,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         }
 
         # Test contexts
-        Context -Name 'The IntuneWifiConfigurationPolicyAndroidDeviceAdministrator should exist but it DOES NOT' -Fixture {
+        Context -Name 'The IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic should exist but it DOES NOT' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    ConnectAutomatically           = $True
                     ConnectWhenNetworkNameIsHidden = $True
                     Description                    = 'FakeStringValue'
                     DisplayName                    = 'FakeStringValue'
@@ -65,7 +64,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     NetworkName                    = 'FakeStringValue'
                     Ssid                           = 'FakeStringValue'
                     WiFiSecurityType               = 'open'
-
                     Ensure                         = 'Present'
                     Credential                     = $Credential
                 }
@@ -86,10 +84,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
         }
 
-        Context -Name 'The IntuneWifiConfigurationPolicyAndroidDeviceAdministrator exists but it SHOULD NOT' -Fixture {
+        Context -Name 'The IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic exists but it SHOULD NOT' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    ConnectAutomatically           = $True
                     ConnectWhenNetworkNameIsHidden = $True
                     Description                    = 'FakeStringValue'
                     DisplayName                    = 'FakeStringValue'
@@ -134,10 +131,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 Should -Invoke -CommandName Remove-MgBetaDeviceManagementDeviceConfiguration -Exactly 1
             }
         }
-        Context -Name 'The IntuneWifiConfigurationPolicyAndroidDeviceAdministrator Exists and Values are already in the desired state' -Fixture {
+        Context -Name 'The IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic Exists and Values are already in the desired state' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    ConnectAutomatically           = $True
                     ConnectWhenNetworkNameIsHidden = $True
                     Description                    = 'FakeStringValue'
                     DisplayName                    = 'FakeStringValue'
@@ -169,16 +165,14 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 }
             }
 
-
             It 'Should return true from the Test method' {
                 Test-TargetResource @testParams | Should -Be $true
             }
         }
 
-        Context -Name 'The IntuneWifiConfigurationPolicyAndroidDeviceAdministrator exists and values are NOT in the desired state' -Fixture {
+        Context -Name 'The IntuneWifiConfigurationPolicyAndroidDeviceAdministratorBasic exists and values are NOT in the desired state' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    ConnectAutomatically           = $True
                     ConnectWhenNetworkNameIsHidden = $True
                     Description                    = 'FakeStringValue'
                     DisplayName                    = 'FakeStringValue'


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request updates the DSC resource for the Android Device Administrator Wi-Fi profile, specifically the "Basic" version of that Wi-Fi profile. 

This change most likely results in a breaking change because the old DSC resource no longer exists. 

More of these pull requests will be created soon, where the management of the Enterprise and Basic Wi-Fi profiles for Android systems will change. 

- Renames the `IntuneWiFiConfigurationPolicyAndroidDeviceAdministrator` to `[...]Basic`, making clear that this is the "Basic" Wi-Fi profile. Management of the "Enterprise" variant will be implemented with a separate pull request. 
- Updates the modifiable properties and allowed values. For a "Basic" Wi-Fi profile, the `WiFiSecurityType` is always `open`. Only Enterprise profiles have the `wpaEnterprise` resp. `wpa2Enterprise` possibilities.

#### This Pull Request (PR) fixes the following issues
- Fixes #3975
