### PR TITLE
SPOTenantCdnPolicy: Export properties as empty arrays if in the tenant they are empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* SPOTenantCdnPolicy
+  * If properties in the tenant are empty then export them as empty arrays
+    instead of null strings, missed while fixing #4658
+
 # 1.24.515.2
 
 * EXOManagementRoleEntry

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantCdnPolicy/MSFT_SPOTenantCdnPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantCdnPolicy/MSFT_SPOTenantCdnPolicy.psm1
@@ -77,23 +77,23 @@ function Get-TargetResource
     try
     {
         $Policies = Get-PnPTenantCdnPolicies -CdnType $CDNType -ErrorAction Stop
-        if ($null -ne $Policies['ExcludeRestrictedSiteClassifications'])
+        if ($Policies['ExcludeRestrictedSiteClassifications'].Length -gt 0)
         {
             $ExcludeRestrictedSiteClassifications = `
                 $Policies['ExcludeRestrictedSiteClassifications'].Split(',')
         }
         else
         {
-            $ExcludeRestrictedSiteClassifications = $null
+            $ExcludeRestrictedSiteClassifications = @()
         }
-        if ($null -ne $Policies['IncludeFileExtensions'])
+        if ($Policies['IncludeFileExtensions'].Length -gt 0)
         {
             $IncludeFileExtensions = `
                 $Policies['IncludeFileExtensions'].Split(',')
         }
         else
         {
-            $IncludeFileExtensions = $null
+            $IncludeFileExtensions = @()
         }
 
         return @{


### PR DESCRIPTION
#### Pull Request (PR) description

It seems I missed this while fixing #4658.

If *IncludeFileExtensions* or *ExcludeRestrictedSiteClassifications* are null in the tenant they are currently being exported as null to the blueprint, but these properties in DSC side are declared as string arrays so when we call *Compare-Object* against these properties in the blueprint (and they are assigned with an empty array) and the tenant properties (which might be null strings) then it will return that the objects differ and therefore will try to make a change with a null value.

As explained in my original issue the cmdlet *Set-PnPTenantCdnPolicy* doesn't work with a null *PolicyValue* so calling it that way will result in an error, this PR doesn't fix the issue with the cmdlet but at least the comparison will work correctly avoiding the call to the cmdlet in this specific case and therefore also avoiding the error.

#### This Pull Request (PR) fixes the following issues

