### PR TITLE
Fix AuthenticationFlows in Conditional Access Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # UNRELEASED
 
+* AADConditionalAccessPolicy
+  * Fixes an issue where the `AuthenticationFlows` property changed in Graph
+    and updates on the documentation for the possible values of `TransferMethods`.
+    FIXES [#4961](https://github.com/microsoft/Microsoft365DSC/issues/4961)
+    FIXES [#4960](https://github.com/microsoft/Microsoft365DSC/issues/4960)
+    FIXES [#4734](https://github.com/microsoft/Microsoft365DSC/issues/4734)
+    FIXES [#4725](https://github.com/microsoft/Microsoft365DSC/issues/4725)
 * EXOHostedContentFilterRule
   * Don't check if associated `EXOHostedContentFilterPolicy` is present
     while removing resource since it's not required

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -1519,15 +1519,23 @@ function Set-TargetResource
         if ($currentParameters.ContainsKey('TransferMethods'))
         {
             #create and provision TransferMethods condition object if used
-            if (-not $conditions.Contains('authenticationFlows'))
+            $authenticationFlows = if ([System.String]::IsNullOrEmpty($TransferMethods))
             {
-                $conditions.Add('authenticationFlows', @{
-                        transferMethods = $TransferMethods
-                    })
+                $null
             }
             else
             {
-                $conditions.authenticationFlows.Add('transferMethods', $TransferMethods)
+                @{
+                    transferMethods = $TransferMethods
+                }
+            }
+            if (-not $conditions.Contains('authenticationFlows'))
+            {
+                $conditions.Add('authenticationFlows', $authenticationFlows)
+            }
+            else
+            {
+                $conditions.authenticationFlows = $authenticationFlows
             }
 
         }
@@ -1972,10 +1980,28 @@ function Test-TargetResource
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('Id') | Out-Null
 
-    $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
-        -Source $($MyInvocation.MyCommand.Source) `
-        -DesiredValues $PSBoundParameters `
-        -ValuesToCheck $ValuesToCheck.Keys
+    # If no TransferMethod is specified, ignore it
+    # If a TransferMethod is specified, check if it is equal to the current value
+    # while ignoring the order of the values
+    if (-not $PSBoundParameters.ContainsKey('TransferMethods') -or
+        $null -eq (Compare-Object -ReferenceObject $TransferMethods.Split(',') -DifferenceObject $CurrentValues.TransferMethods.Split(',')))
+    {
+        $ValuesToCheck.Remove('TransferMethods') | Out-Null
+        $TestResult = $true
+    }
+    else
+    {
+        Write-Verbose -Message "TransferMethods are not equal: [$TransferMethods] - [$($CurrentValues.TransferMethods)]"
+        $TestResult  = $false
+    }
+
+    if ($TestResult)
+    {
+        $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -DesiredValues $PSBoundParameters `
+            -ValuesToCheck $ValuesToCheck.Keys
+    }
 
     Write-Verbose -Message "Test-TargetResource returned $TestResult"
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.schema.mof
@@ -44,7 +44,7 @@ class MSFT_AADConditionalAccessPolicy : OMI_BaseResource
     [Write, Description("Specifies, whether Browser Persistence is controlled by the Policy.")] Boolean PersistentBrowserIsEnabled;
     [Write, Description("Specifies, what Browser Persistence control is enforced by the Policy."), ValueMap{"Always","Never",""}, Values{"Always","Never",""}] String PersistentBrowserMode;
     [Write, Description("Name of the associated authentication strength policy.")] String AuthenticationStrength;
-    [Write, Description("Names of the associated authentication flow transfer methods")] String TransferMethods;
+    [Write, Description("Names of the associated authentication flow transfer methods. Possible values are '', 'deviceCodeFlow', 'authenticationTransfer', or 'deviceCodeFlow,authenticationTransfer'.")] String TransferMethods;
     [Write, Description("Authentication context class references.")] String AuthenticationContexts[];
     [Write, Description("Specify if the Azure AD CA Policy should exist or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Credentials for the Microsoft Graph delegated permissions."), EmbeddedInstance("MSFT_Credential")] string Credential;


### PR DESCRIPTION
#### Pull Request (PR) description
This Pull Request addresses an issue where the `AuthenticationFlows` property of a conditional access policy changed in Graph, thus leading to an incorrect provisioning of `TransferMethods` in the `AADConditionalAccessPolicy` resource. 

The new definition of `AuthenticationFlows` is the following: 

* `$null` if no transfer method is specified
* `@{ transferMethods = '<value>' }` if a transfer method is specified

Since one or two values can be used, separated by a comma, an additional check in `Test-TargetResource` was introduced, which checkes that if two values are specified, they can be written in any order. 

To preserve backwards compatibility since `TransferMethods` doesn't have to be specified (while in newer exports it is always done by default), the property is only checked in `Test-TargetResource` if it is contained in `PSBoundParameters`. Otherwise, it will be ignored. 

#### This Pull Request (PR) fixes the following issues
- Fixes #4961 
- Fixes #4960 
- Fixes #4734 
- Fixes #4725 