### PR TITLE
ExoAuthenticationPolicyAssignment: Return all users when exporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+* EXOAuthenticationPolicyAssignment
+  * Removes the 1000 user limit when exporting authentication policy assignments
+    FIXES [#4956](https://github.com/microsoft/Microsoft365DSC/issues/4956)
+
 * EXOHostedContentFilterRule
   * Don't check if associated `EXOHostedContentFilterPolicy` is present
     while removing resource since it's not required

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAuthenticationPolicyAssignment/MSFT_EXOAuthenticationPolicyAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAuthenticationPolicyAssignment/MSFT_EXOAuthenticationPolicyAssignment.psm1
@@ -356,7 +356,7 @@ function Export-TargetResource
         foreach ($AuthenticationPolicy in $AllAuthenticationPolicies)
         {
             Write-Host "    |---[$i/$($AllAuthenticationPolicies.Count)] $($AuthenticationPolicy.Identity)" -NoNewline
-            $assignedUsers = Get-User -Filter "AuthenticationPolicy -eq '$($AuthenticationPolicy.DistinguishedName)'"
+            $assignedUsers = Get-User -Filter "AuthenticationPolicy -eq '$($AuthenticationPolicy.DistinguishedName)'" -ResultSize unlimited
 
             foreach ($user in $assignedUsers)
             {


### PR DESCRIPTION
#### Pull Request (PR) description
When exporting Exchange authentication policy assignments, only 1000 users are returned with each authentication policy. This PR adds the unlimited result size parameter to the Get-User call while exporting the resource.

#### This Pull Request (PR) fixes the following issues
Fixes #4956 