### PR TITLE
Fix AADGroup delta report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCReport
+  * Update key properties for delta report in `AADGroup` resource.
+    FIXES [#4921](https://github.com/microsoft/Microsoft365DSC/issues/4921)
+
 # 1.24.724.1
 
 * IntuneAntivirusPolicyWindows10SettingCatalog

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -1243,6 +1243,10 @@ function Get-M365DSCResourceKey
         {
             return @('Id')
         }
+        if ($Resource.ResourceName -eq 'AADGroup' -and -not [System.String]::IsNullOrEmpty($Resource.MailNickname))
+        {
+            return ('DisplayName', 'MailNickname')
+        }
         if ($Resource.ResourceName -eq 'IntuneDeviceEnrollmentPlatformRestriction' -and $Resource.Keys.Where({ $_ -like "*Restriction"}))
         {
             return @('ResourceInstanceName')


### PR DESCRIPTION
#### Pull Request (PR) description
This Pull Request fixes an issue with the `New-M365DSCDeltaReport` for the `AADGroup` resource, where two exact same configurations with multiple entries that have the same display name return a difference result instead of no differences.

#### This Pull Request (PR) fixes the following issues
- Fixes #4921 
