### PR TITLE
Update Get-ComputerInfo call to Get-CimInstance to improve telemetry performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * DEPENDENCIES
   * Updated Microsoft.Graph dependencies to version 2.17.0.
   * Updated MicrosoftTeams to version 6.1.0.
+* MISC
+  * Telemetry
+    * Get operating system using faster method to speed up telemetry calls.
 
 # 1.24.403.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCTelemetryEngine.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCTelemetryEngine.psm1
@@ -205,7 +205,7 @@ function Add-M365DSCTelemetryEvent
             {
                 if ($null -eq $Global:M365DSCOSInfo)
                 {
-                    $Global:M365DSCOSInfo = (Get-ComputerInfo -Property OSName -ErrorAction SilentlyContinue).OSName
+                    $Global:M365DSCOSInfo = (Get-CimInstance -ClassName Win32_OperatingSystem -Property Caption -ErrorAction SilentlyContinue).Caption
                 }
                 $Data.Add('M365DSCOSVersion', $Global:M365DSCOSInfo)
             }


### PR DESCRIPTION
#### Pull Request (PR) description
As described in #4529, there is a call to Get-ComputerInfo in the telemetry which takes 2 seconds on each resource run.

Switching to Get-CimInstance to do a direct WMI call massively improves performance.

NB **Both** [Get-ComputerInfo](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-computerinfo?view=powershell-7.4) and Get-CimInstance Win32_ComputerSystem are only available on Windows platforms, so there's no loss in cross-compatibility.

I have tested Get-CimInstance on Windows client and server OSes - it generates identical output to Get-ComputerInfo.

#### This Pull Request (PR) fixes the following issues
- Fixes #4529