### PR TITLE
Fix issue where Set-TargetResource was failing to apply when Verbose is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Fix issue with deploying/creating a new AU with members and/or adding members to an existing AU
     FIXES [#4404](https://github.com/microsoft/Microsoft365DSC/issues/4404)
   * Updated examples to include setting Visibility and ScopedRoleMembers
+  * Fix issue with Set-TargetResource was failing to apply when Verbose is set
+    FIXES [#4497](https://github.com/microsoft/Microsoft365DSC/issues/4497)
 * All resources
   * Fix issue where Ensure cannot be left as default 'Present'
 * AADAdministrativeUnit

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
@@ -372,6 +372,7 @@ function Set-TargetResource
     $PSBoundParameters.Remove('TenantId') | Out-Null
     $PSBoundParameters.Remove('CertificateThumbprint') | Out-Null
     $PSBoundParameters.Remove('ManagedIdentity') | Out-Null
+    $PSBoundParameters.Remove('Verbose') | Out-Null
 
     $backCurrentMembers = $currentInstance.Members
     $backCurrentScopedRoleMembers = $currentInstance.ScopedRoleMembers


### PR DESCRIPTION
#### Pull Request (PR) description
AADAdministrativeUnit fails with Set-TargetResource after the fix for #4437

Looks like it's not a good idea to leave the Verbose variable in PSBoundParameters after all.

#### This Pull Request (PR) fixes the following issues
 - Fixes #4497
