### PR TITLE
M365DSCReport: Always return mandatory parameters on Get-M365DSCResourceKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,9 @@
     be found by its Id it tries to search it by display name
     FIXES [#4467](https://github.com/microsoft/Microsoft365DSC/issues/4467)
   * M365DSCReport
-    Fix issue when asserting TeamsGroupPolicyAssignment configurations by
-    returning its both mandatory parameters in Get-M365DSCResourceKey
+    Fix issue when asserting resources not covered by current conditions in
+    Get-M365DSCResourceKey by always returning all their mandatory parameters
+    FIXES [#4502](https://github.com/microsoft/Microsoft365DSC/issues/4502)
   * Fix broken links to integration tests in README.md
 
 # 1.24.313.1

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -1256,23 +1256,14 @@ function Get-M365DSCResourceKey
     {
         return @('OrgWideAccount')
     }
-    elseif ($Resource.ResourceName -eq 'TeamsGroupPolicyAssignment')
+    elseif ($mandatoryParameters.count -gt 0)
     {
-        return @('GroupDisplayName', 'PolicyType')
-    }
-    elseif ($mandatoryParameters.count -eq 1)
-    {
-        # returning the only mandatory parameter name
-        return @($mandatoryParameters[0].Name)
+        # return all mandatory parameters
+        return @($mandatoryParameters.Name)
     }
     elseif ($mandatoryParameters.count -eq 0)
     {
         Write-Verbose -Message "No mandatory parameters found for $($Resource.ResourceName)"
-    }
-    else
-    {
-        # the function failed to find any key params
-        throw "Multiple mandatory parameters found for $($Resource.ResourceName) but none of them are returned by the function"
     }
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description

Following up on my PR #4486 it seems that there are still resources out there that don't return their mandatory parameters, see #4502, so if none of the conditions in *Get-M365DSCResourceKey* are met then return all mandatory parameters of the resource and stop throwing an exception at the end of the cmdlet.

#### This Pull Request (PR) fixes the following issues

- Fixes #4502