### PR TITLE
AADAdministrativeUnit, AADApplication, AADEntitlementManagementConnectedOrganization, AADGroup, AADUser: Replace old cmdlets with Remove-Mg*DirectoryObjectByRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* AADGroup, AADUser
+  * Replace old cmdlet with Remove-MgGroupMemberDirectoryObjectByRef which is
+    available in Graph 2.17.0
 * EXOMailboxSettings
   * Simplifyied the Setlogic and removed Timezone validation to remove checks
     to regstry key which caused issues in Linux.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
   * Replace old cmdlet with Remove-MgGroupMemberDirectoryObjectByRef which is
     available in Graph 2.17.0
 * EXOMailboxSettings
-  * Simplifyied the Setlogic and removed Timezone validation to remove checks
-    to regstry key which caused issues in Linux.
+  * Simplified the Set logic and removed Timezone validation to remove checks
+    to registry key which caused issues in Linux.
 * DEPENDENCIES
   * Updated Microsoft.Graph dependencies to version 2.17.0.
   * Updated MicrosoftTeams to version 6.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 # UNRELEASED
 
-* AADGroup, AADUser
-  * Replace old cmdlet with Remove-MgGroupMemberDirectoryObjectByRef which is
-    available in Graph 2.17.0
+* AADAdministrativeUnit, AADApplication,
+  AADEntitlementManagementConnectedOrganization, AADGroup, AADUser
+  * Replace old cmdlet and deprecated Remove-Mg\*ByRef with equivalent
+    Remove-Mg\*DirectoryObjectByRef which is available in Graph 2.17.0
 * EXOMailboxSettings
   * Simplified the Set logic and removed Timezone validation to remove checks
     to registry key which caused issues in Linux.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
@@ -656,7 +656,7 @@ function Set-TargetResource
                     else
                     {
                         Write-Verbose -Message "Administrative Unit {$DisplayName} Removing member {$($diff.Identity)}, type {$($diff.Type)}"
-                        Remove-MgBetaDirectoryAdministrativeUnitMemberByRef -AdministrativeUnitId ($currentInstance.Id) -DirectoryObjectId ($memberObject.Id) | Out-Null
+                        Remove-MgBetaDirectoryAdministrativeUnitMemberDirectoryObjectByRef -AdministrativeUnitId ($currentInstance.Id) -DirectoryObjectId ($memberObject.Id) | Out-Null
                     }
                 }
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -578,7 +578,7 @@ function Set-TargetResource
                     {
                         $ObjectId = $diff.InputObject
                     }
-                    Remove-MgApplicationOwnerByRef -ApplicationId $currentAADApp.ObjectId -DirectoryObjectId $ObjectId -ErrorAction Stop
+                    Remove-MgApplicationOwnerDirectoryObjectByRef -ApplicationId $currentAADApp.ObjectId -DirectoryObjectId $ObjectId -ErrorAction Stop
                 }
                 catch
                 {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementConnectedOrganization/MSFT_AADEntitlementManagementConnectedOrganization.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementConnectedOrganization/MSFT_AADEntitlementManagementConnectedOrganization.psm1
@@ -514,7 +514,7 @@ function Set-TargetResource
         }
         foreach ($sponsor in $sponsorsToRemove)
         {
-            Remove-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorByRef `
+            Remove-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorDirectoryObjectByRef `
                 -ConnectedOrganizationId $currentInstance.Id `
                 -DirectoryObjectId $sponsor
         }
@@ -552,7 +552,7 @@ function Set-TargetResource
         }
         foreach ($sponsor in $sponsorsToRemove)
         {
-            Remove-MgBetaEntitlementManagementConnectedOrganizationInternalSponsorByRef `
+            Remove-MgBetaEntitlementManagementConnectedOrganizationInternalSponsorDirectoryObjectByRef `
                 -ConnectedOrganizationId $currentInstance.Id `
                 -DirectoryObjectId $sponsor
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -664,7 +664,7 @@ function Set-TargetResource
                 elseif ($diff.SideIndicator -eq '<=')
                 {
                     Write-Verbose -Message "Removing new owner {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
-                    Remove-MgGroupOwnerByRef -GroupId ($currentGroup.Id) -DirectoryObjectId ($user.Id) | Out-Null
+                    Remove-MgGroupOwnerDirectoryObjectByRef -GroupId ($currentGroup.Id) -DirectoryObjectId ($user.Id) | Out-Null
                 }
             }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -703,7 +703,7 @@ function Set-TargetResource
                 elseif ($diff.SideIndicator -eq '<=')
                 {
                     Write-Verbose -Message "Removing new member {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
-                    Remove-MgGroupMemberByRef -GroupId ($currentGroup.Id) -DirectoryObjectId ($user.Id) | Out-Null
+                    Remove-MgGroupMemberDirectoryObjectByRef -GroupId ($currentGroup.Id) -DirectoryObjectId ($user.Id) | Out-Null
                 }
             }
         }
@@ -767,7 +767,7 @@ function Set-TargetResource
                         if ($memberOfgroup.psobject.Typenames -match 'Group')
                         {
                             Write-Verbose -Message "Removing AAD Group {$($currentGroup.DisplayName)} from AAD group {$($memberOfGroup.DisplayName)}"
-                            Remove-MgGroupMemberByRef -GroupId ($memberOfGroup.Id) -DirectoryObjectId ($currentGroup.Id) | Out-Null
+                            Remove-MgGroupMemberDirectoryObjectByRef -GroupId ($memberOfGroup.Id) -DirectoryObjectId ($currentGroup.Id) | Out-Null
                         }
                         else
                         {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/MSFT_AADUser.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/MSFT_AADUser.psm1
@@ -638,7 +638,7 @@ function Set-TargetResource
                     {
                         # Group that user is a member of is not present in MemberOf, remove user from group
                         # (no need to test for dynamic groups as they are ignored in Get-TargetResource)
-                        Remove-MgGroupMemberByRef -GroupId $group.Id -DirectoryObjectId $user.Id
+                        Remove-MgGroupMemberDirectoryObjectByRef -GroupId $group.Id -DirectoryObjectId $user.Id
                     }
                 }
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADAdministrativeUnit.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADAdministrativeUnit.Tests.ps1
@@ -58,7 +58,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Remove-MgBetaDirectoryAdministrativeUnit -MockWith {
             }
 
-            Mock -CommandName Remove-MgBetaDirectoryAdministrativeUnitMemberByRef -MockWith {
+            Mock -CommandName Remove-MgBetaDirectoryAdministrativeUnitMemberDirectoryObjectByRef -MockWith {
             }
 
             Mock -CommandName Remove-MgBetaDirectoryAdministrativeUnitScopedRoleMember -MockWith {
@@ -151,7 +151,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             It 'Should return Values from the Get method' {
                 (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
             }
-            
+
             It 'Should return false from the Test method' {
                 Test-TargetResource @testParams | Should -Be $false
             }
@@ -359,7 +359,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should call the Set method without removing existing Members or ScopedRoleMembers' {
                 Set-TargetResource @testParams
-                Should -Not -Invoke -CommandName Remove-MgBetaDirectoryAdministrativeUnitMemberByRef
+                Should -Not -Invoke -CommandName Remove-MgBetaDirectoryAdministrativeUnitMemberDirectoryObjectByRef
                 Should -Not -Invoke -CommandName Remove-MgBetaDirectoryAdministrativeUnitScopedRoleMember
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADEntitlementManagementConnectedOrganization.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADEntitlementManagementConnectedOrganization.Tests.ps1
@@ -42,10 +42,10 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName New-MgBetaEntitlementManagementConnectedOrganizationInternalSponsorByRef -MockWith {
             }
 
-            Mock -CommandName Remove-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorByRef -MockWith {
+            Mock -CommandName Remove-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorDirectoryObjectByRef -MockWith {
             }
 
-            Mock -CommandName Remove-MgBetaEntitlementManagementConnectedOrganizationInternalSponsorByRef -MockWith {
+            Mock -CommandName Remove-MgBetaEntitlementManagementConnectedOrganizationInternalSponsorDirectoryObjectByRef -MockWith {
             }
 
             Mock -CommandName New-M365DSCConnection -MockWith {
@@ -65,7 +65,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     UserPrincipalName = 'John.smith@contoso.com'
                 }
             }
-            
+
             Mock -CommandName Get-MgBetaDirectoryObject -MockWith {
                 return @{
                     Id                   = '12345678-1234-1234-1234-123456789012'
@@ -318,7 +318,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             It 'Should call the Set method' {
                 Set-TargetResource @testParams
                 Should -Invoke -CommandName Update-MgBetaEntitlementManagementConnectedOrganization -Exactly 1
-                Should -Invoke -CommandName Remove-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorByRef -Exactly 1
+                Should -Invoke -CommandName Remove-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorDirectoryObjectByRef -Exactly 1
             }
         }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADGroup.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADGroup.Tests.ps1
@@ -69,7 +69,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName New-MgBetaDirectoryRoleMemberByRef -MockWith {
             }
 
-            Mock -CommandName Remove-MgGroupOwnerByRef -MockWith {
+            Mock -CommandName Remove-MgGroupOwnerDirectoryObjectByRef -MockWith {
             }
 
             Mock -CommandName Remove-MgGroupMemberDirectoryObjectByRef -MockWith {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADGroup.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADGroup.Tests.ps1
@@ -72,7 +72,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Remove-MgGroupOwnerByRef -MockWith {
             }
 
-            Mock -CommandName Remove-MgGroupMemberByRef -MockWith {
+            Mock -CommandName Remove-MgGroupMemberDirectoryObjectByRef -MockWith {
             }
 
             Mock -CommandName Remove-MgBetaDirectoryRoleMemberByRef -MockWith {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADUser.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADUser.Tests.ps1
@@ -47,7 +47,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName New-MgGroupMember -MockWith {
             }
 
-            Mock -CommandName Remove-MgGroupMemberByRef -MockWith {
+            Mock -CommandName Remove-MgGroupMemberDirectoryObjectByRef -MockWith {
             }
 
             # Mock Write-Host to hide output during the tests

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADUser.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADUser.Tests.ps1
@@ -302,7 +302,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should NOT remove the user from the group in the Set Method' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName 'Remove-MgGroupMemberByRef' -Exactly 0
+                Should -Invoke -CommandName 'Remove-MgGroupMemberDirectoryObjectByRef' -Exactly 0
             }
 
             It 'Should return true from the Test method' {
@@ -372,7 +372,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should remove the user from existing group-membership and add the user to the group in the testParams' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName 'Remove-MgGroupMemberByRef' -Exactly 1
+                Should -Invoke -CommandName 'Remove-MgGroupMemberDirectoryObjectByRef' -Exactly 1
                 Should -Invoke -CommandName 'New-MgGroupMember' -Exactly 1
             }
 

--- a/Tests/Unit/Stubs/Microsoft365.psm1
+++ b/Tests/Unit/Stubs/Microsoft365.psm1
@@ -14809,7 +14809,7 @@ function Remove-MgApplication
         $HttpPipelineAppend
     )
 }
-function Remove-MgApplicationOwnerByRef
+function Remove-MgApplicationOwnerDirectoryObjectByRef
 {
     [CmdletBinding()]
     param(
@@ -25887,7 +25887,7 @@ function Remove-MgBetaDirectoryAdministrativeUnit
         $Break
     )
 }
-function Remove-MgBetaDirectoryAdministrativeUnitMemberByRef
+function Remove-MgBetaDirectoryAdministrativeUnitMemberDirectoryObjectByRef
 {
     [CmdletBinding()]
     param(
@@ -30173,7 +30173,7 @@ function Remove-MgBetaEntitlementManagementConnectedOrganization
         $Break
     )
 }
-function Remove-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorByRef
+function Remove-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorDirectoryObjectByRef
 {
     [CmdletBinding()]
     param(
@@ -30230,7 +30230,7 @@ function Remove-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorB
         $Break
     )
 }
-function Remove-MgBetaEntitlementManagementConnectedOrganizationInternalSponsorByRef
+function Remove-MgBetaEntitlementManagementConnectedOrganizationInternalSponsorDirectoryObjectByRef
 {
     [CmdletBinding()]
     param(
@@ -37549,7 +37549,7 @@ function Remove-MgGroupMemberDirectoryObjectByRef
         $Break
     )
 }
-function Remove-MgGroupOwnerByRef
+function Remove-MgGroupOwnerDirectoryObjectByRef
 {
     [CmdletBinding()]
     param(
@@ -41277,7 +41277,7 @@ function Remove-MgApplication
         $HttpPipelineAppend
     )
 }
-function Remove-MgApplicationOwnerByRef
+function Remove-MgApplicationOwnerDirectoryObjectByRef
 {
     [CmdletBinding()]
     param(
@@ -52370,7 +52370,7 @@ function Remove-MgBetaDirectoryAdministrativeUnit
         $Break
     )
 }
-function Remove-MgBetaDirectoryAdministrativeUnitMemberByRef
+function Remove-MgBetaDirectoryAdministrativeUnitMemberDirectoryObjectByRef
 {
     [CmdletBinding()]
     param(
@@ -56322,7 +56322,7 @@ function Remove-MgBetaEntitlementManagementConnectedOrganization
         $Break
     )
 }
-function Remove-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorByRef
+function Remove-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorDirectoryObjectByRef
 {
     [CmdletBinding()]
     param(
@@ -56379,7 +56379,7 @@ function Remove-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorB
         $Break
     )
 }
-function Remove-MgBetaEntitlementManagementConnectedOrganizationInternalSponsorByRef
+function Remove-MgBetaEntitlementManagementConnectedOrganizationInternalSponsorDirectoryObjectByRef
 {
     [CmdletBinding()]
     param(

--- a/Tests/Unit/Stubs/Microsoft365.psm1
+++ b/Tests/Unit/Stubs/Microsoft365.psm1
@@ -37492,7 +37492,7 @@ function Remove-MgGroupLifecyclePolicy
         $Break
     )
 }
-function Remove-MgGroupMemberByRef
+function Remove-MgGroupMemberDirectoryObjectByRef
 {
     [CmdletBinding()]
     param(
@@ -81458,4 +81458,3 @@ function Update-MgBetaDeviceAppManagementMobileApp
 }
 
 #endregion
-


### PR DESCRIPTION
#### Pull Request (PR) description

Graph 2.17.0 deprecated old cmdlet *Remove-Mg\*ByRef* in favor of *Remove-Mg\*DirectoryObjectByRef*, this PR fixes that.

See https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/2670 and https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/2674 where this was reported.

#### This Pull Request (PR) fixes the following issues

- Fixes #4542 