### PR TITLE
TeamsMeetingBroadcastPolicy: Fix deletion of resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 * SPOSharingSettings
   * Fixed an Issue where the MySiteSharingCapability could be returned as an
     empty string instead of a null value from the Get method.
+* TeamsMeetingBroadcastPolicy
+  * Fix deletion of resource
+    FIXES [#4231](https://github.com/microsoft/Microsoft365DSC/issues/4231)
 * DEPENDENCIES
   * Updated Microsoft.Graph dependencies to version 2.12.0.
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingBroadcastPolicy/MSFT_TeamsMeetingBroadcastPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingBroadcastPolicy/MSFT_TeamsMeetingBroadcastPolicy.psm1
@@ -200,7 +200,7 @@ function Set-TargetResource
     }
     elseif ($Ensure -eq 'Absent' -and $currentValues.Ensure -eq 'Present')
     {
-        Remove-CsTeamsMeetingBroadcastPolicy -Identity $Identity -Confirm:$false
+        Remove-CsTeamsMeetingBroadcastPolicy -Identity $Identity
     }
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Fix deletion of resource, cmdlet to remove is not interactive and using Confirm:$false to delete it returns immediately without performing any actions, by removing the parameter then it actually deletes the resource.

#### This Pull Request (PR) fixes the following issues
- Fixes #4231
