### PR TITLE
Add Intune Device Remediation global script export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,16 @@
     DeviceManagementConfiguration.ReadWrite.All to cope with
     getOmaSettingPlainTextValue which is only working if RW is granted
     FIXES [#4412](https://github.com/microsoft/Microsoft365DSC/issues/4412)
-* O365OrgSettings
-  * FIXES [#4741](https://github.com/microsoft/Microsoft365DSC/issues/4741)
+* IntuneDeviceRemediation
+  * Add export of global remediation scripts.
+* M365DSCDRGUtil
+  * Fixes an issue where the `MSFT_IntuneDeviceRemediationPolicyAssignments`
+    type would trigger an incorrect comparison in `Compare-M365DSCComplexObject`.
 * M365DSCUtil
   * Fix `Compare-PSCustomObjectArrays` by allowing empty arrays as input
     FIXES [#4952](https://github.com/microsoft/Microsoft365DSC/issues/4952)
+* O365OrgSettings
+  * FIXES [#4741](https://github.com/microsoft/Microsoft365DSC/issues/4741)
 * MISC
   * Replace some `Write-Host` occurrences in core engine with
     appropriate alternatives.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceRemediation/MSFT_IntuneDeviceRemediation.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceRemediation/MSFT_IntuneDeviceRemediation.schema.mof
@@ -46,7 +46,8 @@ class MSFT_IntuneDeviceRemediation : OMI_BaseResource
     [Write, Description("List of ComplexType DetectionScriptParameters objects."), EmbeddedInstance("MSFT_MicrosoftGraphdeviceHealthScriptParameter")] String DetectionScriptParameters[];
     [Write, Description("DeviceHealthScriptType for the script policy. Possible values are: deviceHealthScript, managedInstallerScript."), ValueMap{"deviceHealthScript","managedInstallerScript"}, Values{"deviceHealthScript","managedInstallerScript"}] String DeviceHealthScriptType;
     [Required, Description("Name of the device health script")] String DisplayName;
-    [Write, Description("Indicate whether the script signature needs be checked")] Boolean EnforceSignatureCheck;
+    [Write, Description("Indicates whether the script signature needs be checked")] Boolean EnforceSignatureCheck;
+    [Write, Description("Indicates whether the script is a global script provided by Microsoft")] Boolean IsGlobalScript;
     [Write, Description("Name of the device health script publisher")] String Publisher;
     [Write, Description("The entire content of the remediation powershell script")] String RemediationScriptContent;
     [Write, Description("List of ComplexType RemediationScriptParameters objects."), EmbeddedInstance("MSFT_MicrosoftGraphdeviceHealthScriptParameter")] String RemediationScriptParameters[];

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceRemediation/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceRemediation/readme.md
@@ -4,3 +4,11 @@
 ## Description
 
 Intune Device Remediation
+
+**Important:** Global scripts only allow the update of the following properties:
+
+* Assignments
+* RoleScopeTagIds
+* RunAs32Bit
+* RunAsAccount
+

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -611,7 +611,8 @@ function Compare-M365DSCComplexObject
         }
 
         if ($Source[0].CimClass.CimClassName -eq 'MSFT_DeviceManagementConfigurationPolicyAssignments' -or
-            $Source[0].CimClass.CimClassName -like 'MSFT_Intune*Assignments')
+            ($Source[0].CimClass.CimClassName -like 'MSFT_Intune*Assignments' -and
+            $Source[0].CimClass.CimClassName -ne 'MSFT_IntuneDeviceRemediationPolicyAssignments'))
         {
             $compareResult = Compare-M365DSCIntunePolicyAssignment `
                 -Source @($Source) `
@@ -1865,7 +1866,7 @@ function Get-IntuneSettingCatalogPolicySettingDSCValue
         $matchesId = $false
         $settingDefinitions = $SettingTemplates.SettingDefinitions `
             | Where-Object -FilterScript { $_.Name -eq $key }
-        
+
         # Edge case where the same setting is defined twice in the template, with the same name and id
         if ($settingDefinitions.Count -eq 2)
         {
@@ -1884,7 +1885,7 @@ function Get-IntuneSettingCatalogPolicySettingDSCValue
             {
                 $parentSettingName = $key.Split('_')[0]
                 $parentDefinition = $SettingTemplates.SettingDefinitions | Where-Object -FilterScript { $_.Name -eq $parentSettingName }
-                $childDefinition = $SettingTemplates.SettingDefinitions | Where-Object -FilterScript { 
+                $childDefinition = $SettingTemplates.SettingDefinitions | Where-Object -FilterScript {
                     $_.Name -eq $SettingName -and
                     (($_.AdditionalProperties.dependentOn.Count -gt 0 -and $_.AdditionalProperties.dependentOn.parentSettingId.Contains($parentDefinition.Id)) -or
                     ($_.AdditionalProperties.options.dependentOn.Count -gt 0 -and $_.AdditionalProperties.options.dependentOn.parentSettingId.Contains($parentDefinition.Id))


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request adds the ability to export global Intune remediations. Previously, only non-global (meaning: user created) Intune device remediations were exported. This feature was proposed by @ricmestre in https://github.com/microsoft/Microsoft365DSC/pull/4768#issuecomment-2171493013. 

Global scripts are now always exported. During comparison, if the target instance is a global script, all read-only properties like `enforceSignatureCheck`, `DetectionScriptContent` etc. are ignored, and on update, only the allowed properties are updated. When an attempt is made to remove a global remediation, an exception is thrown stating that removing it is not allowed.

#### This Pull Request (PR) fixes the following issues
None.