### PR TITLE
Typo fixed for SecurityAndCompliance.png

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -368,7 +368,7 @@ function Get-IconPath
     }
     elseif ($ResourceName.StartsWith('SC'))
     {
-        return Get-Base64EncodedImage -IconName "SecurityAndComplance.png"
+        return Get-Base64EncodedImage -IconName "SecurityAndCompliance.png"
     }
     elseif ($ResourceName.StartsWith('SPO'))
     {


### PR DESCRIPTION
#### Pull Request (PR) description
The image being called for "SC" resources the DSC Report had a typo in `Modules\Microsoft365DSC\Modules\M365DSCReport.psm1`. The proper filename is "SecurityAndCompl**i**ance.png" as seen here [SecurityAndCompliance.png](https://github.com/microsoft/Microsoft365DSC/blob/Dev/Modules/Microsoft365DSC/Dependencies/Images/SecurityAndCompliance.png)

#### This Pull Request (PR) fixes the following issues
None
