### PR TITLE
Update to M365DSCReport.psm1 due to typo in script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
   * Replace some `Write-Host` occurrences in core engine with
     appropriate alternatives.
     FIXES [#4943](https://github.com/microsoft/Microsoft365DSC/issues/4943)
+  * Fixed a typo within M365DSCReport.psm1 related to a .png file
+    FIXES [#4983](https://github.com/microsoft/Microsoft365DSC/pull/4983)
 
 # 1.24.731.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -368,7 +368,7 @@ function Get-IconPath
     }
     elseif ($ResourceName.StartsWith('SC'))
     {
-        return Get-Base64EncodedImage -IconName "SecurityAndComplance.png"
+        return Get-Base64EncodedImage -IconName "SecurityAndCompliance.png"
     }
     elseif ($ResourceName.StartsWith('SPO'))
     {


### PR DESCRIPTION
Correcting a typo for the name of the Security & compliance.png file the M365DSCReport.psm1 script when it tries to pull it. Essentially it was missing an 'i' in compliance which meant it errored out every time it tries to call the .png file.