### PR TITLE
Add missing class version in AADAuthenticationMethodPolicyFido2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* AADAuthenticationMethodPolicyFido2
+  * Add missing class identifier to schema.
+    FIXES [#4900](https://github.com/microsoft/Microsoft365DSC/issues/4900)
+    FIXES [#4079](https://github.com/microsoft/Microsoft365DSC/issues/4079)
+
 # 1.24.724.1
 
 * IntuneAntivirusPolicyWindows10SettingCatalog
@@ -9,7 +16,7 @@
     FIXES [#3966](https://github.com/microsoft/Microsoft365DSC/issues/3966)
 * IntuneEndpointDetectionAndResponsePolicyLinux
   * Initial release.
-* IntuneEndointDetectionAndResponsePolicyMacOS
+* IntuneEndpointDetectionAndResponsePolicyMacOS
   * Initial release.
 * IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10
   * Introduces new properties and updates the handling of the

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyFido2/MSFT_AADAuthenticationMethodPolicyFido2.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyFido2/MSFT_AADAuthenticationMethodPolicyFido2.schema.mof
@@ -11,7 +11,7 @@ class MSFT_AADAuthenticationMethodPolicyFido2ExcludeTarget
     [Write, Description("The object identifier of an Azure AD group.")] String Id;
     [Write, Description("The type of the authentication method target. Possible values are: group and unknownFutureValue."), ValueMap{"user","group","unknownFutureValue"}, Values{"user","group","unknownFutureValue"}] String TargetType;
 };
-
+[ClassVersion("1.0.0")]
 class MSFT_AADAuthenticationMethodPolicyFido2IncludeTarget
 {
     [Write, Description("The object identifier of an Azure AD group.")] String Id;


### PR DESCRIPTION
#### Pull Request (PR) description
This Pull Request adds the missing class version for the `MSFT_AADAuthenticationMethodPolicyFido2IncludeTarget` class in the schema. 

#### This Pull Request (PR) fixes the following issues
- Fixes #4900 
- Fixes #4079 