### PR TITLE
Fix empty array parameter to comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * SCAutoSensitivityLabelPolicy
   * Fix incorrect mandatory Credential parameter in Set and Test methods
     FIXES [#4283](https://github.com/microsoft/Microsoft365DSC/issues/4283)
+* M365DSCUtil
+  * Fixed an issue where one could not pass empty arrays to the 
+    `Compare-PSCustomObjectArrays` function.
 * DEPENDENCIES
   * Updated Microsoft.Graph to version 2.18.0.
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.182.

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -437,10 +437,12 @@ function Compare-PSCustomObjectArrays
     param
     (
         [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [System.Object[]]
         $DesiredValues,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [System.Object[]]
         $CurrentValues
     )


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request addresses an issue where one could not pass an empty array to the `Compare-PSCustomObjectArrays` function. If an empty array was passed, the error message `Cannot bind argument to parameter 'DesiredValues' because it is an empty array` was thrown. 

#### This Pull Request (PR) fixes the following issues
None
