### PR TITLE
TeamsChannel: Add error handling if GroupId is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* TeamsChannel
+  * Add error handling if GroupId of a team is null
+    FIXES [#3943](https://github.com/microsoft/Microsoft365DSC/issues/3943)
+
 # 1.23.1227.1
 
 * EXOAntiPhishPolicy


### PR DESCRIPTION
#### Pull Request (PR) description
Skip a team during export if GroupId of the team is null. See linked issue for more information.

#### This Pull Request (PR) fixes the following issues
- Fixes #3943 
