### PR TITLE
Fix Windows SCEP Certificate Key Usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneDeviceConfigurationScepCertificatePolicyWindows10
+  * Fixes an issue where the keyUsage property format was not correctly handled
+
 # 1.24.221.1
 
 * AADApplication

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationScepCertificatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationScepCertificatePolicyWindows10.psm1
@@ -22,7 +22,7 @@ function Get-TargetResource
 
         [Parameter()]
         [ValidateSet('keyEncipherment','digitalSignature')]
-        [System.String]
+        [System.String[]]
         $KeyUsage,
 
         [Parameter()]
@@ -255,7 +255,7 @@ function Get-TargetResource
             CertificateStore                   = $enumCertificateStore
             HashAlgorithm                      = $enumHashAlgorithm
             KeySize                            = $enumKeySize
-            KeyUsage                           = $enumKeyUsage
+            KeyUsage                           = $enumKeyUsage.Split(',')
             ScepServerUrls                     = $getValue.AdditionalProperties.scepServerUrls
             SubjectAlternativeNameFormatString = $getValue.AdditionalProperties.subjectAlternativeNameFormatString
             SubjectNameFormatString            = $getValue.AdditionalProperties.subjectNameFormatString
@@ -332,7 +332,7 @@ function Set-TargetResource
 
         [Parameter()]
         [ValidateSet('keyEncipherment','digitalSignature')]
-        [System.String]
+        [System.String[]]
         $KeyUsage,
 
         [Parameter()]
@@ -460,6 +460,7 @@ function Set-TargetResource
         $CreateParameters = ([Hashtable]$BoundParameters).clone()
         $CreateParameters = Rename-M365DSCCimInstanceParameter -Properties $CreateParameters
         $CreateParameters.Remove('Id') | Out-Null
+        $CreateParameters['keyUsage'] = $CreateParameters['keyUsage'] -join ','
 
         $keys = (([Hashtable]$CreateParameters).clone()).Keys
         foreach ($key in $keys)
@@ -497,6 +498,7 @@ function Set-TargetResource
         $UpdateParameters = Rename-M365DSCCimInstanceParameter -Properties $UpdateParameters
 
         $UpdateParameters.Remove('Id') | Out-Null
+        $UpdateParameters['keyUsage'] = $UpdateParameters['keyUsage'] -join ','
 
         $keys = (([Hashtable]$UpdateParameters).clone()).Keys
         foreach ($key in $keys)
@@ -559,7 +561,7 @@ function Test-TargetResource
 
         [Parameter()]
         [ValidateSet('keyEncipherment','digitalSignature')]
-        [System.String]
+        [System.String[]]
         $KeyUsage,
 
         [Parameter()]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationScepCertificatePolicyWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationScepCertificatePolicyWindows10.schema.mof
@@ -27,7 +27,7 @@ class MSFT_IntuneDeviceConfigurationScepCertificatePolicyWindows10 : OMI_BaseRes
     [Write, Description("Target store certificate. Possible values are: user, machine."), ValueMap{"user","machine"}, Values{"user","machine"}] String CertificateStore;
     [Write, Description("SCEP Hash Algorithm. Possible values are: sha1, sha2."), ValueMap{"sha1","sha2"}, Values{"sha1","sha2"}] String HashAlgorithm;
     [Write, Description("SCEP Key Size. Possible values are: size1024, size2048, size4096."), ValueMap{"size1024","size2048","size4096"}, Values{"size1024","size2048","size4096"}] String KeySize;
-    [Write, Description("SCEP Key Usage. Possible values are: keyEncipherment, digitalSignature.")] String KeyUsage[];
+    [Write, Description("SCEP Key Usage. Possible values are: keyEncipherment, digitalSignature."), ValueMap{"keyEncipherment","digitalSignature"}, Values{"keyEncipherment","digitalSignature"}] String KeyUsage[];
     [Write, Description("SCEP Server Url(s).")] String ScepServerUrls[];
     [Write, Description("Custom String that defines the AAD Attribute.")] String SubjectAlternativeNameFormatString;
     [Write, Description("Custom format to use with SubjectNameFormat = Custom. Example: CN={{UserName}},E={{EmailAddress}},OU=Enterprise Users,O=Contoso Corporation,L=Redmond,ST=WA,C=US")] String SubjectNameFormatString;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationScepCertificatePolicyWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationScepCertificatePolicyWindows10.schema.mof
@@ -27,7 +27,7 @@ class MSFT_IntuneDeviceConfigurationScepCertificatePolicyWindows10 : OMI_BaseRes
     [Write, Description("Target store certificate. Possible values are: user, machine."), ValueMap{"user","machine"}, Values{"user","machine"}] String CertificateStore;
     [Write, Description("SCEP Hash Algorithm. Possible values are: sha1, sha2."), ValueMap{"sha1","sha2"}, Values{"sha1","sha2"}] String HashAlgorithm;
     [Write, Description("SCEP Key Size. Possible values are: size1024, size2048, size4096."), ValueMap{"size1024","size2048","size4096"}, Values{"size1024","size2048","size4096"}] String KeySize;
-    [Write, Description("SCEP Key Usage. Possible values are: keyEncipherment, digitalSignature."), ValueMap{"keyEncipherment","digitalSignature"}, Values{"keyEncipherment","digitalSignature"}] String KeyUsage;
+    [Write, Description("SCEP Key Usage. Possible values are: keyEncipherment, digitalSignature.")] String KeyUsage[];
     [Write, Description("SCEP Server Url(s).")] String ScepServerUrls[];
     [Write, Description("Custom String that defines the AAD Attribute.")] String SubjectAlternativeNameFormatString;
     [Write, Description("Custom format to use with SubjectNameFormat = Custom. Example: CN={{UserName}},E={{EmailAddress}},OU=Enterprise Users,O=Contoso Corporation,L=Redmond,ST=WA,C=US")] String SubjectNameFormatString;

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/1-Create.ps1
@@ -43,7 +43,7 @@ Configuration Example
             HashAlgorithm                  = "sha2";
             KeySize                        = "size2048";
             KeyStorageProvider             = "useTpmKspOtherwiseUseSoftwareKsp";
-            KeyUsage                       = "digitalSignature";
+            KeyUsage                       = @("digitalSignature");
             RenewalThresholdPercentage     = 25;
             ScepServerUrls                 = @("https://mydomain.com/certsrv/mscep/mscep.dll");
             SubjectAlternativeNameType     = "none";

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/2-Update.ps1
@@ -43,7 +43,7 @@ Configuration Example
             HashAlgorithm                  = "sha2";
             KeySize                        = "size2048";
             KeyStorageProvider             = "useTpmKspOtherwiseUseSoftwareKsp";
-            KeyUsage                       = "digitalSignature";
+            KeyUsage                       = @("digitalSignature");
             RenewalThresholdPercentage     = 30; # Updated Property
             ScepServerUrls                 = @("https://mydomain.com/certsrv/mscep/mscep.dll");
             SubjectAlternativeNameType     = "none";

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationScepCertificatePolicyWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationScepCertificatePolicyWindows10.Tests.ps1
@@ -86,7 +86,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     id = "FakeStringValue"
                     KeySize = "size1024"
                     keyStorageProvider = "useTpmKspOtherwiseUseSoftwareKsp"
-                    KeyUsage = "keyEncipherment"
+                    KeyUsage = @("keyEncipherment")
                     renewalThresholdPercentage = 25
                     ScepServerUrls = @("FakeStringValue")
                     SubjectAlternativeNameFormatString = "FakeStringValue"
@@ -138,7 +138,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     id = "FakeStringValue"
                     KeySize = "size1024"
                     keyStorageProvider = "useTpmKspOtherwiseUseSoftwareKsp"
-                    KeyUsage = "keyEncipherment"
+                    KeyUsage = @("keyEncipherment")
                     renewalThresholdPercentage = 25
                     ScepServerUrls = @("FakeStringValue")
                     SubjectAlternativeNameFormatString = "FakeStringValue"
@@ -225,7 +225,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     id = "FakeStringValue"
                     KeySize = "size1024"
                     keyStorageProvider = "useTpmKspOtherwiseUseSoftwareKsp"
-                    KeyUsage = "keyEncipherment"
+                    KeyUsage = @("keyEncipherment")
                     renewalThresholdPercentage = 25
                     ScepServerUrls = @("FakeStringValue")
                     SubjectAlternativeNameFormatString = "FakeStringValue"
@@ -305,7 +305,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     id = "FakeStringValue"
                     KeySize = "size1024"
                     keyStorageProvider = "useTpmKspOtherwiseUseSoftwareKsp"
-                    KeyUsage = "keyEncipherment"
+                    KeyUsage = @("keyEncipherment")
                     renewalThresholdPercentage = 25
                     ScepServerUrls = @("FakeStringValue")
                     SubjectAlternativeNameFormatString = "FakeStringValue"


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request addresses an issue in the `IntuneDeviceConfigurationScepCertificatePolicyWindows10` resource, where the `KeyUsage` property was defined as a single String with a ValidateSet, whereas the exported configuration of that property could actually be a String with multiple entries, separated by a comma as the delimiter, e.g. `keyEncipherment,digitalSignature`.

I implemented option 3 from #4091 that describes to use a string collection and join them together in the Get and Set method to work around that issue and still have a pretty decent user experience. 

This is most likely considered a breaking change, but since only the export of the policy ever worked and as soon as one wanted to compile the `M365TenantConfig.ps1`, an error would occur since the configuration `keyEncipherment,digitalSignature` is not valid value when supplied. 

#### This Pull Request (PR) fixes the following issues
None