### PR TITLE
O365OrgSettings: Add read permission for extracting M365 apps installation settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* O365OrgSettings
+  * Add read permission for extracting M365 apps installation settings instead
+    of extracting them only with read/write permissions
+    FIXES [#4418](https://github.com/microsoft/Microsoft365DSC/issues/4418)
 
 # 1.24.228.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
@@ -12,6 +12,9 @@
                         "name": "ReportSettings.Read.All"
                     },
                     {
+                        "name": "OrgSettings-Microsoft365Install.Read.All"
+                    },
+                    {
                         "name": "OrgSettings-Forms.Read.All"
                     },
                     {
@@ -55,6 +58,9 @@
                     },
                     {
                         "name": "ReportSettings.Read.All"
+                    },
+                    {
+                        "name": "OrgSettings-Microsoft365Install.Read.All"
                     },
                     {
                         "name": "OrgSettings-Forms.Read.All"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
@@ -77,7 +77,7 @@
                         "name": "ReportSettings.ReadWrite.All"
                     },
                     {
-                        "name": "83f7232f-763c-47b2-a097-e35d2cbe1da5"
+                        "name": "OrgSettings-Microsoft365Install.ReadWrite.All"
                     },
                     {
                         "name": "OrgSettings-Forms.ReadWrite.All"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
@@ -32,6 +32,9 @@
                         "name": "ReportSettings.ReadWrite.All"
                     },
                     {
+                        "name": "OrgSettings-Microsoft365Install.ReadWrite.All"
+                    },
+                    {
                         "name": "OrgSettings-Forms.ReadWrite.All"
                     },
                     {


### PR DESCRIPTION
#### Pull Request (PR) description

Currently the Installation* properties of resource O365OrgSettings can only be extracted when the app (or delegated permission) is granted read/write permissions but these properties can actually be exported with a specific read perm called OrgSettings-Microsoft365Install.Read.All which this PR adds to settings.json.

#### This Pull Request (PR) fixes the following issues

- Fixes #4418