### PR TITLE
Compare-PSCustomObjectArrays: Allow empty arrays as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCUtil
+  * Fix `Compare-PSCustomObjectArrays` by allowing empty arrays as input
+    FIXES [#4952](https://github.com/microsoft/Microsoft365DSC/issues/4952)
+
 # 1.24.731.1
 
 * AADAuthenticationMethodPolicyFido2

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -437,10 +437,12 @@ function Compare-PSCustomObjectArrays
     param
     (
         [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [System.Object[]]
         $DesiredValues,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
         [System.Object[]]
         $CurrentValues
     )


### PR DESCRIPTION
#### Pull Request (PR) description

Function ```Compare-PSCustomObjectArrays``` in M365DSCUtil must allow empty arrays as input otherwise it may fail.

This fix was actually already in but disappeared during the merge of my patch c27478112d66d04dc517d674f679de7aaa7c9c1f for something else not related, this PR puts the fix back in.

#### This Pull Request (PR) fixes the following issues

- Fix #4952
