### PR TITLE
TeamsEventsPolicy: Add missing attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
 * SPOSharingSettings
   * Fixed an Issue where the MySiteSharingCapability could be returned as an
     empty string instead of a null value from the Get method.
+* TeamsEventsPolicy
+  * Add missing attributes
+    FIXES [#4242](https://github.com/microsoft/Microsoft365DSC/issues/4242)
 * DEPENDENCIES
   * Updated Microsoft.Graph dependencies to version 2.12.0.
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEventsPolicy/MSFT_TeamsEventsPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEventsPolicy/MSFT_TeamsEventsPolicy.psm1
@@ -23,6 +23,44 @@ function Get-TargetResource
         $EventAccessType,
 
         [Parameter()]
+        [ValidateSet('Enabled', 'Disabled')]
+        [System.String]
+        $AllowEmailEditing,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowEventIntegrations,
+
+        [Parameter()]
+        [ValidateSet('Enabled', 'Disabled')]
+        [System.String]
+        $AllowTownhalls,
+
+        [Parameter()]
+        [ValidateSet('DefaultOnly', 'DefaultAndPredefinedOnly', 'AllQuestions')]
+        [System.String]
+        $AllowedQuestionTypesInRegistrationForm,
+
+        [Parameter()]
+        [ValidateSet('None', 'InviteOnly', 'EveryoneInCompanyIncludingGuests', 'Everyone')]
+        [System.String]
+        $AllowedWebinarTypesForRecordingPublish,
+
+        [Parameter()]
+        [ValidateSet('None', 'InviteOnly', 'EveryoneInCompanyIncludingGuests', 'Everyone')]
+        [System.String]
+        $AllowedTownhallTypesForRecordingPublish,
+
+        [Parameter()]
+        [ValidateSet('Optimized', 'None')]
+        [System.String]
+        $TownhallChatExperience,
+
+        [Parameter()]
+        [System.Boolean]
+        $UseMicrosoftECDN,
+
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present',
@@ -75,15 +113,23 @@ function Get-TargetResource
         }
         Write-Verbose -Message "Found Teams Events Policy {$Identity}"
         $result = @{
-            Identity              = $Identity
-            Description           = $policy.Description
-            AllowWebinars         = $policy.AllowWebinars
-            EventAccessType       = $policy.EventAccessType
-            Ensure                = 'Present'
-            Credential            = $Credential
-            ApplicationId         = $ApplicationId
-            TenantId              = $TenantId
-            CertificateThumbprint = $CertificateThumbprint
+            Identity                                = $Identity
+            Description                             = $policy.Description
+            AllowWebinars                           = $policy.AllowWebinars
+            EventAccessType                         = $policy.EventAccessType
+            AllowEmailEditing                       = $policy.AllowEmailEditing
+            AllowEventIntegrations                  = $policy.AllowEventIntegrations
+            AllowTownhalls                          = $policy.AllowTownhalls
+            AllowedQuestionTypesInRegistrationForm  = $policy.AllowedQuestionTypesInRegistrationForm
+            AllowedWebinarTypesForRecordingPublish  = $policy.AllowedWebinarTypesForRecordingPublish
+            AllowedTownhallTypesForRecordingPublish = $policy.AllowedTownhallTypesForRecordingPublish
+            TownhallChatExperience                  = $policy.TownhallChatExperience
+            UseMicrosoftECDN                        = $policy.UseMicrosoftECDN
+            Ensure                                  = 'Present'
+            Credential                              = $Credential
+            ApplicationId                           = $ApplicationId
+            TenantId                                = $TenantId
+            CertificateThumbprint                   = $CertificateThumbprint
         }
 
         return $result
@@ -122,6 +168,44 @@ function Set-TargetResource
         [System.String]
         [ValidateSet('Everyone', 'EveryoneInCompanyExcludingGuests')]
         $EventAccessType,
+
+        [Parameter()]
+        [ValidateSet('Enabled', 'Disabled')]
+        [System.String]
+        $AllowEmailEditing,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowEventIntegrations,
+
+        [Parameter()]
+        [ValidateSet('Enabled', 'Disabled')]
+        [System.String]
+        $AllowTownhalls,
+
+        [Parameter()]
+        [ValidateSet('DefaultOnly', 'DefaultAndPredefinedOnly', 'AllQuestions')]
+        [System.String]
+        $AllowedQuestionTypesInRegistrationForm,
+
+        [Parameter()]
+        [ValidateSet('None', 'InviteOnly', 'EveryoneInCompanyIncludingGuests', 'Everyone')]
+        [System.String]
+        $AllowedWebinarTypesForRecordingPublish,
+
+        [Parameter()]
+        [ValidateSet('None', 'InviteOnly', 'EveryoneInCompanyIncludingGuests', 'Everyone')]
+        [System.String]
+        $AllowedTownhallTypesForRecordingPublish,
+
+        [Parameter()]
+        [ValidateSet('Optimized', 'None')]
+        [System.String]
+        $TownhallChatExperience,
+
+        [Parameter()]
+        [System.Boolean]
+        $UseMicrosoftECDN,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
@@ -211,6 +295,44 @@ function Test-TargetResource
         [System.String]
         [ValidateSet('Everyone', 'EveryoneInCompanyExcludingGuests')]
         $EventAccessType,
+
+        [Parameter()]
+        [ValidateSet('Enabled', 'Disabled')]
+        [System.String]
+        $AllowEmailEditing,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowEventIntegrations,
+
+        [Parameter()]
+        [ValidateSet('Enabled', 'Disabled')]
+        [System.String]
+        $AllowTownhalls,
+
+        [Parameter()]
+        [ValidateSet('DefaultOnly', 'DefaultAndPredefinedOnly', 'AllQuestions')]
+        [System.String]
+        $AllowedQuestionTypesInRegistrationForm,
+
+        [Parameter()]
+        [ValidateSet('None', 'InviteOnly', 'EveryoneInCompanyIncludingGuests', 'Everyone')]
+        [System.String]
+        $AllowedWebinarTypesForRecordingPublish,
+
+        [Parameter()]
+        [ValidateSet('None', 'InviteOnly', 'EveryoneInCompanyIncludingGuests', 'Everyone')]
+        [System.String]
+        $AllowedTownhallTypesForRecordingPublish,
+
+        [Parameter()]
+        [ValidateSet('Optimized', 'None')]
+        [System.String]
+        $TownhallChatExperience,
+
+        [Parameter()]
+        [System.Boolean]
+        $UseMicrosoftECDN,
 
         [Parameter()]
         [ValidateSet('Present', 'Absent')]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEventsPolicy/MSFT_TeamsEventsPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEventsPolicy/MSFT_TeamsEventsPolicy.schema.mof
@@ -3,9 +3,17 @@ class MSFT_TeamsEventsPolicy : OMI_BaseResource
 {
     [Key, Description("Identity of the Teams Events Policy.")] String Identity;
     [Write, Description("Description of the Teams Events Policy.")] String Description;
+    [Write, Description("This setting governs if a user is allowed to edit the communication emails in Teams Town Hall or Teams Webinar events."), ValueMap{"Disabled","Enabled"}, Values{"Disabled","Enabled"}] String AllowEmailEditing;
+    [Write, Description("This setting governs access to the integrations tab in the event creation workflow.")] Boolean AllowEventIntegrations;
     [Write, Description("Determines if webinars are allowed by the policy or not."), ValueMap{"Disabled","Enabled"}, Values{"Disabled","Enabled"}] String AllowWebinars;
+    [Write, Description("This setting governs if a user can create town halls using Teams Events."), ValueMap{"Disabled","Enabled"}, Values{"Disabled","Enabled"}] String AllowTownhalls;
+    [Write, Description("This setting governs which users in a tenant can add which registration form questions to an event registration page for attendees to answer when registering for the event."), ValueMap{"DefaultOnly","DefaultAndPredefinedOnly","AllQuestions"}, Values{"DefaultOnly","DefaultAndPredefinedOnly","AllQuestions"}] String AllowedQuestionTypesInRegistrationForm;
+    [Write, Description("This setting describes how IT admins can control which types of Town Hall attendees can have their recordings published."), ValueMap{"None","InviteOnly","EveryoneInCompanyIncludingGuests","Everyone"}, Values{"None","InviteOnly","EveryoneInCompanyIncludingGuests","Everyone"}] String AllowedTownhallTypesForRecordingPublish;
+    [Write, Description("This setting describes how IT admins can control which types of webinar attendees can have their recordings published."), ValueMap{"None","InviteOnly","EveryoneInCompanyIncludingGuests","Everyone"}, Values{"None","InviteOnly","EveryoneInCompanyIncludingGuests","Everyone"}] String AllowedWebinarTypesForRecordingPublish;
     [Write, Description("Defines who is allowed to join the event."), ValueMap{"Everyone", "EveryoneInCompanyExcludingGuests"}, Values{"Everyone", "EveryoneInCompanyExcludingGuests"}] String EventAccessType;
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("This setting governs whether the user can enable the Comment Stream chat experience for Town Halls."), ValueMap{"Optimized","None"}, Values{"Optimized","None"}] String TownhallChatExperience;
+    [Write, Description("This setting governs whether the global admin disables this property and prevents the organizers from creating town halls that use Microsoft eCDN even though they have been assigned a Teams Premium license.")] Boolean UseMicrosoftECDN;
     [Write, Description("Credentials of the Teams Global Admin."), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Name of the Azure Active Directory tenant used for authentication. Format contoso.onmicrosoft.com")] String TenantId;


### PR DESCRIPTION
#### Pull Request (PR) description
Add missing attributes according to https://learn.microsoft.com/en-us/powershell/module/teams/set-csteamseventspolicy?view=teams-ps, the only change I did from that URL was to set UseMicrosoftECDN as boolean since it doesn't accept anything else and the documention is incorrect mentioning it's a string.

#### This Pull Request (PR) fixes the following issues
- Fixes #4242