### PR TITLE
Fix SCRoleGroup 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 * IntuneAntivirusPolicyWindows10SettingCatalog
   * Fixes an issue with invalid parameter definition.
     FIXES [#5015](https://github.com/microsoft/Microsoft365DSC/issues/5015)
+* SCRoleGroup
+  * Fixes an issue with creation without specifying Displayname
+  * Fixes an issue with Drifts because of returned Role format
+    FIXES [#5036](https://github.com/microsoft/Microsoft365DSC/issues/5036)
 * SentinelSetting
   * Initial release.
 * SPOAccessControlSettings

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRoleGroup/MSFT_SCRoleGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRoleGroup/MSFT_SCRoleGroup.psm1
@@ -11,6 +11,10 @@ function Get-TargetResource
 
         [Parameter()]
         [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.String]
         $Description,
 
         [Parameter()]
@@ -95,8 +99,9 @@ function Get-TargetResource
         {
             $result = @{
                 Name                  = $RoleGroup.Name
+                DisplayName           = $RoleGroup.DisplayName
                 Description           = $RoleGroup.Description
-                Roles                 = $RoleGroup.Roles
+                Roles                 = $RoleGroup.Roles -replace "^.*\/(?=[^\/]*$)"
                 Ensure                = 'Present'
                 Credential            = $Credential
                 ApplicationId         = $ApplicationId
@@ -133,6 +138,11 @@ function Set-TargetResource
         [ValidateLength(1, 64)]
         [System.String]
         $Name,
+
+        [Parameter()]
+        [ValidateLength(1, 256)]
+        [System.String]
+        $DisplayName,
 
         [Parameter()]
         [System.String]
@@ -205,6 +215,14 @@ function Set-TargetResource
         Roles       = $Roles
         Confirm     = $false
     }
+    # Add DisplayName Parameter equals Name if null or Empty as creation with no value will lead to a corrupted state of the created RoleGroup
+    if ([System.String]::IsNullOrEmpty($DisplayName))
+    {
+        $NewRoleGroupParams.Add('DisplayName', $Name)
+    }
+    else {
+        $NewRoleGroupParams.Add('DisplayName', $DisplayName)
+    }
     # Remove Description Parameter if null or Empty as the creation fails with $null parameter
     if ([System.String]::IsNullOrEmpty($Description))
     {
@@ -239,6 +257,11 @@ function Test-TargetResource
         [ValidateLength(1, 64)]
         [System.String]
         $Name,
+
+        [Parameter()]
+        [ValidateLength(1, 256)]
+        [System.String]
+        $DisplayName,
 
         [Parameter()]
         [System.String]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRoleGroup/MSFT_SCRoleGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRoleGroup/MSFT_SCRoleGroup.psm1
@@ -10,6 +10,7 @@ function Get-TargetResource
         $Name,
 
         [Parameter()]
+        [ValidateLength(1, 256)]
         [System.String]
         $DisplayName,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRoleGroup/MSFT_SCRoleGroup.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRoleGroup/MSFT_SCRoleGroup.schema.mof
@@ -2,6 +2,7 @@
 class MSFT_SCRoleGroup : OMI_BaseResource
 {
     [Key, Description("The Name parameter specifies the name of the role. The maximum length of the name is 64 characters.")] String Name;
+    [Write, Description("The DisplayName parameter specifies the name of the role. The maximum length of the name is 256 characters.")] String DisplayName;
     [Write, Description("The Description parameter specifies the description that's displayed when the role group is viewed using the Get-RoleGroup cmdlet. Enclose the description in quotation marks")] String Description;
     [Write, Description("The Roles parameter specifies the management roles to assign to the role group when it's created. If a role name contains spaces, enclose the name in quotation marks. If you want to assign more that one role, separate the role names with commas.")] String Roles[];
     [Write, Description("Specify if the Role Group should exist or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRoleGroup/MSFT_SCRoleGroup.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRoleGroup/MSFT_SCRoleGroup.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_SCRoleGroup : OMI_BaseResource
 {
     [Key, Description("The Name parameter specifies the name of the role. The maximum length of the name is 64 characters.")] String Name;
-    [Write, Description("The DisplayName parameter specifies the name of the role. The maximum length of the name is 256 characters.")] String DisplayName;
+    [Write, Description("The DisplayName parameter specifies the friendly name of the role group. If the name contains spaces, enclose the name in quotation marks. This parameter has a maximum length of 256 characters.")] String DisplayName;
     [Write, Description("The Description parameter specifies the description that's displayed when the role group is viewed using the Get-RoleGroup cmdlet. Enclose the description in quotation marks")] String Description;
     [Write, Description("The Roles parameter specifies the management roles to assign to the role group when it's created. If a role name contains spaces, enclose the name in quotation marks. If you want to assign more that one role, separate the role names with commas.")] String Roles[];
     [Write, Description("Specify if the Role Group should exist or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;


### PR DESCRIPTION
#### Pull Request (PR) description
Add the DisplayName Parameter, use Name Value as DisplayName if not specified. Remove extra Role information from the output value when getting the resource. This way no Drifts occur when monitoring an existing Purview Role Group.

#### This Pull Request (PR) fixes the following issues
- Fixes #5036 
