### PR TITLE
IntuneDeviceEnrollmentStatusPageWindows10: Return all authentication methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 # UNRELEASED
 
 * IntuneDeviceConfigurationPlatformScriptWindows
-  * Initial Release  
+  * Initial Release
   FIXES [#4157](https://github.com/microsoft/Microsoft365DSC/issues/4157)
 * IntuneDeviceConfigurationPlatformScriptMacOS
-  * Initial Release  
+  * Initial Release
   FIXES [#4157](https://github.com/microsoft/Microsoft365DSC/issues/4157)
+* IntuneDeviceEnrollmentStatusPageWindows10
+  * Return all authentication methods when retrieving the policies otherwise
+    it may fail deducing the OrganizationName via TenantId
 * SPOTenantCdnPolicy
   * If properties in the tenant are empty then export them as empty arrays
     instead of null strings, missed while fixing #4658
@@ -17,7 +20,7 @@
 * M365DSCUtil
   * Fixed an issue in `Assert-M365DSCBlueprint` where the clone and export
     of a blueprint with a GUID could lead to configuration name starting
-    with a digit instead of a letter.  
+    with a digit instead of a letter.
     Partially fixes [#4681](https://github.com/microsoft/Microsoft365DSC/issues/4681)
 
 # 1.24.515.2

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1
@@ -192,6 +192,12 @@ function Get-TargetResource
             DisplayName                             = $getValue.DisplayName
             Id                                      = $getValue.Id
             Ensure                                  = 'Present'
+            Credential                              = $Credential
+            ApplicationId                           = $ApplicationId
+            TenantId                                = $TenantId
+            ApplicationSecret                       = $ApplicationSecret
+            CertificateThumbprint                   = $CertificateThumbprint
+            ManagedIdentity                         = $ManagedIdentity.IsPresent
             AccessTokens                            = $AccessTokens
             #endregion
         }


### PR DESCRIPTION
#### Pull Request (PR) description

*IntuneDeviceEnrollmentStatusPageWindows10* doesn't return all authentication methods on Get nor TenantId, currently only AccessTokens is returned. This may fail deducing the OrganizationName via TenantId, which is null, just like it's currently happening to me. The fix is to just return all authentication methods on Get.

The error message taken from the event log is the following:

```
{ You cannot call a method on a null-valued expression. } \ at Get-M365DSCExportContentForResource, C:\Program Files\WindowsPowerShell\Modules\Microsoft365DSC\1.24.515.2\Modules\M365DSCUtil.psm1: line 3554
 \ at Export-TargetResource, C:\Program Files\WindowsPowerShell\Modules\Microsoft365DSC\1.24.515.2\DSCResources\MSFT_IntuneDeviceEnrollmentStatusPageWindows10\MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1: line 778
 \ at Start-M365DSCConfigurationExtract, C:\Program Files\WindowsPowerShell\Modules\Microsoft365DSC\1.24.515.2\Modules\M365DSCReverse.psm1: line 677
 \ at Export-M365DSCConfiguration, C:\Program Files\WindowsPowerShell\Modules\Microsoft365DSC\1.24.515.2\Modules\M365DSCUtil.psm1: line 1375
 \ at <ScriptBlock>, D:\a\1\s\Source\Scripts\TestADOConnectivity.ps1: line 124
 \ at <ScriptBlock>, D:\a\_temp\169d254d-e56a-41a6-9741-a145801e34b3.ps1: line 37
 \ at <ScriptBlock>, <No file>: line 1
```

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
