### PR TITLE
Remaining affected Teams resources: Fix condition when resource is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@
 * SPOSharingSettings
   * Fixed an Issue where the MySiteSharingCapability could be returned as an
     empty string instead of a null value from the Get method.
-* TeamsIPPhonePolicy, TeamsMobilityPolicy, TeamsNetworkRoamingPolicy,
+* TeamsAppPermissionPolicy, TeamsAppSetupPolicy, TeamsCallHoldPolicy,
+  TeamsIPPhonePolicy, TeamsMobilityPolicy, TeamsNetworkRoamingPolicy,
   TeamsShiftsPolicy, TeamsTenantNetworkRegion, TeamsTenantNetworkSite,
   TeamsTenantNetworkSubnet, TeamsTenantTrustedIPAddress, TeamsTranslationRule,
   TeamsUnassignedNumberTreatment, TeamsVdiPolicy, TeamsWorkloadPolicy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
 * SPOSharingSettings
   * Fixed an Issue where the MySiteSharingCapability could be returned as an
     empty string instead of a null value from the Get method.
+* TeamsIPPhonePolicy, TeamsMobilityPolicy, TeamsNetworkRoamingPolicy,
+  TeamsShiftsPolicy, TeamsTenantNetworkRegion, TeamsTenantNetworkSite,
+  TeamsTenantNetworkSubnet, TeamsTenantTrustedIPAddress, TeamsTranslationRule,
+  TeamsUnassignedNumberTreatment, TeamsVdiPolicy, TeamsWorkloadPolicy
+  * Fix condition when resource is absent
+    FIXES [#4227](https://github.com/microsoft/Microsoft365DSC/issues/4227)
 * DEPENDENCIES
   * Updated Microsoft.Graph dependencies to version 2.12.0.
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAppPermissionPolicy/MSFT_TeamsAppPermissionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAppPermissionPolicy/MSFT_TeamsAppPermissionPolicy.psm1
@@ -39,7 +39,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -171,7 +171,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -311,7 +311,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -347,7 +347,7 @@ function Test-TargetResource
     $CurrentValues = Get-TargetResource @PSBoundParameters
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAppSetupPolicy/MSFT_TeamsAppSetupPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAppSetupPolicy/MSFT_TeamsAppSetupPolicy.psm1
@@ -39,7 +39,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -153,7 +153,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -307,10 +307,11 @@ function Test-TargetResource
         [Parameter()]
         [System.Boolean]
         $AllowSideLoading,
+
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -346,7 +347,7 @@ function Test-TargetResource
     $CurrentValues = Get-TargetResource @PSBoundParameters
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsCallHoldPolicy/MSFT_TeamsCallHoldPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsCallHoldPolicy/MSFT_TeamsCallHoldPolicy.psm1
@@ -19,7 +19,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -108,7 +108,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -219,7 +219,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -256,7 +256,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsIPPhonePolicy/MSFT_TeamsIPPhonePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsIPPhonePolicy/MSFT_TeamsIPPhonePolicy.psm1
@@ -43,7 +43,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -161,7 +161,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -296,7 +296,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsIPPhonePolicy/MSFT_TeamsIPPhonePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsIPPhonePolicy/MSFT_TeamsIPPhonePolicy.psm1
@@ -333,7 +333,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMobilityPolicy/MSFT_TeamsMobilityPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMobilityPolicy/MSFT_TeamsMobilityPolicy.psm1
@@ -29,7 +29,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -130,7 +130,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -251,7 +251,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMobilityPolicy/MSFT_TeamsMobilityPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMobilityPolicy/MSFT_TeamsMobilityPolicy.psm1
@@ -288,7 +288,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsNetworkRoamingPolicy/MSFT_TeamsNetworkRoamingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsNetworkRoamingPolicy/MSFT_TeamsNetworkRoamingPolicy.psm1
@@ -23,7 +23,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -117,7 +117,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -232,7 +232,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsNetworkRoamingPolicy/MSFT_TeamsNetworkRoamingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsNetworkRoamingPolicy/MSFT_TeamsNetworkRoamingPolicy.psm1
@@ -269,7 +269,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsShiftsPolicy/MSFT_TeamsShiftsPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsShiftsPolicy/MSFT_TeamsShiftsPolicy.psm1
@@ -42,7 +42,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -160,7 +160,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -300,7 +300,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsShiftsPolicy/MSFT_TeamsShiftsPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsShiftsPolicy/MSFT_TeamsShiftsPolicy.psm1
@@ -338,7 +338,7 @@ function Test-TargetResource
     $ValuesToCheck.Remove('Identity') | Out-Null
     $ValuesToCheck.Remove('EnableShiftPresence') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkRegion/MSFT_TeamsTenantNetworkRegion.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkRegion/MSFT_TeamsTenantNetworkRegion.psm1
@@ -256,7 +256,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkRegion/MSFT_TeamsTenantNetworkRegion.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkRegion/MSFT_TeamsTenantNetworkRegion.psm1
@@ -19,7 +19,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -108,7 +108,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -219,7 +219,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkSite/MSFT_TeamsTenantNetworkSite.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkSite/MSFT_TeamsTenantNetworkSite.psm1
@@ -43,7 +43,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -162,7 +162,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -297,7 +297,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkSite/MSFT_TeamsTenantNetworkSite.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkSite/MSFT_TeamsTenantNetworkSite.psm1
@@ -334,7 +334,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkSubnet/MSFT_TeamsTenantNetworkSubnet.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkSubnet/MSFT_TeamsTenantNetworkSubnet.psm1
@@ -23,7 +23,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -117,7 +117,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -232,7 +232,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkSubnet/MSFT_TeamsTenantNetworkSubnet.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkSubnet/MSFT_TeamsTenantNetworkSubnet.psm1
@@ -269,7 +269,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantTrustedIPAddress/MSFT_TeamsTenantTrustedIPAddress.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantTrustedIPAddress/MSFT_TeamsTenantTrustedIPAddress.psm1
@@ -19,7 +19,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -110,7 +110,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -221,7 +221,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantTrustedIPAddress/MSFT_TeamsTenantTrustedIPAddress.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantTrustedIPAddress/MSFT_TeamsTenantTrustedIPAddress.psm1
@@ -258,7 +258,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTranslationRule/MSFT_TeamsTranslationRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTranslationRule/MSFT_TeamsTranslationRule.psm1
@@ -23,7 +23,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -117,7 +117,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -232,7 +232,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTranslationRule/MSFT_TeamsTranslationRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTranslationRule/MSFT_TeamsTranslationRule.psm1
@@ -269,7 +269,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUnassignedNumberTreatment/MSFT_TeamsUnassignedNumberTreatment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUnassignedNumberTreatment/MSFT_TeamsUnassignedNumberTreatment.psm1
@@ -32,7 +32,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -137,7 +137,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -261,7 +261,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUnassignedNumberTreatment/MSFT_TeamsUnassignedNumberTreatment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUnassignedNumberTreatment/MSFT_TeamsUnassignedNumberTreatment.psm1
@@ -298,7 +298,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVdiPolicy/MSFT_TeamsVdiPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVdiPolicy/MSFT_TeamsVdiPolicy.psm1
@@ -256,7 +256,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVdiPolicy/MSFT_TeamsVdiPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVdiPolicy/MSFT_TeamsVdiPolicy.psm1
@@ -19,7 +19,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -108,7 +108,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -219,7 +219,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsWorkloadPolicy/MSFT_TeamsWorkloadPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsWorkloadPolicy/MSFT_TeamsWorkloadPolicy.psm1
@@ -39,7 +39,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -153,7 +153,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -284,7 +284,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure,
+        $Ensure = 'Present',
 
         [Parameter()]
         [System.Management.Automation.PSCredential]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsWorkloadPolicy/MSFT_TeamsWorkloadPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsWorkloadPolicy/MSFT_TeamsWorkloadPolicy.psm1
@@ -321,7 +321,7 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $ValuesToCheck.Remove('Identity') | Out-Null
 
-    if ($CurrentValues.Ensure -eq 'Absent')
+    if ($CurrentValues.Ensure -ne $PSBoundParameters.Ensure)
     {
         Write-Verbose -Message "Test-TargetResource returned $false"
         return $false


### PR DESCRIPTION
#### Pull Request (PR) description
Fix condition when resource is absent for resources below

TeamsAppPermissionPolicy
TeamsAppSetupPolicy
TeamsCallHoldPolicy
TeamsIPPhonePolicy
TeamsMobilityPolicy
TeamsNetworkRoamingPolicy
TeamsShiftsPolicy
TeamsTenantNetworkRegion
TeamsTenantNetworkSite
TeamsTenantNetworkSubnet
TeamsTenantTrustedIPAddress
TeamsTranslationRule
TeamsUnassignedNumberTreatment
TeamsVdiPolicy
TeamsWorkloadPolicy

#### This Pull Request (PR) fixes the following issues
- Fixes #4227
