### PR TITLE
[SCAutoSensitivityLabelPolicy] Fixes incorrect mandatory Credential parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* SCAutoSensitivityLabelPolicy
+  * Fix incorrect mandatory Credential parameter in Set and Test methods
+    FIXES [#4283](https://github.com/microsoft/Microsoft365DSC/issues/4283)
 * DEPENDENCIES
   * Updated Microsoft.Graph to version 2.18.0.
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.182.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCAutoSensitivityLabelPolicy/MSFT_SCAutoSensitivityLabelPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCAutoSensitivityLabelPolicy/MSFT_SCAutoSensitivityLabelPolicy.psm1
@@ -334,7 +334,7 @@ function Set-TargetResource
         [System.String]
         $Ensure = 'Present',
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -601,7 +601,7 @@ function Test-TargetResource
         [System.String]
         $Ensure = 'Present',
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 


### PR DESCRIPTION
#### Pull Request (PR) description
This PR removes the mandatory setting for the Credential parameter, which should not have been there and is causing issues.

#### This Pull Request (PR) fixes the following issues
- Fixes #4283
