### PR TITLE
TeamsTeam: Skip teams without displayname during export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+* TeamsTeam
+  * Add error handling for teams without displayname during export
+  FIXES [#4406](https://github.com/microsoft/Microsoft365DSC/issues/4406)
 
 # 1.24.228.1
 


### PR DESCRIPTION
#### Pull Request (PR) description
Skip teams without displayname during export (orphaned/deleted Teams) because the Get method cannot be called without a display name.
Please see discussion in linked issue.

#### This Pull Request (PR) fixes the following issues
- Fixes #4406 
