### PR TITLE
TeamsAudioConferencingPolicy: Fix condition when resource is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 * SPOSharingSettings
   * Fixed an Issue where the MySiteSharingCapability could be returned as an
     empty string instead of a null value from the Get method.
+* TeamsAudioConferencingPolicy
+  * Fix condition in Test-TargetResource when resource is absent
+    FIXES [#4215](https://github.com/microsoft/Microsoft365DSC/issues/4215)
 * DEPENDENCIES
   * Updated Microsoft.Graph dependencies to version 2.12.0.
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAudioConferencingPolicy/MSFT_TeamsAudioConferencingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAudioConferencingPolicy/MSFT_TeamsAudioConferencingPolicy.psm1
@@ -256,7 +256,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAudioConferencingPolicy/MSFT_TeamsAudioConferencingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAudioConferencingPolicy/MSFT_TeamsAudioConferencingPolicy.psm1
@@ -19,7 +19,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -108,7 +108,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -219,7 +219,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]


### PR DESCRIPTION
#### Pull Request (PR) description
Fix condition in Test-TargetResource when resource is absent

#### This Pull Request (PR) fixes the following issues
- Fixes #4215