### PR TITLE
EXOAntiPhishRule: Don't check AntiPhishPolicy while removing resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* EXOAntiPhishRule
+  * Don't check if associated `EXOAntiPhishPolicy` is present while removing
+    resource since it's not required
+    FIXES [#4846](https://github.com/microsoft/Microsoft365DSC/issues/4846)
+
 # 1.24.703.1
 
 * EXOCASMailboxPlan

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishRule/MSFT_EXOAntiPhishRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishRule/MSFT_EXOAntiPhishRule.psm1
@@ -295,14 +295,6 @@ function Set-TargetResource
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
         -InboundParameters $PSBoundParameters
 
-    # Make sure that the associated Policy exists;
-    $AssociatedPolicy = Get-AntiPhishPolicy -Identity $AntiPhishPolicy -ErrorAction 'SilentlyContinue'
-    if ($null -eq $AssociatedPolicy)
-    {
-        throw "Error attempting to create EXOAntiPhishRule {$Identity}. The specified AntiPhishPolicy {$AntiPhishPolicy} " + `
-            "doesn't exist. Make sure you either create it first or specify a valid policy."
-    }
-
     $CurrentValues = Get-TargetResource @PSBoundParameters
     $BoundParameters = ([System.Collections.Hashtable]$PSBoundParameters).Clone()
     $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
@@ -311,6 +303,14 @@ function Set-TargetResource
     {
         $BoundParameters.Add('Name', $Identity) | Out-Null
         $BoundParameters.Remove('Identity') | Out-Null
+
+        # Make sure that the associated Policy exists;
+        $AssociatedPolicy = Get-AntiPhishPolicy -Identity $AntiPhishPolicy -ErrorAction 'SilentlyContinue'
+        if ($null -eq $AssociatedPolicy)
+        {
+            throw "Error attempting to create EXOAntiPhishRule {$Identity}. The specified AntiPhishPolicy {$AntiPhishPolicy} " + `
+                "doesn't exist. Make sure you either create it first or specify a valid policy."
+        }
 
         # New-AntiPhishRule has the Enabled parameter, Set-AntiPhishRule does not.
         # There doesn't appear to be any way to change the Enabled state of a rule once created.
@@ -326,6 +326,14 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Present' -and $CurrentValues.Ensure -eq 'Present')
     {
         $BoundParameters.Remove('Enabled') | Out-Null
+
+        # Make sure that the associated Policy exists;
+        $AssociatedPolicy = Get-AntiPhishPolicy -Identity $AntiPhishPolicy -ErrorAction 'SilentlyContinue'
+        if ($null -eq $AssociatedPolicy)
+        {
+            throw "Error attempting to create EXOAntiPhishRule {$Identity}. The specified AntiPhishPolicy {$AntiPhishPolicy} " + `
+                "doesn't exist. Make sure you either create it first or specify a valid policy."
+        }
 
         # Check to see if the specified policy already has the rule assigned;
         $existingRule = Get-AntiPhishRule | Where-Object -FilterScript { $_.AntiPhishPolicy -eq $AntiPhishPolicy }


### PR DESCRIPTION
#### Pull Request (PR) description

While removing the rule don't check for its associated policy since it might have been removed already.

#### This Pull Request (PR) fixes the following issues

- Fixes #4846