### PR TITLE
Update Intune Windows Update resource logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10
+  * Introduces new properties and updates the handling of the  
+    start and end dates.  
+    FIXES [#4614](https://github.com/microsoft/Microsoft365DSC/issues/4614)  
+    FIXES [#3438](https://github.com/microsoft/Microsoft365DSC/issues/3438)
+
 # 1.24.717.1
 
 * AADConditionalAccessPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10.psm1
@@ -22,6 +22,14 @@ function Get-TargetResource
         $FeatureUpdateVersion,
 
         [Parameter()]
+        [System.Boolean]
+        $InstallFeatureUpdatesOptional,
+
+        [Parameter()]
+        [System.Boolean]
+        $InstallLatestWindows10OnWindows11IneligibleDevice,
+
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance]
         $RolloutSettings,
 
@@ -94,8 +102,11 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementWindowsFeatureUpdateProfile `
-                    -Filter "DisplayName eq '$DisplayName'" `
-                    -ErrorAction SilentlyContinue
+                    -All `
+                    -ErrorAction SilentlyContinue | Where-Object `
+                    -FilterScript {
+                        $_.DisplayName -eq $DisplayName
+                    }
             }
         }
         #endregion
@@ -126,21 +137,24 @@ function Get-TargetResource
 
         $results = @{
             #region resource generator code
-            Description           = $getValue.Description
-            DisplayName           = $getValue.DisplayName
-            FeatureUpdateVersion  = $getValue.FeatureUpdateVersion
-            RolloutSettings       = $complexRolloutSettings
-            Id                    = $getValue.Id
-            Ensure                = 'Present'
-            Credential            = $Credential
-            ApplicationId         = $ApplicationId
-            TenantId              = $TenantId
-            ApplicationSecret     = $ApplicationSecret
-            CertificateThumbprint = $CertificateThumbprint
-            Managedidentity       = $ManagedIdentity.IsPresent
-            AccessTokens          = $AccessTokens
+            Description                                       = $getValue.Description
+            DisplayName                                       = $getValue.DisplayName
+            FeatureUpdateVersion                              = $getValue.FeatureUpdateVersion
+            InstallFeatureUpdatesOptional                     = $getValue.InstallFeatureUpdatesOptional
+            InstallLatestWindows10OnWindows11IneligibleDevice = $getValue.InstallLatestWindows10OnWindows11IneligibleDevice
+            RolloutSettings                                   = $complexRolloutSettings
+            Id                                                = $getValue.Id
+            Ensure                                            = 'Present'
+            Credential                                        = $Credential
+            ApplicationId                                     = $ApplicationId
+            TenantId                                          = $TenantId
+            ApplicationSecret                                 = $ApplicationSecret
+            CertificateThumbprint                             = $CertificateThumbprint
+            ManagedIdentity                                   = $ManagedIdentity.IsPresent
+            AccessTokens                                      = $AccessTokens
             #endregion
         }
+
         $assignmentsValues = Get-MgBetaDeviceManagementWindowsFeatureUpdateProfileAssignment -WindowsFeatureUpdateProfileId $Id
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)
@@ -186,6 +200,14 @@ function Set-TargetResource
         [Parameter()]
         [System.String]
         $FeatureUpdateVersion,
+
+        [Parameter()]
+        [System.Boolean]
+        $InstallFeatureUpdatesOptional,
+
+        [Parameter()]
+        [System.Boolean]
+        $InstallLatestWindows10OnWindows11IneligibleDevice,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance]
@@ -242,43 +264,103 @@ function Set-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    $currentInstance = Get-TargetResource @PSBoundParameters
+    # Rollout is not "As soon as possible"
+    if ($null -ne $RolloutSettings)
+    {
+        # Rollout is either "On a specific date" or "gradually"
+        if (-not [string]::IsNullOrEmpty($RolloutSettings.OfferStartDateTimeInUTC))
+        {
+            $currentTime = Get-Date
+            $offerStartDate = [datetime]::Parse($RolloutSettings.OfferStartDateTimeInUTC)
+            # Rollout is "On a specific date"
+            if (-not [string]::IsNullOrEmpty($RolloutSettings.OfferEndDateTimeInUTC))
+            {
+                $offerEndDate = [datetime]::Parse($RolloutSettings.OfferEndDateTimeInUTC)
+                if ($offerEndDate -lt $offerStartDate.AddDays(1))
+                {
+                    throw 'OfferEndDateTimeInUTC must be greater than OfferStartDateTimeInUTC + 1 day.'
+                }
 
-    $PSBoundParameters.Remove('Ensure') | Out-Null
-    $PSBoundParameters.Remove('Credential') | Out-Null
-    $PSBoundParameters.Remove('ApplicationId') | Out-Null
-    $PSBoundParameters.Remove('ApplicationSecret') | Out-Null
-    $PSBoundParameters.Remove('TenantId') | Out-Null
-    $PSBoundParameters.Remove('CertificateThumbprint') | Out-Null
-    $PSBoundParameters.Remove('ManagedIdentity') | Out-Null
-    $PSBoundParameters.Remove('Verbose') | Out-Null
-    $PSBoundParameters.Remove('AccessTokens') | Out-Null
+                if ($offerEndDate -le $currentTime)
+                {
+                    throw 'OfferEndDateTimeInUTC must be greater than the current time.'
+                }
+            }
+        }
+    }
+
+    $currentInstance = Get-TargetResource @PSBoundParameters
+    $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+
+    if ($null -eq $RolloutSettings)
+    {
+        $BoundParameters.RolloutSettings = @{
+            OfferStartDateTimeInUTC = $null
+            OfferEndDateTimeInUTC = $null
+            OfferIntervalInDays = $null
+        }
+    }
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {
         Write-Verbose -Message "Creating an Intune Windows Update For Business Feature Update Profile for Windows10 with DisplayName {$DisplayName}"
-        $PSBoundParameters.Remove('Assignments') | Out-Null
+        $BoundParameters.Remove('Assignments') | Out-Null
 
-        $CreateParameters = ([Hashtable]$PSBoundParameters).clone()
+        if ($null -ne $RolloutSettings)
+        {
+            if (-not [string]::IsNullOrEmpty($RolloutSettings.OfferStartDateTimeInUTC))
+            {
+                $minTimeForAvailable = $currentTime
+                $newOfferStartDate = $offerStartDate
+                if ($offerStartDate -lt $minTimeForAvailable)
+                {
+                    $newOfferStartDate = $minTimeForAvailable
+                    $BoundParameters.RolloutSettings.OfferStartDateTimeInUTC = $newOfferStartDate.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+                }
+
+                if (-not [string]::IsNullOrEmpty($RolloutSettings.OfferEndDateTimeInUTC))
+                {
+                    # If an end date is configured, then the start date must be greater than the current time + 2 days
+                    $minTimeForAvailable = $currentTime.AddDays(2)
+                    if ($newOfferStartDate -lt $minTimeForAvailable)
+                    {
+                        $newOfferStartDate = $minTimeForAvailable
+                        $BoundParameters.RolloutSettings.OfferStartDateTimeInUTC = $newOfferStartDate.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+                    }
+
+                    if ($offerEndDate -lt $newOfferStartDate)
+                    {
+                        throw 'OfferEndDateTimeInUTC must be greater than current time + 2 days.'
+                    }
+
+                    if ($RolloutSettings.OfferIntervalInDays -gt ($offerEndDate - $newOfferStartDate).Days)
+                    {
+                        throw 'OfferIntervalInDays must be less than or equal to the difference between OfferEndDateTimeInUTC and OfferStartDateTimeInUTC in days.'
+                    }
+                }
+            }
+        }
+
+        $CreateParameters = ([Hashtable]$BoundParameters).Clone()
         $CreateParameters = Rename-M365DSCCimInstanceParameter -Properties $CreateParameters
         $CreateParameters.Remove('Id') | Out-Null
 
-        $keys = (([Hashtable]$CreateParameters).clone()).Keys
+        $keys = (([Hashtable]$CreateParameters).Clone()).Keys
         foreach ($key in $keys)
         {
-            if ($null -ne $CreateParameters.$key -and $CreateParameters.$key.getType().Name -like '*cimInstance*')
+            if ($null -ne $CreateParameters.$key -and $CreateParameters.$key.GetType().Name -like '*cimInstance*')
             {
                 $CreateParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $CreateParameters.$key
             }
         }
-        #region resource generator code
-        $CreateParameters.Add("@odata.type", "#microsoft.graph.WindowsFeatureUpdateProfile")
-        $policy=New-MgBetaDeviceManagementWindowsFeatureUpdateProfile -BodyParameter $CreateParameters
-        $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
 
-        if ($policy.id)
+        #region resource generator code
+        $policy = New-MgBetaDeviceManagementWindowsFeatureUpdateProfile -BodyParameter $CreateParameters
+
+        if ($policy.Id)
         {
-            Update-DeviceConfigurationPolicyAssignment -DeviceConfigurationPolicyId $policy.id `
+            $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
+            Update-DeviceConfigurationPolicyAssignment -DeviceConfigurationPolicyId $policy.Id `
                 -Targets $assignmentsHash `
                 -Repository 'deviceManagement/windowsFeatureUpdateProfiles'
         }
@@ -287,24 +369,83 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
     {
         Write-Verbose -Message "Updating the Intune Windows Update For Business Feature Update Profile for Windows10 with Id {$($currentInstance.Id)}"
-        $PSBoundParameters.Remove('Assignments') | Out-Null
+        $BoundParameters.Remove('Assignments') | Out-Null
+        $BoundParameters.Remove('InstallLatestWindows10OnWindows11IneligibleDevice') | Out-Null
 
-        $UpdateParameters = ([Hashtable]$PSBoundParameters).clone()
+        if ($null -ne $RolloutSettings)
+        {
+            if (-not [string]::IsNullOrEmpty($RolloutSettings.OfferStartDateTimeInUTC))
+            {
+                $minTimeForAvailable = $currentTime
+                if (-not [string]::IsNullOrEmpty($currentInstance.RolloutSettings.OfferStartDateTimeInUTC))
+                {
+                    $currentOfferDate = [datetime]::Parse($currentInstance.RolloutSettings.OfferStartDateTimeInUTC)
+                }
+                else
+                {
+                    $currentOfferDate = [datetime]::MinValue
+                }
+                $newOfferStartDate = $offerStartDate
+
+                # If the configured start date is different from the current start date and is less than the current time, we use the current start date
+                if ($offerStartDate -ne $currentOfferDate -and $offerStartDate -lt $minTimeForAvailable)
+                {
+                    if ($currentOfferDate -eq [datetime]::MinValue)
+                    {
+                        $newOfferStartDate = $minTimeForAvailable
+                        $currentOfferDate = $minTimeForAvailable
+                    }
+                    else
+                    {
+                        $newOfferStartDate = $currentOfferDate
+                    }
+                    $BoundParameters.RolloutSettings.OfferStartDateTimeInUTC = $currentOfferDate.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+                }
+
+                if (-not [string]::IsNullOrEmpty($RolloutSettings.OfferEndDateTimeInUTC))
+                {
+                    # If an end date is configured, then the start date must be greater than the current time + 2 days
+                    $offerEndDate = [datetime]::Parse($RolloutSettings.OfferEndDateTimeInUTC)
+                    $minTimeForAvailable = $currentTime.AddDays(2)
+                    if ($newOfferStartDate -lt $minTimeForAvailable)
+                    {
+                        $newOfferStartDate = $minTimeForAvailable
+                        $BoundParameters.RolloutSettings.OfferStartDateTimeInUTC = $newOfferStartDate.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+                    }
+
+                    if (-not [string]::IsNullOrEmpty($currentInstance.RolloutSettings.OfferEndDateTimeInUTC))
+                    {
+                        $currentOfferEndDate = [datetime]::Parse($currentInstance.RolloutSettings.OfferEndDateTimeInUTC)
+                    }
+
+                    # If the end date is less than the start date + 1 day or the current time, we throw an error
+                    if ($offerEndDate -lt $newOfferStartDate.AddDays(1) -or $offerEndDate -lt $currentTime)
+                    {
+                        throw 'OfferEndDateTimeInUTC must be greater than OfferStartDateTimeInUTC and current time (+ 2 days if not previously specified).'
+                    }
+
+                    if ($RolloutSettings.OfferIntervalInDays -gt ($offerEndDate - $newOfferStartDate).Days)
+                    {
+                        throw 'OfferIntervalInDays must be less than or equal to the difference between OfferEndDateTimeInUTC and OfferStartDateTimeInUTC in days.'
+                    }
+                }
+            }
+        }
+
+        $UpdateParameters = ([Hashtable]$BoundParameters).Clone()
         $UpdateParameters = Rename-M365DSCCimInstanceParameter -Properties $UpdateParameters
-
         $UpdateParameters.Remove('Id') | Out-Null
 
-        $keys = (([Hashtable]$UpdateParameters).clone()).Keys
+        $keys = (([Hashtable]$UpdateParameters).Clone()).Keys
         foreach ($key in $keys)
         {
-            if ($null -ne $UpdateParameters.$key -and $UpdateParameters.$key.getType().Name -like '*cimInstance*')
+            if ($null -ne $UpdateParameters.$key -and $UpdateParameters.$key.GetType().Name -like '*cimInstance*')
             {
                 $UpdateParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $UpdateParameters.$key
             }
         }
 
         #region resource generator code
-        $UpdateParameters.Add("@odata.type", "#microsoft.graph.WindowsFeatureUpdateProfile")
         Update-MgBetaDeviceManagementWindowsFeatureUpdateProfile  `
             -WindowsFeatureUpdateProfileId $currentInstance.Id `
             -BodyParameter $UpdateParameters
@@ -346,6 +487,14 @@ function Test-TargetResource
         [Parameter()]
         [System.String]
         $FeatureUpdateVersion,
+
+        [Parameter()]
+        [System.Boolean]
+        $InstallFeatureUpdatesOptional,
+
+        [Parameter()]
+        [System.Boolean]
+        $InstallLatestWindows10OnWindows11IneligibleDevice,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance]
@@ -405,35 +554,112 @@ function Test-TargetResource
     Write-Verbose -Message "Testing configuration of the Intune Windows Update For Business Feature Update Profile for Windows10 with Id {$Id} and DisplayName {$DisplayName}"
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
-    $ValuesToCheck = ([Hashtable]$PSBoundParameters).clone()
-
-    if ($CurrentValues.Ensure -ne $Ensure)
-    {
-        Write-Verbose -Message "Test-TargetResource returned $false"
-        return $false
-    }
+    $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
     $testResult = $true
+
+    # Cannot be changed after creation
+    $ValuesToCheck.Remove('InstallLatestWindows10OnWindows11IneligibleDevice') | Out-Null
 
     #Compare Cim instances
     foreach ($key in $PSBoundParameters.Keys)
     {
+        if ($key -eq 'RolloutSettings')
+        {
+            continue
+        }
+
         $source = $PSBoundParameters.$key
         $target = $CurrentValues.$key
-        if ($source.getType().Name -like '*CimInstance*')
+        if ($null -ne $source -and $source.GetType().Name -like '*CimInstance*')
         {
             $testResult = Compare-M365DSCComplexObject `
                 -Source ($source) `
                 -Target ($target)
 
-            if (-Not $testResult)
+            if (-not $testResult)
             {
-                $testResult = $false
                 break
             }
 
             $ValuesToCheck.Remove($key) | Out-Null
         }
     }
+
+    if (-not $testResult)
+    {
+        Write-Verbose -Message "Test-TargetResource returned $false"
+        return $false
+    }
+
+    if (($null -eq $RolloutSettings -and $null -ne $CurrentValues.RolloutSettings) -or `
+        ($null -ne $RolloutSettings -and $null -eq $CurrentValues.RolloutSettings))
+    {
+        Write-Verbose -Message 'RolloutSettings is null in either the desired configuration or the current configuration.'
+        Write-Verbose -Message "Test-TargetResource returned $false"
+        return $false
+    }
+
+    $currentTime = Get-Date
+    [datetime]$offerStartDate = [datetime]::MinValue
+    [datetime]$offerEndDate = [datetime]::MinValue
+    [datetime]::TryParse($RolloutSettings.OfferStartDateTimeInUTC, [ref]$offerStartDate) | Out-Null
+    [datetime]::TryParse($RolloutSettings.OfferEndDateTimeInUTC, [ref]$offerEndDate) | Out-Null
+    if ($CurrentValues.Ensure -ne $Ensure)
+    {
+        if ($Ensure -eq 'Present')
+        {
+            if (($offerStartDate -ne [datetime]::MinValue -and $offerStartDate -lt $currentTime) `
+                    -and ($offerEndDate -ne [datetime]::MinValue -and $offerEndDate -lt $currentTime))
+            {
+                Write-Verbose -Message "Start and end time are in the past, skip the configuration."
+                Write-Verbose -Message "Test-TargetResource returned $true"
+                return $true
+            }
+        }
+
+        Write-Verbose -Message "Test-TargetResource returned $false"
+        return $false
+    }
+
+    [datetime]$currentOfferStartDate = [datetime]::MinValue
+    [datetime]$currentOfferEndDate = [datetime]::MinValue
+    [datetime]::TryParse($CurrentValues.RolloutSettings.OfferStartDateTimeInUTC, [ref]$currentOfferStartDate) | Out-Null
+    [datetime]::TryParse($CurrentValues.RolloutSettings.OfferEndDateTimeInUTC, [ref]$currentOfferEndDate) | Out-Null
+    if (($offerEndDate -eq [datetime]::MinValue -and $currentOfferEndDate -ne [datetime]::MinValue) -or `
+        ($offerEndDate -ne [datetime]::MinValue -and $currentOfferEndDate -eq [datetime]::MinValue))
+    {
+        Write-Verbose -Message 'OfferEndDateTimeInUTC is null in either the desired configuration or the current configuration.'
+        Write-Verbose -Message "Test-TargetResource returned $false"
+        return $false
+    }
+
+    if ($offerStartDate -ne [datetime]::MinValue -and $currentOfferStartDate -ne [datetime]::MinValue)
+    {
+        if ($offerStartDate -ne $currentOfferStartDate `
+                -and $offerStartDate -gt $currentTime)
+        {
+            Write-Verbose -Message 'OfferStartDateTimeInUTC is different from current.'
+            $testResult = $false
+        }
+
+        if ($testResult -and $offerEndDate -ne [datetime]::MinValue -and $currentOfferEndDate -ne [datetime]::MinValue)
+        {
+            if ($offerEndDate -ne $currentOfferEndDate `
+                    -and $offerEndDate -gt $currentTime `
+                    -and $offerEndDate -gt $offerStartDate)
+            {
+                Write-Verbose -Message 'OfferEndDateTimeInUTC is different from current.'
+                $testResult = $false
+            }
+
+            if ($testResult -and $RolloutSettings.OfferIntervalInDays -ne $CurrentValues.RolloutSettings.OfferIntervalInDays)
+            {
+                Write-Verbose -Message 'OfferIntervalInDays is different from current.'
+                $testResult = $false
+            }
+        }
+    }
+    $ValuesToCheck.Remove('RolloutSettings') | Out-Null
     $ValuesToCheck.Remove('Id') | Out-Null
 
     Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
@@ -554,7 +780,7 @@ function Export-TargetResource
                 TenantId              = $TenantId
                 ApplicationSecret     = $ApplicationSecret
                 CertificateThumbprint = $CertificateThumbprint
-                Managedidentity       = $ManagedIdentity.IsPresent
+                ManagedIdentity       = $ManagedIdentity.IsPresent
                 AccessTokens          = $AccessTokens
             }
 
@@ -565,7 +791,7 @@ function Export-TargetResource
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
                     -ComplexObject $Results.RolloutSettings `
-                    -CIMInstanceName 'MicrosoftGraphwindowsUpdateRolloutSettings'
+                    -CIMInstanceName 'MicrosoftGraphWindowsUpdateRolloutSettings'
                 if (-Not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
                 {
                     $Results.RolloutSettings = $complexTypeStringResult

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10.schema.mof
@@ -23,7 +23,9 @@ class MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10 : OMI_Bas
     [Key, Description("The display name of the profile.")] String DisplayName;
     [Write, Description("The description of the profile which is specified by the user.")] String Description;
     [Write, Description("The feature update version that will be deployed to the devices targeted by this profile. The version could be any supported version for example 1709, 1803 or 1809 and so on.")] String FeatureUpdateVersion;
-    [Write, Description("The windows update rollout settings, including offer start date time, offer end date time, and days between each set of offers."), EmbeddedInstance("MSFT_MicrosoftGraphwindowsUpdateRolloutSettings")] String RolloutSettings;
+    [Write, Description("If true, the Windows 11 update will become optional")] Boolean InstallFeatureUpdatesOptional;
+    [Write, Description("If true, the latest Microsoft Windows 10 update will be installed on devices ineligible for Microsoft Windows 11. Cannot be changed after creation of the policy.")] Boolean InstallLatestWindows10OnWindows11IneligibleDevice;
+    [Write, Description("The windows update rollout settings, including offer start date time, offer end date time, and days between each set of offers. For 'as soon as possible' installation, set this setting to $null or do not configure it."), EmbeddedInstance("MSFT_MicrosoftGraphwindowsUpdateRolloutSettings")] String RolloutSettings;
     [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10/readme.md
@@ -4,3 +4,24 @@
 ## Description
 
 Intune Windows Update For Business Feature Update Profile for Windows10
+
+## RolloutSettings
+
+The RolloutSettings for this resource have the following constraints and notes: 
+
+* When creating a policy:
+    * If only a start date is specified, then the start date must be at least today. 
+        * If the desired state date is before the current date, it will be adjusted to the current date.
+    * If a start and end date is specified, the start date must be the current date + 2 days, and  
+      the end date must be at least one day after the start date.
+        * If the start date is before the current date + 2 days, it will be adjusted to this date.
+* When updating a policy:
+    * If only a start date is specified, then the start date must either be the date from the current   
+      configuration or the current date (or later). 
+        * If the desired state date is before the current date, it will be adjusted to the current date.
+    * If a start and end date is specified, the start date must be the current date + 2 days, and  
+      the end date must be at least one day after the start date.
+        * If the start date is before the current date + 2 days, it will be adjusted to this date.
+* When testing a policy:
+    * If the policy is missing and the start and end date are before the current date, it will return true.
+    * If the start date is different but before the current start date and time, it will return true.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10/readme.md
@@ -24,4 +24,4 @@ The RolloutSettings for this resource have the following constraints and notes:
         * If the start date is before the current date + 2 days, it will be adjusted to this date.
 * When testing a policy:
     * If the policy is missing and the start and end date are before the current date, it will return true.
-    * If the start date is different but before the current start date and time, it will return true.
+    * If the start date is different but before the current start date or time, it will return true.

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10.Tests.ps1
@@ -27,6 +27,24 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MgBetaDeviceManagementWindowsFeatureUpdateProfile -MockWith {
+                return @{
+                    Description          = 'FakeStringValue'
+                    DisplayName          = 'FakeStringValue'
+                    FeatureUpdateVersion = 'FakeStringValue'
+                    Id                   = 'FakeStringValue'
+                    RolloutSettings      = @{
+                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferIntervalInDays     = 2
+                    }
+                }
+            }
+
+            Mock -CommandName 'Get-Date' -MockWith {
+                return [datetime]::new(2022, 12, 30)
+            }
+
             Mock -CommandName Update-MgBetaDeviceManagementWindowsFeatureUpdateProfile -MockWith {
             }
 
@@ -59,10 +77,10 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                            OfferEndDateTimeInUTC   = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferStartDateTimeInUTC = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferIntervalInDays     = 25
-                        } -ClientOnly)
+                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'    
+                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferIntervalInDays     = 2
+                    } -ClientOnly)
                     Ensure               = 'Present'
                     Credential           = $Credential
                 }
@@ -91,30 +109,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                            OfferEndDateTimeInUTC   = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferStartDateTimeInUTC = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferIntervalInDays     = 25
-                        } -ClientOnly)
+                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferIntervalInDays     = 2
+                    } -ClientOnly)
                     Ensure               = 'Absent'
                     Credential           = $Credential
-                }
-
-                Mock -CommandName Get-MgBetaDeviceManagementWindowsFeatureUpdateProfile -MockWith {
-                    return @{
-                        AdditionalProperties = @{
-                            '@odata.type' = '#microsoft.graph.WindowsFeatureUpdateProfile'
-                        }
-                        Description          = 'FakeStringValue'
-                        DisplayName          = 'FakeStringValue'
-                        FeatureUpdateVersion = 'FakeStringValue'
-                        Id                   = 'FakeStringValue'
-                        RolloutSettings      = @{
-                            OfferEndDateTimeInUTC   = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferStartDateTimeInUTC = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferIntervalInDays     = 25
-                        }
-
-                    }
                 }
             }
 
@@ -122,16 +122,16 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
             }
 
-            It 'Should return true from the Test method' {
+            It 'Should return false from the Test method' {
                 Test-TargetResource @testParams | Should -Be $false
             }
 
-            It 'Should Remove the group from the Set method' {
+            It 'Should remove the profile from the Set method' {
                 Set-TargetResource @testParams
                 Should -Invoke -CommandName Remove-MgBetaDeviceManagementWindowsFeatureUpdateProfile -Exactly 1
             }
         }
-        Context -Name 'The IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10 Exists and Values are already in the desired state' -Fixture {
+        Context -Name 'The IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10 exists and values are already in the desired state' -Fixture {
             BeforeAll {
                 $testParams = @{
                     Description          = 'FakeStringValue'
@@ -139,33 +139,14 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                            OfferEndDateTimeInUTC   = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferStartDateTimeInUTC = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferIntervalInDays     = 25
-                        } -ClientOnly)
+                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'    
+                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferIntervalInDays     = 2
+                    } -ClientOnly)
                     Ensure               = 'Present'
                     Credential           = $Credential
                 }
-
-                Mock -CommandName Get-MgBetaDeviceManagementWindowsFeatureUpdateProfile -MockWith {
-                    return @{
-                        AdditionalProperties = @{
-                            '@odata.type' = '#microsoft.graph.WindowsFeatureUpdateProfile'
-                        }
-                        Description          = 'FakeStringValue'
-                        DisplayName          = 'FakeStringValue'
-                        FeatureUpdateVersion = 'FakeStringValue'
-                        Id                   = 'FakeStringValue'
-                        RolloutSettings      = @{
-                            OfferEndDateTimeInUTC   = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferStartDateTimeInUTC = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferIntervalInDays     = 25
-                        }
-
-                    }
-                }
             }
-
 
             It 'Should return true from the Test method' {
                 Test-TargetResource @testParams | Should -Be $true
@@ -180,10 +161,10 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                            OfferEndDateTimeInUTC   = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferStartDateTimeInUTC = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferIntervalInDays     = 25
-                        } -ClientOnly)
+                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'    
+                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferIntervalInDays     = 2
+                    } -ClientOnly)
                     Ensure               = 'Present'
                     Credential           = $Credential
                 }
@@ -195,9 +176,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         FeatureUpdateVersion = 'FakeStringValue'
                         Id                   = 'FakeStringValue'
                         RolloutSettings      = @{
-                            OfferEndDateTimeInUTC   = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferStartDateTimeInUTC = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferIntervalInDays     = 7
+                            OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'
+                            OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                            OfferIntervalInDays     = 1 #drift
                         }
                     }
                 }
@@ -217,30 +198,164 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
         }
 
+        Context -Name 'The IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10 exists and the RolloutSettings are NOT in the desired state' -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Description          = 'FakeStringValue'
+                    DisplayName          = 'FakeStringValue'
+                    FeatureUpdateVersion = 'FakeStringValue'
+                    Id                   = 'FakeStringValue'
+                    RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
+                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'    
+                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferIntervalInDays     = 2
+                    } -ClientOnly)
+                    Ensure               = 'Present'
+                    Credential           = $Credential
+                }
+            }
+
+            It 'Should return false from the Test method because OfferEndDateTimeInUTC is missing' {
+                Mock -CommandName Get-MgBetaDeviceManagementWindowsFeatureUpdateProfile -MockWith {
+                    return @{
+                        Description          = 'FakeStringValue'
+                        DisplayName          = 'FakeStringValue'
+                        FeatureUpdateVersion = 'FakeStringValue'
+                        Id                   = 'FakeStringValue'
+                        RolloutSettings      = @{
+                            OfferStartDateTimeInUTC = '2023-01-03T00:00:00.000Z'
+                            OfferEndDateTimeInUTC   = $null
+                            OfferIntervalInDays     = $null
+                        }
+                    }
+                }
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should return false from the Test method because neither OfferStartDateTimeInUTC nor OfferEndDateTimeInUTC is set' {
+                Mock -CommandName Get-MgBetaDeviceManagementWindowsFeatureUpdateProfile -MockWith {
+                    return @{
+                        Description          = 'FakeStringValue'
+                        DisplayName          = 'FakeStringValue'
+                        FeatureUpdateVersion = 'FakeStringValue'
+                        Id                   = 'FakeStringValue'
+                        RolloutSettings      = @{
+                            OfferEndDateTimeInUTC   = $null
+                            OfferStartDateTimeInUTC = $null
+                            OfferIntervalInDays     = $null
+                        }
+                    }
+                }
+                Test-TargetResource @testParams | Should -Be $false
+            }
+        }
+
+        Context -Name 'The IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10 exists and RolloutSettings are different but still valid' -Fixture {
+            It 'Should return true from the Test method because OfferStartDateTimeInUTC is before the current value and time' {
+                $testParams = @{
+                    Description          = 'FakeStringValue'
+                    DisplayName          = 'FakeStringValue'
+                    FeatureUpdateVersion = 'FakeStringValue'
+                    Id                   = 'FakeStringValue'
+                    RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
+                        OfferStartDateTimeInUTC = '2022-12-31T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferIntervalInDays     = 2
+                    } -ClientOnly)
+                    Ensure               = 'Present'
+                    Credential           = $Credential
+                }
+                Mock -CommandName 'Get-Date' -MockWith {
+                    return [datetime]::new(2023, 1, 1)
+                }
+                Test-TargetResource @testParams | Should -Be $true
+            }
+
+            It 'Should return true from the Test method because OfferStartDateTimeInUTC and OfferEndDateTimeInUTC are in the past' {
+                $testParams = @{
+                    Description          = 'FakeStringValue'
+                    DisplayName          = 'FakeStringValue'
+                    FeatureUpdateVersion = 'FakeStringValue'
+                    Id                   = 'FakeStringValue'
+                    RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
+                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'    
+                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferIntervalInDays     = 2
+                    } -ClientOnly)
+                    Ensure               = 'Present'
+                    Credential           = $Credential
+                }
+
+                Mock -CommandName 'Get-Date' -MockWith {
+                    return [datetime]::new(2023, 02, 02)
+                }
+
+                Test-TargetResource @testParams | Should -Be $true
+            }
+        }
+
+        Context -Name 'The IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10 exists and RolloutSettings are different and invalid' -Fixture {
+            It 'Should throw from the Set method because OfferStartDateTimeInUTC is after OfferEndDateTimeInUTC' {
+                $testParams = @{
+                    Description          = 'FakeStringValue'
+                    DisplayName          = 'FakeStringValue'
+                    FeatureUpdateVersion = 'FakeStringValue'
+                    Id                   = 'FakeStringValue'
+                    RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
+                        OfferStartDateTimeInUTC = '2023-01-04T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferIntervalInDays     = 2
+                    } -ClientOnly)
+                    Ensure               = 'Present'
+                    Credential           = $Credential
+                }
+                { Set-TargetResource @testParams } | Should -Throw 'OfferEndDateTimeInUTC must be greater than OfferStartDateTimeInUTC + 1 day.'
+            }
+
+            It 'Should throw from the Set method because OfferStartDateTimeInUTC is already set and OfferEndDateTimeInUTC is not greater than the current time' {
+                $testParams = @{
+                    Description          = 'FakeStringValue'
+                    DisplayName          = 'FakeStringValue'
+                    FeatureUpdateVersion = 'FakeStringValue'
+                    Id                   = 'FakeStringValue'
+                    RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
+                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferIntervalInDays     = 2
+                    } -ClientOnly)
+                    Ensure               = 'Present'
+                    Credential           = $Credential
+                }
+                Mock -CommandName 'Get-Date' -MockWith {
+                    return [datetime]::new(2023, 1, 4)
+                }
+                { Set-TargetResource @testParams } | Should -Throw 'OfferEndDateTimeInUTC must be greater than the current time.'
+            }
+
+            It 'Should throw from the Set method because OfferIntervalInDays is more than the gap between start and end time' {
+                $testParams = @{
+                    Description          = 'FakeStringValue'
+                    DisplayName          = 'FakeStringValue'
+                    FeatureUpdateVersion = 'FakeStringValue'
+                    Id                   = 'FakeStringValue'
+                    RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
+                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferIntervalInDays     = 3
+                    } -ClientOnly)
+                    Ensure               = 'Present'
+                    Credential           = $Credential
+                }
+                { Set-TargetResource @testParams } | Should -Throw 'OfferIntervalInDays must be less than or equal to the difference between OfferEndDateTimeInUTC and OfferStartDateTimeInUTC in days.'
+            }
+        }
+
         Context -Name 'ReverseDSC Tests' -Fixture {
             BeforeAll {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
                     Credential = $Credential
-                }
-
-                Mock -CommandName Get-MgBetaDeviceManagementWindowsFeatureUpdateProfile -MockWith {
-                    return @{
-                        AdditionalProperties = @{
-                            '@odata.type' = '#microsoft.graph.WindowsFeatureUpdateProfile'
-                        }
-                        Description          = 'FakeStringValue'
-                        DisplayName          = 'FakeStringValue'
-                        FeatureUpdateVersion = 'FakeStringValue'
-                        Id                   = 'FakeStringValue'
-                        RolloutSettings      = @{
-                            OfferEndDateTimeInUTC   = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferStartDateTimeInUTC = '2023-01-01T00:00:00.0000000+00:00'
-                            OfferIntervalInDays     = 25
-                        }
-
-                    }
                 }
             }
             It 'Should Reverse Engineer resource from the Export method' {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10.Tests.ps1
@@ -34,15 +34,15 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = @{
-                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'
-                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferStartDateTimeInUTC = '2024-01-05T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2024-01-07T00:00:00.000Z'
                         OfferIntervalInDays     = 2
                     }
                 }
             }
 
             Mock -CommandName 'Get-Date' -MockWith {
-                return [datetime]::new(2022, 12, 30)
+                return [datetime]::new(2024, 01, 01)
             }
 
             Mock -CommandName Update-MgBetaDeviceManagementWindowsFeatureUpdateProfile -MockWith {
@@ -77,8 +77,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'    
-                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferStartDateTimeInUTC = '2024-01-05T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2024-01-07T00:00:00.000Z'
                         OfferIntervalInDays     = 2
                     } -ClientOnly)
                     Ensure               = 'Present'
@@ -109,8 +109,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'
-                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferStartDateTimeInUTC = '2024-01-05T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2024-01-07T00:00:00.000Z'
                         OfferIntervalInDays     = 2
                     } -ClientOnly)
                     Ensure               = 'Absent'
@@ -139,8 +139,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'    
-                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferStartDateTimeInUTC = '2024-01-05T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2024-01-07T00:00:00.000Z'
                         OfferIntervalInDays     = 2
                     } -ClientOnly)
                     Ensure               = 'Present'
@@ -161,8 +161,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'    
-                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferStartDateTimeInUTC = '2024-01-05T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2024-01-07T00:00:00.000Z'
                         OfferIntervalInDays     = 2
                     } -ClientOnly)
                     Ensure               = 'Present'
@@ -176,8 +176,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         FeatureUpdateVersion = 'FakeStringValue'
                         Id                   = 'FakeStringValue'
                         RolloutSettings      = @{
-                            OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'
-                            OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                            OfferStartDateTimeInUTC = '2024-01-05T00:00:00.000Z'
+                            OfferEndDateTimeInUTC   = '2024-01-07T00:00:00.000Z'
                             OfferIntervalInDays     = 1 #drift
                         }
                     }
@@ -206,8 +206,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'    
-                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferStartDateTimeInUTC = '2024-01-05T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2024-01-07T00:00:00.000Z'
                         OfferIntervalInDays     = 2
                     } -ClientOnly)
                     Ensure               = 'Present'
@@ -223,7 +223,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         FeatureUpdateVersion = 'FakeStringValue'
                         Id                   = 'FakeStringValue'
                         RolloutSettings      = @{
-                            OfferStartDateTimeInUTC = '2023-01-03T00:00:00.000Z'
+                            OfferStartDateTimeInUTC = '2024-01-07T00:00:00.000Z'
                             OfferEndDateTimeInUTC   = $null
                             OfferIntervalInDays     = $null
                         }
@@ -258,15 +258,15 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                        OfferStartDateTimeInUTC = '2022-12-31T00:00:00.000Z'
-                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferStartDateTimeInUTC = '2024-01-05T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2024-01-07T00:00:00.000Z'
                         OfferIntervalInDays     = 2
                     } -ClientOnly)
                     Ensure               = 'Present'
                     Credential           = $Credential
                 }
                 Mock -CommandName 'Get-Date' -MockWith {
-                    return [datetime]::new(2023, 1, 1)
+                    return [datetime]::new(2024, 1, 5)
                 }
                 Test-TargetResource @testParams | Should -Be $true
             }
@@ -278,8 +278,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'    
-                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferStartDateTimeInUTC = '2024-01-05T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2024-01-07T00:00:00.000Z'
                         OfferIntervalInDays     = 2
                     } -ClientOnly)
                     Ensure               = 'Present'
@@ -287,7 +287,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 }
 
                 Mock -CommandName 'Get-Date' -MockWith {
-                    return [datetime]::new(2023, 02, 02)
+                    return [datetime]::new(2024, 02, 01)
                 }
 
                 Test-TargetResource @testParams | Should -Be $true
@@ -302,8 +302,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                        OfferStartDateTimeInUTC = '2023-01-04T00:00:00.000Z'
-                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferStartDateTimeInUTC = '2024-01-08T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2024-01-07T00:00:00.000Z'
                         OfferIntervalInDays     = 2
                     } -ClientOnly)
                     Ensure               = 'Present'
@@ -312,24 +312,24 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 { Set-TargetResource @testParams } | Should -Throw 'OfferEndDateTimeInUTC must be greater than OfferStartDateTimeInUTC + 1 day.'
             }
 
-            It 'Should throw from the Set method because OfferStartDateTimeInUTC is already set and OfferEndDateTimeInUTC is not greater than the current time' {
+            It 'Should throw from the Set method because OfferStartDateTimeInUTC is adjusted and OfferEndDateTimeInUTC is not greater than that time + 1 day' {
                 $testParams = @{
                     Description          = 'FakeStringValue'
                     DisplayName          = 'FakeStringValue'
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'
-                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferStartDateTimeInUTC = '2024-01-05T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2024-01-07T00:00:00.000Z'
                         OfferIntervalInDays     = 2
                     } -ClientOnly)
                     Ensure               = 'Present'
                     Credential           = $Credential
                 }
                 Mock -CommandName 'Get-Date' -MockWith {
-                    return [datetime]::new(2023, 1, 4)
+                    return [datetime]::new(2024, 1, 5)
                 }
-                { Set-TargetResource @testParams } | Should -Throw 'OfferEndDateTimeInUTC must be greater than the current time.'
+                { Set-TargetResource @testParams } | Should -Throw 'OfferEndDateTimeInUTC must be greater than OfferStartDateTimeInUTC + 1 day.'
             }
 
             It 'Should throw from the Set method because OfferIntervalInDays is more than the gap between start and end time' {
@@ -339,8 +339,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     FeatureUpdateVersion = 'FakeStringValue'
                     Id                   = 'FakeStringValue'
                     RolloutSettings      = (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsUpdateRolloutSettings -Property @{
-                        OfferStartDateTimeInUTC = '2023-01-01T00:00:00.000Z'
-                        OfferEndDateTimeInUTC   = '2023-01-03T00:00:00.000Z'
+                        OfferStartDateTimeInUTC = '2024-01-05T00:00:00.000Z'
+                        OfferEndDateTimeInUTC   = '2024-01-07T00:00:00.000Z'
                         OfferIntervalInDays     = 3
                     } -ClientOnly)
                     Ensure               = 'Present'


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes the `IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10` resource so that create, update and test works with the requirements of the backend. Some errors might still be thrown during `Set-TargetResource`, and it is in the responsibility of the configuration owner to adhere to these requirements.

**Please note:** The RolloutSettings for this resource have the following constraints and notes: 

* When creating a policy:
    * If only a start date is specified, then the start date must be at least today. 
        * If the desired state date is before the current date, it will be adjusted to the current date.
    * If a start and end date is specified, the start date must be the current date + 2 days, and  
      the end date must be at least one day after the start date.
        * If the start date is before the current date + 2 days, it will be adjusted to this date.
* When updating a policy:
    * If only a start date is specified, then the start date must either be the date from the current   
      configuration or the current date (or later). 
        * If the desired state date is before the current date, it will be adjusted to the current date.
    * If a start and end date is specified, the start date must be the current date + 2 days, and  
      the end date must be at least one day after the start date.
        * If the start date is before the current date + 2 days, it will be adjusted to this date.
* When testing a policy:
    * If the policy is missing and the start and end date are before the current date, it will return true.
    * If the start date is different but before the current start date and time, it will return true.

#### This Pull Request (PR) fixes the following issues
- Fixes #4614
- Fixes #3438
