### PR TITLE
Fix code coverage workflow

### DIFF
--- a/.github/workflows/CodeCoverage.yml
+++ b/.github/workflows/CodeCoverage.yml
@@ -18,6 +18,7 @@ jobs:
         shell: pwsh
         run: |
           Install-Module ReverseDSC -Force -Scope AllUsers
+          Install-Module DSCParser -Force -Scope AllUsers
           Install-Module PSDesiredStateConfiguration -Force -Scope AllUsers
           Install-Module Pester -Force -SkipPublisherCheck -Scope AllUsers
           [System.Environment]::SetEnvironmentVariable('M365DSCTelemetryEnabled', $false, [System.EnvironmentVariableTarget]::Machine);


### PR DESCRIPTION
#### Pull Request (PR) description

M365DScRuleEvaluation relies on ConvertTo-DSCObject but DSCParser is not installed in the code coverage workflow so tests fail, fix is to simply install missing DSCParser module (just like it's done in the unit tests).

#### This Pull Request (PR) fixes the following issues
