### PR TITLE
Check that Test-DscConfiguration and Get-DscConfiguration also function as expected in integration tests

### DIFF
--- a/Tests/Integration/M365DSCTestEngine.psm1
+++ b/Tests/Integration/M365DSCTestEngine.psm1
@@ -97,6 +97,13 @@ function New-M365DSCIntegrationTest
     {
         Master -ConfigurationData $ConfigurationData -Credscredential $Credential
         Start-DscConfiguration Master -Wait -Force -Verbose -ErrorAction Stop
+
+        $TestDscConfigurationResult = Test-DscConfiguration Master -Verbose
+        if ($TestDscConfigurationResult.InDesiredState -ne $true) {
+            throw "Resources not in desired state: $($TestDscConfigurationResult.ResourcesNotInDesiredState.ResourceId)"
+        }
+
+        $GetDscConfigurationResult = Get-DscConfiguration -Verbose
     }
     catch
     {

--- a/Tests/Integration/Microsoft365DSC/M365DSCIntegration.AAD.Create.Tests.ps1
+++ b/Tests/Integration/Microsoft365DSC/M365DSCIntegration.AAD.Create.Tests.ps1
@@ -332,6 +332,13 @@
     {
         Master -ConfigurationData $ConfigurationData -Credscredential $Credential
         Start-DscConfiguration Master -Wait -Force -Verbose -ErrorAction Stop
+
+        $TestDscConfigurationResult = Test-DscConfiguration Master -Verbose
+        if ($TestDscConfigurationResult.InDesiredState -ne $true) {
+            throw "Resources not in desired state: $($TestDscConfigurationResult.ResourcesNotInDesiredState.ResourceId)"
+        }
+
+        $GetDscConfigurationResult = Get-DscConfiguration -Verbose
     }
     catch
     {

--- a/Tests/Integration/Microsoft365DSC/M365DSCIntegration.AAD.Remove.Tests.ps1
+++ b/Tests/Integration/Microsoft365DSC/M365DSCIntegration.AAD.Remove.Tests.ps1
@@ -245,6 +245,13 @@
     {
         Master -ConfigurationData $ConfigurationData -Credscredential $Credential
         Start-DscConfiguration Master -Wait -Force -Verbose -ErrorAction Stop
+
+        $TestDscConfigurationResult = Test-DscConfiguration Master -Verbose
+        if ($TestDscConfigurationResult.InDesiredState -ne $true) {
+            throw "Resources not in desired state: $($TestDscConfigurationResult.ResourcesNotInDesiredState.ResourceId)"
+        }
+
+        $GetDscConfigurationResult = Get-DscConfiguration -Verbose
     }
     catch
     {

--- a/Tests/Integration/Microsoft365DSC/M365DSCIntegration.AAD.Update.Tests.ps1
+++ b/Tests/Integration/Microsoft365DSC/M365DSCIntegration.AAD.Update.Tests.ps1
@@ -773,6 +773,13 @@
     {
         Master -ConfigurationData $ConfigurationData -Credscredential $Credential
         Start-DscConfiguration Master -Wait -Force -Verbose -ErrorAction Stop
+
+        $TestDscConfigurationResult = Test-DscConfiguration Master -Verbose
+        if ($TestDscConfigurationResult.InDesiredState -ne $true) {
+            throw "Resources not in desired state: $($TestDscConfigurationResult.ResourcesNotInDesiredState.ResourceId)"
+        }
+
+        $GetDscConfigurationResult = Get-DscConfiguration -Verbose
     }
     catch
     {

--- a/Tests/Integration/Microsoft365DSC/M365DSCIntegration.EXO.Create.Tests.ps1
+++ b/Tests/Integration/Microsoft365DSC/M365DSCIntegration.EXO.Create.Tests.ps1
@@ -796,6 +796,13 @@
     {
         Master -ConfigurationData $ConfigurationData -Credscredential $Credential
         Start-DscConfiguration Master -Wait -Force -Verbose -ErrorAction Stop
+
+        $TestDscConfigurationResult = Test-DscConfiguration Master -Verbose
+        if ($TestDscConfigurationResult.InDesiredState -ne $true) {
+            throw "Resources not in desired state: $($TestDscConfigurationResult.ResourcesNotInDesiredState.ResourceId)"
+        }
+
+        $GetDscConfigurationResult = Get-DscConfiguration -Verbose
     }
     catch
     {

--- a/Tests/Integration/Microsoft365DSC/M365DSCIntegration.EXO.Update.Tests.ps1
+++ b/Tests/Integration/Microsoft365DSC/M365DSCIntegration.EXO.Update.Tests.ps1
@@ -1124,6 +1124,13 @@
     {
         Master -ConfigurationData $ConfigurationData -Credscredential $Credential
         Start-DscConfiguration Master -Wait -Force -Verbose -ErrorAction Stop
+
+        $TestDscConfigurationResult = Test-DscConfiguration Master -Verbose
+        if ($TestDscConfigurationResult.InDesiredState -ne $true) {
+            throw "Resources not in desired state: $($TestDscConfigurationResult.ResourcesNotInDesiredState.ResourceId)"
+        }
+
+        $GetDscConfigurationResult = Get-DscConfiguration -Verbose
     }
     catch
     {

--- a/Tests/Integration/Microsoft365DSC/M365DSCIntegration.INTUNE.Create.Tests.ps1
+++ b/Tests/Integration/Microsoft365DSC/M365DSCIntegration.INTUNE.Create.Tests.ps1
@@ -308,7 +308,7 @@
                     ManagedEmailProfileRequired                 = $True
                     Ensure                                      = 'Present'
                     Credential                                  = $Credscredential
-        
+
                 }
                 IntuneDeviceCompliancePolicyMacOS 'ConfigureDeviceCompliancePolicyMacOS'
                 {
@@ -412,7 +412,7 @@
                                         {
                                             Name = 'hosted_app'
                                         }
-        
+
                                         MSFT_IntuneGroupPolicyDefinitionValuePresentationValueKeyValuePair
                                         {
                                             Name = 'user_script'
@@ -446,7 +446,7 @@
                                     Id                          = '14c48993-35af-4b77-a4f8-12de917b1bb9'
                                     odataType                   = '#microsoft.graph.groupPolicyPresentationValueDecimal'
                                 }
-        
+
                                 MSFT_IntuneGroupPolicyDefinitionValuePresentationValue
                                 {
                                     presentationDefinitionId    = '98998e7f-cc2a-4d96-8c47-35dd4b2ce56b'
@@ -455,7 +455,7 @@
                                     Id                          = '4d654df9-6826-470f-af4e-d37491663c76'
                                     odataType                   = '#microsoft.graph.groupPolicyPresentationValueDecimal'
                                 }
-        
+
                                 MSFT_IntuneGroupPolicyDefinitionValuePresentationValue
                                 {
                                     presentationDefinitionId    = '6900e752-4bc3-463b-9fc8-36d78c77bc3e'
@@ -2587,6 +2587,13 @@
     {
         Master -ConfigurationData $ConfigurationData -Credscredential $Credential
         Start-DscConfiguration Master -Wait -Force -Verbose -ErrorAction Stop
+
+        $TestDscConfigurationResult = Test-DscConfiguration Master -Verbose
+        if ($TestDscConfigurationResult.InDesiredState -ne $true) {
+            throw "Resources not in desired state: $($TestDscConfigurationResult.ResourcesNotInDesiredState.ResourceId)"
+        }
+
+        $GetDscConfigurationResult = Get-DscConfiguration -Verbose
     }
     catch
     {


### PR DESCRIPTION
#### Pull Request (PR) description
At present the integration tests do not appear to do either of these things:
- Check if resources are truly idempotent (if you run Test-DscConfiguration once a resource has been applied without errors, it should always return 'true'.
- Check if Get-TargetResource is working correctly without errors
This pull request is an attempt to resolve it. I fear it may throw up quite a number of errors in existing modules.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
