### PR TITLE
Add support for Exchange Online ARC Config

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/MSFT_EXOArcConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/MSFT_EXOArcConfig.psm1
@@ -1,0 +1,397 @@
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [String]
+        $IsSingleInstance,
+
+        [Parameter()]
+        [ValidateSet('Present')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.String]
+        $ArcTrustedSealers,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [System.String]
+        $CertificatePath,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $CertificatePassword,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    New-M365DSCConnection -Workload 'ExchangeOnline' `
+        -InboundParameters $PSBoundParameters | Out-Null
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    $nullResult = $PSBoundParameters
+    $nullResult.Ensure = 'Absent'
+    try
+    {
+        $instance = Get-ArcConfig -ErrorAction SilentlyContinue
+        if ($null -eq $instance)
+        {
+            return $nullResult
+        }
+
+        Write-Verbose -Message "Found an instance with <PrimaryKey> {$<PrimaryKey>}"
+        $results = @{
+            IsSingleInstance    = 'Yes'
+            ArcTrustedSealers   = $instance.ArcTrustedSealers
+            Ensure              = 'Present'
+        }
+        return [System.Collections.Hashtable] $results
+    }
+    catch
+    {
+        New-M365DSCLogEntry -Message 'Error retrieving data:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return $nullResult
+    }
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [String]
+        $IsSingleInstance,
+
+        [Parameter()]
+        [System.String]
+        $Identity = 'Default',
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $ArcTrustedSealers,
+
+        [Parameter()]
+        [ValidateSet('Present')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [System.String]
+        $CertificatePath,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $CertificatePassword,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    New-M365DSCConnection -Workload '<#Workload#>' `
+        -InboundParameters $PSBoundParameters | Out-Null
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    if ('Default' -ne $Identity)
+    {
+        throw "EXOArcConfig configurations MUST specify Identity value of 'Default'"
+    }
+
+    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
+        -InboundParameters $PSBoundParameters
+
+    $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+
+    Set-ArcConfig $BoundParameters
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [String]
+        $IsSingleInstance,
+
+        [Parameter()]
+        [System.String]
+        $Identity = 'Default',
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $ArcTrustedSealers,
+
+        [Parameter()]
+        [ValidateSet('Present')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [System.String]
+        $CertificatePath,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $CertificatePassword,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    Write-Verbose -Message "Testing configuration of {$<PrimaryKey>}"
+
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+
+    $ValuesToCheck = $PSBoundParameters
+    $ValuesToCheck.Remove('Ensure') | Out-Null
+
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
+    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $ValuesToCheck)"
+
+    #Convert any DateTime to String
+    foreach ($key in $ValuesToCheck.Keys)
+    {
+        if (($null -ne $CurrentValues[$key]) `
+                -and ($CurrentValues[$key].GetType().Name -eq 'DateTime'))
+        {
+            $CurrentValues[$key] = $CurrentValues[$key].toString()
+        }
+    }
+
+    $testResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
+        -Source $($MyInvocation.MyCommand.Source) `
+        -DesiredValues $PSBoundParameters `
+        -ValuesToCheck $ValuesToCheck.Keys
+
+    Write-Verbose -Message "Test-TargetResource returned $testResult"
+
+    return $testResult
+}
+
+function Export-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity
+    )
+
+   $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
+        -InboundParameters $PSBoundParameters
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    try
+    {
+        [array]$getValue = Get-ArcConfig -ErrorAction Stop
+
+        $i = 1
+        $dscContent = ''
+        if ($getValue.Length -eq 0)
+        {
+            Write-Host $Global:M365DSCEmojiGreenCheckMark
+        }
+        else
+        {
+            Write-Host "`r`n" -NoNewline
+        }
+        foreach ($config in $getValue)
+        {
+            if ($null -ne $Global:M365DSCExportResourceInstancesCount)
+            {
+                $Global:M365DSCExportResourceInstancesCount++
+            }
+
+            $displayedKey = "Authenticated Received Chain (ARC) Settings"
+            Write-Host "    |---[$i/$($getValue.Count)] $displayedKey" -NoNewline
+            $params = @{
+                IsSingleInstance      = 'Yes'
+                Credential            = $Credential
+                ApplicationId         = $ApplicationId
+                TenantId              = $TenantId
+                CertificateThumbprint = $CertificateThumbprint
+                CertificatePassword   = $CertificatePassword
+                Managedidentity       = $ManagedIdentity.IsPresent
+                CertificatePath       = $CertificatePath
+                AccessTokens          = $AccessTokens
+            }
+
+            $Results = Get-TargetResource @Params
+            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
+                -Results $Results
+
+            $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
+                -ConnectionMode $ConnectionMode `
+                -ModulePath $PSScriptRoot `
+                -Results $Results `
+                -Credential $Credential
+            $dscContent += $currentDSCBlock
+
+            if ($script:ExportMode) {
+                Save-M365DSCPartialExport -Content $currentDSCBlock `
+                -FileName $Global:PartialExportFileName
+            }
+            $i++
+            Write-Host $Global:M365DSCEmojiGreenCheckMark
+        }
+        return $dscContent
+    }
+    catch
+    {
+        Write-Host $Global:M365DSCEmojiRedX
+
+        New-M365DSCLogEntry -Message 'Error during Export:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return ''
+    }
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/MSFT_EXOArcConfig.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/MSFT_EXOArcConfig.schema.mof
@@ -1,0 +1,6 @@
+[ClassVersion("1.0.0.0"), FriendlyName("EXOArcConfig")]
+class MSFT_EXOArcConfig: OMI_BaseResource
+{
+    [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'"), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
+    [Write, Description("Comma separated list of trusted Authentication Received Chain (ARC) sealers")] String ArcTrustedSealers;
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/readme.md
@@ -1,0 +1,7 @@
+
+# EXOArcConfig
+
+## Description
+
+This resource configured the Authenticated Received Chain (ARC) configuration in
+Microsoft Defender for Office 365.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/settings.json
@@ -1,0 +1,33 @@
+{
+    "resourceName": "EXOArcConfig",
+    "description": "This resource configures an <ResourceDescription>.",
+    "roles": {
+        "read": [
+            "Security Reader"
+        ],
+        "update": [
+            "Security Administrator"
+        ]
+    },
+    "permissions": {
+        "graph": {
+            "delegated": {
+                "read": [],
+                "update": []
+            },
+            "application": {
+                "read": [],
+                "update": []
+            }
+        },
+        "exchange": {
+            "requiredroles": [
+                "Transport Hygiene",
+                "Security Admin",
+                "View-Only Configuration",
+                "Security Reader"
+            ],
+            "requiredrolegroups": "Organization Management"
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/EXOArcConfig/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/EXOArcConfig/2-Update.ps1
@@ -1,0 +1,37 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    Node localhost
+    {
+        EXOArcConfig "EXOArcConfig"
+        {
+            ArcTrustedSealers     = "example.com,example.org";
+            Ensure                = "Present";
+            IsSingleInstance      = "Yes";
+            ApplicationId         = $ApplicationId
+            TenantId              = $TenantId
+            CertificateThumbprint = $CertificateThumbprint
+        }
+    }
+}
+
+Example -ConfigurationData .\ConfigurationData.psd1 -Credential $Credential

--- a/Tests/Integration/Microsoft365DSC/M365DSCIntegration.EXO.Create.Tests.ps1
+++ b/Tests/Integration/Microsoft365DSC/M365DSCIntegration.EXO.Create.Tests.ps1
@@ -129,6 +129,15 @@
                     TenantId              = $TenantId
                     CertificateThumbprint = $CertificateThumbprint
                 }
+                EXOArcConfig 'EXOArcConfig'
+                {
+                    ArcTrustedSealers     = "example.com,example.org";
+                    Ensure                = "Present";
+                    IsSingleInstance      = "Yes";
+                    ApplicationId         = $ApplicationId
+                    TenantId              = $TenantId
+                    CertificateThumbprint = $CertificateThumbprint
+                }
                 EXOAuthenticationPolicy 'ConfigureAuthenticationPolicy'
                 {
                     Identity                            = "Block Basic Auth"

--- a/Tests/Integration/Microsoft365DSC/M365DSCIntegration.EXO.Remove.Tests.ps1
+++ b/Tests/Integration/Microsoft365DSC/M365DSCIntegration.EXO.Remove.Tests.ps1
@@ -115,6 +115,15 @@
                     TenantId              = $TenantId
                     CertificateThumbprint = $CertificateThumbprint
                 }
+                EXOArcConfig 'EXOArcConfig'
+                {
+                    ArcTrustedSealers     = $null;
+                    Ensure                = "Present";
+                    IsSingleInstance      = "Yes";
+                    ApplicationId         = $ApplicationId
+                    TenantId              = $TenantId
+                    CertificateThumbprint = $CertificateThumbprint
+                }
                 EXOAuthenticationPolicy 'ConfigureAuthenticationPolicy'
                 {
                     Identity                            = "Block Basic Auth"
@@ -438,7 +447,7 @@
                 }
                 EXORecipientPermission 'AddSendAs'
                 {
-        
+
                     Identity     = 'AdeleV@$Domain'
                     Trustee      = "admin@$TenantId"
                     Ensure       = 'Absent'

--- a/Tests/Integration/Microsoft365DSC/M365DSCIntegration.EXO.Update.Tests.ps1
+++ b/Tests/Integration/Microsoft365DSC/M365DSCIntegration.EXO.Update.Tests.ps1
@@ -130,6 +130,15 @@
                     TenantId              = $TenantId
                     CertificateThumbprint = $CertificateThumbprint
                 }
+                EXOArcConfig 'EXOArcConfig'
+                {
+                    ArcTrustedSealers     = "example.com,example.org,example.net";
+                    Ensure                = "Present";
+                    IsSingleInstance      = "Yes";
+                    ApplicationId         = $ApplicationId
+                    TenantId              = $TenantId
+                    CertificateThumbprint = $CertificateThumbprint
+                }
                 EXOAtpPolicyForO365 'ConfigureAntiPhishPolicy'
                 {
                     IsSingleInstance        = "Yes"

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOArcConfig.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOArcConfig.Tests.ps1
@@ -1,0 +1,131 @@
+[CmdletBinding()]
+param(
+)
+$M365DSCTestFolder = Join-Path -Path $PSScriptRoot `
+    -ChildPath '..\..\Unit' `
+    -Resolve
+$CmdletModule = (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\Stubs\Microsoft365.psm1' `
+        -Resolve)
+$GenericStubPath = (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\Stubs\Generic.psm1' `
+        -Resolve)
+Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\UnitTestHelper.psm1' `
+        -Resolve)
+
+$Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
+    -DscResource 'EXOArcConfig' -GenericStubModule $GenericStubPath
+Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
+        BeforeAll {
+
+            $secpasswd = ConvertTo-SecureString (New-Guid | Out-String) -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
+
+            Mock -CommandName Confirm-M365DSCDependencies -MockWith {
+            }
+
+            Mock -CommandName Get-PSSession -MockWith {
+            }
+
+            Mock -CommandName Remove-PSSession -MockWith {
+            }
+
+            Mock -CommandName Get-ArcConfig -MockWith {
+            }
+
+            Mock -CommandName Set-ArcConfig -MockWith {
+            }
+
+            Mock -CommandName Confirm-ImportedCmdletIsAvailable -MockWith {
+                return $true
+            }
+
+            Mock -CommandName New-M365DSCConnection -MockWith {
+                return 'Credentials'
+            }
+
+            # Mock Write-Host to hide output during the tests
+            Mock -CommandName Write-Host -MockWith {
+            }
+            $Script:exportedInstances = $null
+            $Script:ExportMode = $false
+        }
+        # Test contexts
+        Context -Name 'EXOArcConfig update not required.' -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    IsSingleInstance  = 'Yes'
+                    Ensure            = 'Present'
+                    Credential        = $Credential
+                    ArcTrustedSealers = "test1,test2"
+                }
+
+                Mock -CommandName Get-ArcConfig -MockWith {
+                    return @{
+                        IsSingleInstance  = 'Yes'
+                        Ensure            = 'Present'
+                        Identity          = 'Default'
+                        Credential        = $Credential
+                        ArcTrustedSealers = "test1,test2"
+                    }
+                }
+            }
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+        }
+
+        Context -Name 'EXOArchConfig update needed' -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    IsSingleInstance  = 'Yes'
+                    Ensure            = 'Present'
+                    Credential        = $Credential
+                    ArcTrustedSealers = "test1,test2"
+                }
+
+                Mock -CommandName Get-ArcConfig -MockWith {
+                    return @{
+                        IsSingleInstance  = 'Yes'
+                        Ensure            = 'Present'
+                        Identity          = 'Default'
+                        Credential        = $Credential
+                        ArcTrustedSealers = "test3,test4"
+                    }
+                }
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+            }
+        }
+
+        Context -Name 'ReverseDSC Tests' -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Credential = $Credential
+                }
+
+                Mock -CommandName Get-ArcConfig -MockWith {
+                    return @{
+                        ArcTrustedSealers = "test1,test2"
+                    }
+                }
+            }
+
+            It 'Should Reverse Engineer resource from the Export method' {
+                $result = Export-TargetResource @testParams
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}
+
+Invoke-Command -ScriptBlock $Global:DscHelper.CleanupScript -NoNewScope

--- a/Tests/Unit/Stubs/Microsoft365.psm1
+++ b/Tests/Unit/Stubs/Microsoft365.psm1
@@ -485,6 +485,14 @@ function Get-ApplicationAccessPolicy
         $Identity
     )
 }
+
+function Get-ArcConfig
+{
+    [CmdletBinding()]
+    param(
+    )
+}
+
 function Get-AtpPolicyForO365
 {
     [CmdletBinding()]
@@ -7527,6 +7535,21 @@ function Set-ApplicationAccessPolicy
         $Identity
     )
 }
+
+function Set-ArcConfig
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.Object]
+        $Identity,
+
+        [Parameter()]
+        [System.String]
+        $ArcTrustedSealers
+    )
+}
+
 function Set-AtpPolicyForO365
 {
     [CmdletBinding()]


### PR DESCRIPTION
#### Pull Request (PR) description
Add support for the Exchange Online Authenticated Received Change configuration

- Add the EXOArcConfig resources
- Added unit tests for EXOArcConfig
- Add EXOArcConfig to EXO Integration tests
- Add stubs for Get/Set-ArcConfig to Stubs/Microsoft365.psm1

Note the EXOArcConfig resource is single instanced, and currently only has a single ArcTrustedSealers property