### PR TITLE
FIXES #4496

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@
   * Fix output of property NormalizationRules as a string to the blueprint
     FIXES [#4428](https://github.com/microsoft/Microsoft365DSC/issues/4428)
   * Fix creation, update and deletion of resource
+* TeamsUpdateManagementPolicy
+  * Adds support for the NewTeamsOnly value or the UseNewTeamsClient property.
+    FIXES [#4496](https://github.com/microsoft/Microsoft365DSC/issues/4496)
 * DEPENDENCIES
   * Updated DSCParser to version 2.0.0.2.
 * MISC

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpdateManagementPolicy/MSFT_TeamsUpdateManagementPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpdateManagementPolicy/MSFT_TeamsUpdateManagementPolicy.psm1
@@ -39,7 +39,7 @@ function Get-TargetResource
         $UpdateTimeOfDay,
 
         [Parameter()]
-        [ValidateSet('UserChoice', 'MicrosoftChoice', 'AdminDisabled', 'NewTeamsAsDefault')]
+        [ValidateSet('UserChoice', 'MicrosoftChoice', 'AdminDisabled', 'NewTeamsAsDefault', 'NewTeamsOnly')]
         [System.String]
         $UseNewTeamsClient,
 
@@ -174,7 +174,7 @@ function Set-TargetResource
         $UpdateTimeOfDay,
 
         [Parameter()]
-        [ValidateSet('UserChoice', 'MicrosoftChoice', 'AdminDisabled', 'NewTeamsAsDefault')]
+        [ValidateSet('UserChoice', 'MicrosoftChoice', 'AdminDisabled', 'NewTeamsAsDefault', 'NewTeamsOnly')]
         [System.String]
         $UseNewTeamsClient,
 
@@ -297,7 +297,7 @@ function Test-TargetResource
         $UpdateTimeOfDay,
 
         [Parameter()]
-        [ValidateSet('UserChoice', 'MicrosoftChoice', 'AdminDisabled', 'NewTeamsAsDefault')]
+        [ValidateSet('UserChoice', 'MicrosoftChoice', 'AdminDisabled', 'NewTeamsAsDefault', 'NewTeamsOnly')]
         [System.String]
         $UseNewTeamsClient,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpdateManagementPolicy/MSFT_TeamsUpdateManagementPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpdateManagementPolicy/MSFT_TeamsUpdateManagementPolicy.schema.mof
@@ -9,7 +9,7 @@ class MSFT_TeamsUpdateManagementPolicy : OMI_BaseResource
     [Write, Description("Determines the day of week to perform the updates. Value shoud be between 0 and 6.")] UInt32 UpdateDayOfWeek;
     [Write, Description("Determines the time of day to perform the updates. Must be a valid HH:MM format string with leading 0. For instance 08:30.")] String UpdateTime;
     [Write, Description("Determines the time of day to perform the updates. Accepts a DateTime as string. Only the time will be considered.")] String UpdateTimeOfDay;
-    [Write, Description("Determines whether or not users will use the new Teams client."), ValueMap{"NewTeamsAsDefault","UserChoice","MicrosoftChoice","AdminDisabled"}, Values{"NewTeamsAsDefault","UserChoice","MicrosoftChoice","AdminDisabled"}] String UseNewTeamsClient;
+    [Write, Description("Determines whether or not users will use the new Teams client."), ValueMap{"NewTeamsAsDefault","UserChoice","MicrosoftChoice","AdminDisabled","NewTeamsOnly"}, Values{"NewTeamsAsDefault","UserChoice","MicrosoftChoice","AdminDisabled","NewTeamsOnly"}] String UseNewTeamsClient;
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Credentials of the Teams Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;


### PR DESCRIPTION
#### Pull Request (PR) description
* TeamsUpdateManagementPolicy
  * Adds support for the NewTeamsOnly value or the UseNewTeamsClient property.

#### This Pull Request (PR) fixes the following issues
* FIXES #4496 