### PR TITLE
TeamsMeetingPolicy Update for Test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* TeamsMeetingPolicy
+  * Ignore the AllowUserToJoinExternalMeeting  parameterfor drift evaluation
+    since it doesn't do anything based on official documentation.
 * DEPENDENCIES
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.180.
   * Updated MSCloudLoginAssistant to version 1.1.11

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingPolicy/MSFT_TeamsMeetingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingPolicy/MSFT_TeamsMeetingPolicy.psm1
@@ -1118,6 +1118,9 @@ function Test-TargetResource
     # The AllowIPVideo is temporarly not working, therefore we won't check the value.
     $ValuesToCheck.Remove('AllowIPVideo') | Out-Null
 
+    # The AllowUserToJoinExternalMeeting doesn't do anything based on official documentation
+    $ValuesToCheck.Remove('AllowUserToJoinExternalMeeting') | Out-Null
+
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `
         -DesiredValues $PSBoundParameters `


### PR DESCRIPTION
#### Pull Request (PR) description
* Ignore the AllowUserToJoinExternalMeeting parameter for drift evaluation since it doesn't do anything based on official documentation.

#### This Pull Request (PR) fixes the following issues
* N/A
