### PR TITLE
TeamsEmergencyCallRoutingPolicy: Fix deletion of resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@
   * Fix CIM instances comparison in Test-TargetResource and export
     CompliantAppsList with the correct type
     FIXES [#4144](https://github.com/microsoft/Microsoft365DSC/issues/4144)
+* TeamsEmergencyCallRoutingPolicy
+  * Fix deletion of resource
+    FIXES [#4219](https://github.com/microsoft/Microsoft365DSC/issues/4219)
 * DEPENDENCIES
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.178.
   * Updated MSCloudLoginAssistant to version 1.1.7.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallingPolicy/MSFT_TeamsEmergencyCallingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallingPolicy/MSFT_TeamsEmergencyCallingPolicy.psm1
@@ -237,7 +237,7 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Absent' -and $CurrentValues.Ensure -eq 'Present')
     {
         Write-Verbose -Message "Removing existing Teams Emergency Calling Policy {$Identity}"
-        Remove-CsTeamsEmergencyCallingPolicy -Identity $Identity -Confirm:$false
+        Remove-CsTeamsEmergencyCallingPolicy -Identity $Identity
     }
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Fix deletion of resource, cmdlet to remove is not interactive and using *Confirm:$false* to delete it returns immediately without performing any actions, by removing the parameter then it actually deletes the resource.

#### This Pull Request (PR) fixes the following issues
- Fixes #4219
