### PR TITLE
IntuneDeviceConfigurationPolicyMacOS: Fix deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneDeviceConfigurationPolicyMacOS
+  * Fix resource deployment
+    FIXES [#3539](https://github.com/microsoft/Microsoft365DSC/issues/3539)
+  * Ensure resource can cope with Id being empty since it's not mandatory
+
 # 1.23.1220.1
 
 * AADEntitlementManagementAccessPackage

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
@@ -769,15 +769,6 @@ function Set-TargetResource
 
     $currentInstance = Get-TargetResource @PSBoundParameters
 
-    $PSBoundParameters.Remove('Ensure') | Out-Null
-    $PSBoundParameters.Remove('Credential') | Out-Null
-    $PSBoundParameters.Remove('ApplicationId') | Out-Null
-    $PSBoundParameters.Remove('ApplicationSecret') | Out-Null
-    $PSBoundParameters.Remove('TenantId') | Out-Null
-    $PSBoundParameters.Remove('CertificateThumbprint') | Out-Null
-    $PSBoundParameters.Remove('ManagedIdentity') | Out-Null
-
-
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {
         Write-Verbose -Message "Creating {$DisplayName}"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
@@ -806,6 +806,7 @@ function Set-TargetResource
             $CreateParameters.add('AdditionalProperties', $AdditionalProperties)
         }#>
         $CreateParameters.add('@odata.type','#microsoft.graph.macOSGeneralDeviceConfiguration')
+        $CreateParameters = $CreateParameters | ConvertTo-Json -Depth 100
         #region resource generator code
         $policy = New-MgBetaDeviceManagementDeviceConfiguration -BodyParameter $CreateParameters
         $assignmentsHash = @()

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
@@ -249,7 +249,7 @@ function Get-TargetResource
 
         [Parameter()]
         [ValidateSet('none', 'delayOSUpdateVisibility', 'delayAppUpdateVisibility', 'unknownFutureValue', 'delayMajorOsUpdateVisibility')]
-        [System.String]
+        [System.String[]]
         $UpdateDelayPolicy,
 
         [Parameter()]
@@ -703,7 +703,7 @@ function Set-TargetResource
 
         [Parameter()]
         [ValidateSet('none', 'delayOSUpdateVisibility', 'delayAppUpdateVisibility', 'unknownFutureValue', 'delayMajorOsUpdateVisibility')]
-        [System.String]
+        [System.String[]]
         $UpdateDelayPolicy,
 
         [Parameter()]
@@ -1138,7 +1138,7 @@ function Test-TargetResource
 
         [Parameter()]
         [ValidateSet('none', 'delayOSUpdateVisibility', 'delayAppUpdateVisibility', 'unknownFutureValue', 'delayMajorOsUpdateVisibility')]
-        [System.String]
+        [System.String[]]
         $UpdateDelayPolicy,
 
         [Parameter()]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
@@ -249,7 +249,7 @@ function Get-TargetResource
 
         [Parameter()]
         [ValidateSet('none', 'delayOSUpdateVisibility', 'delayAppUpdateVisibility', 'unknownFutureValue', 'delayMajorOsUpdateVisibility')]
-        [System.String[]]
+        [System.String]
         $UpdateDelayPolicy,
 
         [Parameter()]
@@ -398,7 +398,7 @@ function Get-TargetResource
             SoftwareUpdatesEnforcedDelayInDays              = $getValue.AdditionalProperties.softwareUpdatesEnforcedDelayInDays
             SpotlightBlockInternetResults                   = $getValue.AdditionalProperties.spotlightBlockInternetResults
             TouchIdTimeoutInHours                           = $getValue.AdditionalProperties.touchIdTimeoutInHours
-            UpdateDelayPolicy                               = $getValue.AdditionalProperties.updateDelayPolicy -split ','
+            UpdateDelayPolicy                               = $getValue.AdditionalProperties.updateDelayPolicy
             WallpaperModificationBlocked                    = $getValue.AdditionalProperties.wallpaperModificationBlocked
             Ensure                                          = 'Present'
             Credential                                      = $Credential
@@ -696,7 +696,7 @@ function Set-TargetResource
 
         [Parameter()]
         [ValidateSet('none', 'delayOSUpdateVisibility', 'delayAppUpdateVisibility', 'unknownFutureValue', 'delayMajorOsUpdateVisibility')]
-        [System.String[]]
+        [System.String]
         $UpdateDelayPolicy,
 
         [Parameter()]
@@ -1139,7 +1139,7 @@ function Test-TargetResource
 
         [Parameter()]
         [ValidateSet('none', 'delayOSUpdateVisibility', 'delayAppUpdateVisibility', 'unknownFutureValue', 'delayMajorOsUpdateVisibility')]
-        [System.String[]]
+        [System.String]
         $UpdateDelayPolicy,
 
         [Parameter()]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
@@ -317,7 +317,14 @@ function Get-TargetResource
     $nullResult.Ensure = 'Absent'
     try
     {
-        $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -DeviceConfigurationId $id -ErrorAction SilentlyContinue
+        try
+        {
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -DeviceConfigurationId $id -ErrorAction Stop
+        }
+        catch
+        {
+            $getValue = $null
+        }
 
         #region resource generator code
         if ($null -eq $getValue)
@@ -417,7 +424,7 @@ function Get-TargetResource
             $results.Add('PrivacyAccessControls', $getValue.additionalProperties.privacyAccessControls)
         }
 
-        $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
+        $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $getValue.Id
         $assignmentResult = @()
         foreach ($assignmentEntry in $AssignmentsValues)
         {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.schema.mof
@@ -119,7 +119,7 @@ class MSFT_IntuneDeviceConfigurationPolicyMacOS : OMI_BaseResource
     [Write, Description("Delay the user's software update for this many days. The maximum is 90 days. (1-90)")] UInt32 SoftwareUpdatesEnforcedDelayInDays;
     [Write, Description("Blocks Spotlight from returning any results from an Internet search")] Boolean SpotlightBlockInternetResults;
     [Write, Description("")] UInt32 TouchIdTimeoutInHours;
-    [Write, Description(""), ValueMap{"none","delayOSUpdateVisibility","delayAppUpdateVisibility","unknownFutureValue","delayMajorOsUpdateVisibility"}, Values{"none","delayOSUpdateVisibility","delayAppUpdateVisibility","unknownFutureValue","delayMajorOsUpdateVisibility"}] String UpdateDelayPolicy;
+    [Write, Description(""), ValueMap{"none","delayOSUpdateVisibility","delayAppUpdateVisibility","unknownFutureValue","delayMajorOsUpdateVisibility"}, Values{"none","delayOSUpdateVisibility","delayAppUpdateVisibility","unknownFutureValue","delayMajorOsUpdateVisibility"}] String UpdateDelayPolicy[];
     [Write, Description("")] Boolean WallpaperModificationBlocked;
     [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.schema.mof
@@ -119,7 +119,7 @@ class MSFT_IntuneDeviceConfigurationPolicyMacOS : OMI_BaseResource
     [Write, Description("Delay the user's software update for this many days. The maximum is 90 days. (1-90)")] UInt32 SoftwareUpdatesEnforcedDelayInDays;
     [Write, Description("Blocks Spotlight from returning any results from an Internet search")] Boolean SpotlightBlockInternetResults;
     [Write, Description("")] UInt32 TouchIdTimeoutInHours;
-    [Write, Description(""), ValueMap{"none","delayOSUpdateVisibility","delayAppUpdateVisibility","unknownFutureValue","delayMajorOsUpdateVisibility"}, Values{"none","delayOSUpdateVisibility","delayAppUpdateVisibility","unknownFutureValue","delayMajorOsUpdateVisibility"}] String UpdateDelayPolicy[];
+    [Write, Description(""), ValueMap{"none","delayOSUpdateVisibility","delayAppUpdateVisibility","unknownFutureValue","delayMajorOsUpdateVisibility"}, Values{"none","delayOSUpdateVisibility","delayAppUpdateVisibility","unknownFutureValue","delayMajorOsUpdateVisibility"}] String UpdateDelayPolicy;
     [Write, Description("")] Boolean WallpaperModificationBlocked;
     [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;


### PR DESCRIPTION
#### Pull Request (PR) description

By the looks of it *IntuneDeviceConfigurationPolicyMacOS* never worked for making new deployments, this PR fixes that by using the correct type for var *UpdateDelayPolicy* (this is a String, as enum, not a String[], see https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceconfig-macossoftwareupdatedelaypolicy?view=graph-rest-beta).

While here ensure that resource can cope with *Id* not being present since it's not a mandatory parameter.

#### This Pull Request (PR) fixes the following issues

- Fixes #3539
