### PR TITLE
Fix settings instance array return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCDRGUtil
+  * Fixes an issue where the return value was changed to a single object  
+    instead of an array.  
+    FIXES [#4844](https://github.com/microsoft/Microsoft365DSC/issues/4844)
+
 # 1.24.703.1
 
 * EXOCASMailboxPlan

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1476,7 +1476,7 @@ function Get-IntuneSettingCatalogPolicySetting
         }
     }
 
-    return $settingInstances
+    return ,$settingInstances
 }
 
 function Get-IntuneSettingCatalogPolicySettingInstanceValue


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request fixes an issue where the supposed return value of an array with items was mangled to the single element by PowerShell in case there was only one element in the array.

#### This Pull Request (PR) fixes the following issues
- Fixes #4844 