### PR TITLE
AADAdministrativeUnit - fix #4404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 # UNRELEASED
 
-<<<<<<< HEAD
 * AADAdministrativeUnit
-  * Fix issue with omitted Ensure and/or Id
-    FIXES [#4437](https://github.com/microsoft/Microsoft365DSC/issues/4437)
-=======
+  * Fix issue with deploying/creating a new AU with members and/or adding members to an existing AU
+    FIXES [#4404](https://github.com/microsoft/Microsoft365DSC/issues/4404)
 * All resources
   * Fix issue where Ensure cannot be left as default 'Present'
 * AADAdministrativeUnit
@@ -28,7 +26,6 @@
 * EXOTransportRule
   * Change data type of Priority from String to Int (BREAKING)
     FIXES [[#4136](https://github.com/microsoft/Microsoft365DSC/issues/4136)]
->>>>>>> Dev
 * IntuneAppConfigurationPolicy
   * Fix comparison in Test-TargetResource
     FIXES [#4451](https://github.com/microsoft/Microsoft365DSC/issues/4451)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* AADAdministrativeUnit
+  * Fix issue with omitted Ensure and/or Id
+    FIXES [#4437](https://github.com/microsoft/Microsoft365DSC/issues/4437)
 * IntuneAppConfigurationPolicy
   * Fix comparison in Test-TargetResource
     FIXES [#4451](https://github.com/microsoft/Microsoft365DSC/issues/4451)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
@@ -548,8 +548,8 @@ function Set-TargetResource
             foreach ($member in $memberSpecification)
             {
                 Write-Verbose -Message "Adding new dynamic member {$($member.Id)}"
+                $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/$($member.Type)/$($member.Id)"
                 $memberBodyParam = @{
-                    $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/$($member.Type)/$($member.Id)"
                     '@odata.id' = $url
                 }
 
@@ -646,8 +646,8 @@ function Set-TargetResource
                     {
                         Write-Verbose -Message "AdministrativeUnit {$DisplayName} Adding member {$($diff.Identity)}, type {$($diff.Type)}"
 
+                        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/$memberType/$($memberObject.Id)"
                         $memberBodyParam = @{
-                            $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/$memberType/$($memberObject.Id)"
                             '@odata.id' = $url
                         }
                         New-MgBetaDirectoryAdministrativeUnitMemberByRef -AdministrativeUnitId ($currentInstance.Id) -BodyParameter $memberBodyParam | Out-Null


### PR DESCRIPTION
#### Pull Request (PR) description
When adding members to an AU (new or existing), the bodyparam hashtable unintentionally contains an unexpected key ($url, where the keyname is whatever content is in the variable). The assignment has been moved outside the hashtable

#### This Pull Request (PR) fixes the following issues
Fixes #4404 