### PR TITLE
AADAdministrativeUnit - Resolve issue where directory roles are not yet enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # UNRELEASED
 
+* AADAdministrativeUnit
+  * Fixed an issue when assigning a directory role which is not yet enabled.
+  * Fixed a potential issue if the total directory roles increases in future.
+* AADConditionalAccessPolicy
+  * Fixed a potential issue if the total directory roles increases in future.
+* AADGroup
+  * Fixed a potential issue if the total directory roles increases in future.
 * AADRoleEligibilitySecheduleRquest
   * Cleaned Export logic.
 * EXOActiveSyncDeviceAccessRule

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
@@ -472,7 +472,7 @@ function Set-TargetResource
                 catch
                 {
                     Write-Verbose -Message "Azure AD role {$($rolemember.RoleName)} is not enabled"
-                    $roleTemplate = Get-MgBetaDirectoryRoleTemplate -Filter "DisplayName eq '$($roleMember.RoleName)'" -ErrorAction Stop
+                    $roleTemplate = Get-MgBetaDirectoryRoleTemplate -All -ErrorAction Stop | Where-Object { $_.DisplayName -eq $rolemember.RoleName }
                     if ($null -ne $roleTemplate)
                     {
                         Write-Verbose -Message "Enable Azure AD role {$($rolemember.RoleName)} with id {$($roleTemplate.Id)}"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -418,7 +418,7 @@ function Get-TargetResource
         Write-Verbose -Message 'Get-TargetResource: Role condition defined, processing'
         #build role translation table
         $rolelookup = @{}
-        foreach ($role in Get-MgBetaDirectoryRoleTemplate)
+        foreach ($role in Get-MgBetaDirectoryRoleTemplate -All)
         {
             $rolelookup[$role.Id] = $role.DisplayName
         }
@@ -1195,7 +1195,7 @@ function Set-TargetResource
             {
                 #translate role names to template guid if defined
                 $rolelookup = @{}
-                foreach ($role in Get-MgBetaDirectoryRoleTemplate)
+                foreach ($role in Get-MgBetaDirectoryRoleTemplate -All)
                 {
                     $rolelookup[$role.DisplayName] = $role.Id
                 }
@@ -1229,7 +1229,7 @@ function Set-TargetResource
             {
                 #translate role names to template guid if defined
                 $rolelookup = @{}
-                foreach ($role in Get-MgBetaDirectoryRoleTemplate)
+                foreach ($role in Get-MgBetaDirectoryRoleTemplate -All)
                 {
                     $rolelookup[$role.DisplayName] = $role.Id
                 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -804,7 +804,7 @@ function Set-TargetResource
                     # If the role hasn't been activated, we need to get the role template ID to first activate the role
                     if ($null -eq $role)
                     {
-                        $adminRoleTemplate = Get-MgBetaDirectoryRoleTemplate | Where-Object { $_.DisplayName -eq $diff.InputObject }
+                        $adminRoleTemplate = Get-MgBetaDirectoryRoleTemplate -All | Where-Object { $_.DisplayName -eq $diff.InputObject }
                         $role = New-MgBetaDirectoryRole -RoleTemplateId $adminRoleTemplate.Id
                     }
                 }


### PR DESCRIPTION
#### Pull Request (PR) description

(Sorry, messed up my previous PR so had to resubmit.)

If a role assignment is included, but the Azure AD role is not enabled, Set-TargetResource fails

The reason appears to be because the resource is calling Get-MgBetaDirectoryRoleTemplate with the -filter parameter, but when running that cmdlet using any -Filter parameter, the following is returned:

`Get-MgBetaDirectoryRoleTemplate : Filtered searches against this resource are not supported.`

The fix is to use Where-Object instead - the same as the AADGroup resource already does.

Hopefully this will fix the issue, and the integration tests.

I have also updated all the unfiltered calls to Get-MgBetaDirectoryRoleTemplate with the -All parameter, just in case the count of default DirectoryRoleTemplates exceeds the default page size in the future

https://github.com/microsoft/Microsoft365DSC/actions/runs/8528086606/job/23360939733

#### This Pull Request (PR) fixes the following issues
- Fixes #4549
