### PR TITLE
TeamsVoiceRoute: Fix policy removal and also comparison in Test-TargetResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* TeamsVoiceRoute
+  * Fix policy removal and also comparison in Test-TargetResource
 
 # 1.24.228.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
@@ -223,19 +223,12 @@ function Set-TargetResource
     Write-Verbose -Message "Setting Voice Route {$Identity}"
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
-
-    $SetParameters = $PSBoundParameters
-    $SetParameters.Remove('Ensure') | Out-Null
-    $SetParameters.Remove('Credential') | Out-Null
-    $SetParameters.Remove('ApplicationId') | Out-Null
-    $SetParameters.Remove('TenantId') | Out-Null
-    $SetParameters.Remove('CertificateThumbprint') | Out-Null
-    $SetParameters.Remove('ManagedIdentity') | Out-Null
+    $PSBoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
 
     if ($Ensure -eq 'Present' -and $CurrentValues.Ensure -eq 'Absent')
     {
         Write-Verbose -Message "Creating a new Voice Route {$Identity}"
-        New-CsOnlineVoiceRoute @SetParameters
+        New-CsOnlineVoiceRoute @PSBoundParameters
     }
     elseif ($Ensure -eq 'Present' -and $CurrentValues.Ensure -eq 'Present')
     {
@@ -244,7 +237,7 @@ function Set-TargetResource
             into the Set-CsOnlineVoiceRoute cmdlet.
         #>
         Write-Verbose -Message "Updating settings for Voice Route {$Identity}"
-        Set-CsOnlineVoiceRoute @SetParameters
+        Set-CsOnlineVoiceRoute @PSBoundParameters
     }
     elseif ($Ensure -eq 'Absent' -and $CurrentValues.Ensure -eq 'Present')
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
@@ -242,7 +242,7 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Absent' -and $CurrentValues.Ensure -eq 'Present')
     {
         Write-Verbose -Message "Removing existing Voice Route {$Identity}"
-        Remove-CsOnlineVoiceRoute -Identity $Identity -Confirm:$false
+        Remove-CsOnlineVoiceRoute -Identity $Identity
     }
 }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
@@ -215,7 +215,7 @@ function Set-TargetResource
         }
     }
 
-    if ($notFoundUsageList)
+    if ($notFoundGatewayList)
     {
         $notFoundGateways = $notFoundGatewayList -join ','
         throw "Please create the Voice Gateway object(s) ($notFoundGateways) using `"TeamsVoiceRoute`""

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
@@ -218,7 +218,7 @@ function Set-TargetResource
     if ($notFoundGatewayList)
     {
         $notFoundGateways = $notFoundGatewayList -join ','
-        throw "Please create the Voice Gateway object(s) ($notFoundGateways) using `"TeamsVoiceRoute`""
+        throw "Please create the Voice Gateway object(s) ($notFoundGateways) using cmdlet `"New-CsOnlinePSTNGateway`""
     }
 
     Write-Verbose -Message "Setting Voice Route {$Identity}"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
@@ -171,6 +171,7 @@ function Set-TargetResource
         [Switch]
         $ManagedIdentity
     )
+
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
 
@@ -301,6 +302,7 @@ function Test-TargetResource
         [Switch]
         $ManagedIdentity
     )
+
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
 
@@ -373,6 +375,7 @@ function Export-TargetResource
         [Switch]
         $ManagedIdentity
     )
+
     $InformationPreference = 'Continue'
 
     $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftTeams' `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
@@ -192,7 +192,7 @@ function Set-TargetResource
     $notFoundUsageList = @()
     foreach ($usage in $OnlinePstnUsages)
     {
-        if ( -not ($existingUsages -match $usage))
+        if (-not ($existingUsages -match $usage))
         {
             $notFoundUsageList += $usage
         }
@@ -209,7 +209,7 @@ function Set-TargetResource
     $notFoundGatewayList = @()
     foreach ($gateway in $OnlinePstnGatewayList)
     {
-        if ( -not ($existingGateways -match $gateway))
+        if (-not ($existingGateways -match $gateway))
         {
             $notFoundGatewayList += $gateway
         }


### PR DESCRIPTION
#### Pull Request (PR) description

As already done on other Teams resources the *Confirm* switch cannot be used when calling the cmdlet to remove the policy, the cmdlets are not interactive so they don't need the switch and it actually makes the cmdlet fail.

While here also fix the comparison in Test-TargetResource.

Note: M365DSC doesn't support creating voice gateways yet so if they are referenced in TeamsVoiceRoute and not created an exception will be thrown.

#### This Pull Request (PR) fixes the following issues
