### PR TITLE
Fix Test-TargetResource and properties for IOS Wi-Fi Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneWifiConfigurationPolicyIOS
+  * Fix Test-TargetResource and available properties
+  FIXES [#3973](https://github.com/microsoft/Microsoft365DSC/issues/3973)
+
 # 1.23.1129.1
 
 * AADRoleSetting

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyIOS/MSFT_IntuneWifiConfigurationPolicyIOS.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyIOS/MSFT_IntuneWifiConfigurationPolicyIOS.schema.mof
@@ -18,6 +18,7 @@ class MSFT_IntuneWifiConfigurationPolicyIOS : OMI_BaseResource
     [Write, Description("Connect automatically")] Boolean ConnectAutomatically;
     [Write, Description("Connect when network name is hidden")] Boolean ConnectWhenNetworkNameIsHidden;
     [Write, Description("Disable the MAC address randomization.")] Boolean DisableMacAddressRandomization;
+    [Write, Description("If the pre shared key should be updated, even if the policy is already equal.")] Boolean ForcePreSharedKeyUpdate;
     [Write, Description("Network name")] String NetworkName;
     [Write, Description("Pre shared key")] String PreSharedKey;
     [Write, Description("Proxy automatic configuration url")] String ProxyAutomaticConfigurationUrl;
@@ -25,7 +26,7 @@ class MSFT_IntuneWifiConfigurationPolicyIOS : OMI_BaseResource
     [Write, Description("Proxy manual port")] UInt32 ProxyManualPort;
     [Write, Description("Proxy settings"), ValueMap{"none","manual","automatic"}, Values{"none","manual","automatic"}] String ProxySettings;
     [Write, Description("SSID")] String Ssid;
-    [Write, Description("Wi-Fi security"), ValueMap{"open","wpaPersonal","wpaEnterprise","wep","wpa2Personal","wpa2Enterprise"}, Values{"open","wpaPersonal","wpaEnterprise","wep","wpa2Personal","wpa2Enterprise"}] String WiFiSecurityType;
+    [Write, Description("Wi-Fi security"), ValueMap{"open","wpaPersonal","wep"}, Values{"open","wpaPersonal","wep"}] String WiFiSecurityType;
     [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Intune Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneWifiConfigurationPolicyIOS.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneWifiConfigurationPolicyIOS.Tests.ps1
@@ -65,7 +65,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Id                             = 'FakeStringValue'
                     NetworkName                    = 'FakeStringValue'
                     PreSharedKey                   = 'FakeStringValue'
-                    ProxyAutomaticConfigurationUrl = 'FakeStringValue'
+                    ProxyAutomaticConfigurationUrl = ''
                     ProxyManualAddress             = 'FakeStringValue'
                     ProxyManualPort                = 25
                     ProxySettings                  = 'none'
@@ -103,7 +103,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Id                             = 'FakeStringValue'
                     NetworkName                    = 'FakeStringValue'
                     PreSharedKey                   = 'FakeStringValue'
-                    ProxyAutomaticConfigurationUrl = 'FakeStringValue'
+                    ProxyAutomaticConfigurationUrl = ''
                     ProxyManualAddress             = 'FakeStringValue'
                     ProxyManualPort                = 25
                     ProxySettings                  = 'none'
@@ -123,7 +123,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             WiFiSecurityType               = 'open'
                             DisableMacAddressRandomization = $True
                             ConnectAutomatically           = $True
-                            ProxyAutomaticConfigurationUrl = 'FakeStringValue'
+                            ProxyAutomaticConfigurationUrl = $null
                             PreSharedKey                   = 'FakeStringValue'
                             ConnectWhenNetworkNameIsHidden = $True
                             ProxySettings                  = 'none'
@@ -163,7 +163,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Id                             = 'FakeStringValue'
                     NetworkName                    = 'FakeStringValue'
                     PreSharedKey                   = 'FakeStringValue'
-                    ProxyAutomaticConfigurationUrl = 'FakeStringValue'
+                    ProxyAutomaticConfigurationUrl = ''
                     ProxyManualAddress             = 'FakeStringValue'
                     ProxyManualPort                = 25
                     ProxySettings                  = 'none'
@@ -183,7 +183,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             WiFiSecurityType               = 'open'
                             DisableMacAddressRandomization = $True
                             ConnectAutomatically           = $True
-                            ProxyAutomaticConfigurationUrl = 'FakeStringValue'
+                            ProxyAutomaticConfigurationUrl = $null
                             PreSharedKey                   = 'FakeStringValue'
                             ConnectWhenNetworkNameIsHidden = $True
                             ProxySettings                  = 'none'
@@ -216,7 +216,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Id                             = 'FakeStringValue'
                     NetworkName                    = 'FakeStringValue'
                     PreSharedKey                   = 'FakeStringValue'
-                    ProxyAutomaticConfigurationUrl = 'FakeStringValue'
+                    ProxyAutomaticConfigurationUrl = ''
                     ProxyManualAddress             = 'FakeStringValue'
                     ProxyManualPort                = 25
                     ProxySettings                  = 'none'
@@ -233,7 +233,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             '@odata.type'                  = '#microsoft.graph.iosWifiConfiguration'
                             NetworkName                    = 'FakeStringValue'
                             WiFiSecurityType               = 'open'
-                            ProxyAutomaticConfigurationUrl = 'FakeStringValue'
+                            ProxyAutomaticConfigurationUrl = $null
                             PreSharedKey                   = 'FakeStringValue'
                             ProxyManualPort                = 7
                             ProxySettings                  = 'none'
@@ -278,7 +278,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             WiFiSecurityType               = 'open'
                             DisableMacAddressRandomization = $True
                             ConnectAutomatically           = $True
-                            ProxyAutomaticConfigurationUrl = 'FakeStringValue'
+                            ProxyAutomaticConfigurationUrl = ''
                             PreSharedKey                   = 'FakeStringValue'
                             ConnectWhenNetworkNameIsHidden = $True
                             ProxySettings                  = 'none'


### PR DESCRIPTION
#### Pull Request (PR) description
- Fixes an issue where the IOS Wi-Fi Profiles are not properly checked and verified by the DSC resource. 
- Updated the available properties

#### This Pull Request (PR) fixes the following issues
- Fixes #3973
