### PR TITLE
Fixes AuthenticationPolicyX509

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   * Removed the ability to specify a value of Absent for the Ensure property.
 * AADAUthenticationMethodPolicyX509
   * Fix the way we returned an empty rule set from the Get method. This caused
-    the Test-TargetResource method to return true even when instanes matched.
+    the Test-TargetResource method to return true even when instances matched.
 * DEPENDENCIES
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.178.
   * Updated MSCloudLoginAssistant to version 1.1.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   * Removed the ability to specify a value of Absent for the Ensure property.
 * AADAUthenticationMethodPolicy
   * Removed the ability to specify a value of Absent for the Ensure property.
+* AADAUthenticationMethodPolicyX509
+  * Fix the way we returned an empty rule set from the Get method. This caused
+    the Test-TargetResource method to return true even when instanes matched.
 * DEPENDENCIES
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.178.
   * Updated MSCloudLoginAssistant to version 1.1.5.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyX509/MSFT_AADAuthenticationMethodPolicyX509.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyX509/MSFT_AADAuthenticationMethodPolicyX509.psm1
@@ -108,16 +108,20 @@ function Get-TargetResource
                 {
                     $myRules.Add('X509CertificateRuleType', $currentRules.x509CertificateRuleType.toString())
                 }
-                if ($myRules.values.Where({ $null -ne $_ }).count -gt 0)
+                if ($myRules.values.Where({ $null -ne $_ }).count -gt 0 -and $myRules.Keys.Length -gt 0)
                 {
                     $complexRules += $myRules
+                }
+                if ($complexRules.Length -le 0)
+                {
+                    $complexRules = $null
                 }
                 $complexAuthenticationModeConfiguration.Add('Rules', $complexRules)
             }
         }
         else
         {
-            $complexAuthenticationModeConfiguration.Add('Rules', @(''))
+            $complexAuthenticationModeConfiguration.Add('Rules', @())
         }
 
         if ($null -ne $getValue.AdditionalProperties.authenticationModeConfiguration.x509CertificateAuthenticationDefaultMode)

--- a/Modules/Microsoft365DSC/Examples/Resources/AADAuthenticationMethodPolicyX509/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/AADAuthenticationMethodPolicyX509/1-Create.ps1
@@ -19,7 +19,7 @@ Configuration Example
         {
             AuthenticationModeConfiguration = MSFT_MicrosoftGraphx509CertificateAuthenticationModeConfiguration{
                 X509CertificateAuthenticationDefaultMode = 'x509CertificateSingleFactor'
-                Rules = @()
+                Rules = @(@())
             };
             CertificateUserBindings         = @(
                 MSFT_MicrosoftGraphx509CertificateUserBinding{


### PR DESCRIPTION
#### Pull Request (PR) description
* AADAUthenticationMethodPolicyX509
  * Fix the way we returned an empty rule set from the Get method. This caused the Test-TargetResource method to return true even when instances matched.

#### This Pull Request (PR) fixes the following issues
* N/A
