### PR TITLE
IntuneDeviceConfigurationEmailProfilePolicyWindows10: Fix export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,19 @@
 * EXOHostedOutboundSpamFilterPolicy
   * Changed the RecipientLimitInternalPerHour, RecipientLimitPerDay, and
     RecipientLimitExternalPerHour parameters to UInt32.
+* IntuneDeviceConfigurationEmailProfilePolicyWindows10
+  * Fix export by fixing some typos and from where values are extracted
+    FIXES [#3960](https://github.com/microsoft/Microsoft365DSC/issues/3960)
 * IntuneDiskEncryptionWindows10
-  * Initial Release  
+  * Initial Release
     FIXES [#4050](https://github.com/microsoft/Microsoft365DSC/issues/4050)
 * M365DSCDRGUtil
   * Fixes an issue with nested and duplicate settings in the settings catalog
 * M365DSCResourceGenerator
   * Update Intune resource generation.
 * M365DSCReport
-  * Changes behaviour to not throw on empty configuration during report generation.  
-    FIXES [#4559](https://github.com/microsoft/Microsoft365DSC/issues/4559)  
+  * Changes behaviour to not throw on empty configuration during report generation.
+    FIXES [#4559](https://github.com/microsoft/Microsoft365DSC/issues/4559)
     FIXES [#4505](https://github.com/microsoft/Microsoft365DSC/issues/4505)
   * Fixes an issue where the comparison treats empty arrays as an empty string.
     FIXES [#4796](https://github.com/microsoft/Microsoft365DSC/issues/4796)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10.psm1
@@ -187,21 +187,21 @@ function Get-TargetResource
         }
 
         $enumUserDomainNameSource = $null
-        if ($null -ne $getValue.UserDomainNameSource)
+        if ($null -ne $getValue.AdditionalProperties.userDomainNameSource)
         {
-            $enumUserDomainNameSource = $getValue.UserDomainNameSource.ToString()
+            $enumUserDomainNameSource = $getValue.AdditionalProperties.userDomainNameSource.ToString()
         }
 
         $enumUsernameAADSource = $null
-        if ($null -ne $getValue.UsernameAADSource)
+        if ($null -ne $getValue.AdditionalProperties.usernameAADSource)
         {
-            $enumUsernameAADSource = $getValue.UsernameAADSource.ToString()
+            $enumUsernameAADSource = $getValue.AdditionalProperties.usernameAADSource.ToString()
         }
 
         $enumUsernameSource = $null
-        if ($null -ne $getValue.UsernameSource)
+        if ($null -ne $getValue.AdditionalProperties.usernameSource)
         {
-            $enumUsernameSource = $getValue.UsernameSource.ToString()
+            $enumUsernameSource = $getValue.AdditionalProperties.usernameSource.ToString()
         }
         #endregion
 
@@ -216,7 +216,7 @@ function Get-TargetResource
             SyncCalendar          = $getValue.AdditionalProperties.syncCalendar
             SyncContacts          = $getValue.AdditionalProperties.syncContacts
             SyncTasks             = $getValue.AdditionalProperties.syncTasks
-            CustomDomainName      = $getValue.CustomDomainName
+            CustomDomainName      = $getValue.AdditionalProperties.customDomainName
             UserDomainNameSource  = $enumUserDomainNameSource
             UsernameAADSource     = $enumUsernameAADSource
             UsernameSource        = $enumUsernameSource

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationEmailProfilePolicyWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationEmailProfilePolicyWindows10.Tests.ps1
@@ -127,15 +127,14 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             emailAddressSource = "userPrincipalName"
                             durationOfEmailToSync = "userDefined"
                             syncCalendar = $True
+                            customDomainName = "FakeStringValue"
+                            userDomainNameSource = "fullDomainName"
+                            usernameAADSource = "userPrincipalName"
+                            usernameSource = "userPrincipalName"
                         }
-                        CustomDomainName = "FakeStringValue"
                         Description = "FakeStringValue"
                         DisplayName = "FakeStringValue"
                         Id = "FakeStringValue"
-                        UserDomainNameSource = "fullDomainName"
-                        UsernameAADSource = "userPrincipalName"
-                        UsernameSource = "userPrincipalName"
-
                     }
                 }
             }
@@ -189,15 +188,14 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             emailAddressSource = "userPrincipalName"
                             durationOfEmailToSync = "userDefined"
                             syncCalendar = $True
+                            customDomainName = "FakeStringValue"
+                            userDomainNameSource = "fullDomainName"
+                            usernameAADSource = "userPrincipalName"
+                            usernameSource = "userPrincipalName"
                         }
-                        CustomDomainName = "FakeStringValue"
                         Description = "FakeStringValue"
                         DisplayName = "FakeStringValue"
                         Id = "FakeStringValue"
-                        UserDomainNameSource = "fullDomainName"
-                        UsernameAADSource = "userPrincipalName"
-                        UsernameSource = "userPrincipalName"
-
                     }
                 }
             }
@@ -240,14 +238,14 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             emailSyncSchedule = "userDefined"
                             emailAddressSource = "userPrincipalName"
                             durationOfEmailToSync = "userDefined"
+                            customDomainName = "FakeStringValue"
+                            userDomainNameSource = "fullDomainName"
+                            usernameAADSource = "userPrincipalName"
+                            usernameSource = "userPrincipalName"
                         }
-                        CustomDomainName = "FakeStringValue"
                         Description = "FakeStringValue"
                         DisplayName = "FakeStringValue"
                         Id = "FakeStringValue"
-                        UserDomainNameSource = "fullDomainName"
-                        UsernameAADSource = "userPrincipalName"
-                        UsernameSource = "userPrincipalName"
                     }
                 }
             }
@@ -287,15 +285,14 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             emailAddressSource = "userPrincipalName"
                             durationOfEmailToSync = "userDefined"
                             syncCalendar = $True
+                            customDomainName = "FakeStringValue"
+                            userDomainNameSource = "fullDomainName"
+                            usernameAADSource = "userPrincipalName"
+                            usernameSource = "userPrincipalName"
                         }
-                        CustomDomainName = "FakeStringValue"
                         Description = "FakeStringValue"
                         DisplayName = "FakeStringValue"
                         Id = "FakeStringValue"
-                        UserDomainNameSource = "fullDomainName"
-                        UsernameAADSource = "userPrincipalName"
-                        UsernameSource = "userPrincipalName"
-
                     }
                 }
             }


### PR DESCRIPTION
#### Pull Request (PR) description

Some values were never exported due to some typos and/or from those values were being extracted, the export itself worked but trying to deploy the resource with only the current values extracted would result in an error message from Graph.

This PR fixes this by fixing the typos and exporting the values from the correct sub-property.

#### This Pull Request (PR) fixes the following issues

- Fixes #3960