### PR TITLE
EXOHostedContentFilterRule: Don't check if associated policy is present while removing resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* EXOHostedContentFilterRule
+  * Don't check if associated `EXOHostedContentFilterPolicy` is present
+    while removing resource since it's not required
+
 # 1.24.731.1
 
 * AADAuthenticationMethodPolicyFido2

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/MSFT_EXOHostedContentFilterRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/MSFT_EXOHostedContentFilterRule.psm1
@@ -297,26 +297,26 @@ function Set-TargetResource
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
         -InboundParameters $PSBoundParameters
 
-    # Make sure that the associated Policy exists;
-    $AssociatedPolicy = Get-HostedContentFilterPolicy -Identity $HostedContentFilterPolicy -ErrorAction 'SilentlyContinue'
-    if ($null -eq $AssociatedPolicy)
-    {
-        throw "Error attempting to create EXOHostedContentFilterRule {$Identity}. The specified HostedContentFilterPolicy " + `
-            "{$HostedContentFilterPolicy} doesn't exist. Make sure you either create it first or specify a valid policy."
-    }
-
-    # Make sure that the associated Policy is not Default;
-    if ($AssociatedPolicy.IsDefault -eq $true )
-    {
-        throw "Policy $Identity is marked as the default. Creating a rule to apply the default policy is not allowed."
-    }
-
     $CurrentValues = Get-TargetResource @PSBoundParameters
     $BoundParameters = ([System.Collections.Hashtable]$PSBoundParameters).Clone()
     $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
 
     if ($Ensure -eq 'Present' -and $CurrentValues.Ensure -eq 'Absent')
     {
+        # Make sure that the associated Policy exists;
+        $AssociatedPolicy = Get-HostedContentFilterPolicy -Identity $HostedContentFilterPolicy -ErrorAction 'SilentlyContinue'
+        if ($null -eq $AssociatedPolicy)
+        {
+            throw "Error attempting to create EXOHostedContentFilterRule {$Identity}. The specified HostedContentFilterPolicy " + `
+                "{$HostedContentFilterPolicy} doesn't exist. Make sure you either create it first or specify a valid policy."
+        }
+
+        # Make sure that the associated Policy is not Default;
+        if ($AssociatedPolicy.IsDefault -eq $true )
+        {
+            throw "Policy $Identity is marked as the default. Creating a rule to apply the default policy is not allowed."
+        }
+
         if ($Enabled -and ('Disabled' -eq $CurrentValues.State))
         {
             # New-HostedContentFilterRule has the Enabled parameter, Set-HostedContentFilterRule does not.
@@ -332,6 +332,20 @@ function Set-TargetResource
     }
     elseif ($Ensure -eq 'Present' -and $CurrentValues.Ensure -eq 'Present')
     {
+        # Make sure that the associated Policy exists;
+        $AssociatedPolicy = Get-HostedContentFilterPolicy -Identity $HostedContentFilterPolicy -ErrorAction 'SilentlyContinue'
+        if ($null -eq $AssociatedPolicy)
+        {
+            throw "Error attempting to create EXOHostedContentFilterRule {$Identity}. The specified HostedContentFilterPolicy " + `
+                "{$HostedContentFilterPolicy} doesn't exist. Make sure you either create it first or specify a valid policy."
+        }
+
+        # Make sure that the associated Policy is not Default;
+        if ($AssociatedPolicy.IsDefault -eq $true )
+        {
+            throw "Policy $Identity is marked as the default. Creating a rule to apply the default policy is not allowed."
+        }
+
         $BoundParameters.Remove('Enabled') | Out-Null
         if ($CurrentValues.HostedContentFilterPolicy -eq $BoundParameters.HostedContentFilterPolicy)
         {


### PR DESCRIPTION
#### Pull Request (PR) description

This resource doesn't depend on having the associated policy present while removing the resource, this PR fixes it the same way I did with ```EXOHostedOutboundSpamFilterRule``` which essentially only checks for the associated policy if we are creating or updating the resource but not while removing.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
