### PR TITLE
Fix missing default policy export of enrollment platform restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * IntuneDeviceConfigurationPlatformScriptMacOS
   * Initial Release  
   FIXES [#4157](https://github.com/microsoft/Microsoft365DSC/issues/4157)
+* IntuneDeviceEnrollmentPlatformRestriction
+  * Fix missing export of the default policy  
+  FIXES [#4694](https://github.com/microsoft/Microsoft365DSC/issues/4694)
 * SPOTenantCdnPolicy
   * If properties in the tenant are empty then export them as empty arrays
     instead of null strings, missed while fixing #4658

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentPlatformRestriction/MSFT_IntuneDeviceEnrollmentPlatformRestriction.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentPlatformRestriction/MSFT_IntuneDeviceEnrollmentPlatformRestriction.psm1
@@ -712,7 +712,7 @@ function Export-TargetResource
     try
     {
         [array]$configs = Get-MgBetaDeviceManagementDeviceEnrollmentConfiguration -Filter $Filter -All `
-            -ErrorAction Stop | Where-Object -FilterScript { $_.DeviceEnrollmentConfigurationType -eq 'singlePlatformRestriction' }
+            -ErrorAction Stop | Where-Object -FilterScript { $_.DeviceEnrollmentConfigurationType -like '*platformRestriction*' }
 
         $i = 1
         $dscContent = ''
@@ -792,6 +792,7 @@ function Export-TargetResource
                     $Results.Remove('WindowsHomeSkuRestriction') | Out-Null
                 }
             }
+
             if ($null -ne $Results.WindowsMobileRestriction)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject ($Results.WindowsMobileRestriction) -CIMInstanceName DeviceEnrollmentPlatformRestriction


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request fixes an issue where the default policy of the `IntuneDeviceEnrollmentPlatformRestriction` resource was not exported. This is due to a refactoring, where the export was not properly updated to represent all of the configuration types associated with the platform restrictions. 

#### This Pull Request (PR) fixes the following issues
- Fixes #4694 