### PR TITLE
M365DSCRuleEvaluation: Fix issue when it didn't find any matching resources and it tried to make a comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCRuleEvaluation
+  * Fix issue when it didn't find any matching resources and it tried to make a
+    comparison
 
 # 1.24.228.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
@@ -250,7 +250,9 @@ function Test-TargetResource
                     -EntryType 'Warning' `
                     -EventID 1 -Source $CurrentResourceName
         }
+
         Write-Verbose -Message "Test-TargetResource returned $result"
+
         return $result
     }
 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
@@ -243,16 +243,13 @@ function Test-TargetResource
                 $invalidInstancesLogNames += "[$ResourceName]$($invalidInstance.InputObject)`r`n"
             }
 
-            if (-not $result)
-            {
-                $message = [System.Text.StringBuilder]::New()
-                [void]$message.AppendLine("The following resource instance(s) failed a rule validation:`r`n$invalidInstancesLogNames")
-                [void]$message.AppendLine("`r`nRuleDefinition:`r`n$RuleDefinition")
-                Add-M365DSCEvent -Message $message.ToString() `
-                        -EventType 'RuleEvaluation' `
-                        -EntryType 'Warning' `
-                        -EventID 1 -Source $CurrentResourceName
-            }
+            $message = [System.Text.StringBuilder]::New()
+            [void]$message.AppendLine("The following resource instance(s) failed a rule validation:`r`n$invalidInstancesLogNames")
+            [void]$message.AppendLine("`r`nRuleDefinition:`r`n$RuleDefinition")
+            Add-M365DSCEvent -Message $message.ToString() `
+                    -EventType 'RuleEvaluation' `
+                    -EntryType 'Warning' `
+                    -EventID 1 -Source $CurrentResourceName
         }
         Write-Verbose -Message "Test-TargetResource returned $result"
         return $result

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
@@ -205,13 +205,13 @@ function Test-TargetResource
 
         $result = ($instances.Length - $DSCConvertedInstances.Length) -eq 0
 
+        $message = [System.Text.StringBuilder]::New()
         if (-not [System.String]::IsNullOrEmpty($AfterRuleCountQuery))
         {
             Write-Verbose -Message "Checking the After Rule Count"
             $afterRuleCountQueryString = "`$instances.Length $AfterRuleCountQuery"
             $afterRuleCountQueryBlock = [Scriptblock]::Create($afterRuleCountQueryString)
             $result = [Boolean](Invoke-Command -ScriptBlock $afterRuleCountQueryBlock)
-            $message = [System.Text.StringBuilder]::New()
             if ($instances.Length -eq 0)
             {
                 [void]$message.AppendLine("No instances were found for the given Rule Definition.")
@@ -243,7 +243,6 @@ function Test-TargetResource
                 $invalidInstancesLogNames += "[$ResourceName]$($invalidInstance.InputObject)`r`n"
             }
 
-            $message = [System.Text.StringBuilder]::New()
             [void]$message.AppendLine("The following resource instance(s) failed a rule validation:`r`n$invalidInstancesLogNames")
             [void]$message.AppendLine("`r`nRuleDefinition:`r`n$RuleDefinition")
             Add-M365DSCEvent -Message $message.ToString() `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
@@ -224,12 +224,17 @@ function Test-TargetResource
                 if (-not $result)
                 {
                     $invalidInstances = $instances.ResourceInstanceName
+
+                    [void]$message.AppendLine("AfterRuleCountQuery:`r`n$AfterRuleCountQuery`r`n")
+                    $MessagePrefix = "The following resource instance(s) matched a rule validation, but did not meet the AfterRuleCountQuery:`r`n"
                 }
             }
             else
             {
                 $invalidInstances = Compare-Object -ReferenceObject $DSCConvertedInstances.ResourceInstanceName -DifferenceObject $instances.ResourceInstanceName
                 $invalidInstances = $invalidInstances.InputObject
+
+                $MessagePrefix = "The following resource instance(s) failed a rule validation:`r`n"
             }
 
             if (-not $result)
@@ -241,17 +246,12 @@ function Test-TargetResource
                     $invalidInstancesLogNames += "[$ResourceName]$invalidInstance`r`n"
                 }
 
-                [void]$message.AppendLine("The following resource instance(s) failed a rule validation:`r`n$invalidInstancesLogNames")
+                [void]$message.AppendLine("$MessagePrefix$invalidInstancesLogNames")
             }
         }
 
         if (-not $result)
         {
-            if (-not [System.String]::IsNullOrEmpty($AfterRuleCountQuery))
-            {
-                [void]$message.AppendLine("AfterRuleCountQuery:`r`n$AfterRuleCountQuery")
-            }
-
             Add-M365DSCEvent -Message $message.ToString() `
                 -EventType 'RuleEvaluation' `
                 -EntryType 'Warning' `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
@@ -206,6 +206,9 @@ function Test-TargetResource
         $result = ($instances.Length - $DSCConvertedInstances.Length) -eq 0
 
         $message = [System.Text.StringBuilder]::New()
+        [void]$message.AppendLine("ResourceName:`r`n$ResourceName`r`n")
+        [void]$message.AppendLine("RuleDefinition:`r`n$RuleDefinition`r`n")
+
         if (-not [System.String]::IsNullOrEmpty($AfterRuleCountQuery))
         {
             Write-Verbose -Message "Checking the After Rule Count"
@@ -225,12 +228,6 @@ function Test-TargetResource
                 }
 
                 [void]$message.AppendLine("The following resource instance(s) failed a rule validation:`r`n$invalidInstancesLogNames")
-                [void]$message.AppendLine("`r`nRuleDefinition:`r`n$RuleDefinition")
-                [void]$message.AppendLine("`r`AfterRuleCountQuery:`r`n$AfterRuleCountQuery")
-                Add-M365DSCEvent -Message $message.ToString() `
-                            -EventType 'RuleEvaluation' `
-                            -EntryType 'Warning' `
-                            -EventID 1 -Source $CurrentResourceName
             }
         }
         elseif (-not $result)
@@ -244,11 +241,19 @@ function Test-TargetResource
             }
 
             [void]$message.AppendLine("The following resource instance(s) failed a rule validation:`r`n$invalidInstancesLogNames")
-            [void]$message.AppendLine("`r`nRuleDefinition:`r`n$RuleDefinition")
+        }
+
+        if (-not $result)
+        {
+            if (-not [System.String]::IsNullOrEmpty($AfterRuleCountQuery))
+            {
+                [void]$message.AppendLine("AfterRuleCountQuery:`r`n$AfterRuleCountQuery")
+            }
+
             Add-M365DSCEvent -Message $message.ToString() `
-                    -EventType 'RuleEvaluation' `
-                    -EntryType 'Warning' `
-                    -EventID 1 -Source $CurrentResourceName
+                -EventType 'RuleEvaluation' `
+                -EntryType 'Warning' `
+                -EventID 1 -Source $CurrentResourceName
         }
 
         Write-Verbose -Message "Test-TargetResource returned $result"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
@@ -223,23 +223,22 @@ function Test-TargetResource
                 $result = [Boolean](Invoke-Command -ScriptBlock $afterRuleCountQueryBlock)
                 if (-not $result)
                 {
-                    $invalidInstancesLogNames = ''
-                    foreach ($invalidInstance in $instances)
-                    {
-                        $invalidInstancesLogNames += "[$ResourceName]$($invalidInstance.ResourceInstanceName)`r`n"
-                    }
-
-                    [void]$message.AppendLine("The following resource instance(s) failed a rule validation:`r`n$invalidInstancesLogNames")
+                    $invalidInstances = $instances.ResourceInstanceName
                 }
             }
-            elseif (-not $result)
+            else
             {
                 $invalidInstances = Compare-Object -ReferenceObject $DSCConvertedInstances.ResourceInstanceName -DifferenceObject $instances.ResourceInstanceName
+                $invalidInstances = $invalidInstances.InputObject
+            }
+
+            if (-not $result)
+            {
                 # Log drifts for each invalid instances found.
                 $invalidInstancesLogNames = ''
                 foreach ($invalidInstance in $invalidInstances)
                 {
-                    $invalidInstancesLogNames += "[$ResourceName]$($invalidInstance.InputObject)`r`n"
+                    $invalidInstancesLogNames += "[$ResourceName]$invalidInstance`r`n"
                 }
 
                 [void]$message.AppendLine("The following resource instance(s) failed a rule validation:`r`n$invalidInstancesLogNames")


### PR DESCRIPTION
#### Pull Request (PR) description

First time I was experimenting with M365DSCRuleEvaluation and found right away that if there aren't any matching resources to the rule being evaluated it trips over an error, this is because it calls Compare-Object on a null object, check error at the bottom.

While here also changed a few more things such as showing different messages when using AfterRuleCountQuery and when not and dedup some code.

```powershell
Cannot bind argument to parameter 'DifferenceObject' because it is null.
+ CategoryInfo          : InvalidData: (:) [], CimException
+ FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.CompareObjectCommand
+ PSComputerName        : localhost
```

#### This Pull Request (PR) fixes the following issues
