### PR TITLE
EXOHostedContentFilterRule: Fix wrong identity parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* EXOHostedContentFilterRule
+  * Fixed issue in case of different names of filter rule and filter policy
+  FIXES [#4401](https://github.com/microsoft/Microsoft365DSC/issues/4401)
 
 # 1.24.228.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/MSFT_EXOHostedContentFilterRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/MSFT_EXOHostedContentFilterRule.psm1
@@ -114,7 +114,7 @@ function Get-TargetResource
     {
         try
         {
-            $HostedContentFilterRule = Get-HostedContentFilterRule -Identity $HostedContentFilterPolicy -ErrorAction Stop
+            $HostedContentFilterRule = Get-HostedContentFilterRule -Identity $Identity -ErrorAction Stop
         }
         catch
         {


### PR DESCRIPTION
#### Pull Request (PR) description
Fix wrong identity parameter if name of filter rule is different from name of filter policy.

#### This Pull Request (PR) fixes the following issues
- Fixes #4401 
