### PR TITLE
Update MSFT_EXORoleGroup.psm1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* EXORoleGroup
+ * Fix an issue where roles that have empty members cannot be compared
+   FIXES [#4977] (https://github.com/microsoft/Microsoft365DSC/issues/4977)
 * AADConditionalAccessPolicy
   * Fixing issue where the resource crashed when trying to retrieve groups
     and users from Entra ID which no longer existed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 # UNRELEASED
 
-* EXORoleGroup
- * Fix an issue where roles that have empty members cannot be compared
-   FIXES [#4977] (https://github.com/microsoft/Microsoft365DSC/issues/4977)
+
 * AADConditionalAccessPolicy
   * Fixing issue where the resource crashed when trying to retrieve groups
     and users from Entra ID which no longer existed
@@ -20,6 +18,9 @@
 * EXOHostedContentFilterRule
   * Don't check if associated `EXOHostedContentFilterPolicy` is present
     while removing resource since it's not required
+ * EXORoleGroup
+    * Fix an issue where roles that have empty members cannot be compared
+   FIXES [#4977] (https://github.com/microsoft/Microsoft365DSC/issues/4977)
 * IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy
   * Fixed issue if `PasswordComplexity` was set to 5 by allowing that value
     FIXES [#4963](https://github.com/microsoft/Microsoft365DSC/issues/4963)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleGroup/MSFT_EXORoleGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleGroup/MSFT_EXORoleGroup.psm1
@@ -240,7 +240,14 @@ function Set-TargetResource
         Remove-RoleGroup -Identity $Name -Confirm:$false -Force
     }
     # CASE: Role Group exists and it should, but has different member values than the desired ones
-    elseif ($Ensure -eq 'Present' -and $currentRoleGroupConfig.Ensure -eq 'Present' -and $null -ne (Compare-Object -ReferenceObject $($currentRoleGroupConfig.Members) -DifferenceObject $Members))
+    elseif ($Ensure -eq 'Present' -and $currentRoleGroupConfig.Ensure -eq 'Present' -and $null -ne (Compare-Object -ReferenceObject @($($currentRoleGroupConfig.Members) | Select-Object) -DifferenceObject @($Members | Select-Object)))
+    {
+        Write-Verbose -Message "Role Group '$($Name)' already exists, but members need updating."
+        Write-Verbose -Message "Updating Role Group $($Name) members with values: $(Convert-M365DscHashtableToString -Hashtable $NewRoleGroupParams)"
+        Update-RoleGroupMember -Identity $Name -Members $Members -Confirm:$false
+    }
+    # CASE: Role Assignment Policy exists and it should, but Role has no members as its never been set
+    elseif ($Ensure -eq 'Present' -and $currentRoleGroupConfig.Ensure -eq 'Present' -and $currentRoleGroupConfig.Members -eq '')
     {
         Write-Verbose -Message "Role Group '$($Name)' already exists, but members need updating."
         Write-Verbose -Message "Updating Role Group $($Name) members with values: $(Convert-M365DscHashtableToString -Hashtable $NewRoleGroupParams)"


### PR DESCRIPTION
Updated to handle $null on compare-object and also allows the adding of members to the Role with empty members

#### Pull Request (PR) description
<!--
   Updated the code to avoid errors on null values on the compare-object when looking at existing members of the role and adding new memebrs. Not all the roles have members in initially.
-->

#### This Pull Request (PR) fixes the following issues
- Fixes #4977 
