### PR TITLE
Return mandatory params for TGPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@
     Fix Update-DeviceConfigurationPolicyAssignment so that if the group cannot
     be found by its Id it tries to search it by display name
     FIXES [#4467](https://github.com/microsoft/Microsoft365DSC/issues/4467)
+  * M365DSCReport
+    Fix issue when asserting TeamsGroupPolicyAssignment configurations by
+    returning its both mandatory parameters in Get-M365DSCResourceKey
   * Fix broken links to integration tests in README.md
 
 # 1.24.313.1

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -1256,6 +1256,10 @@ function Get-M365DSCResourceKey
     {
         return @('OrgWideAccount')
     }
+    elseif ($Resource.ResourceName -eq 'TeamsGroupPolicyAssignment')
+    {
+        return @('GroupDisplayName', 'PolicyType')
+    }
     elseif ($mandatoryParameters.count -eq 1)
     {
         # returning the only mandatory parameter name


### PR DESCRIPTION
#### Pull Request (PR) description

While asserting a blueprint with several resources I noticed at the end it displayed the following:

```
Error: Multiple mandatory parameters found for TeamsGroupPolicyAssignment but none of them are returned by the function
```

The error message comes from Get-M365DSCResourceKey in M365DSCReport.psm1, the fix is to just return here both mandatory parameters of TeamsGroupPolicyAssignment which are GroupDisplayName and PolicyType.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
