### PR TITLE
TeamsMobilityPolicy: Validate string set on parameter MobileDialerPreference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@
 * TeamsMeetingBroadcastPolicy
   * Fix deletion of resource
     FIXES [#4231](https://github.com/microsoft/Microsoft365DSC/issues/4231)
+* TeamsMobilityPolicy
+  * Validate string set on parameter MobileDialerPreference
 * DEPENDENCIES
   * Updated Microsoft.Graph dependencies to version 2.12.0.
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMobilityPolicy/MSFT_TeamsMobilityPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMobilityPolicy/MSFT_TeamsMobilityPolicy.psm1
@@ -24,6 +24,7 @@ function Get-TargetResource
 
         [Parameter()]
         [System.String]
+        [ValidateSet('Teams', 'Native', 'UserOverride')]
         $MobileDialerPreference,
 
         [Parameter()]
@@ -125,6 +126,7 @@ function Set-TargetResource
 
         [Parameter()]
         [System.String]
+        [ValidateSet('Teams', 'Native', 'UserOverride')]
         $MobileDialerPreference,
 
         [Parameter()]
@@ -246,6 +248,7 @@ function Test-TargetResource
 
         [Parameter()]
         [System.String]
+        [ValidateSet('Teams', 'Native', 'UserOverride')]
         $MobileDialerPreference,
 
         [Parameter()]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMobilityPolicy/MSFT_TeamsMobilityPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMobilityPolicy/MSFT_TeamsMobilityPolicy.schema.mof
@@ -5,7 +5,7 @@ class MSFT_TeamsMobilityPolicy : OMI_BaseResource
     [Write, Description("Enables administrators to provide explanatory text about the policy. For example, the Description might indicate the users the policy should be assigned to.")] String Description;
     [Write, Description("When set to WifiOnly, prohibits the user from making and receiving calls or joining meetings using VoIP calls on the mobile device while on a cellular data connection. Possible values are: WifiOnly, AllNetworks."), ValueMap{"WifiOnly","AllNetworks"}, Values{"WifiOnly","AllNetworks"}] String IPAudioMobileMode;
     [Write, Description("When set to WifiOnly, prohibits the user from making and receiving video calls or enabling video in meetings using VoIP calls on the mobile device while on a cellular data connection. Possible values are: WifiOnly, AllNetworks."), ValueMap{"WifiOnly","AllNetworks"}, Values{"WifiOnly","AllNetworks"}] String IPVideoMobileMode;
-    [Write, Description("Determines the mobile dialer preference, possible values are: Teams, Native, UserOverride.")] String MobileDialerPreference;
+    [Write, Description("Determines the mobile dialer preference, possible values are: Teams, Native, UserOverride."), ValueMap{"Teams","Native","UserOverride"}, Values{"Teams","Native","UserOverride"}] String MobileDialerPreference;
     [Write, Description("Present ensures the instance exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the workload's Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMobilityPolicy/MSFT_TeamsMobilityPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMobilityPolicy/MSFT_TeamsMobilityPolicy.schema.mof
@@ -5,7 +5,7 @@ class MSFT_TeamsMobilityPolicy : OMI_BaseResource
     [Write, Description("Enables administrators to provide explanatory text about the policy. For example, the Description might indicate the users the policy should be assigned to.")] String Description;
     [Write, Description("When set to WifiOnly, prohibits the user from making and receiving calls or joining meetings using VoIP calls on the mobile device while on a cellular data connection. Possible values are: WifiOnly, AllNetworks."), ValueMap{"WifiOnly","AllNetworks"}, Values{"WifiOnly","AllNetworks"}] String IPAudioMobileMode;
     [Write, Description("When set to WifiOnly, prohibits the user from making and receiving video calls or enabling video in meetings using VoIP calls on the mobile device while on a cellular data connection. Possible values are: WifiOnly, AllNetworks."), ValueMap{"WifiOnly","AllNetworks"}, Values{"WifiOnly","AllNetworks"}] String IPVideoMobileMode;
-    [Write, Description("N/A")] String MobileDialerPreference;
+    [Write, Description("Determines the mobile dialer preference, possible values are: Teams, Native, UserOverride.")] String MobileDialerPreference;
     [Write, Description("Present ensures the instance exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the workload's Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsMobilityPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsMobilityPolicy.Tests.ps1
@@ -16,6 +16,7 @@ Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
 
 $Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
     -DscResource 'TeamsMobilityPolicy' -GenericStubModule $GenericStubPath
+
 Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
     InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
         Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
@@ -59,7 +60,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The TeamsMobilityPolicy should exist but it DOES NOT' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    MobileDialerPreference = 'FakeStringValue'
+                    MobileDialerPreference = 'Teams'
                     Description            = 'FakeStringValue'
                     IPVideoMobileMode      = 'AllNetworks'
                     IPAudioMobileMode      = 'AllNetworks'
@@ -90,7 +91,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The TeamsMobilityPolicy exists but it SHOULD NOT' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    MobileDialerPreference = 'FakeStringValue'
+                    MobileDialerPreference = 'Teams'
                     Description            = 'FakeStringValue'
                     IPVideoMobileMode      = 'AllNetworks'
                     IPAudioMobileMode      = 'AllNetworks'
@@ -101,7 +102,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
                 Mock -CommandName Get-CsTeamsMobilityPolicy -MockWith {
                     return @{
-                        MobileDialerPreference = 'FakeStringValue'
+                        MobileDialerPreference = 'Teams'
                         Description            = 'FakeStringValue'
                         IPVideoMobileMode      = 'AllNetworks'
                         IPAudioMobileMode      = 'AllNetworks'
@@ -127,7 +128,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The TeamsMobilityPolicy Exists and Values are already in the desired state' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    MobileDialerPreference = 'FakeStringValue'
+                    MobileDialerPreference = 'Teams'
                     Description            = 'FakeStringValue'
                     IPVideoMobileMode      = 'AllNetworks'
                     IPAudioMobileMode      = 'AllNetworks'
@@ -138,7 +139,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
                 Mock -CommandName Get-CsTeamsMobilityPolicy -MockWith {
                     return @{
-                        MobileDialerPreference = 'FakeStringValue'
+                        MobileDialerPreference = 'Teams'
                         Description            = 'FakeStringValue'
                         IPVideoMobileMode      = 'AllNetworks'
                         IPAudioMobileMode      = 'AllNetworks'
@@ -155,7 +156,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The TeamsMobilityPolicy exists and values are NOT in the desired state' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    MobileDialerPreference = 'FakeStringValue'
+                    MobileDialerPreference = 'Teams'
                     Description            = 'FakeStringValue'
                     IPVideoMobileMode      = 'AllNetworks'
                     IPAudioMobileMode      = 'AllNetworks'
@@ -166,7 +167,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
                 Mock -CommandName Get-CsTeamsMobilityPolicy -MockWith {
                     return @{
-                        MobileDialerPreference = 'FakeStringValueDrift #Drift'
+                        MobileDialerPreference = 'Native'
                         Description            = 'FakeStringValueDrift #Drift'
                         IPVideoMobileMode      = 'AllNetworks'
                         IPAudioMobileMode      = 'AllNetworks'
@@ -199,7 +200,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
                 Mock -CommandName Get-CsTeamsMobilityPolicy -MockWith {
                     return @{
-                        MobileDialerPreference = 'FakeStringValue'
+                        MobileDialerPreference = 'Teams'
                         Description            = 'FakeStringValue'
                         IPVideoMobileMode      = 'AllNetworks'
                         IPAudioMobileMode      = 'AllNetworks'

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsMobilityPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsMobilityPolicy.Tests.ps1
@@ -21,7 +21,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
     InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
         Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
         BeforeAll {
-
             $secpasswd = ConvertTo-SecureString 'f@kepassword1' -AsPlainText -Force
             $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
 


### PR DESCRIPTION
#### Pull Request (PR) description
Validate string set on parameter MobileDialerPreference, it can only be set to Teams, Native, or UserOverride. Info taken from https://learn.microsoft.com/en-us/powershell/module/skype/set-csteamsmobilitypolicy?view=skype-ps.

#### This Pull Request (PR) fixes the following issues
None
