### PR TITLE
TeamsGroupPolicyAssignment: Search group by its displayname if not found by id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@
 * TeamsFilesPolicy
   * Fix condition when resource is absent
     FIXES [#4225](https://github.com/microsoft/Microsoft365DSC/issues/4225)
+* TeamsGroupPolicyAssignment
+  * Ensure assignment can still be created if GroupId is not found by trying to
+    search by DisplayName afterwards
+    FIXES [#4248](https://github.com/microsoft/Microsoft365DSC/issues/4248)
 * TeamsMeetingBroadcastPolicy
   * Fix deletion of resource
     FIXES [#4231](https://github.com/microsoft/Microsoft365DSC/issues/4231)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsGroupPolicyAssignment/MSFT_TeamsGroupPolicyAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsGroupPolicyAssignment/MSFT_TeamsGroupPolicyAssignment.psm1
@@ -66,39 +66,44 @@ function Get-TargetResource
 
     try
     {
-        if (-not [System.String]::IsNullOrEmpty($GroupId))
-        {
-            Write-Verbose -Message "Getting GroupPolicyAssignment for {$GroupId}"
-            $group = Find-CsGroup -SearchQuery $GroupId -ErrorAction SilentlyContinue
-            if ($group.Length -gt 1)
-            {
-                Write-Verbose -Message "Found $($group.Length) groups with the id {$GroupId}"
-                $Group = $Group | Where-Object { $_.DisplayName -eq $GroupDisplayName }
-            }
-        }
-        else
-        {
-            Write-Verbose -Message "Getting GroupPolicyAssignment for {$GroupDisplayName}"
-            $Group = Find-CsGroup -SearchQuery $GroupDisplayName -ErrorAction SilentlyContinue
-            if ($Group.Length -gt 1)
-            {
-                Write-Verbose -Message "Found $($group.Length) groups with the name $GroupDisplayName"
-                $Group = $Group | Where-Object { $_.DisplayName -eq $GroupDisplayName }
-            }
-        }
+        Write-Verbose -Message "Getting Group with Id {$GroupId}"
+        $Group = Find-CsGroup -SearchQuery $GroupId -ExactMatchOnly $true -ErrorAction SilentlyContinue
+
         if ($null -eq $Group)
         {
-            Write-Verbose -Message "Group not found for $GroupDisplayName"
-            return $nullReturn
+            Write-Verbose -Message "Could not find Group with Id {$GroupId}, searching with DisplayName {$GroupDisplayName}"
+            $Group = Find-CsGroup -SearchQuery $GroupDisplayName -ExactMatchOnly $true -ErrorAction SilentlyContinue
+
+            if ($null -eq $Group)
+            {
+                Write-Verbose -Message "Could not find Group with DisplayName {$GroupDisplayName}"
+                return $nullReturn
+            }
+
+            if ($Group -and $Group.Count -gt 1)
+            {
+                Write-Verbose -Message "Found $($Group.Count) groups with DisplayName {$GroupDisplayName}"
+                $Group = $Group | Where-Object -FilterScript { $_.DisplayName -eq $GroupDisplayName }
+                if ($Group -and $Group.Count -gt 1)
+                {
+                    Write-Verbose -Message "Still found $($Group.Count) groups with DisplayName {$GroupDisplayName}"
+                    return $nullReturn
+                }
+            }
         }
+
+        Write-Verbose -Message "Getting GroupPolicyAssignment with PolicyType {$PolicyType} for Group {$($Group.DisplayName)}"
         $GroupPolicyAssignment = Get-CsGroupPolicyAssignment -GroupId $Group.Id -PolicyType $PolicyType -ErrorAction SilentlyContinue
         if ($null -eq $GroupPolicyAssignment)
         {
-            Write-Verbose -Message "GroupPolicyAssignment not found for $GroupDisplayName"
+            Write-Verbose -Message "GroupPolicyAssignment not found for Group $GroupDisplayName"
             $nullReturn.GroupId = $Group.Id
             return $nullReturn
         }
-        Write-Verbose -Message "Found GroupPolicyAssignment $($Group.Displayname) with PolicyType:$($GroupPolicyAssignment.PolicyType) and Policy Name:$($GroupPolicyAssignment.PolicyName)"
+
+        $Message = "Found GroupPolicyAssignment with PolicyType {$($GroupPolicyAssignment.PolicyType)}, " + `
+            "PolicyName {$($GroupPolicyAssignment.PolicyName)} and Priority {$($GroupPolicyAssignment.Priority)} for Group {$($Group.Displayname)}"
+        Write-Verbose -Message $Message
         return @{
             GroupId               = $Group.Id
             GroupDisplayName      = $Group.Displayname

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsGroupPolicyAssignment/MSFT_TeamsGroupPolicyAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsGroupPolicyAssignment/MSFT_TeamsGroupPolicyAssignment.psm1
@@ -96,7 +96,7 @@ function Get-TargetResource
         $GroupPolicyAssignment = Get-CsGroupPolicyAssignment -GroupId $Group.Id -PolicyType $PolicyType -ErrorAction SilentlyContinue
         if ($null -eq $GroupPolicyAssignment)
         {
-            Write-Verbose -Message "GroupPolicyAssignment not found for Group $GroupDisplayName"
+            Write-Verbose -Message "GroupPolicyAssignment not found for Group {$GroupDisplayName}"
             $nullReturn.GroupId = $Group.Id
             return $nullReturn
         }


### PR DESCRIPTION
#### Pull Request (PR) description
If group to create the assignment for cannot be found by its Id it should search by its DisplayName, this way the assignment can be cloned to another tenant without having to manually remove the GroupId field from the blueprint or set it to $null.

#### This Pull Request (PR) fixes the following issues
- Fixes #4248
