### PR TITLE
Add JSON conversion to app configuration device policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * IntuneAppConfigurationDevicePolicy
   * Add assignment group display name and fix compilation
     FIXES [#4724](https://github.com/microsoft/Microsoft365DSC/issues/4724)
+  * Add conversion from `payloadJson` to actual JSON.
 * M365DSCResourceGenerator
   * Add support for generating Intune settings catalog policies
 * M365DSCDRGUtil

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationDevicePolicy/MSFT_IntuneAppConfigurationDevicePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationDevicePolicy/MSFT_IntuneAppConfigurationDevicePolicy.psm1
@@ -200,11 +200,17 @@ function Get-TargetResource
             }
         }
 
+        $payloadJson = $null
+        if (-not [System.String]::IsNullOrEmpty($getValue.AdditionalProperties.payloadJson))
+        {
+            $payloadJson = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($getValue.AdditionalProperties.payloadJson))
+        }
+
         $results = @{
             #region resource generator code
             ConnectedAppsEnabled  = $getValue.AdditionalProperties.connectedAppsEnabled
             PackageId             = $getValue.AdditionalProperties.packageId
-            PayloadJson           = $getValue.AdditionalProperties.payloadJson
+            PayloadJson           = $payloadJson
             PermissionActions     = $complexPermissionActions
             ProfileApplicability  = $enumProfileApplicability
             EncodedSettingXml     = $getValue.AdditionalProperties.encodedSettingXml
@@ -360,6 +366,11 @@ function Set-TargetResource
     if ($BoundParameters.ContainsKey('EncodedSettingXml') -or $BoundParameters.ContainsKey('Settings'))
     {
         $platform = 'ios'
+    }
+
+    if (-not [System.String]::IsNullOrEmpty($BoundParameters.PayloadJson))
+    {
+        $BoundParameters.PayloadJson = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($BoundParameters.PayloadJson))
     }
 
     $mobileApps = Get-MgBetaDeviceAppManagementMobileApp -All

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAppConfigurationDevicePolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAppConfigurationDevicePolicy.Tests.ps1
@@ -71,7 +71,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     displayName = "FakeStringValue"
                     id = "FakeStringValue"
                     PackageId = "FakeStringValue"
-                    PayloadJson = "FakeStringValue"
+                    PayloadJson = "{`"test`":`"value`"}"
                     permissionActions = [CimInstance[]]@(
                         (New-CimInstance -ClassName MSFT_MicrosoftGraphandroidPermissionAction -Property @{
                             permission = "FakeStringValue"
@@ -119,7 +119,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     displayName = "FakeStringValue"
                     id = "FakeStringValue"
                     PackageId = "FakeStringValue"
-                    PayloadJson = "FakeStringValue"
+                    PayloadJson = "{`"test`":`"value`"}"
                     permissionActions = [CimInstance[]]@(
                         (New-CimInstance -ClassName MSFT_MicrosoftGraphandroidPermissionAction -Property @{
                             permission = "FakeStringValue"
@@ -148,7 +148,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         AdditionalProperties = @{
                             appSupportsOemConfig = $True
                             '@odata.type' = "#microsoft.graph.androidManagedStoreAppConfiguration"
-                            payloadJson = "FakeStringValue"
+                            payloadJson = "eyJ0ZXN0IjoidmFsdWUifQ=="
                             profileApplicability = "default"
                             permissionActions = @(
                                 @{
@@ -192,7 +192,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     displayName = "FakeStringValue"
                     id = "FakeStringValue"
                     PackageId = "FakeStringValue"
-                    PayloadJson = "FakeStringValue"
+                    PayloadJson = "{`"test`":`"value`"}"
                     permissionActions = [CimInstance[]]@(
                         (New-CimInstance -ClassName MSFT_MicrosoftGraphandroidPermissionAction -Property @{
                             permission = "FakeStringValue"
@@ -221,7 +221,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         AdditionalProperties = @{
                             appSupportsOemConfig = $True
                             '@odata.type' = "#microsoft.graph.androidManagedStoreAppConfiguration"
-                            payloadJson = "FakeStringValue"
+                            payloadJson = "eyJ0ZXN0IjoidmFsdWUifQ=="
                             profileApplicability = "default"
                             permissionActions = @(
                                 @{
@@ -258,7 +258,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     displayName = "FakeStringValue"
                     id = "FakeStringValue"
                     PackageId = "FakeStringValue"
-                    PayloadJson = "FakeStringValue"
+                    PayloadJson = "{`"test`":`"value`"}"
                     permissionActions = [CimInstance[]]@(
                         (New-CimInstance -ClassName MSFT_MicrosoftGraphandroidPermissionAction -Property @{
                             permission = "FakeStringValue"
@@ -293,7 +293,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                     action = "prompt"
                                 }
                             )
-                            payloadJson = "FakeStringValue"
+                            payloadJson = "eyJ0ZXN0IjoidmFsdWUifQ=="
                         }
                         createdDateTime = "2023-01-01T00:00:00.0000000+01:00"
                         description = "FakeStringValue"
@@ -334,7 +334,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         AdditionalProperties = @{
                             appSupportsOemConfig = $True
                             '@odata.type' = "#microsoft.graph.androidManagedStoreAppConfiguration"
-                            payloadJson = "FakeStringValue"
+                            payloadJson = "{`"test`":`"value`"}"
                             profileApplicability = "default"
                             permissionActions = @(
                                 @{


### PR DESCRIPTION
#### Pull Request (PR) description
Adds the JSON conversion to the `PayloadJson` property for better readability of the settings to the `IntuneAppConfigurationDevicePolicy` resource.

Example of the new version: 

```
Id                   = "23ab5a34-dc1e-4a53-84cc-fcb91a93a880";
PackageId            = "app:com.azure.authenticator";
PayloadJson          = "{`"kind`":`"androidenterprise#managedConfiguration`",`"productId`":`"app:com.azure.authenticator`",`"managedProperty`":[{`"key`":`"sharedDeviceRegistrationToken`",`"valueString`":`"asdf`"},{`"key`":`"sharedDeviceTenantId`",`"valueString`":`"asdf`"},{`"key`":`"sharedDeviceRegistrationPrefillUpn`",`"valueString`":`"{{IMEI}}`"},{`"key`":`"sharedDeviceMode`",`"valueBool`":false}]}";
ProfileApplicability = "default";
```

#### This Pull Request (PR) fixes the following issues
None.
