### PR TITLE
Release 1.24.403.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log for Microsoft365DSC
 
-# UNRELEASED
+# 1.24.403.1
 
 * AADAdministrativeUnit
   * Fix issue with deploying/creating a new AU with members and/or adding members to an existing AU
@@ -71,7 +71,7 @@
   * Adds support for the NewTeamsOnly value or the UseNewTeamsClient property.
     FIXES [#4496](https://github.com/microsoft/Microsoft365DSC/issues/4496)
 * DEPENDENCIES
-  * Updated DSCParser to version 2.0.0.2.
+  * Updated DSCParser to version 2.0.0.3.
 * MISC
   * Initial release of Get-M365DSCEvaluationRulesForConfiguration
   * M365DSCDRGUtil

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -800,6 +800,7 @@ function Test-TargetResource
     }
     else
     {
+        $driftedParams = @{}
         if ($Permissions.Length -gt 0)
         {
             Write-Verbose -Message 'No Permissions exist for the current Azure AD App, but permissions were specified for desired state'

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleEligibilityScheduleRequest/MSFT_AADRoleEligibilityScheduleRequest.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleEligibilityScheduleRequest/MSFT_AADRoleEligibilityScheduleRequest.psm1
@@ -154,15 +154,16 @@
             else
             {
                 Write-Verbose -Message "Getting Role Eligibility by PrincipalId and RoleDefinitionId"
-                Write-Verbose -Message "Retrieving principal {$Principal} of type {$PrincipalType}"
                 if ($PrincipalType -eq 'User')
                 {
+                    Write-Verbose -Message "Retrieving principal {$Principal} of type {$PrincipalType}"
                     $PrincipalIdValue = Get-MgUser -Filter "UserPrincipalName eq '$Principal'" -ErrorAction SilentlyContinue
                     $PrincipalTypeValue = 'User'
                 }
 
                 if ($null -eq $PrincipalIdValue -or $PrincipalType -eq 'Group')
                 {
+                    Write-Verbose -Message "Retrieving principal {$Principal} of type {$PrincipalType}"
                     $PrincipalIdValue = Get-MgGroup -Filter "DisplayName eq '$Principal'" -ErrorAction SilentlyContinue
                     $PrincipalTypeValue = 'Group'
                 }
@@ -816,10 +817,10 @@ function Export-TargetResource
         }
         foreach ($request in $Script:exportedInstances)
         {
-            $RoleDefinitionId = Get-MgBetaRoleManagementDirectoryRoleDefinition -UnifiedRoleDefinitionId $request.RoleDefinitionId
-            $displayedKey = $RoleDefinitionId.DisplayName + " - " + $request.PrincipalId
+            $displayedKey = $request.Id
             Write-Host "    |---[$i/$($Script:exportedInstances.Count)] $displayedKey" -NoNewline
 
+            $RoleDefinitionId = Get-MgBetaRoleManagementDirectoryRoleDefinition -UnifiedRoleDefinitionId $request.RoleDefinitionId
             $params = @{
                 Id                    = $request.Id
                 Principal             = $request.PrincipalId

--- a/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
+++ b/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
@@ -2,7 +2,7 @@
     Dependencies = @(
         @{
             ModuleName      = 'DSCParser'
-            RequiredVersion = '2.0.0.2'
+            RequiredVersion = '2.0.0.3'
         },
         @{
             ModuleName      = 'ExchangeOnlineManagement'


### PR DESCRIPTION
#### Pull Request (PR) description
* AADAdministrativeUnit
  * Fix issue with deploying/creating a new AU with members and/or adding members to an existing AU
    FIXES [#4404](https://github.com/microsoft/Microsoft365DSC/issues/4404)
  * Updated examples to include setting Visibility and ScopedRoleMembers
  * Fix issue with Set-TargetResource was failing to apply when Verbose is set
    FIXES [#4497](https://github.com/microsoft/Microsoft365DSC/issues/4497)
* All resources
  * Fix issue where Ensure cannot be left as default 'Present'
* AADAdministrativeUnit
  * Fix issue with omitted Ensure and/or Id
    FIXES [#4437](https://github.com/microsoft/Microsoft365DSC/issues/4437)
* AADConditionalAccessPolicy
  * Fixed schema file
* EXOCalendarProcessing
  * Fixed schema file
* EXOGroupSettings
  * Fixed schema file
* EXOMailTips
  * [BREAKING CHANGE] Replaced the Organization parameter with IsSingleInstance
    FIXES [#4117](https://github.com/microsoft/Microsoft365DSC/issues/4117)
* EXOMessageClassification
  * Fixed schema file
* EXOOMEConfiguration
  * Fixed schema file
* EXOTransportRule
  * [BREAKING CHANGE] Change data type of Priority from String to Int
    FIXES [[#4136](https://github.com/microsoft/Microsoft365DSC/issues/4136)]
* IntuneAntivirusPolicyWindows10SettingCatalog
  * Add missing properties
* IntuneAppConfigurationPolicy
  * Fix comparison in Test-TargetResource
    FIXES [#4451](https://github.com/microsoft/Microsoft365DSC/issues/4451)
* IntuneDeviceCompliancePolicyWindows10
  * Fix group assignment by using the corrected function
    Update-DeviceConfigurationPolicyAssignment from module M365DSCDRGUtil
    FIXES [#4467](https://github.com/microsoft/Microsoft365DSC/issues/4467)
* IntuneDeviceEnrollmentStatusPageWindows10
  * Added support for specifying SelectedMobileAppNames in addition to SelectedMobileAppIds,
    which are different for each tenant.
    FIXES [#4494](https://github.com/microsoft/Microsoft365DSC/issues/4494)
* M365DSCRuleEvaluation
  * Log both matching and not matching resources and in XML format
* O365OrgSettings
  * Fixed missing permissions in settings.json
* SPOAccessControlSettings
  * [BREAKING CHANGE] Removed CommentsOnSitePagesDisabled parameter, because of
    duplication in SPOTenantSettings
    FIXES [#3576](https://github.com/microsoft/Microsoft365DSC/issues/3576)
  * [BREAKING CHANGE] Moved SocialBarOnSitePagesDisabled parameter to SPOTenantSettings,
    because it makes more sense there. This has nothing to do with Access Control.
* SPOTenantSettings
  * [BREAKING CHANGE] Removed ConditionalAccessPolicy parameter, because of
    duplication in SPOAccessControlSettings
    FIXES [#3576](https://github.com/microsoft/Microsoft365DSC/issues/3576)
  * Added SocialBarOnSitePagesDisabled parameter, moved from SPOAccessControlSettings.
* TeamsChannelTab
  * Fixed schema file
* TeamsGroupPolicyAssignment
  * Skip assignments that have orphaned/deleted groups or without display name
    instead of throwing an error
    FIXES [#4407](https://github.com/microsoft/Microsoft365DSC/issues/4407)
* TeamsTenantDialPlan
  * Fix output of property NormalizationRules as a string to the blueprint
    FIXES [#4428](https://github.com/microsoft/Microsoft365DSC/issues/4428)
  * Fix creation, update and deletion of resource
* TeamsUpdateManagementPolicy
  * Adds support for the NewTeamsOnly value or the UseNewTeamsClient property.
    FIXES [#4496](https://github.com/microsoft/Microsoft365DSC/issues/4496)
* DEPENDENCIES
  * Updated DSCParser to version 2.0.0.3.
* MISC
  * Initial release of Get-M365DSCEvaluationRulesForConfiguration
  * M365DSCDRGUtil
    Fix Update-DeviceConfigurationPolicyAssignment so that if the group cannot
    be found by its Id it tries to search it by display name
    FIXES [#4467](https://github.com/microsoft/Microsoft365DSC/issues/4467)
  * M365DSCReport
    Fix issue when asserting resources not covered by current conditions in
    Get-M365DSCResourceKey by always returning all their mandatory parameters
    FIXES [#4502](https://github.com/microsoft/Microsoft365DSC/issues/4502)
  * Fix broken links to integration tests in README.md
  * Changing logic to retrieve DSC Resources properties not to use DSC
    specific cmdlets.

#### This Pull Request (PR) fixes the following issues
* N/A
