### PR TITLE
TeamsEmergencyCallRoutingPolicy: Fix deletion of resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* TeamsEmergencyCallRoutingPolicy
+  * Fix deletion of resource
+    FIXES [#4261](https://github.com/microsoft/Microsoft365DSC/issues/4261)
+
 # 1.24.124.1
 
 * AADAuthenticationMethodPolicyAuthenticator

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallRoutingPolicy/MSFT_TeamsEmergencyCallRoutingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallRoutingPolicy/MSFT_TeamsEmergencyCallRoutingPolicy.psm1
@@ -230,7 +230,7 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Absent' -and $CurrentValues.Ensure -eq 'Present')
     {
         Write-Verbose -Message "Removing existing Teams Meeting Policy {$Identity}"
-        Remove-CsTeamsEmergencyCallRoutingPolicy -Identity $Identity -Confirm:$false
+        Remove-CsTeamsEmergencyCallRoutingPolicy -Identity $Identity
     }
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Fix deletion of resource, remove parameter Confirm from cmdlet since it's not interactive and having it there actually causes the problem in the first place.

#### This Pull Request (PR) fixes the following issues
- Fixes #4261
