### PR TITLE
fix #4994

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
-
+* AADGroup
+  * FIXES [#4994](https://github.com/microsoft/Microsoft365DSC/issues/4994)
 * AADAdministrativeUnit
   * Fix Properties for Dynamic Administrative Units in Graph have moved
 * AADConditionalAccessPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.schema.mof
@@ -14,6 +14,7 @@ class MSFT_AADGroup : OMI_BaseResource
     [Write, Description("Specifies an ID for the group.")] String Id;
     [Write, Description("User Service Principal values for the group's owners.")] String Owners[];
     [Write, Description("User Service Principal values for the group's members.")] String Members[];
+    [Write, Description("Displayname values for the groups member of the group.")] String GroupAsMembers[];
     [Write, Description("DisplayName values for the groups that this group is a member of.")] String MemberOf[];
     [Write, Description("Specifies that the group is a dynamic group. To create a dynamic group, specify a value of DynamicMembership.")] String GroupTypes[];
     [Write, Description("Specifies the membership rule for a dynamic group.")] String MembershipRule;

--- a/Modules/Microsoft365DSC/Examples/Resources/AADGroup/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/AADGroup/1-Create.ps1
@@ -30,6 +30,8 @@ Configuration Example
             MailEnabled     = $True
             GroupTypes      = @("Unified")
             MailNickname    = "M365DSC"
+            Members         = @("admin@$TenantId", "AdeleV@$TenantId")
+            GroupAsMembers  = @("Group1", "Group2")
             Visibility      = "Private"
             Owners          = @("admin@$TenantId", "AdeleV@$TenantId")
             Ensure          = "Present"

--- a/Modules/Microsoft365DSC/Examples/Resources/AADGroup/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/AADGroup/2-Update.ps1
@@ -29,6 +29,8 @@ Configuration Example
             MailEnabled     = $True
             GroupTypes      = @("Unified")
             MailNickname    = "M365DSC"
+            Members         = @("AdeleV@$TenantId")
+            GroupAsMembers  = @("Group1")
             Visibility      = "Private"
             Owners          = @("admin@$TenantId", "AdeleV@$TenantId")
             Ensure          = "Present"


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes #4994 , Add functionality to define Groups as memebers of the group in a separate parameter to keep backward compatibility and avoid unintentional member deletion (Break change).

#### This Pull Request (PR) fixes the following issues
    - Fixes #4994
