### PR TITLE
[O365OrgSettings] Fixed incorrect permissions in settings.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,14 @@
 * IntuneAppConfigurationPolicy
   * Fix comparison in Test-TargetResource
     FIXES [#4451](https://github.com/microsoft/Microsoft365DSC/issues/4451)
-* M365DSCRuleEvaluation
-  * Log both matching and not matching resources and in XML format
 * IntuneDeviceCompliancePolicyWindows10
   * Fix group assignment by using the corrected function
     Update-DeviceConfigurationPolicyAssignment from module M365DSCDRGUtil
     FIXES [#4467](https://github.com/microsoft/Microsoft365DSC/issues/4467)
+* M365DSCRuleEvaluation
+  * Log both matching and not matching resources and in XML format
+* O365OrgSettings
+  * Fixed missing permissions in settings.json
 * TeamsChannelTab
   * Fixed schema file
 * TeamsGroupPolicyAssignment

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCrossTenantAccessPolicyConfigurationDefault/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCrossTenantAccessPolicyConfigurationDefault/settings.json
@@ -1,5 +1,5 @@
 {
-    "resourceName": "AADAuthenticationMethodPolicyConfigurationDefault",
+    "resourceName": "AADCrossTenantAccessPolicyConfigurationDefault",
     "description": "This resource configures an Azure AD Authentication Method Policy Configuration Default.",
     "roles": {
         "read": [

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCrossTenantAccessPolicyConfigurationPartner/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCrossTenantAccessPolicyConfigurationPartner/settings.json
@@ -1,5 +1,5 @@
 {
-    "resourceName": "AADAuthenticationMethodPolicyConfigurationPartner",
+    "resourceName": "AADCrossTenantAccessPolicyConfigurationPartner",
     "description": "This resource configures an Azure AD Authentication Method Policy Configuration Partner.",
     "roles": {
         "read": [

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADSocialIdentityProvider/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADSocialIdentityProvider/settings.json
@@ -1,5 +1,5 @@
 {
-    "resourceName": "AADAttributeSet",
+    "resourceName": "AADSocialIdentityProvider",
     "description": "Represents a group of related custom security attribute definitions.",
     "roles": {
         "read": [

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/settings.json
@@ -1,5 +1,5 @@
 ﻿{
-    "resourceName": "EXOAddressList",
+    "resourceName": "EXODistributionGroup",
     "roles": {
         "read": [],
         "update": [

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailContact/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailContact/settings.json
@@ -1,5 +1,5 @@
 ﻿{
-    "resourceName": "EXOAddressList",
+    "resourceName": "EXOMailContact",
     "description": "",
     "roles": {
         "read": [

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroid/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroid/settings.json
@@ -1,5 +1,5 @@
 {
-    "resourceName": "IntuneAndroidDeviceCompliancePolicy",
+    "resourceName": "IntuneDeviceCompliancePolicyAndroid",
     "description": "This resource configures the settings of Android device compliance policies in your cloud-based organization.",
     "permissions": {
         "graph": {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/settings.json
@@ -1,5 +1,5 @@
 ﻿{
-    "resourceName": "AADTenantDetails",
+    "resourceName": "M365DSCRuleEvaluation",
     "description": "This resource configures the Azure AD Tenant Details.",
     "roles": {
         "read": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
@@ -1,5 +1,5 @@
 ﻿{
-    "resourceName": "O365OrgCustomizationSetting",
+    "resourceName": "O365OrgSettings",
     "description": "",
     "permissions": {
         "graph": {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
@@ -6,7 +6,7 @@
             "delegated": {
                 "read": [
                     {
-                        "name": "Application.Read.All"
+                        "name": "Application.ReadWrite.All"
                     },
                     {
                         "name": "ReportSettings.Read.All"
@@ -54,7 +54,7 @@
             "application": {
                 "read": [
                     {
-                        "name": "Application.Read.All"
+                        "name": "Application.ReadWrite.All"
                     },
                     {
                         "name": "ReportSettings.Read.All"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOrgWideAppSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOrgWideAppSettings/settings.json
@@ -1,5 +1,5 @@
 ﻿{
-    "resourceName": "TeamsUpgradeConfiguration",
+    "resourceName": "TeamsOrgWideAppSettings",
     "description": "",
     "roles": {
         "read": [

--- a/Tests/QA/Microsoft365DSC.SettingsJson.Tests.ps1
+++ b/Tests/QA/Microsoft365DSC.SettingsJson.Tests.ps1
@@ -69,10 +69,18 @@ Describe -Name 'Successfully validate all used permissions in Settings.json file
                 'ChannelMember.ReadWrite.All'
             )
         }
+
         if ($settings.ResourceName -like 'AADAuthenticationMethod*' -or $settings.ResourceName -eq 'AADAuthenticationStrengthPolicy')
         {
             $allowedPermissions = @(
                 'Policy.ReadWrite.AuthenticationMethod'
+            )
+        }
+
+        if ($settings.ResourceName -eq 'O365OrgSettings')
+        {
+            $allowedPermissions = @(
+                'Application.ReadWrite.All'
             )
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description
For the O365OrgSettings resource, the Read permissions had Application.Read.All, but the Get method uses a "New" cmdlet that requires ReadWrite permissions. Corrected this in the settings.json.

It also corrects the resourcename property used in several settings.json files, that I found to be incorrect.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
