### PR TITLE
SPOTenantSettings: Remove property UserVoiceForFeedbackEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* SPOTenantSettings
+  * Remove property UserVoiceForFeedbackEnabled when setting the resource since
+    it has been deprecated
+
 # 1.24.515.2
 
 * EXOManagementRoleEntry

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
@@ -413,6 +413,11 @@ function Set-TargetResource
     $CurrentParameters.Remove('AccessTokens') | Out-Null
 
     $CurrentParameters.Remove('TenantDefaultTimezone') | Out-Null # this one is updated separately using Graph
+    if ($CurrentParameters.Keys.Contains('UserVoiceForFeedbackEnabled'))
+    {
+        Write-Verbose -Message 'Property UserVoiceForFeedbackEnabled is not supported, removing it'
+        $CurrentParameters.Remove('UserVoiceForFeedbackEnabled') | Out-Null
+    }
 
     if ($PublicCdnEnabled -eq $false)
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
@@ -415,7 +415,7 @@ function Set-TargetResource
     $CurrentParameters.Remove('TenantDefaultTimezone') | Out-Null # this one is updated separately using Graph
     if ($CurrentParameters.Keys.Contains('UserVoiceForFeedbackEnabled'))
     {
-        Write-Verbose -Message 'Property UserVoiceForFeedbackEnabled is not supported, removing it'
+        Write-Verbose -Message 'Property UserVoiceForFeedbackEnabled is deprecated, removing it'
         $CurrentParameters.Remove('UserVoiceForFeedbackEnabled') | Out-Null
     }
 


### PR DESCRIPTION
#### Pull Request (PR) description

While running my integration tests I noticed an error message on *SPOTenantSettings* when setting property *UserVoiceForFeedbackEnabled*, although it still can export without issues. After reporting this problem on the PnPPS repo it looks like the property is deprecated, see https://github.com/pnp/powershell/issues/3963, so this PR fixes that by removing the property while setting the resource and showing a verbose message in the log about it.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
