### PR TITLE
Adds Intune logo to Delta reports 

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -374,6 +374,10 @@ function Get-IconPath
     {
         return 'http://microsoft365dsc.com/Images/Teams.jpg'
     }
+    elseif ($ResourceName.StartsWith('Intune'))
+    {
+        return 'http://microsoft365dsc.com/Images/Intune.jpg'
+    }
     return $null
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Adds Intune logo to `Get-IconPath` function when producing DSC Delta reports that contain Intune resources

#### This Pull Request (PR) fixes the following issues
When producing delta reports, the logo for Intune is currently an empty img src. This update simply points to Intune.jpg asset on the official Microsoft365dsc images static content path.
