### PR TITLE
Fix issue where an unspecified DSC param was not handled correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCDRGUtil
+  * Fixes an issue where a Intune settings catalog DSC param was not handled
+    correctly when it was not specified.
+    FIXES [#5000](https://github.com/microsoft/Microsoft365DSC/issues/5000)
+
 # 1.24.828.1
 
 * AADAdministrativeUnit

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1870,6 +1870,11 @@ function Get-IntuneSettingCatalogPolicySettingInstanceValue
                 -SettingDefinition $SettingDefinition `
                 -DSCParams $DSCParams
 
+            if ($null -eq $valuesResult)
+            {
+                return $null
+            }
+
             $values = $valuesResult.Value
             $SettingValueType = $valuesResult.SettingDefinition.AdditionalProperties.valueDefinition.'@odata.type'.Replace('Definition', '')
 


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request fixes an issue where the `SimpleSettingCollection` type was not handled correctly for the Intune Settings Catalog if it was not specified in the DSC params. A null check was missing, leading to a `You cannot call a method on a null-valued expression.`.

#### This Pull Request (PR) fixes the following issues
- Fixes #5000 