### PR TITLE
IntuneDeviceConfigurationCustomPolicyWindows10: Fix issue deploying decrypted OmaSettings to another tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneDeviceConfigurationCustomPolicyWindows10
+  * Fix issue deploying decrypted OmaSettings to another tenant
+  FIXES [#4083](https://github.com/microsoft/Microsoft365DSC/issues/4083)
+
 # 1.23.1220.1
 
 * AADEntitlementManagementAccessPackage

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10.psm1
@@ -120,6 +120,7 @@ function Get-TargetResource
                 if (![String]::IsNullOrEmpty($OmaSettingPlainTextValue))
                 {
                     $currentomaSettings.value = $OmaSettingPlainTextValue
+                    $currentomaSettings.isEncrypted = $false
                 }
                 else
                 {


### PR DESCRIPTION
#### Pull Request (PR) description

I added support to decrypt encrypted OmaSettings for IntuneDeviceConfigurationCustomPolicyWindows10 on https://github.com/microsoft/Microsoft365DSC/pull/4059, nevertheless I forgot to change the property *isEncrypted* to *$False* if the setting was actually able to be decrypted, this leads to have the decrypted value in the blueprint but still mention that *isEncrypted* is *$True* so that config cannot be applied to other tenant.

This PR fixes this by setting *isEncrypted* to *$False* if the OmaSetting can be decrypted.

#### This Pull Request (PR) fixes the following issues

- Fixes #4083 
