### PR TITLE
write failures to error output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+* MSFT_AADConditionalAccessPolicy
+  * Made failures write to the error output instead of just verbose
 * EXOHostedOutboundSpamFilterPolicy
   * Changed the RecipientLimitInternalPerHour, RecipientLimitPerDay, and
     RecipientLimitExternalPerHour parameters to UInt32.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 # UNRELEASED
 
-* MSFT_AADConditionalAccessPolicy
-  * Made failures write to the error output instead of just verbose
+* AADConditionalAccessPolicy
+  * Made failures write to the error output instead of just verbose.
 * EXOHostedOutboundSpamFilterPolicy
   * Changed the RecipientLimitInternalPerHour, RecipientLimitPerDay, and
     RecipientLimitExternalPerHour parameters to UInt32.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -1666,7 +1666,7 @@ function Set-TargetResource
                 -TenantId $TenantId `
                 -Credential $Credential
 
-            Write-Verbose -Message "Set-Targetresource: Failed change policy $DisplayName"
+            Write-Error -Message "Set-Targetresource: Failed change policy $DisplayName"
         }
     }
     elseif ($Ensure -eq 'Present' -and $currentPolicy.Ensure -eq 'Absent')
@@ -1689,7 +1689,7 @@ function Set-TargetResource
                     -TenantId $TenantId `
                     -Credential $Credential
 
-                Write-Verbose -Message 'Set-Targetresource: Failed creating new policy'
+                Write-Error -Message 'Set-Targetresource: Failed creating new policy'
             }
         }
         else
@@ -1699,7 +1699,7 @@ function Set-TargetResource
                 -TenantId $TenantId `
                 -Credential $Credential
 
-            Write-Verbose -Message 'Set-Targetresource: Failed creating new policy. At least a user rule, application rule and grant or session control is required'
+            Write-Error -Message 'Set-Targetresource: Failed creating new policy. At least a user rule, application rule and grant or session control is required'
         }
     }
     elseif ($Ensure -eq 'Absent' -and $currentPolicy.Ensure -eq 'Present')
@@ -1717,7 +1717,7 @@ function Set-TargetResource
                 -TenantId $TenantId `
                 -Credential $Credential
 
-            Write-Verbose -Message "Set-Targetresource: Failed deleting policy $DisplayName"
+            Write-Error -Message "Set-Targetresource: Failed deleting policy $DisplayName"
         }
     }
     Write-Verbose -Message "Set-Targetresource: Finished processing Policy $Displayname"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -1666,7 +1666,7 @@ function Set-TargetResource
                 -TenantId $TenantId `
                 -Credential $Credential
 
-            Write-Error -Message "Set-Targetresource: Failed change policy $DisplayName"
+            Write-Error -Message "Set-Targetresource: Failed changing policy $DisplayName"
         }
     }
     elseif ($Ensure -eq 'Present' -and $currentPolicy.Ensure -eq 'Absent')


### PR DESCRIPTION
Change failures from verbose to error output

#### Pull Request (PR) description
During application of a MOF, not all resources were created. Finding out why required searching through the verbose output. Errors should be output using the error stream so they are highlighted and easily available.

#### This Pull Request (PR) fixes the following issues
- None
