### PR TITLE
IntuneDeviceConfigurationCustomPolicyWindows10: Add support to decrypt encrypted OmaSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneDeviceConfigurationCustomPolicyWindows10
+  * Add support to decrypt encrypted OmaSettings and export them in plaintext
+    FIXES [#3655](https://github.com/microsoft/Microsoft365DSC/issues/3655)
+
 # 1.23.1213.1
 
 * IntuneEndpointDetectionAndResponsePolicyWindows10

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10.psm1
@@ -112,11 +112,25 @@ function Get-TargetResource
         foreach ($currentomaSettings in $getValue.AdditionalProperties.omaSettings)
         {
             $myomaSettings = @{}
+
+            if ($currentomaSettings.isEncrypted -eq $true)
+            {
+                $SecretReferenceValueId = $currentomaSettings.secretReferenceValueId
+                $OmaSettingPlainTextValue = Get-OmaSettingPlainTextValue -SecretReferenceValueId $SecretReferenceValueId
+                if (![String]::IsNullOrEmpty($OmaSettingPlainTextValue))
+                {
+                    $currentomaSettings.value = $OmaSettingPlainTextValue
+                }
+                else
+                {
+                    $myomaSettings.Add('IsEncrypted', $currentomaSettings.isEncrypted)
+                    $myomaSettings.Add('SecretReferenceValueId', $currentomaSettings.secretReferenceValueId)
+                }
+            }
+
             $myomaSettings.Add('Description', $currentomaSettings.description)
             $myomaSettings.Add('DisplayName', $currentomaSettings.displayName)
-            $myomaSettings.Add('IsEncrypted', $currentomaSettings.isEncrypted)
             $myomaSettings.Add('OmaUri', $currentomaSettings.omaUri)
-            $myomaSettings.Add('SecretReferenceValueId', $currentomaSettings.secretReferenceValueId)
             $myomaSettings.Add('FileName', $currentomaSettings.fileName)
             $myomaSettings.Add('Value', $currentomaSettings.value)
             if ($currentomaSettings.'@odata.type' -eq '#microsoft.graph.omaSettingInteger')


### PR DESCRIPTION
#### Pull Request (PR) description

*IntuneDeviceConfigurationCustomPolicyWindows10* policies export OmaSettings which their values then can be either plaintext or encrypted, when they are encrypted they will be exported to a blueprint with value '****' which of course cannot be deployed to other tenants. This also creates a problem if comparing that blueprint with those other tenants since the *OmaSettings* will always show up as drifts since the corresponding *SecretReferenceValueId* won't be available in the target tenant and therefore the only solution as of now is to just exclude that property from being asserted.

This PR fixes this by always try to decrypt encrypted *OmaSettings* and export their values to the blueprint in plaintext, if it's not possible for some reason then the export will still contain '****' as it does now. This fix doesn't change behavior for *OmaSettings* that already have their corresponding values in plaintext.

#### This Pull Request (PR) fixes the following issues

- Fixes #3655 
