### PR TITLE
EXOOfflineAddressBook: Fix EXO example used in integration tests

### DIFF
--- a/Modules/Microsoft365DSC/Examples/Resources/EXOOfflineAddressBook/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/EXOOfflineAddressBook/2-Update.ps1
@@ -20,8 +20,8 @@ Configuration Example
         {
             Name                 = "Integration Address Book"
             AddressLists         = @('\All Users')
-            DiffRetentionPeriod  = "30"
-            IsDefault            = $false # Updated Property
+            DiffRetentionPeriod  = "60" # Updated Property
+            IsDefault            = $true
             Ensure               = "Present"
             Credential           = $Credscredential
         }


### PR DESCRIPTION
#### Pull Request (PR) description

The EXO integration tests pipeline is failing on updating EXOOfflineAddressBook because *IsDefault* is being set from $true to $false but that can only be done if an additional OAB is created which is then set to default before changing the current one.

The quickest fix is to just update another property like I did for *DiffRetentionPeriod* instead of *IsDefault*.

#### This Pull Request (PR) fixes the following issues

