### PR TITLE
Fix AADGroup owners, only updating owners  when specified in dsc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change log for Microsoft365DSC
 
 
+# UNRELEASED
+
+* AADGroup
+  * Fixed issue where group owners were removed from existing groups when unspecified in the config
+    FIXES [#4390](https://github.com/microsoft/Microsoft365DSC/issues/4390)
+
 # 1.24.228.1
 
 * AADApplication


### PR DESCRIPTION
#### Pull Request (PR) description

Prevent removal of AADGroup owners on existing AADGroups when no Owners parameter was specified in DSC.

#### This Pull Request (PR) fixes the following issues
    - Fixes #4390 : AADGroup: Group owners are removed (while they shouldn't if the owners property is not present in the dsc)
