### PR TITLE
EXOMailboxPermission: Ignore SendAs permissions during export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+* EXOMailboxPermission
+  * Ignore SendAs permissions during export
+    FIXES [#3942](https://github.com/microsoft/Microsoft365DSC/issues/3942)
+
 # 1.23.1220.1
 
 * AADEntitlementManagementAccessPackage

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPermission/MSFT_EXOMailboxPermission.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPermission/MSFT_EXOMailboxPermission.psm1
@@ -425,7 +425,7 @@ function Export-TargetResource
                 Write-Host "        |---[$j/$($permissions.Count)] $($permission.Identity)" -NoNewline
                 $Params = @{
                     Identity              = $mailbox.UserPrincipalName
-                    AccessRights          = [Array]$permission.AccessRights.Replace(' ','').Split(',')
+                    AccessRights          = [Array]$permission.AccessRights.Replace(' ','').Replace('SendAs,','').Split(',') # ignore SendAs permissions since they are not supported by *-MailboxPermission cmdlets
                     InheritanceType       = $permission.InheritanceType
                     User                  = $permission.User
                     Credential            = $Credential


### PR DESCRIPTION
#### Pull Request (PR) description
SendAs permissions are not supported by *-MailboxPermission cmdlets. For some reason (see issue), there could be cases where SendAs is included during Get-MailboxPermission. We must ignore this, since we cannot set these permissions.

#### This Pull Request (PR) fixes the following issues
- Fixes #3942 
