### PR TITLE
Telemetry: Don't run engine if telemetry was set to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* TELEMETRY
+  * Don't run engine if telemetry was set to be disabled
+
 # 1.24.710.1
 
 * AADApplication

--- a/Modules/Microsoft365DSC/Modules/M365DSCTelemetryEngine.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCTelemetryEngine.psm1
@@ -63,8 +63,14 @@ function Add-M365DSCTelemetryEvent
         [System.Collections.Generic.Dictionary[[System.String], [System.Double]]]
         $Metrics
     )
+
     $TelemetryEnabled = [System.Environment]::GetEnvironmentVariable('M365DSCTelemetryEnabled', `
             [System.EnvironmentVariableTarget]::Machine)
+
+    if ($TelemetryEnabled -eq $false)
+    {
+        return
+    }
 
     if ($Type -eq 'DriftEvaluation')
     {


### PR DESCRIPTION
#### Pull Request (PR) description

Return early from function ```Add-M365DSCTelemetryEvent``` if telemetry was set to be disabled.

#### This Pull Request (PR) fixes the following issues

- Fixes #4857