### PR TITLE
Fix operating system build range in Intune device compliance policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 * IntuneAntivirusPolicyWindows10SettingCatalog
   * Fixes an issue with invalid parameter definition.
     FIXES [#5015](https://github.com/microsoft/Microsoft365DSC/issues/5015)
+* IntuneDeviceCompliancePolicyWindows10
+  * Fixes an issue where the property `ValidOperatingSystemBuildRanges` was
+    not exported properly.
+    FIXES [#5030](https://github.com/microsoft/Microsoft365DSC/issues/5030)
 * IntuneDeviceConfigurationSharedMultiDevicePolicyWindows10
   * Add missing `AccessTokens` parameter to `Export-TargetResource`
     FIXES [#5034](https://github.com/microsoft/Microsoft365DSC/issues/5034)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyWindows10/MSFT_IntuneDeviceCompliancePolicyWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyWindows10/MSFT_IntuneDeviceCompliancePolicyWindows10.schema.mof
@@ -9,6 +9,14 @@ class MSFT_DeviceManagementConfigurationPolicyAssignments
     [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
 };
 
+[ClassVersion("1.0.0.0")]
+class MSFT_MicrosoftGraphOperatingSystemVersionRange
+{
+    [Write, Description("The description of this range (e.g. Valid 1702 builds)")] String Description;
+    [Write, Description("The lowest inclusive version that this range contains.")] String LowestVersion;
+    [Write, Description("The highest inclusive version that this range contains.")] String HighestVersion;
+};
+
 [ClassVersion("1.0.0.0"), FriendlyName("IntuneDeviceCompliancePolicyWindows10")]
 class MSFT_IntuneDeviceCompliancePolicyWindows10 : OMI_BaseResource
 {
@@ -46,7 +54,7 @@ class MSFT_IntuneDeviceCompliancePolicyWindows10 : OMI_BaseResource
     [Write, Description("ConfigurationManagerComplianceRequired of the Windows 10 device compliance policy.")] Boolean ConfigurationManagerComplianceRequired;
     [Write, Description("TpmRequired of the Windows 10 device compliance policy.")] Boolean TpmRequired;
     [Write, Description("DeviceCompliancePolicyScript of the Windows 10 device compliance policy.")] String DeviceCompliancePolicyScript;
-    [Write, Description("ValidOperatingSystemBuildRanges of the Windows 10 device compliance policy.")] String ValidOperatingSystemBuildRanges[];
+    [Write, Description("ValidOperatingSystemBuildRanges of the Windows 10 device compliance policy."), EmbeddedInstance("MSFT_MicrosoftGraphOperatingSystemVersionRange")] String ValidOperatingSystemBuildRanges[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Intune Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;


### PR DESCRIPTION
#### Pull Request (PR) description
**Breaking change due to update of property type.**
This pull request fixes an issue with the handling of the `ValidOperatingSystemBuildRanges` property in the `IntuneDeviceCompliancePolicyWindows10` resource. The property was neither exported correctly nor otherwise handled correctly. 

#### This Pull Request (PR) fixes the following issues
- Fixes #5030 
