### PR TITLE
EXOActiveSyncDeviceAccessRule: Remove extra property GUID that is stopping EXO integration tests from running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Change log for Microsoft365DSC
 
-# Unreleased
+# UNRELEASED
 
 * AADConditionalAccessPolicy
   * Improved verbose logging to show that items are being skipped.
+* EXOActiveSyncDeviceAccessRule
+  * Remove extra property GUID that is stopping EXO integration tests from
+    running
 * IntuneExploitProtectionPolicyWindows10SettingCatalog
   * Fix update and removal of resource when Identity is from another tenant
     FIXES [#3962](https://github.com/microsoft/Microsoft365DSC/issues/3962)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/MSFT_EXOActiveSyncDeviceAccessRule.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/MSFT_EXOActiveSyncDeviceAccessRule.schema.mof
@@ -2,7 +2,6 @@
 class MSFT_EXOActiveSyncDeviceAccessRule : OMI_BaseResource
 {
     [Key, Description("The Identity parameter specifies the identity of the device access rule.")] String Identity;
-    [Write, Description("Unique Identifier. Read-Only")] String GUID;
     [Write, Description("The AccessLevel parameter specifies whether the devices are allowed, blocked or quarantined."), ValueMap{"Allow","Block","Quarantine"}, Values{"Allow","Block","Quarantine"}] String AccessLevel;
     [Write, Description("The Characteristic parameter specifies the device characteristic or category that's used by the rule."), ValueMap{"DeviceModel","DeviceType","DeviceOS","UserAgent","XMSWLHeader"}, Values{"DeviceModel","DeviceType","DeviceOS","UserAgent","XMSWLHeader"}] String Characteristic;
     [Write, Description("The QueryString parameter specifies the device identifier that's used by the rule. This parameter uses a text value that's used with Characteristic parameter value to define the device.")] String QueryString;


### PR DESCRIPTION
#### Pull Request (PR) description

Remove extra property GUID that is stopping EXO integration tests from running

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
