### PR TITLE
Fix blueprint export configuration name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCUtil
+  * Fixed an issue in `Assert-M365DSCBlueprint` where the clone and export
+    of a blueprint with a GUID could lead to configuration name starting
+    with a digit instead of a letter.  
+    Partially fixes [#4681](https://github.com/microsoft/Microsoft365DSC/issues/4681)
+
 # 1.24.515.2
 
 * EXOManagementRoleEntry

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2720,7 +2720,7 @@ function Assert-M365DSCBlueprint
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    $TempBluePrintName = (New-Guid).ToString() + '.M365'
+    $TempBluePrintName = 'TempBlueprint_' + (New-Guid).ToString() + '.M365'
     $LocalBluePrintPath = Join-Path -Path $env:Temp -ChildPath $TempBluePrintName
     try
     {
@@ -2793,7 +2793,7 @@ function Assert-M365DSCBlueprint
         # Call the Export-M365DSCConfiguration cmdlet to extract only the resource
         # types contained within the BluePrint;
         Write-Host "Initiating the Export of those ($($ResourcesInBluePrint.Length)) components from the tenant..."
-        $TempExportName = (New-Guid).ToString() + '.ps1'
+        $TempExportName = 'TempExport_' + (New-Guid).ToString() + '.ps1'
         Export-M365DSCConfiguration -Components $ResourcesInBluePrint `
             -Path $env:temp `
             -FileName $TempExportName `


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request addresses an issue where the `Assert-M365DSCBlueprint` function would create a GUID for a temporary configuration export and the GUID starts with a digit instead of a letter. The PowerShell configuration parser requires that a configuration name starts with a letter, therefore the call would fail when detecting the configuration and report that the entire configuration has drifted (which is not true). 

#### This Pull Request (PR) fixes the following issues
- Partially fixes #4681 
