### PR TITLE
AAD workload: Show current values of resources in Test-TargetResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,39 @@
 
 # UNRELEASED
 
+* AADApplication
+  * Show current values of resource in Test-TargetResource
+* AADAuthorizationPolicy
+  * Show current values of resource in Test-TargetResource
 * AADConditionalAccessPolicy
   * Improved verbose logging to show that items are being skipped.
+  * Show current values of resource in Test-TargetResource
+* AADExternalIdentityPolicy
+  * Show current values of resource in Test-TargetResource
 * AADGroup
   * Fixed issue with single quotes in the display name.
     FIXES [#4358](https://github.com/microsoft/Microsoft365DSC/issues/4358)
+  * Show current values of resource in Test-TargetResource
+* AADGroupLifecyclePolicy
+  * Show current values of resource in Test-TargetResource
+* AADGroupsNamingPolicy
+  * Show current values of resource in Test-TargetResource
+* AADGroupsSettings
+  * Show current values of resource in Test-TargetResource
+* AADNamedLocationPolicy
+  * Show current values of resource in Test-TargetResource
+* AADRoleDefinition
+  * Show current values of resource in Test-TargetResource
+* AADRoleSetting
+  * Show current values of resource in Test-TargetResource
+* AADSecurityDefaults
+  * Show current values of resource in Test-TargetResource
+* AADServicePrincipal
+  * Show current values of resource in Test-TargetResource
+* AADTenantDetails
+  * Show current values of resource in Test-TargetResource
+* AADTokenLifetimePolicy
+  * Show current values of resource in Test-TargetResource
 * EXOActiveSyncDeviceAccessRule
   * Remove extra property GUID that is stopping EXO integration tests from
     running

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -813,6 +813,7 @@ function Test-TargetResource
             Write-Verbose -Message 'No Permissions exist for the current Azure AD App and no permissions were specified'
         }
     }
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthorizationPolicy/MSFT_AADAuthorizationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthorizationPolicy/MSFT_AADAuthorizationPolicy.psm1
@@ -489,6 +489,7 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -1914,6 +1914,7 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADExternalIdentityPolicy/MSFT_AADExternalIdentityPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADExternalIdentityPolicy/MSFT_AADExternalIdentityPolicy.psm1
@@ -241,6 +241,7 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -947,6 +947,7 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     # Check Licenses

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupLifecyclePolicy/MSFT_AADGroupLifecyclePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupLifecyclePolicy/MSFT_AADGroupLifecyclePolicy.psm1
@@ -324,6 +324,8 @@ function Test-TargetResource
     Write-Verbose -Message 'Testing configuration of AzureAD Groups Lifecycle Policy'
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
+
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsNamingPolicy/MSFT_AADGroupsNamingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsNamingPolicy/MSFT_AADGroupsNamingPolicy.psm1
@@ -284,6 +284,7 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsSettings/MSFT_AADGroupsSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsSettings/MSFT_AADGroupsSettings.psm1
@@ -415,6 +415,7 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
@@ -398,6 +398,7 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleDefinition/MSFT_AADRoleDefinition.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleDefinition/MSFT_AADRoleDefinition.psm1
@@ -365,6 +365,7 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.psm1
@@ -1316,6 +1316,7 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADSecurityDefaults/MSFT_AADSecurityDefaults.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADSecurityDefaults/MSFT_AADSecurityDefaults.psm1
@@ -253,6 +253,7 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
@@ -603,6 +603,7 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADTenantDetails/MSFT_AADTenantDetails.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADTenantDetails/MSFT_AADTenantDetails.psm1
@@ -283,7 +283,8 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
-    Write-Verbose -Message "Target-Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
+    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('Credential') | Out-Null

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADTokenLifetimePolicy/MSFT_AADTokenLifetimePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADTokenLifetimePolicy/MSFT_AADTokenLifetimePolicy.psm1
@@ -300,6 +300,7 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters


### PR DESCRIPTION
#### Pull Request (PR) description

Looking at the AAD integration tests pipeline it looks like it's failing the test in AADGroup, but since it only shows the target values it's difficult to understand exactly why the test fails, it can be seen earlier in the logs that it's using a restored group instead of creating a new one, but it's still not clear without having access to the current values of the resource.

It seems that showing the current values wasn't only missing in AADGroup but for several other resources as well from the AAD workload so I added it to all that had it missing.

#### This Pull Request (PR) fixes the following issues
