### PR TITLE
AADConditionalAccessPolicy: Fix get method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* AADConditionalAccessPolicy
+  * Fix get method if value is null instead of false
+
 # 1.24.522.1
 
 * IntuneDeviceConfigurationPlatformScriptWindows
@@ -9,16 +14,16 @@
   * Initial Release
   FIXES [#4157](https://github.com/microsoft/Microsoft365DSC/issues/4157)
 * IntuneDeviceEnrollmentPlatformRestriction
-  * Fix missing export of the default policy  
+  * Fix missing export of the default policy
   FIXES [#4694](https://github.com/microsoft/Microsoft365DSC/issues/4694)
 * IntuneDeviceEnrollmentStatusPageWindows10
   * Return all authentication methods when retrieving the policies otherwise
     it may fail deducing the OrganizationName via TenantId
 * IntuneDeviceRemediation
-  * Initial Release  
+  * Initial Release
     FIXES [#4159](https://github.com/microsoft/Microsoft365DSC/issues/4159)
 * IntuneWindowsUpdateForBusinessDriverUpdateProfileWindows10
-  * Initial Release  
+  * Initial Release
     FIXES [#3747](https://github.com/microsoft/Microsoft365DSC/issues/3747)
 * SPOTenantCdnPolicy
   * If properties in the tenant are empty then export them as empty arrays

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -661,20 +661,20 @@ function Get-TargetResource
         BuiltInControls                          = [System.String[]](@() + $Policy.GrantControls.BuiltInControls)
         CustomAuthenticationFactors              = [System.String[]](@() + $Policy.GrantControls.CustomAuthenticationFactors)
         #no translation needed, return empty string array if undefined
-        ApplicationEnforcedRestrictionsIsEnabled = $Policy.SessionControls.ApplicationEnforcedRestrictions.IsEnabled
+        ApplicationEnforcedRestrictionsIsEnabled = $false -or $Policy.SessionControls.ApplicationEnforcedRestrictions.IsEnabled
         #make false if undefined, true if true
-        CloudAppSecurityIsEnabled                = $Policy.SessionControls.CloudAppSecurity.IsEnabled
+        CloudAppSecurityIsEnabled                = $false -or $Policy.SessionControls.CloudAppSecurity.IsEnabled
         #make false if undefined, true if true
         CloudAppSecurityType                     = [System.String]$Policy.SessionControls.CloudAppSecurity.CloudAppSecurityType
         #no translation needed, return empty string array if undefined
-        SignInFrequencyIsEnabled                 = $Policy.SessionControls.SignInFrequency.IsEnabled
+        SignInFrequencyIsEnabled                 = $false -or $Policy.SessionControls.SignInFrequency.IsEnabled
         #make false if undefined, true if true
         SignInFrequencyValue                     = $Policy.SessionControls.SignInFrequency.Value
         #no translation or conversion needed, $null returned if undefined
         SignInFrequencyType                      = [System.String]$Policy.SessionControls.SignInFrequency.Type
         SignInFrequencyInterval                  = $SignInFrequencyIntervalValue
         #no translation needed
-        PersistentBrowserIsEnabled               = $Policy.SessionControls.PersistentBrowser.IsEnabled
+        PersistentBrowserIsEnabled               = $false -or $Policy.SessionControls.PersistentBrowser.IsEnabled
         #make false if undefined, true if true
         PersistentBrowserMode                    = [System.String]$Policy.SessionControls.PersistentBrowser.Mode
         #no translation needed


### PR DESCRIPTION
#### Pull Request (PR) description
Get-MgBetaIdentityConditionalAccessPolicy returns null for these parameters if they are false: CloudAppSecurityIsEnabled, SignInFrequencyIsEnabled, ApplicationEnforcedRestrictionsIsEnabled, PersistentBrowserIsEnabled.

This PR replaces the null value output of the cmdlet with false.

#### This Pull Request (PR) fixes the following issues
None
