### PR TITLE
TeamsTenantDialPlan: Fix output of property NormalizationRules as a string to the blueprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* TeamsTenantDialPlan
+  * Fix output of property NormalizationRules as a string to the blueprint
+    FIXES [#4428](https://github.com/microsoft/Microsoft365DSC/issues/4428)
 
 # 1.24.228.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantDialPlan/MSFT_TeamsTenantDialPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantDialPlan/MSFT_TeamsTenantDialPlan.psm1
@@ -646,20 +646,20 @@ function Get-M365DSCNormalizationRulesAsString
     {
         return $null
     }
-    $currentProperty = '@('
+    $currentProperty = "@(`r`n"
 
     foreach ($rule in $params)
     {
-        $currentProperty += "MSFT_TeamsVoiceNormalizationRule{`r`n"
+        $currentProperty += "                MSFT_TeamsVoiceNormalizationRule{`r`n"
         foreach ($key in $rule.Keys)
         {
             if ($key -eq 'Priority')
             {
-                $currentProperty += '                ' + $key + ' = ' + $rule[$key] + "`r`n"
+                $currentProperty += '                    ' + $key + ' = ' + $rule[$key] + "`r`n"
             }
             elseif ($key -eq 'IsInternalExtension')
             {
-                $currentProperty += '                ' + $key + " = `$" + $rule[$key] + "`r`n"
+                $currentProperty += '                    ' + $key + " = `$" + $rule[$key] + "`r`n"
             }
             else
             {
@@ -668,12 +668,13 @@ function Get-M365DSCNormalizationRulesAsString
                 {
                     $value = $value.Replace("'", "''")
                 }
-                $currentProperty += '                ' + $key + " = '" + $value + "'`r`n"
+                $currentProperty += '                    ' + $key + " = '" + $value + "'`r`n"
             }
         }
-        $currentProperty += '            }'
+        $currentProperty += "                }`r`n"
     }
-    $currentProperty += ')'
+    $currentProperty += '            )'
+
     return $currentProperty
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description

The property NormalizationRules is not correctly exported to the blueprint, didn't test it but it may still work in compiling it to MOF but ConvertTo-DSCObject from DSCParser cannot cope with that and the resource is not properly converted into a PSObject.

This PR fixes that by adding a few extra carriage returns and properly aligning the CIM instances.

#### This Pull Request (PR) fixes the following issues

- Fixes #4428