### PR TITLE
Add Intune Platform Scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneDeviceConfigurationPlatformScriptWindows
+  * Initial Release  
+  FIXES [#4157](https://github.com/microsoft/Microsoft365DSC/issues/4157)
+* IntuneDeviceConfigurationPlatformScriptMacOS
+  * Initial Release  
+  FIXES [#4157](https://github.com/microsoft/Microsoft365DSC/issues/4157)
+
 # 1.24.515.2
 
 * EXOManagementRoleEntry

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.schema.mof
@@ -1,0 +1,34 @@
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementConfigurationPolicyAssignments
+{
+    [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}] String dataType;
+    [Write, Description("The type of filter of the target assignment i.e. Exclude or Include. Possible values are:none, include, exclude."), ValueMap{"none","include","exclude"}, Values{"none","include","exclude"}] String deviceAndAppManagementAssignmentFilterType;
+    [Write, Description("The Id of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterId;
+    [Write, Description("The group Id that is the target of the assignment.")] String groupId;
+    [Write, Description("The group Display Name that is the target of the assignment.")] String groupDisplayName;
+    [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
+};
+
+[ClassVersion("1.0.0.0"), FriendlyName("IntuneDeviceConfigurationPlatformScriptMacOS")]
+class MSFT_IntuneDeviceConfigurationPlatformScriptMacOS : OMI_BaseResource
+{
+    [Write, Description("Does not notify the user a script is being executed")] Boolean BlockExecutionNotifications;
+    [Write, Description("Optional description for the device management script.")] String Description;
+    [Required, Description("Name of the device management script.")] String DisplayName;
+    [Write, Description("The script file name.")] String FileName;
+    [Write, Description("The interval for script to run. If not defined the script will run once")] String ExecutionFrequency;
+    [Write, Description("Number of times for the script to be retried if it fails")] UInt32 RetryCount;
+    [Write, Description("List of Scope Tag IDs for this PowerShellScript instance.")] String RoleScopeTagIds[];
+    [Write, Description("Indicates the type of execution context. Possible values are: system, user."), ValueMap{"system","user"}, Values{"system","user"}] String RunAsAccount;
+    [Write, Description("The script content in Base64.")] String ScriptContent;
+    [Key, Description("The unique identifier for an entity. Read-only.")] String Id;
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
+    [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
+    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
+    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
+    [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
+    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Access token used for authentication.")] String AccessTokens[];
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/readme.md
@@ -1,0 +1,6 @@
+
+# IntuneDeviceConfigurationPlatformScriptMacOS
+
+## Description
+
+Intune Device Configuration Platform Script MacOS

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/settings.json
@@ -1,0 +1,45 @@
+{
+    "resourceName": "IntuneDeviceConfigurationPlatformScriptMacOS",
+    "description": "This resource configures an Intune Device Configuration Platform Script MacOS.",
+    "permissions":    {
+  "graph": {
+    "delegated": {
+      "read": [
+        {
+          "name": "DeviceManagementConfiguration.Read.All"
+        },
+        {
+          "name": "DeviceManagementManagedDevices.Read.All"
+        }
+      ],
+      "update": [
+        {
+          "name": "DeviceManagementConfiguration.ReadWrite.All"
+        },
+        {
+          "name": "DeviceManagementManagedDevices.ReadWrite.All"
+        }
+      ]
+    },
+    "application": {
+      "read": [
+        {
+          "name": "DeviceManagementConfiguration.Read.All"
+        },
+        {
+          "name": "DeviceManagementManagedDevices.Read.All"
+        }
+      ],
+      "update": [
+        {
+          "name": "DeviceManagementConfiguration.ReadWrite.All"
+        },
+        {
+          "name": "DeviceManagementManagedDevices.ReadWrite.All"
+        }
+      ]
+    }
+  }
+}
+
+}

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
@@ -1,0 +1,660 @@
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.Boolean]
+        $EnforceSignatureCheck,
+
+        [Parameter()]
+        [System.String]
+        $FileName,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [System.Boolean]
+        $RunAs32Bit,
+
+        [Parameter()]
+        [ValidateSet('system','user')]
+        [System.String]
+        $RunAsAccount,
+
+        [Parameter()]
+        [System.String]
+        $ScriptContent,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    try
+    {
+        $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+            -InboundParameters $PSBoundParameters
+
+        #Ensure the proper dependencies are installed in the current environment.
+        Confirm-M365DSCDependencies
+
+        #region Telemetry
+        $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+        $CommandName = $MyInvocation.MyCommand
+        $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+            -CommandName $CommandName `
+            -Parameters $PSBoundParameters
+        Add-M365DSCTelemetryEvent -Data $data
+        #endregion
+
+        $nullResult = $PSBoundParameters
+        $nullResult.Ensure = 'Absent'
+
+        $getValue = $null
+        #region resource generator code
+        $getValue = Get-MgBetaDeviceManagementScript -DeviceManagementScriptId $Id -ErrorAction SilentlyContinue
+
+        if ($null -eq $getValue)
+        {
+            Write-Verbose -Message "Could not find an Intune Device Configuration Platform Script Windows with Id {$Id}"
+
+            if (-Not [string]::IsNullOrEmpty($DisplayName))
+            {
+                $getValue = Get-MgBetaDeviceManagementScript `
+                    -Filter "DisplayName eq '$DisplayName'" `
+                    -ErrorAction SilentlyContinue
+                $getValue = Get-MgBetaDeviceManagementScript -DeviceManagementScriptId $getValue.Id
+            }
+        }
+        #endregion
+        if ($null -eq $getValue)
+        {
+            Write-Verbose -Message "Could not find an Intune Device Configuration Platform Script Windows with DisplayName {$DisplayName}"
+            return $nullResult
+        }
+        $Id = $getValue.Id
+
+        Write-Verbose -Message "An Intune Device Configuration Platform Script Windows with Id {$Id} and DisplayName {$DisplayName} was found."
+
+        #region resource generator code
+        $enumRunAsAccount = $null
+        if ($null -ne $getValue.RunAsAccount)
+        {
+            $enumRunAsAccount = $getValue.RunAsAccount.ToString()
+        }
+        #endregion
+
+        $results = @{
+            #region resource generator code
+            Description           = $getValue.Description
+            DisplayName           = $getValue.DisplayName
+            EnforceSignatureCheck = $getValue.EnforceSignatureCheck
+            FileName              = $getValue.FileName
+            RoleScopeTagIds       = $getValue.RoleScopeTagIds
+            RunAs32Bit            = $getValue.RunAs32Bit
+            RunAsAccount          = $enumRunAsAccount
+            ScriptContent         = [System.Convert]::ToBase64String($getValue.ScriptContent)
+            Id                    = $getValue.Id
+            Ensure                = 'Present'
+            Credential            = $Credential
+            ApplicationId         = $ApplicationId
+            TenantId              = $TenantId
+            ApplicationSecret     = $ApplicationSecret
+            CertificateThumbprint = $CertificateThumbprint
+            ManagedIdentity       = $ManagedIdentity.IsPresent
+            AccessTokens          = $AccessTokens
+            #endregion
+        }
+        $assignmentsValues = Get-MgBetaDeviceManagementScriptAssignment -DeviceManagementScriptId $Id
+        $assignmentResult = @()
+        foreach ($assignmentEntry in $AssignmentsValues)
+        {
+            $assignmentValue = @{
+                dataType = $assignmentEntry.Target.AdditionalProperties.'@odata.type'
+                deviceAndAppManagementAssignmentFilterType = $(if ($null -ne $assignmentEntry.Target.DeviceAndAppManagementAssignmentFilterType)
+                    {$assignmentEntry.Target.DeviceAndAppManagementAssignmentFilterType.ToString()})
+                deviceAndAppManagementAssignmentFilterId = $assignmentEntry.Target.DeviceAndAppManagementAssignmentFilterId
+                groupId = $assignmentEntry.Target.AdditionalProperties.groupId
+            }
+            $assignmentResult += $assignmentValue
+        }
+        $results.Add('Assignments', $assignmentResult)
+
+        return [System.Collections.Hashtable] $results
+    }
+    catch
+    {
+        New-M365DSCLogEntry -Message 'Error retrieving data:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return $nullResult
+    }
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.Boolean]
+        $EnforceSignatureCheck,
+
+        [Parameter()]
+        [System.String]
+        $FileName,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [System.Boolean]
+        $RunAs32Bit,
+
+        [Parameter()]
+        [ValidateSet('system','user')]
+        [System.String]
+        $RunAsAccount,
+
+        [Parameter()]
+        [System.String]
+        $ScriptContent,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    $currentInstance = Get-TargetResource @PSBoundParameters
+
+    $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+
+    if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
+    {
+        Write-Verbose -Message "Creating an Intune Device Configuration Platform Script Windows with DisplayName {$DisplayName}"
+        $BoundParameters.Remove("Assignments") | Out-Null
+
+        $CreateParameters = ([Hashtable]$BoundParameters).clone()
+        $CreateParameters = Rename-M365DSCCimInstanceParameter -Properties $CreateParameters
+        $CreateParameters.ScriptContent = [System.Convert]::FromBase64String($CreateParameters.ScriptContent)
+
+        $CreateParameters.Remove('Id') | Out-Null
+
+        $keys = (([Hashtable]$CreateParameters).clone()).Keys
+        foreach ($key in $keys)
+        {
+            if ($null -ne $CreateParameters.$key -and $CreateParameters.$key.getType().Name -like '*cimInstance*')
+            {
+                $CreateParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $CreateParameters.$key
+            }
+        }
+        #region resource generator code
+        $CreateParameters.Add("@odata.type", "#microsoft.graph.DeviceManagementScript")
+        $policy = New-MgBetaDeviceManagementScript -BodyParameter $CreateParameters
+        $assignmentsHash = @()
+        foreach ($assignment in $Assignments)
+        {
+            $assignmentsHash += Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $Assignment
+        }
+
+        if ($policy.Id)
+        {
+            Update-DeviceConfigurationPolicyAssignment -DeviceConfigurationPolicyId  $policy.Id `
+                -Targets $assignmentsHash `
+                -Repository 'deviceManagement/deviceManagementScripts' `
+                -RootIdentifier 'deviceManagementScriptAssignments'
+        }
+        #endregion
+    }
+    elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Updating the Intune Device Configuration Platform Script Windows with Id {$($currentInstance.Id)}"
+        $BoundParameters.Remove("Assignments") | Out-Null
+
+        $UpdateParameters = ([Hashtable]$BoundParameters).clone()
+        $UpdateParameters = Rename-M365DSCCimInstanceParameter -Properties $UpdateParameters
+        $UpdateParameters.ScriptContent = [System.Convert]::FromBase64String($UpdateParameters.ScriptContent)
+
+        $UpdateParameters.Remove('Id') | Out-Null
+
+        $keys = (([Hashtable]$UpdateParameters).clone()).Keys
+        foreach ($key in $keys)
+        {
+            if ($null -ne $UpdateParameters.$key -and $UpdateParameters.$key.getType().Name -like '*cimInstance*')
+            {
+                $UpdateParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $UpdateParameters.$key
+            }
+        }
+        #region resource generator code
+        $UpdateParameters.Add("@odata.type", "#microsoft.graph.DeviceManagementScript")
+        Update-MgBetaDeviceManagementScript  `
+            -DeviceManagementScriptId $currentInstance.Id `
+            -BodyParameter $UpdateParameters
+        $assignmentsHash = @()
+        foreach ($assignment in $Assignments)
+        {
+            $assignmentsHash += Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $Assignment
+        }
+        Update-DeviceConfigurationPolicyAssignment `
+            -DeviceConfigurationPolicyId $currentInstance.id `
+            -Targets $assignmentsHash `
+            -Repository 'deviceManagement/deviceManagementScripts' `
+            -RootIdentifier 'deviceManagementScriptAssignments'
+        #endregion
+    }
+    elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Removing the Intune Device Configuration Platform Script Windows with Id {$($currentInstance.Id)}" 
+        #region resource generator code
+        Remove-MgBetaDeviceManagementScript -DeviceManagementScriptId $currentInstance.Id
+        #endregion
+    }
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.Boolean]
+        $EnforceSignatureCheck,
+
+        [Parameter()]
+        [System.String]
+        $FileName,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [System.Boolean]
+        $RunAs32Bit,
+
+        [Parameter()]
+        [ValidateSet('system','user')]
+        [System.String]
+        $RunAsAccount,
+
+        [Parameter()]
+        [System.String]
+        $ScriptContent,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    Write-Verbose -Message "Testing configuration of the Intune Device Configuration Platform Script Windows with Id {$Id} and DisplayName {$DisplayName}"
+
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+    $ValuesToCheck = ([Hashtable]$PSBoundParameters).clone()
+
+    if ($CurrentValues.Ensure -ne $Ensure)
+    {
+        Write-Verbose -Message "Test-TargetResource returned $false"
+        return $false
+    }
+    $testResult = $true
+
+    #Compare Cim instances
+    foreach ($key in $PSBoundParameters.Keys)
+    {
+        $source = $PSBoundParameters.$key
+        $target = $CurrentValues.$key
+        if ($source.getType().Name -like '*CimInstance*')
+        {
+            $source = Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $source
+
+            $testResult = Compare-M365DSCComplexObject `
+                -Source ($source) `
+                -Target ($target)
+
+            if (-Not $testResult)
+            {
+                $testResult = $false
+                break
+            }
+
+            $ValuesToCheck.Remove($key) | Out-Null
+        }
+    }
+
+    $ValuesToCheck.remove('Id') | Out-Null
+    $ValuesToCheck.Remove('Credential') | Out-Null
+    $ValuesToCheck.Remove('ApplicationId') | Out-Null
+    $ValuesToCheck.Remove('TenantId') | Out-Null
+    $ValuesToCheck.Remove('ApplicationSecret') | Out-Null
+
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
+    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $ValuesToCheck)"
+
+    if ($testResult)
+    {
+        $testResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -DesiredValues $PSBoundParameters `
+            -ValuesToCheck $ValuesToCheck.Keys
+    }
+
+    Write-Verbose -Message "Test-TargetResource returned $testResult"
+
+    return $testResult
+}
+
+function Export-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+        -InboundParameters $PSBoundParameters
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    try
+    {
+        #region resource generator code
+        [array]$getValue = Get-MgBetaDeviceManagementScript `
+            -Filter $Filter `
+            -All `
+            -ErrorAction Stop
+        #endregion
+
+        $i = 1
+        $dscContent = ''
+        if ($getValue.Length -eq 0)
+        {
+            Write-Host $Global:M365DSCEmojiGreenCheckMark
+        }
+        else
+        {
+            Write-Host "`r`n" -NoNewline
+        }
+        foreach ($config in $getValue)
+        {
+            $displayedKey = $config.Id
+            if (-not [String]::IsNullOrEmpty($config.displayName))
+            {
+                $displayedKey = $config.displayName
+            }
+            Write-Host "    |---[$i/$($getValue.Count)] $displayedKey" -NoNewline
+            $params = @{
+                Id = $config.Id
+                DisplayName           =  $config.DisplayName
+                Ensure = 'Present'
+                Credential = $Credential
+                ApplicationId = $ApplicationId
+                TenantId = $TenantId
+                ApplicationSecret = $ApplicationSecret
+                CertificateThumbprint = $CertificateThumbprint
+                ManagedIdentity = $ManagedIdentity.IsPresent
+                AccessTokens    = $AccessTokens
+            }
+
+            $Results = Get-TargetResource @Params
+            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
+                -Results $Results
+            if ($Results.Assignments)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
+                if ($complexTypeStringResult)
+                {
+                    $Results.Assignments = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('Assignments') | Out-Null
+                }
+            }
+            $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
+                -ConnectionMode $ConnectionMode `
+                -ModulePath $PSScriptRoot `
+                -Results $Results `
+                -Credential $Credential
+            if ($Results.Assignments)
+            {
+                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "Assignments" -isCIMArray:$true
+            }
+
+            $dscContent += $currentDSCBlock
+            Save-M365DSCPartialExport -Content $currentDSCBlock `
+                -FileName $Global:PartialExportFileName
+            $i++
+            Write-Host $Global:M365DSCEmojiGreenCheckMark
+        }
+        return $dscContent
+    }
+    catch
+    {
+        Write-Host $Global:M365DSCEmojiRedX
+
+        New-M365DSCLogEntry -Message 'Error during Export:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return ''
+    }
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.schema.mof
@@ -1,0 +1,33 @@
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementConfigurationPolicyAssignments
+{
+    [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}] String dataType;
+    [Write, Description("The type of filter of the target assignment i.e. Exclude or Include. Possible values are:none, include, exclude."), ValueMap{"none","include","exclude"}, Values{"none","include","exclude"}] String deviceAndAppManagementAssignmentFilterType;
+    [Write, Description("The Id of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterId;
+    [Write, Description("The group Id that is the target of the assignment.")] String groupId;
+    [Write, Description("The group Display Name that is the target of the assignment.")] String groupDisplayName;
+    [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
+};
+
+[ClassVersion("1.0.0.0"), FriendlyName("IntuneDeviceConfigurationPlatformScriptWindows")]
+class MSFT_IntuneDeviceConfigurationPlatformScriptWindows : OMI_BaseResource
+{
+    [Write, Description("Optional description for the device management script.")] String Description;
+    [Required, Description("Name of the device management script.")] String DisplayName;
+    [Write, Description("Indicate whether the script signature needs be checked.")] Boolean EnforceSignatureCheck;
+    [Write, Description("The script file name.")] String FileName;
+    [Write, Description("List of Scope Tag IDs for this PowerShellScript instance.")] String RoleScopeTagIds[];
+    [Write, Description("A value indicating whether the PowerShell script should run as 32-bit")] Boolean RunAs32Bit;
+    [Write, Description("Indicates the type of execution context. Possible values are: system, user."), ValueMap{"system","user"}, Values{"system","user"}] String RunAsAccount;
+    [Write, Description("The script content in Base64.")] String ScriptContent;
+    [Key, Description("The unique identifier for an entity. Read-only.")] String Id;
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
+    [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
+    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
+    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
+    [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
+    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Access token used for authentication.")] String AccessTokens[];
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/readme.md
@@ -1,0 +1,6 @@
+
+# IntuneDeviceConfigurationPlatformScriptWindows
+
+## Description
+
+Intune Device Configuration Platform Script Windows

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/settings.json
@@ -1,0 +1,17 @@
+{
+    "resourceName": "IntuneDeviceConfigurationPlatformScriptWindows",
+    "description": "This resource configures an Intune Device Configuration Platform Script Windows.",
+    "permissions":    {
+  "graph": {
+    "delegated": {
+      "read": [],
+      "update": []
+    },
+    "application": {
+      "read": [],
+      "update": []
+    }
+  }
+}
+
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationPlatformScriptMacOS/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationPlatformScriptMacOS/1-Create.ps1
@@ -1,0 +1,40 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $Credscredential
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneDeviceConfigurationPlatformScriptMacOS 'Example'
+        {
+            Assignments          = @(
+                MSFT_DeviceManagementConfigurationPolicyAssignments{
+                    deviceAndAppManagementAssignmentFilterType = 'none'
+                    dataType = '#microsoft.graph.allDevicesAssignmentTarget'
+                }
+            );
+            Credential           = $Credscredential;
+            DisplayName          = "custom";
+            Ensure               = "Present";
+            BlockExecutionNotifications = $False;
+            Description                 = "";
+            ExecutionFrequency          = "00:00:00";
+            FileName                    = "shellscript.sh";
+            Id                          = "00000000-0000-0000-0000-000000000000";
+            RetryCount                  = 0;
+            RoleScopeTagIds             = @("0");
+            RunAsAccount                = "user";
+            ScriptContent               = "Base64 encoded script content";
+            TenantId                    = $OrganizationName;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationPlatformScriptMacOS/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationPlatformScriptMacOS/2-Update.ps1
@@ -1,0 +1,40 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $Credscredential
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneDeviceConfigurationPlatformScriptMacOS 'Example'
+        {
+            Assignments          = @(
+                MSFT_DeviceManagementConfigurationPolicyAssignments{
+                    deviceAndAppManagementAssignmentFilterType = 'none'
+                    dataType = '#microsoft.graph.allDevicesAssignmentTarget'
+                }
+            );
+            Credential           = $Credscredential;
+            DisplayName          = "custom";
+            Ensure               = "Present";
+            BlockExecutionNotifications = $False;
+            Description                 = "";
+            ExecutionFrequency          = "00:00:00";
+            FileName                    = "shellscript.sh";
+            Id                          = "00000000-0000-0000-0000-000000000000";
+            RetryCount                  = 1; # Updated property
+            RoleScopeTagIds             = @("0");
+            RunAsAccount                = "user";
+            ScriptContent               = "Base64 encoded script content";
+            TenantId                    = $OrganizationName;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationPlatformScriptMacOS/3-Remove.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationPlatformScriptMacOS/3-Remove.ps1
@@ -1,0 +1,25 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $Credscredential
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneDeviceConfigurationPlatformScriptMacOS 'Example'
+        {
+            Credential           = $Credscredential;
+            DisplayName          = "custom";
+            Ensure               = "Absent";
+            Id                   = "00000000-0000-0000-0000-000000000000";
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationPlatformScriptWindows/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationPlatformScriptWindows/1-Create.ps1
@@ -1,0 +1,37 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $Credscredential
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneDeviceConfigurationPlatformScriptWindows 'Example'
+        {
+            Assignments          = @(
+                MSFT_DeviceManagementConfigurationPolicyAssignments{
+                    deviceAndAppManagementAssignmentFilterType = 'none'
+                    dataType = '#microsoft.graph.allDevicesAssignmentTarget'
+                }
+            );
+            Credential            = $Credscredential;
+            DisplayName           = "custom";
+            Ensure                = "Present";
+            EnforceSignatureCheck = $False;
+            FileName              = "script.ps1";
+            Id                    = "00000000-0000-0000-0000-000000000000";
+            RunAs32Bit            = $True;
+            RunAsAccount          = "system";
+            ScriptContent         = "Base64 encoded script content";
+            TenantId              = $OrganizationName;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationPlatformScriptWindows/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationPlatformScriptWindows/2-Update.ps1
@@ -1,0 +1,37 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $Credscredential
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneDeviceConfigurationPlatformScriptWindows 'Example'
+        {
+            Assignments          = @(
+                MSFT_DeviceManagementConfigurationPolicyAssignments{
+                    deviceAndAppManagementAssignmentFilterType = 'none'
+                    dataType = '#microsoft.graph.allDevicesAssignmentTarget'
+                }
+            );
+            Credential            = $Credscredential;
+            DisplayName           = "custom";
+            Ensure                = "Present";
+            EnforceSignatureCheck = $False;
+            FileName              = "script.ps1";
+            Id                    = "00000000-0000-0000-0000-000000000000";
+            RunAs32Bit            = $False; # Updated property
+            RunAsAccount          = "system";
+            ScriptContent         = "Base64 encoded script content";
+            TenantId              = $OrganizationName;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationPlatformScriptWindows/3-Remove.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneDeviceConfigurationPlatformScriptWindows/3-Remove.ps1
@@ -1,0 +1,26 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $Credscredential
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneDeviceConfigurationPlatformScriptWindows 'Example'
+        {
+            Credential            = $Credscredential;
+            DisplayName           = "custom";
+            Ensure                = "Absent";
+            Id                    = "00000000-0000-0000-0000-000000000000";
+            TenantId              = $OrganizationName;
+        }
+    }
+}

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationPlatformScriptMacOS.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationPlatformScriptMacOS.Tests.ps1
@@ -15,7 +15,7 @@ Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
         -Resolve)
 
 $Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
-    -DscResource "IntuneDeviceConfigurationPlatformScriptWindows" -GenericStubModule $GenericStubPath
+    -DscResource "IntuneDeviceConfigurationPlatformScriptMacOS" -GenericStubModule $GenericStubPath
 Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
     InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
         Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
@@ -33,13 +33,13 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Remove-PSSession -MockWith {
             }
 
-            Mock -CommandName Update-MgBetaDeviceManagementScript -MockWith {
+            Mock -CommandName Update-MgBetaDeviceManagementDeviceShellScript -MockWith {
             }
 
-            Mock -CommandName New-MgBetaDeviceManagementScript -MockWith {
+            Mock -CommandName New-MgBetaDeviceManagementDeviceShellScript -MockWith {
             }
 
-            Mock -CommandName Remove-MgBetaDeviceManagementScript -MockWith {
+            Mock -CommandName Remove-MgBetaDeviceManagementDeviceShellScript -MockWith {
             }
 
             Mock -CommandName New-M365DSCConnection -MockWith {
@@ -55,28 +55,27 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             $Script:exportedInstances =$null
             $Script:ExportMode = $false
 
-            Mock -CommandName Get-MgBetaDeviceManagementScriptAssignment -MockWith {
+            Mock -CommandName Get-MgBetaDeviceManagementDeviceShellScriptAssignment -MockWith {
             }
 
         }
         # Test contexts
-        Context -Name "The IntuneDeviceConfigurationPlatformScriptWindows should exist but it DOES NOT" -Fixture {
+        Context -Name "The IntuneDeviceConfigurationPlatformScriptMacOS should exist but it DOES NOT" -Fixture {
             BeforeAll {
                 $testParams = @{
+                    BlockExecutionNotifications = $True
                     Description = "FakeStringValue"
                     DisplayName = "FakeStringValue"
-                    EnforceSignatureCheck = $True
                     FileName = "FakeStringValue"
                     Id = "FakeStringValue"
                     RoleScopeTagIds = @("FakeStringValue")
-                    RunAs32Bit = $True
                     RunAsAccount = "system"
                     ScriptContent = "AAAAAAA="
                     Ensure = "Present"
                     Credential = $Credential
                 }
 
-                Mock -CommandName Get-MgBetaDeviceManagementScript -MockWith {
+                Mock -CommandName Get-MgBetaDeviceManagementDeviceShellScript -MockWith {
                     return $null
                 }
             }
@@ -88,38 +87,36 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
             It 'Should Create the group from the Set method' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName New-MgBetaDeviceManagementScript -Exactly 1
+                Should -Invoke -CommandName New-MgBetaDeviceManagementDeviceShellScript -Exactly 1
             }
         }
 
-        Context -Name "The IntuneDeviceConfigurationPlatformScriptWindows exists but it SHOULD NOT" -Fixture {
+        Context -Name "The IntuneDeviceConfigurationPlatformScriptMacOS exists but it SHOULD NOT" -Fixture {
             BeforeAll {
                 $testParams = @{
+                    BlockExecutionNotifications = $True
                     Description = "FakeStringValue"
                     DisplayName = "FakeStringValue"
-                    EnforceSignatureCheck = $True
                     FileName = "FakeStringValue"
                     Id = "FakeStringValue"
                     RoleScopeTagIds = @("FakeStringValue")
-                    RunAs32Bit = $True
                     RunAsAccount = "system"
                     ScriptContent = "AAAAAAA="
                     Ensure = 'Absent'
                     Credential = $Credential
                 }
 
-                Mock -CommandName Get-MgBetaDeviceManagementScript -MockWith {
+                Mock -CommandName Get-MgBetaDeviceManagementDeviceShellScript -MockWith {
                     return @{
                         AdditionalProperties = @{
-                            '@odata.type' = "#microsoft.graph.DeviceManagementScript"
+                            '@odata.type' = "#microsoft.graph.DeviceShellScript"
                         }
+                        BlockExecutionNotifications = $True
                         Description = "FakeStringValue"
                         DisplayName = "FakeStringValue"
-                        EnforceSignatureCheck = $True
                         FileName = "FakeStringValue"
                         Id = "FakeStringValue"
                         RoleScopeTagIds = @("FakeStringValue")
-                        RunAs32Bit = $True
                         RunAsAccount = "system"
                         ScriptContent = [byte[]]::new(5)
                     }
@@ -136,37 +133,36 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should Remove the group from the Set method' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName Remove-MgBetaDeviceManagementScript -Exactly 1
+                Should -Invoke -CommandName Remove-MgBetaDeviceManagementDeviceShellScript -Exactly 1
             }
         }
-        Context -Name "The IntuneDeviceConfigurationPlatformScriptWindows Exists and Values are already in the desired state" -Fixture {
+        Context -Name "The IntuneDeviceConfigurationPlatformScriptMacOS Exists and Values are already in the desired state" -Fixture {
             BeforeAll {
                 $testParams = @{
+                    BlockExecutionNotifications = $True
                     Description = "FakeStringValue"
                     DisplayName = "FakeStringValue"
-                    EnforceSignatureCheck = $True
                     FileName = "FakeStringValue"
                     Id = "FakeStringValue"
                     RoleScopeTagIds = @("FakeStringValue")
-                    RunAs32Bit = $True
                     RunAsAccount = "system"
                     ScriptContent = "AAAAAAA="
                     Ensure = 'Present'
                     Credential = $Credential
                 }
 
-                Mock -CommandName Get-MgBetaDeviceManagementScript -MockWith {
+                Mock -CommandName Get-MgBetaDeviceManagementDeviceShellScript -MockWith {
                     return @{
                         AdditionalProperties = @{
-                            '@odata.type' = "#microsoft.graph.DeviceManagementScript"
+                            '@odata.type' = "#microsoft.graph.DeviceShellScript"
                         }
+                        BlockExecutionNotifications = $True
                         Description = "FakeStringValue"
                         DisplayName = "FakeStringValue"
-                        EnforceSignatureCheck = $True
                         FileName = "FakeStringValue"
                         Id = "FakeStringValue"
+                        LastModifiedDateTime = "2023-01-01T00:00:00.0000000+01:00"
                         RoleScopeTagIds = @("FakeStringValue")
-                        RunAs32Bit = $True
                         RunAsAccount = "system"
                         ScriptContent = [byte[]]::new(5)
                     }
@@ -179,28 +175,30 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
         }
 
-        Context -Name "The IntuneDeviceConfigurationPlatformScriptWindows exists and values are NOT in the desired state" -Fixture {
+        Context -Name "The IntuneDeviceConfigurationPlatformScriptMacOS exists and values are NOT in the desired state" -Fixture {
             BeforeAll {
                 $testParams = @{
+                    BlockExecutionNotifications = $True
                     Description = "FakeStringValue"
                     DisplayName = "FakeStringValue"
-                    EnforceSignatureCheck = $True
                     FileName = "FakeStringValue"
                     Id = "FakeStringValue"
                     RoleScopeTagIds = @("FakeStringValue")
-                    RunAs32Bit = $True
                     RunAsAccount = "system"
                     ScriptContent = "AAAAAAA="
                     Ensure = 'Present'
                     Credential = $Credential
                 }
 
-                Mock -CommandName Get-MgBetaDeviceManagementScript -MockWith {
+                Mock -CommandName Get-MgBetaDeviceManagementDeviceShellScript -MockWith {
                     return @{
+                        CreatedDateTime = "2023-01-01T00:00:00.0000000+01:00"
                         Description = "FakeStringValue"
                         DisplayName = "FakeStringValue"
                         FileName = "FakeStringValue"
                         Id = "FakeStringValue"
+                        LastModifiedDateTime = "2023-01-01T00:00:00.0000000+01:00"
+                        RetryCount = 7
                         RoleScopeTagIds = @("FakeStringValue")
                         RunAsAccount = "system"
                         ScriptContent = [byte[]]::new(5)
@@ -218,7 +216,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should call the Set method' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName Update-MgBetaDeviceManagementScript -Exactly 1
+                Should -Invoke -CommandName Update-MgBetaDeviceManagementDeviceShellScript -Exactly 1
             }
         }
 
@@ -230,20 +228,17 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Credential = $Credential
                 }
 
-                Mock -CommandName Get-MgBetaDeviceManagementScript -MockWith {
+                Mock -CommandName Get-MgBetaDeviceManagementDeviceShellScript -MockWith {
                     return @{
                         AdditionalProperties = @{
-                            '@odata.type' = "#microsoft.graph.DeviceManagementScript"
+                            '@odata.type' = "#microsoft.graph.DeviceShellScript"
                         }
-                        CreatedDateTime = "2023-01-01T00:00:00.0000000+01:00"
+                        BlockExecutionNotifications = $True
                         Description = "FakeStringValue"
                         DisplayName = "FakeStringValue"
-                        EnforceSignatureCheck = $True
                         FileName = "FakeStringValue"
                         Id = "FakeStringValue"
-                        LastModifiedDateTime = "2023-01-01T00:00:00.0000000+01:00"
                         RoleScopeTagIds = @("FakeStringValue")
-                        RunAs32Bit = $True
                         RunAsAccount = "system"
                         ScriptContent = [byte[]]::new(5)
                     }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationPlatformScriptWindows.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationPlatformScriptWindows.Tests.ps1
@@ -1,0 +1,260 @@
+[CmdletBinding()]
+param(
+)
+$M365DSCTestFolder = Join-Path -Path $PSScriptRoot `
+                        -ChildPath '..\..\Unit' `
+                        -Resolve
+$CmdletModule = (Join-Path -Path $M365DSCTestFolder `
+            -ChildPath '\Stubs\Microsoft365.psm1' `
+            -Resolve)
+$GenericStubPath = (Join-Path -Path $M365DSCTestFolder `
+    -ChildPath '\Stubs\Generic.psm1' `
+    -Resolve)
+Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\UnitTestHelper.psm1' `
+        -Resolve)
+
+$Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
+    -DscResource "IntuneDeviceConfigurationPlatformScriptWindows" -GenericStubModule $GenericStubPath
+Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
+        BeforeAll {
+
+            $secpasswd = ConvertTo-SecureString (New-Guid | Out-String) -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
+
+            Mock -CommandName Confirm-M365DSCDependencies -MockWith {
+            }
+
+            Mock -CommandName Get-PSSession -MockWith {
+            }
+
+            Mock -CommandName Remove-PSSession -MockWith {
+            }
+
+            Mock -CommandName Update-MgBetaDeviceManagementScript -MockWith {
+            }
+
+            Mock -CommandName New-MgBetaDeviceManagementScript -MockWith {
+            }
+
+            Mock -CommandName Remove-MgBetaDeviceManagementScript -MockWith {
+            }
+
+            Mock -CommandName New-M365DSCConnection -MockWith {
+                return "Credentials"
+            }
+
+            Mock -CommandName Update-DeviceConfigurationPolicyAssignment -MockWith {
+            }
+
+            # Mock Write-Host to hide output during the tests
+            Mock -CommandName Write-Host -MockWith {
+            }
+            $Script:exportedInstances =$null
+            $Script:ExportMode = $false
+
+            Mock -CommandName Get-MgBetaDeviceManagementScriptAssignment -MockWith {
+            }
+
+        }
+        # Test contexts
+        Context -Name "The IntuneDeviceConfigurationPlatformScriptWindows should exist but it DOES NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Description = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    EnforceSignatureCheck = $True
+                    FileName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    RunAs32Bit = $True
+                    RunAsAccount = "system"
+                    ScriptContent = "AAAAAAA="
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+
+                Mock -CommandName Get-MgBetaDeviceManagementScript -MockWith {
+                    return $null
+                }
+            }
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
+            }
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+            It 'Should Create the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName New-MgBetaDeviceManagementScript -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneDeviceConfigurationPlatformScriptWindows exists but it SHOULD NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Description = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    EnforceSignatureCheck = $True
+                    FileName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    RunAs32Bit = $True
+                    RunAsAccount = "system"
+                    ScriptContent = "AAAAAAA="
+                    Ensure = 'Absent'
+                    Credential = $Credential;
+                }
+
+                Mock -CommandName Get-MgBetaDeviceManagementScript -MockWith {
+                    return @{
+                        AdditionalProperties = @{
+                            '@odata.type' = "#microsoft.graph.DeviceManagementScript"
+                        }
+                        Description = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                        EnforceSignatureCheck = $True
+                        FileName = "FakeStringValue"
+                        Id = "FakeStringValue"
+                        RoleScopeTagIds = @("FakeStringValue")
+                        RunAs32Bit = $True
+                        RunAsAccount = "system"
+                        ScriptContent = [byte[]]::new(5)
+                    }
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should Remove the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Remove-MgBetaDeviceManagementScript -Exactly 1
+            }
+        }
+        Context -Name "The IntuneDeviceConfigurationPlatformScriptWindows Exists and Values are already in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Description = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    EnforceSignatureCheck = $True
+                    FileName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    RunAs32Bit = $True
+                    RunAsAccount = "system"
+                    ScriptContent = "AAAAAAA="
+                    Ensure = 'Present'
+                    Credential = $Credential;
+                }
+
+                Mock -CommandName Get-MgBetaDeviceManagementScript -MockWith {
+                    return @{
+                        AdditionalProperties = @{
+                            '@odata.type' = "#microsoft.graph.DeviceManagementScript"
+                        }
+                        Description = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                        EnforceSignatureCheck = $True
+                        FileName = "FakeStringValue"
+                        Id = "FakeStringValue"
+                        RoleScopeTagIds = @("FakeStringValue")
+                        RunAs32Bit = $True
+                        RunAsAccount = "system"
+                        ScriptContent = [byte[]]::new(5)
+                    }
+                }
+            }
+
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+        }
+
+        Context -Name "The IntuneDeviceConfigurationPlatformScriptWindows exists and values are NOT in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Description = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    EnforceSignatureCheck = $True
+                    FileName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    RunAs32Bit = $True
+                    RunAsAccount = "system"
+                    ScriptContent = "AAAAAAA="
+                    Ensure = 'Present'
+                    Credential = $Credential;
+                }
+
+                Mock -CommandName Get-MgBetaDeviceManagementScript -MockWith {
+                    return @{
+                        Description = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                        FileName = "FakeStringValue"
+                        Id = "FakeStringValue"
+                        RoleScopeTagIds = @("FakeStringValue")
+                        RunAsAccount = "system"
+                        ScriptContent = [byte[]]::new(5)
+                    }
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Update-MgBetaDeviceManagementScript -Exactly 1
+            }
+        }
+
+        Context -Name 'ReverseDSC Tests' -Fixture {
+            BeforeAll {
+                $Global:CurrentModeIsExport = $true
+                $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
+                $testParams = @{
+                    Credential = $Credential
+                }
+
+                Mock -CommandName Get-MgBetaDeviceManagementScript -MockWith {
+                    return @{
+                        AdditionalProperties = @{
+                            '@odata.type' = "#microsoft.graph.DeviceManagementScript"
+                        }
+                        CreatedDateTime = "2023-01-01T00:00:00.0000000+01:00"
+                        Description = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                        EnforceSignatureCheck = $True
+                        FileName = "FakeStringValue"
+                        Id = "FakeStringValue"
+                        LastModifiedDateTime = "2023-01-01T00:00:00.0000000+01:00"
+                        RoleScopeTagIds = @("FakeStringValue")
+                        RunAs32Bit = $True
+                        RunAsAccount = "system"
+                        ScriptContent = [byte[]]::new(5)
+                    }
+                }
+            }
+            It 'Should Reverse Engineer resource from the Export method' {
+                $result = Export-TargetResource @testParams
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}
+
+Invoke-Command -ScriptBlock $Global:DscHelper.CleanupScript -NoNewScope

--- a/Tests/Unit/Stubs/Microsoft365.psm1
+++ b/Tests/Unit/Stubs/Microsoft365.psm1
@@ -82188,3 +82188,933 @@ function Remove-MgBetaDirectoryRoleMemberDirectoryObjectByRef
         $Confirm
     )
 }
+#region MgBetaDeviceManagementScript
+function Get-MgBetaDeviceManagementScript
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $DeviceManagementScriptId,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [System.String[]]
+        $ExpandProperty,
+
+        [Parameter()]
+        [System.String[]]
+        $Property,
+
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.String]
+        $Search,
+
+        [Parameter()]
+        [System.Int32]
+        $Skip,
+
+        [Parameter()]
+        [System.String[]]
+        $Sort,
+
+        [Parameter()]
+        [System.Int32]
+        $Top,
+
+        [Parameter()]
+        [System.String]
+        $ResponseHeadersVariable,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Int32]
+        $PageSize,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $All,
+
+        [Parameter()]
+        [System.String]
+        $CountVariable
+    )
+}
+
+function New-MgBetaDeviceManagementScript
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [PSObject]
+        $BodyParameter,
+
+        [Parameter()]
+        [System.String]
+        $ResponseHeadersVariable,
+
+        [Parameter()]
+        [System.Collections.Hashtable]
+        $AdditionalProperties,
+
+        [Parameter()]
+        [PSObject[]]
+        $Assignments,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [PSObject[]]
+        $DeviceRunStates,
+
+        [Parameter()]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $EnforceSignatureCheck,
+
+        [Parameter()]
+        [System.String]
+        $FileName,
+
+        [Parameter()]
+        [PSObject[]]
+        $GroupAssignments,
+
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $RunAs32Bit,
+
+        [Parameter()]
+        [PSObject]
+        $RunAsAccount,
+
+        [Parameter()]
+        [PSObject]
+        $RunSummary,
+
+        [Parameter()]
+        [System.String]
+        $ScriptContentInputFile,
+
+        [Parameter()]
+        [PSObject[]]
+        $UserRunStates,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm
+    )
+}
+
+function Remove-MgBetaDeviceManagementScript
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $DeviceManagementScriptId,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [System.String]
+        $ResponseHeadersVariable,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $PassThru,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm
+    )
+}
+
+function Update-MgBetaDeviceManagementScript
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $DeviceManagementScriptId,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [PSObject]
+        $BodyParameter,
+
+        [Parameter()]
+        [System.String]
+        $ResponseHeadersVariable,
+
+        [Parameter()]
+        [System.Collections.Hashtable]
+        $AdditionalProperties,
+
+        [Parameter()]
+        [PSObject[]]
+        $Assignments,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [PSObject[]]
+        $DeviceRunStates,
+
+        [Parameter()]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $EnforceSignatureCheck,
+
+        [Parameter()]
+        [System.String]
+        $FileName,
+
+        [Parameter()]
+        [PSObject[]]
+        $GroupAssignments,
+
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $RunAs32Bit,
+
+        [Parameter()]
+        [PSObject]
+        $RunAsAccount,
+
+        [Parameter()]
+        [PSObject]
+        $RunSummary,
+
+        [Parameter()]
+        [System.String]
+        $ScriptContentInputFile,
+
+        [Parameter()]
+        [PSObject[]]
+        $UserRunStates,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm
+    )
+}
+
+#endregion
+
+#region MgBetaDeviceManagementScriptAssignment
+function Get-MgBetaDeviceManagementScriptAssignment
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $DeviceManagementScriptAssignmentId,
+
+        [Parameter()]
+        [System.String]
+        $DeviceManagementScriptId,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [System.String[]]
+        $ExpandProperty,
+
+        [Parameter()]
+        [System.String[]]
+        $Property,
+
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.String]
+        $Search,
+
+        [Parameter()]
+        [System.Int32]
+        $Skip,
+
+        [Parameter()]
+        [System.String[]]
+        $Sort,
+
+        [Parameter()]
+        [System.Int32]
+        $Top,
+
+        [Parameter()]
+        [System.String]
+        $ResponseHeadersVariable,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Int32]
+        $PageSize,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $All,
+
+        [Parameter()]
+        [System.String]
+        $CountVariable
+    )
+}
+
+#endregion
+
+#region MgBetaDeviceManagementDeviceShellScript
+function Get-MgBetaDeviceManagementDeviceShellScript
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $DeviceShellScriptId,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [System.String[]]
+        $ExpandProperty,
+
+        [Parameter()]
+        [System.String[]]
+        $Property,
+
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.String]
+        $Search,
+
+        [Parameter()]
+        [System.Int32]
+        $Skip,
+
+        [Parameter()]
+        [System.String[]]
+        $Sort,
+
+        [Parameter()]
+        [System.Int32]
+        $Top,
+
+        [Parameter()]
+        [System.String]
+        $ResponseHeadersVariable,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Int32]
+        $PageSize,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $All,
+
+        [Parameter()]
+        [System.String]
+        $CountVariable
+    )
+}
+
+function New-MgBetaDeviceManagementDeviceShellScript
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [PSObject]
+        $BodyParameter,
+
+        [Parameter()]
+        [System.String]
+        $ResponseHeadersVariable,
+
+        [Parameter()]
+        [System.Collections.Hashtable]
+        $AdditionalProperties,
+
+        [Parameter()]
+        [PSObject[]]
+        $Assignments,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $BlockExecutionNotifications,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [PSObject[]]
+        $DeviceRunStates,
+
+        [Parameter()]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.TimeSpan]
+        $ExecutionFrequency,
+
+        [Parameter()]
+        [System.String]
+        $FileName,
+
+        [Parameter()]
+        [PSObject[]]
+        $GroupAssignments,
+
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [System.Int32]
+        $RetryCount,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [PSObject]
+        $RunAsAccount,
+
+        [Parameter()]
+        [PSObject]
+        $RunSummary,
+
+        [Parameter()]
+        [System.String]
+        $ScriptContentInputFile,
+
+        [Parameter()]
+        [PSObject[]]
+        $UserRunStates,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm
+    )
+}
+
+function Remove-MgBetaDeviceManagementDeviceShellScript
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $DeviceShellScriptId,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [System.String]
+        $ResponseHeadersVariable,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $PassThru,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm
+    )
+}
+
+function Update-MgBetaDeviceManagementDeviceShellScript
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $DeviceShellScriptId,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [PSObject]
+        $BodyParameter,
+
+        [Parameter()]
+        [System.String]
+        $ResponseHeadersVariable,
+
+        [Parameter()]
+        [System.Collections.Hashtable]
+        $AdditionalProperties,
+
+        [Parameter()]
+        [PSObject[]]
+        $Assignments,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $BlockExecutionNotifications,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [PSObject[]]
+        $DeviceRunStates,
+
+        [Parameter()]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.TimeSpan]
+        $ExecutionFrequency,
+
+        [Parameter()]
+        [System.String]
+        $FileName,
+
+        [Parameter()]
+        [PSObject[]]
+        $GroupAssignments,
+
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [System.Int32]
+        $RetryCount,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [PSObject]
+        $RunAsAccount,
+
+        [Parameter()]
+        [PSObject]
+        $RunSummary,
+
+        [Parameter()]
+        [System.String]
+        $ScriptContentInputFile,
+
+        [Parameter()]
+        [PSObject[]]
+        $UserRunStates,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm
+    )
+}
+
+#endregion
+
+#region MgBetaDeviceManagementDeviceShellScriptAssignment
+function Get-MgBetaDeviceManagementDeviceShellScriptAssignment
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $DeviceManagementScriptAssignmentId,
+
+        [Parameter()]
+        [System.String]
+        $DeviceShellScriptId,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [System.String[]]
+        $ExpandProperty,
+
+        [Parameter()]
+        [System.String[]]
+        $Property,
+
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.String]
+        $Search,
+
+        [Parameter()]
+        [System.Int32]
+        $Skip,
+
+        [Parameter()]
+        [System.String[]]
+        $Sort,
+
+        [Parameter()]
+        [System.Int32]
+        $Top,
+
+        [Parameter()]
+        [System.String]
+        $ResponseHeadersVariable,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelineAppend,
+
+        [Parameter()]
+        [PSObject[]]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.Int32]
+        $PageSize,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $All,
+
+        [Parameter()]
+        [System.String]
+        $CountVariable
+    )
+}
+
+#endregion
+


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request adds two new resources to the Intune workload: `IntuneDeviceConfigurationPlatformScriptWindows` and `IntuneDeviceConfigurationPlatformScriptMacOS`. Support for Linux is still missing, but I don't have that on my production tenant, only on my test tenant.

#### This Pull Request (PR) fixes the following issues
- Fixes #4157
