### PR TITLE
Fixes #3767: Remove Mandatory from param CurrentRules in Get-M365DSCVoiceNormalizationRulesDifference. To Load a empty Dial Plan.

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantDialPlan/MSFT_TeamsTenantDialPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantDialPlan/MSFT_TeamsTenantDialPlan.psm1
@@ -514,7 +514,7 @@ function Get-M365DSCVoiceNormalizationRulesDifference
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.Object[]]
         $CurrentRules,
 


### PR DESCRIPTION
#### Pull Request (PR) description
The Global Policy exist on a new Tenant. But is empty without Normalization Rules. The problem is that an existing Policy without NormalizationRules the Desired NormalizationRules not will be Added.

This because the function "Get-M365DSCVoiceNormalizationRulesDifference" mandatories the CurrentRules. which are null. So I removed the mandatories of CurrentRules in "Get-M365DSCVoiceNormalizationRulesDifference"

#### This Pull Request (PR) fixes the following issues
Fixes #3767

