### PR TITLE
Obfuscate password and avoid extra line feed in verbose logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # UNRELEASED
 
-* AADGroup
+* Verbose logging
   * Enhancement to obfuscate password from verbose logging and avoid empty lines
     FIXES [#4392](https://github.com/microsoft/Microsoft365DSC/issues/4392)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* AADGroup
+  * Enhancement to obfuscate password from verbose logging and avoid empty lines
+    FIXES [#4392](https://github.com/microsoft/Microsoft365DSC/issues/4392)
 
 # 1.24.228.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -618,52 +618,48 @@ function Set-TargetResource
     if ($Ensure -ne 'Absent')
     {
         #Owners
-        if ($PSBoundParameters.ContainsKey('Owners'))
+        $currentOwnersValue = @()
+        if ($currentParameters.Owners.Length -gt 0)
         {
-            $currentOwnersValue = @()
-            if ($currentParameters.Owners.Length -gt 0)
-            {
-                $currentOwnersValue = $backCurrentOwners
-            }
-            $desiredOwnersValue = @()
-            if ($Owners.Length -gt 0)
-            {
-                $desiredOwnersValue = $Owners
-            }
-            if ($backCurrentOwners -eq $null)
-            {
-                $backCurrentOwners = @()
-            }
-            $ownersDiff = Compare-Object -ReferenceObject $backCurrentOwners -DifferenceObject $desiredOwnersValue
-            foreach ($diff in $ownersDiff)
-            {
-                $user = Get-MgUser -UserId $diff.InputObject
+            $currentOwnersValue = $backCurrentOwners
+        }
+        $desiredOwnersValue = @()
+        if ($Owners.Length -gt 0)
+        {
+            $desiredOwnersValue = $Owners
+        }
+        if ($backCurrentOwners -eq $null)
+        {
+            $backCurrentOwners = @()
+        }
+        $ownersDiff = Compare-Object -ReferenceObject $backCurrentOwners -DifferenceObject $desiredOwnersValue
+        foreach ($diff in $ownersDiff)
+        {
+            $user = Get-MgUser -UserId $diff.InputObject
 
-                if ($diff.SideIndicator -eq '=>')
+            if ($diff.SideIndicator -eq '=>')
+            {
+                Write-Verbose -Message "Adding new owner {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
+                $ownerObject = @{
+                    '@odata.id' = "https://graph.microsoft.com/v1.0/users/{$($user.Id)}"
+                }
+                try
                 {
-                    Write-Verbose -Message "Adding new owner {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
-                    $ownerObject = @{
-                        '@odata.id' = "https://graph.microsoft.com/v1.0/users/{$($user.Id)}"
-                    }
-                    try
+                    New-MgGroupOwnerByRef -GroupId ($currentGroup.Id) -BodyParameter $ownerObject -ErrorAction Stop | Out-Null
+                }
+                catch
+                {
+                    if ($_.Exception.Message -notlike '*One or more added object references already exist for the following modified properties*')
                     {
-                        New-MgGroupOwnerByRef -GroupId ($currentGroup.Id) -BodyParameter $ownerObject -ErrorAction Stop | Out-Null
-                    }
-                    catch
-                    {
-                        if ($_.Exception.Message -notlike '*One or more added object references already exist for the following modified properties*')
-                        {
-                            throw $_
-                        }
+                        throw $_
                     }
                 }
-                elseif ($diff.SideIndicator -eq '<=')
-                {
-                    Write-Verbose -Message "Removing new owner {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
-                    Remove-MgGroupOwnerByRef -GroupId ($currentGroup.Id) -DirectoryObjectId ($user.Id) | Out-Null
-                }
             }
-
+            elseif ($diff.SideIndicator -eq '<=')
+            {
+                Write-Verbose -Message "Removing new owner {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
+                Remove-MgGroupOwnerByRef -GroupId ($currentGroup.Id) -DirectoryObjectId ($user.Id) | Out-Null
+            }
         }
 
         #Members

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -128,7 +128,7 @@ function Convert-M365DscHashtableToString
     )
 
     $values = @()
-    $parametersToObfuscate = @('ApplicationId', 'ApplicationSecret', 'TenantId', 'CertificateThumbprint', 'CertificatePath', 'CertificatePassword', 'Credential')
+    $parametersToObfuscate = @('ApplicationId', 'ApplicationSecret', 'TenantId', 'CertificateThumbprint', 'CertificatePath', 'CertificatePassword', 'Credential', 'Password')
     foreach ($pair in $Hashtable.GetEnumerator())
     {
         try
@@ -172,7 +172,7 @@ function Convert-M365DscHashtableToString
     }
 
     [array]::Sort($values)
-    return ($values -join "`r`n")
+    return ($values -join [Environment]::NewLine)
 }
 
 <#


### PR DESCRIPTION
#### Pull Request (PR) description
- Obfuscate password in verbose logging (When a new AADUser is created the password was visible in the verbose logging)
- Avoid extra empty lines in verbose logging (On linux systems an extra empty line was generated between each parameter when using M365DscHashtableToString)

#### This Pull Request (PR) fixes the following issues
    - Fixes #4392 : Verbose logging small enhancements
