### PR TITLE
M365DSCDRGUtil: Fix empty BaseUrl since MSCloudLoginAssistant removed Intune workload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCDRGUtil
+  * Fix empty BaseUrl since MSCloudLoginAssistant removed Intune workload
+    FIXES [#4057](https://github.com/microsoft/Microsoft365DSC/issues/4057)
+
 # 1.23.1213.1
 
 * IntuneEndpointDetectionAndResponsePolicyWindows10

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1019,12 +1019,7 @@ function New-IntuneSettingCatalogPolicy
 
     try
     {
-        $BaseUrl = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl
-        if ($BaseUrl[$BaseUrl.Length - 1] -eq '/')
-        {
-            $BaseUrl = $BaseUrl.Substring(0, $BaseUrl.Length - 1)
-        }
-        $Uri = '$($BaseUrl)/beta/deviceManagement/configurationPolicies'
+        $Uri = '/beta/deviceManagement/configurationPolicies'
 
         $policy = @{
             'name'              = $Name
@@ -1087,12 +1082,7 @@ function Update-IntuneSettingCatalogPolicy
 
     try
     {
-        $BaseUrl = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl
-        if ($BaseUrl[$BaseUrl.Length - 1] -eq '/')
-        {
-            $BaseUrl = $BaseUrl.Substring(0, $BaseUrl.Length - 1)
-        }
-        $Uri = "$($BaseUrl)/beta/deviceManagement/configurationPolicies/$DeviceConfigurationPolicyId"
+        $Uri = "/beta/deviceManagement/configurationPolicies/$DeviceConfigurationPolicyId"
 
         $policy = @{
             'name'              = $Name
@@ -1296,12 +1286,7 @@ function Update-DeviceConfigurationPolicyAssignment
     try
     {
         $deviceManagementPolicyAssignments = @()
-        $BaseUrl = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl
-        if ($BaseUrl[$BaseUrl.Length - 1] -eq '/')
-        {
-            $BaseUrl = $BaseUrl.Substring(0, $BaseUrl.Length - 1)
-        }
-        $Uri = "$($BaseUrl)/$APIVersion/$Repository/$DeviceConfigurationPolicyId/assign"
+        $Uri = "/$APIVersion/$Repository/$DeviceConfigurationPolicyId/assign"
 
         foreach ($target in $targets)
         {

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1019,7 +1019,11 @@ function New-IntuneSettingCatalogPolicy
 
     try
     {
-	$BaseUrl = $Global:MSCloudLoginConnectionProfile.Intune.GraphBaseUrl
+        $BaseUrl = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl
+        if ($BaseUrl[$BaseUrl.Length - 1] -eq '/')
+        {
+            $BaseUrl = $BaseUrl.Substring(0, $BaseUrl.Length - 1)
+        }
         $Uri = '$($BaseUrl)/beta/deviceManagement/configurationPolicies'
 
         $policy = @{
@@ -1083,7 +1087,11 @@ function Update-IntuneSettingCatalogPolicy
 
     try
     {
-        $BaseUrl = $Global:MSCloudLoginConnectionProfile.Intune.GraphBaseUrl
+        $BaseUrl = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl
+        if ($BaseUrl[$BaseUrl.Length - 1] -eq '/')
+        {
+            $BaseUrl = $BaseUrl.Substring(0, $BaseUrl.Length - 1)
+        }
         $Uri = "$($BaseUrl)/beta/deviceManagement/configurationPolicies/$DeviceConfigurationPolicyId"
 
         $policy = @{
@@ -1284,10 +1292,15 @@ function Update-DeviceConfigurationPolicyAssignment
         [System.String]
         $APIVersion = 'beta'
     )
+
     try
     {
         $deviceManagementPolicyAssignments = @()
-        $BaseUrl = $Global:MSCloudLoginConnectionProfile.Intune.GraphBaseUrl
+        $BaseUrl = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl
+        if ($BaseUrl[$BaseUrl.Length - 1] -eq '/')
+        {
+            $BaseUrl = $BaseUrl.Substring(0, $BaseUrl.Length - 1)
+        }
         $Uri = "$($BaseUrl)/$APIVersion/$Repository/$DeviceConfigurationPolicyId/assign"
 
         foreach ($target in $targets)


### PR DESCRIPTION
#### Pull Request (PR) description

The cmdlets mentioned at the bottom need to query Graph and to construct the endpoint URI they rely on getting the BaseUrl from MSCloudLoginAssistant, nevertheless it tries to get that URL from the Intune workload which doesn't exist in that module anymore, this PR fixes that by using the information inside the MicrosoftGraph object instead.

*New-IntuneSettingCatalogPolicy*
*Update-IntuneSettingCatalogPolicy*
*Update-DeviceConfigurationPolicyAssignment*

#### This Pull Request (PR) fixes the following issues

- Fixes #4057 
