### PR TITLE
AADGroup: Fix issue when filtering groups by display name (4508 & 4394)

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -147,7 +147,11 @@ function Get-TargetResource
                 }
                 else
                 {
-                    $filter = "DisplayName eq '$DisplayName'" -replace "'", "''"
+                    if ($DisplayName.Contains("'"))
+                    {
+                        $DisplayName = $DisplayName -replace "'", "''"
+                    }
+                    $filter = "DisplayName eq '$DisplayName'"
                     $Group = Get-MgGroup -Filter $filter -ErrorAction Stop
                 }
                 if ($Group.Length -gt 1)


### PR DESCRIPTION
#### Pull Request (PR) description
<!--
    See https://github.com/microsoft/Microsoft365DSC/pull/4395 by @ricmestre  --> fixes the workaround for ' in AADGroup Displaynames on the name matching fallback when ID is not found (which had a faulty previous fix attempt via https://github.com/microsoft/Microsoft365DSC/pull/4370)
-->

#### This Pull Request (PR) fixes the following issues
- Fixes #4394
- Fixes #4508