### PR TITLE
IntuneAntivirusPolicyWindows10 - Fix invalid parameter definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* IntuneAntivirusPolicyWindows10SettingCatalog
+  * Fixes an issue with invalid parameter definition.
+    FIXES [#5015](https://github.com/microsoft/Microsoft365DSC/issues/5015)
 * SPOAccessControlSettings
   * Added support for property EnableRestrictedAccessControl.
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
@@ -90,11 +90,11 @@ function Get-TargetResource
         [System.int32]
         $avgcpuloadfactor,
 
-        [Parameter]
+        [Parameter()]
         [System.Int32]
         $archivemaxdepth,
 
-        [Parameter]
+        [Parameter()]
         [System.Int32]
         $archivemaxsize,
 
@@ -601,11 +601,11 @@ function Set-TargetResource
         [System.int32]
         $avgcpuloadfactor,
 
-        [Parameter]
+        [Parameter()]
         [System.Int32]
         $archivemaxdepth,
 
-        [Parameter]
+        [Parameter()]
         [System.Int32]
         $archivemaxsize,
 
@@ -1095,11 +1095,11 @@ function Test-TargetResource
         [System.int32]
         $avgcpuloadfactor,
 
-        [Parameter]
+        [Parameter()]
         [System.Int32]
         $archivemaxdepth,
 
-        [Parameter]
+        [Parameter()]
         [System.Int32]
         $archivemaxsize,
 


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request fixes an invalid parameter definition where the round brackets were missing. 

#### This Pull Request (PR) fixes the following issues
- Fixes #5015 
