### PR TITLE
Correcting parameters for Graph Commands in TeamsTeam Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@
 * TeamsGuestMeetingConfiguration
   * Added the missing parameter AllowTranscription.
     FIXES [#4363](https://github.com/microsoft/Microsoft365DSC/issues/4363)
+* TeamsTeam
+  * Corrected Parameters for Graph Commands when creating a new Team
+    FIXES [#4383](https://github.com/microsoft/Microsoft365DSC/issues/4383)
 * MISC
   * M365DSCDRGUtil
     Add new parameter for customizable assignment identifier


### PR DESCRIPTION
#### Pull Request (PR) description

Correct the Microsoft Graph Commands in the TeamsTeam resource.

##### New-MgGroup

Creates the necessary group for the Teams site. Both `SecurityEnabled` and `MailNickname` parameters are Switch parameters, these don't require `$true` passed in as a value.

[Documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.graph.groups/new-mggroup?view=graph-powershell-1.0)

##### Get-MgUser

To get a user using MSGraph using `Search` you need to also pass the `-ConsistencyLevel eventual` parameter.

Also the Search syntax is `property:value` for example: `mail:sam@lantern.ai`. I think I might need to do another change here to cover all scenarios? (creating new + checking existing) I'm not sure and will confirm that. 

The output of this command gives the user's object ID under `$ownerUser.Id` rather than the current  `$ownerUser.ObjectId` 

[Documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.graph.users/get-mguser?view=graph-powershell-1.0#example-5-use-search-to-get-all-the-users-whose-display-name-contains-conf-including-a-count-of-the-returned-users)

##### New-MgGroupOwnerByRef

This requires the User to be passed in as an OdataID in the form: 

```
https://graph.microsoft.com/v1.0/directoryObjects/{UserObjectID}
```

So change the command to handle this like:

```
$ownerOdataID = "https://graph.microsoft.com/v1.0/directoryObjects/$($ownerUser.Id)"
...
New-MgGroupOwnerByRef -GroupId $group.Id -RefObjectId $ownerOdataID  -ErrorAction Stop
```

[Documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.graph.groups/new-mggroupownerbyref?view=graph-powershell-1.0)

#### This Pull Request (PR) fixes the following issues

Fixes #4383 

#### Notes

Please let me know if you want this changed in a specific way or anything else that I need to / should update for this change. 