### PR TITLE
EXOHostedOutboundSpamFilterRule: Don't check HostedOutboundSpamFilterPolicy while removing resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* EXOHostedOutboundSpamFilterRule
+  * Don't check if associated `EXOHostedOutboundSpamFilterPolicy` is present
+    while removing resource since it's not required
+    FIXES [#4847](https://github.com/microsoft/Microsoft365DSC/issues/4847)
+
 # 1.24.703.1
 
 * EXOCASMailboxPlan

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterRule/MSFT_EXOHostedOutboundSpamFilterRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterRule/MSFT_EXOHostedOutboundSpamFilterRule.psm1
@@ -290,20 +290,20 @@ function Set-TargetResource
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
         -InboundParameters $PSBoundParameters
 
-    # Make sure that the associated Policy exists;
-    $AssociatedPolicy = Get-HostedOutboundSpamFilterPolicy -Identity $HostedOutboundSpamFilterPolicy -ErrorAction 'SilentlyContinue'
-    if ($null -eq $AssociatedPolicy)
-    {
-        throw "Error attempting to create EXOHostedOutboundSpamFilterRule {$Identity}. The specified HostedOutboundSpamFilterPolicy " + `
-            "{$HostedOutboundSpamFilterPolicy} doesn't exist. Make sure you either create it first or specify a valid policy."
-    }
-
     $CurrentValues = Get-TargetResource @PSBoundParameters
     $BoundParameters = ([System.Collections.Hashtable]$PSBoundParameters).Clone()
     $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $BoundParameters
 
     if ($Ensure -eq 'Present' -and $CurrentValues.Ensure -eq 'Absent')
     {
+        # Make sure that the associated Policy exists;
+        $AssociatedPolicy = Get-HostedOutboundSpamFilterPolicy -Identity $HostedOutboundSpamFilterPolicy -ErrorAction 'SilentlyContinue'
+        if ($null -eq $AssociatedPolicy)
+        {
+            throw "Error attempting to create EXOHostedOutboundSpamFilterRule {$Identity}. The specified HostedOutboundSpamFilterPolicy " + `
+                "{$HostedOutboundSpamFilterPolicy} doesn't exist. Make sure you either create it first or specify a valid policy."
+        }
+
         if ($Enabled -and ('Disabled' -eq $CurrentValues.State))
         {
             # New-HostedOutboundSpamFilterRule has the Enabled parameter, Set-HostedOutboundSpamFilterRule does not.
@@ -319,6 +319,15 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Present' -and $CurrentValues.Ensure -eq 'Present')
     {
         $BoundParameters.Remove('Enabled') | Out-Null
+
+        # Make sure that the associated Policy exists;
+        $AssociatedPolicy = Get-HostedOutboundSpamFilterPolicy -Identity $HostedOutboundSpamFilterPolicy -ErrorAction 'SilentlyContinue'
+        if ($null -eq $AssociatedPolicy)
+        {
+            throw "Error attempting to create EXOHostedOutboundSpamFilterRule {$Identity}. The specified HostedOutboundSpamFilterPolicy " + `
+                "{$HostedOutboundSpamFilterPolicy} doesn't exist. Make sure you either create it first or specify a valid policy."
+        }
+
         if ($CurrentValues.HostedOutboundSpamFilterPolicy -eq $BoundParameters.HostedOutboundSpamFilterPolicy)
         {
             $BoundParameters.Remove('HostedOutboundSpamFilterPolicy') | Out-Null


### PR DESCRIPTION
#### Pull Request (PR) description

While removing the rule don't check for its associated policy since it might have been removed already.

#### This Pull Request (PR) fixes the following issues

- Fixes #4847