### PR TITLE
Adding MdcSubscriptionDefenderPlan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
-
+* MdcSubscriptionDefenderPlan
+  * Initial release
 * AADPasswordRuleSettings
   * Initial release
 * ADOOrganizationOwner

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_MdcSubscriptionDefenderPlan/MSFT_MdcSubscriptionDefenderPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_MdcSubscriptionDefenderPlan/MSFT_MdcSubscriptionDefenderPlan.psm1
@@ -1,0 +1,475 @@
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $SubscriptionName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $PlanName,
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
+        [ValidateSet('Free', 'Standard')]
+        [System.String]
+        $PricingTier,
+
+        [Parameter()]
+        [System.String]
+        $SubPlanName,
+
+        [Parameter()]
+        [System.String]
+        $Extensions,
+
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    New-M365DSCConnection -Workload 'Azure' `
+        -InboundParameters $PSBoundParameters | Out-Null
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+
+    $nullResult = $PSBoundParameters
+    $nullResult.Ensure = 'Absent'
+    try
+    {
+        if ($null -ne $Script:exportedInstances -and $Script:ExportMode)
+        {
+            if (-not [System.String]::IsNullOrEmpty($SubscriptionId))
+            {
+                $instance = $Script:exportedInstances | Where-Object -FilterScript {$_.SubscriptionId -eq $SubscriptionId -and $_.Name -eq $PlanName}
+            }
+            elseif ($null -eq $instance -and -not [System.String]::IsNullOrEmpty($SubscriptionName))
+            {
+                $instance = $Script:exportedInstances | Where-Object -FilterScript {$_.SubscriptionName -eq $SubscriptionName -and $_.Name -eq $PlanName}
+            }
+        }
+        else
+        {
+            $subscriptionId = $SubscriptionId
+            if ([System.String]::IsNullOrEmpty($subscriptionId))
+            {
+                $subscription = Get-AzSubscription -SubscriptionName $SubscriptionName
+
+                if($subscription -ne $null)
+                {
+                    $subscriptionId = $subscription.Id
+                }
+            }
+
+
+            if($subscriptionId -ne $null)
+            {
+                 Set-AzContext -Subscription $subscriptionId -ErrorAction Stop
+                 $instance = Get-AzSecurityPricing -Name $PlanName -ErrorAction Stop
+                 $azContext = Get-AzContext
+                 Add-Member -InputObject $instance -NotePropertyName "SubscriptionName" -NotePropertyValue $azContext.Subscription.Name
+                 Add-Member -InputObject $instance -NotePropertyName "SubscriptionId" -NotePropertyValue $azContext.Subscription.Id
+            }
+
+        }
+        if ($null -eq $instance)
+        {
+            return $nullResult
+        }
+
+        $results = @{
+            SubscriptionId        = $instance.SubscriptionId
+            SubscriptionName      = $instance.SubscriptionName
+            PlanName              = $PlanName
+            PricingTier           = $instance.PricingTier
+            SubPlanName           = $instance.SubPlan
+            Extensions            = $instance.Extensions
+            Ensure                = 'Present'
+            Credential            = $Credential
+            ApplicationId         = $ApplicationId
+            TenantId              = $TenantId
+            CertificateThumbprint = $CertificateThumbprint
+            ManagedIdentity       = $ManagedIdentity.IsPresent
+            AccessTokens          = $AccessTokens
+        }
+        return [System.Collections.Hashtable] $results
+    }
+    catch
+    {
+        Write-Verbose -Message $_
+        New-M365DSCLogEntry -Message 'Error retrieving data:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return $nullResult
+    }
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $SubscriptionName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $PlanName,
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
+        [ValidateSet('Free', 'Standard')]
+        [System.String]
+        $PricingTier,
+
+        [Parameter()]
+        [System.String]
+        $SubPlanName,
+
+        [Parameter()]
+        [System.String]
+        $Extensions,
+
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    $currentInstance = Get-TargetResource @PSBoundParameters
+
+    $setParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+
+    # CREATE
+    if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
+    {
+        throw "It's not possible to create Microsoft Defender for Cloud bundles"
+    }
+    # UPDATE
+    elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Set-AzContext -Subscription $currentInstance.SubscriptionId -ErrorAction Stop
+        if($Extensions)
+        {
+            Set-AzSecurityPricing -Name $PlanName -PricingTier $PricingTier -SubPlan $SubPlanName -Extension $Extensions -ErrorAction Stop
+        }
+        else
+        {
+            Set-AzSecurityPricing -Name $PlanName -PricingTier $PricingTier -SubPlan $SubPlanName -ErrorAction Stop
+        }
+    }
+    # REMOVE
+    elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
+    {
+        throw "It's not possible to delete Microsoft Defender for Cloud bundles"
+    }
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $SubscriptionName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $PlanName,
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
+        [ValidateSet('Free', 'Standard')]
+        [System.String]
+        $PricingTier,
+
+        [Parameter()]
+        [System.String]
+        $SubPlanName,
+
+        [Parameter()]
+        [System.String]
+        $Extensions,
+
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
+        [System.String]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+    $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
+
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
+    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $ValuesToCheck)"
+
+    $testResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
+        -Source $($MyInvocation.MyCommand.Source) `
+        -DesiredValues $PSBoundParameters `
+        -ValuesToCheck $ValuesToCheck.Keys
+
+    Write-Verbose -Message "Test-TargetResource returned $testResult"
+
+    return $testResult
+}
+
+function Export-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    $ConnectionMode = New-M365DSCConnection -Workload 'Azure' `
+        -InboundParameters $PSBoundParameters
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    try
+    {
+        $Script:ExportMode = $true
+        [array] $Script:exportedInstances = Get-SubscriptionsDefenderPlansFromArg -ErrorAction Stop
+
+        $i = 1
+        $dscContent = ''
+        if ($Script:exportedInstances.Length -eq 0)
+        {
+            Write-Host $Global:M365DSCEmojiGreenCheckMark
+        }
+        else
+        {
+            Write-Host "`r`n" -NoNewline
+        }
+        foreach ($config in $Script:exportedInstances)
+        {
+            $displayedKey = $config.Id
+            Write-Host "    |---[$i/$($Script:exportedInstances.Count)] $displayedKey" -NoNewline
+            $params = @{
+                SubscriptionName      = $config.SubscriptionName
+                SubscriptionId        = $config.SubscriptionId
+                PlanName              = $config.PlanName
+                Credential            = $Credential
+                ApplicationId         = $ApplicationId
+                TenantId              = $TenantId
+                CertificateThumbprint = $CertificateThumbprint
+                ManagedIdentity       = $ManagedIdentity.IsPresent
+                AccessTokens          = $AccessTokens
+            }
+
+            $Results = Get-TargetResource @Params
+            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
+                -Results $Results
+
+            $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
+                -ConnectionMode $ConnectionMode `
+                -ModulePath $PSScriptRoot `
+                -Results $Results `
+                -Credential $Credential
+            $dscContent += $currentDSCBlock
+            Save-M365DSCPartialExport -Content $currentDSCBlock `
+                -FileName $Global:PartialExportFileName
+            $i++
+            Write-Host $Global:M365DSCEmojiGreenCheckMark
+        }
+        return $dscContent
+    }
+    catch
+    {
+        Write-Host $Global:M365DSCEmojiRedX
+
+        New-M365DSCLogEntry -Message 'Error during Export:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return ''
+    }
+}
+
+
+function Get-SubscriptionsDefenderPlansFromArg
+{
+    $results = @()
+    $argQuery=@'
+securityresources | where type == "microsoft.security/pricings" | project Id=id, PlanName=name, SubscriptionId=subscriptionId, SubPlan=tostring(properties.subPlan), PricingTier=tostring(properties.pricingTier), Extensions=tostring(properties.extensions)
+| join kind=inner (resourcecontainers | where type == "microsoft.resources/subscriptions" | project SubscriptionName = name, SubscriptionId = subscriptionId) on SubscriptionId | project-away SubscriptionId1
+'@
+    $queryResult = Search-AzGraph -Query $argQuery -First 1000 -UseTenantScope -ErrorAction Stop
+    $results+=$queryResult.Data
+
+    while($queryResult.SkipToken -ne $null)
+    {
+        $queryResult = Search-AzGraph -Query $argQuery -First 1000 -UseTenantScope -SkipToken $queryResult.SkipToken  -ErrorAction Stop
+        $results+=$queryResult.Data
+    }
+
+    return $results
+}
+
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_MdcSubscriptionDefenderPlan/MSFT_MdcSubscriptionDefenderPlan.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_MdcSubscriptionDefenderPlan/MSFT_MdcSubscriptionDefenderPlan.schema.mof
@@ -1,0 +1,18 @@
+[ClassVersion("1.0.0.0"), FriendlyName("MdcSubscriptionDefenderPlan")]
+class MSFT_MdcSubscriptionDefenderPlan : OMI_BaseResource
+{
+    [Key, Description("The display name of the subscription.")] String SubscriptionName;
+    [Key, Description("The Defender plan name, for the list all of possible Defender plans refer to Defender for Cloud documentation")] String PlanName;
+    [Write, ("The unique identifier of the Azure subscription.")] String SubscriptionId;
+    [Write, Description("The pricing tier ('Standard' or 'Free')")] String PricingTier;
+    [Write, Description("The Defender sub plan name, for the list all of possible sub plans refer to Defender for Cloud documentation")] String SubPlanName;
+    [Write, Description("The extensions offered under the plan, for more information refer to Defender for Cloud documentation")] String Extensions;
+
+    [Write, Description("Present ensures the instance exists, absent ensures it is removed."), ValueMap{"Present"}, Values{"Present"}] string Ensure;
+    [Write, Description("Credentials of the workload's Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
+    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
+    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
+    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Access token used for authentication.")] String AccessTokens[];
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_MdcSubscriptionDefenderPlan/MSFT_MdcSubscriptionDefenderPlan.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_MdcSubscriptionDefenderPlan/MSFT_MdcSubscriptionDefenderPlan.schema.mof
@@ -3,7 +3,7 @@ class MSFT_MdcSubscriptionDefenderPlan : OMI_BaseResource
 {
     [Key, Description("The display name of the subscription.")] String SubscriptionName;
     [Key, Description("The Defender plan name, for the list all of possible Defender plans refer to Defender for Cloud documentation")] String PlanName;
-    [Write, ("The unique identifier of the Azure subscription.")] String SubscriptionId;
+    [Write, Description("The unique identifier of the Azure subscription.")] String SubscriptionId;
     [Write, Description("The pricing tier ('Standard' or 'Free')")] String PricingTier;
     [Write, Description("The Defender sub plan name, for the list all of possible sub plans refer to Defender for Cloud documentation")] String SubPlanName;
     [Write, Description("The extensions offered under the plan, for more information refer to Defender for Cloud documentation")] String Extensions;
@@ -16,3 +16,4 @@ class MSFT_MdcSubscriptionDefenderPlan : OMI_BaseResource
     [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
     [Write, Description("Access token used for authentication.")] String AccessTokens[];
 };
+

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_MdcSubscriptionDefenderPlan/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_MdcSubscriptionDefenderPlan/readme.md
@@ -1,0 +1,12 @@
+
+# MdcSubscriptionDefenderPlan
+
+## Description
+
+Enables or disables Microsoft Defender plans for a subscription in Microsoft Defender for Cloud.
+For more information about the available Defender plans, sub plans and plan extensions refer to Defender for Cloud onboarding API documentation.
+https://learn.microsoft.com/en-us/rest/api/defenderforcloud/pricings/update?view=rest-defenderforcloud-2024-01-01&tabs=HTTP
+
+
+To have all security features enabled during plan enablement, make sure to assign the required Azure RBAC permissions to the application running this module.
+For more information about the required permissions refer to the documentation https://learn.microsoft.com/en-us/azure/defender-for-cloud/permissions.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_MdcSubscriptionDefenderPlan/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_MdcSubscriptionDefenderPlan/settings.json
@@ -1,0 +1,20 @@
+﻿{
+    "resourceName": "MdcSubscriptionDefenderPlan",
+    "description": "Enables or disables Microsoft Defender plans for a subscription in Microsoft Defender for Cloud.",
+    "roles": {
+        "read": [],
+        "update": []
+    },
+    "permissions": {
+        "graph": {
+            "delegated": {
+                "read": [],
+                "update": []
+            },
+            "application": {
+                "read": [],
+                "update": []
+            }
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/MdcSubscriptionDefenderPlan/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/MdcSubscriptionDefenderPlan/2-Update.ps1
@@ -28,7 +28,6 @@ Configuration Example
             SubPlanName           = 'P2'
             PricingTier           = 'Standard'
             SubscriptionId        = 'd620d94d-916d-4dd9-9de5-179292873e20'
-            Enabled               = $true
             ApplicationId         = $ApplicationId
             TenantId              = $TenantId
             CertificateThumbprint = $CertificateThumbprint

--- a/Modules/Microsoft365DSC/Examples/Resources/MdcSubscriptionDefenderPlan/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/MdcSubscriptionDefenderPlan/2-Update.ps1
@@ -1,0 +1,37 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+    node localhost
+    {
+        MdcSubscriptionDefenderPlan 'TestSubscription'
+        {
+            SubscriptionName      = 'MyTestSubscription'
+            PlanName              = 'VirtualMachines'
+            SubPlanName           = 'P2'
+            PricingTier           = 'Standard'
+            SubscriptionId        = 'd620d94d-916d-4dd9-9de5-179292873e20'
+            Enabled               = $true
+            ApplicationId         = $ApplicationId
+            TenantId              = $TenantId
+            CertificateThumbprint = $CertificateThumbprint
+        }
+    }
+}

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.MdcSubscriptionDefenderPlan.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.MdcSubscriptionDefenderPlan.Tests.ps1
@@ -1,0 +1,176 @@
+[CmdletBinding()]
+param(
+)
+$M365DSCTestFolder = Join-Path -Path $PSScriptRoot `
+    -ChildPath '..\..\Unit' `
+    -Resolve
+$CmdletModule = (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\Stubs\Microsoft365.psm1' `
+        -Resolve)
+$GenericStubPath = (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\Stubs\Generic.psm1' `
+        -Resolve)
+Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\UnitTestHelper.psm1' `
+        -Resolve)
+
+$CurrentScriptPath = $PSCommandPath.Split('\')
+$CurrentScriptName = $CurrentScriptPath[$CurrentScriptPath.Length - 1]
+$ResourceName = $CurrentScriptName.Split('.')[1]
+$Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
+    -DscResource $ResourceName -GenericStubModule $GenericStubPath
+
+Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
+        BeforeAll {
+
+            $secpasswd = ConvertTo-SecureString (New-Guid | Out-String) -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
+
+            Mock -CommandName Confirm-M365DSCDependencies -MockWith {
+            }
+
+            Mock -CommandName New-M365DSCConnection -MockWith {
+                return 'Credentials'
+            }
+
+            Mock -CommandName Set-AzSecurityPricing -MockWith {
+            }
+
+            Mock -CommandName Set-AzContext -MockWith {
+            }
+
+            # Mock Write-Host to hide output during the tests
+            Mock -CommandName Write-Host -MockWith {
+            }
+            $Script:exportedInstances = $null
+            $Script:ExportMode = $false
+        }
+        # Test contexts
+        Context -Name 'The instance exists and values are already in the desired state' -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    SubscriptionName = 'MySubscription'
+                    PlanName         = 'VirtualMachines'
+                    SubPlanName      = 'P2'
+                    PricingTier      = 'Standard'
+                    Ensure           = 'Present'
+                    Credential       = $Credential
+                }
+
+                Mock -CommandName Get-AzSubscription -MockWith {
+                    return @{
+                        Id   = '2974ccf2-1e67-4b74-a102-2d921b595a89'
+                        Name = 'MySubscription'
+                    }
+                }
+
+                Mock -CommandName Get-AzContext -MockWith {
+                    return @{
+                        Subscription = @{
+                            Id   = '2974ccf2-1e67-4b74-a102-2d921b595a89'
+                            Name = 'MySubscription'
+                        }
+                    }
+                }
+
+                Mock -CommandName Get-AzSecurityPricing -MockWith {
+                    return @{
+                        Name        = 'VirtualMachines'
+                        SubPlan     = 'P2'
+                        PricingTier = 'Standard'
+                        Extensions  = $null
+                    }
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+        }
+
+        Context -Name 'The instance exists and values are NOT in the desired state' -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    SubscriptionName = 'MySubscription'
+                    PlanName         = 'VirtualMachines'
+                    SubPlanName      = 'P2'
+                    PricingTier      = 'Standard'
+                    Ensure           = 'Present'
+                    Credential       = $Credential
+                }
+
+                Mock -CommandName Get-AzSubscription -MockWith {
+                    return @{
+                        Id   = '2974ccf2-1e67-4b74-a102-2d921b595a89'
+                        Name = 'MySubscription'
+                    }
+                }
+
+                Mock -CommandName Get-AzContext -MockWith {
+                    return @{
+                        Subscription = @{
+                            Id   = '2974ccf2-1e67-4b74-a102-2d921b595a89'
+                            Name = 'MySubscription'
+                        }
+                    }
+                }
+
+                Mock -CommandName Get-AzSecurityPricing -MockWith {
+                    return @{
+                        Name        = 'VirtualMachines'
+                        PricingTier = 'Free' # Drift
+                        SubPlan     = $null
+                        Extensions  = $null
+                    }
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Set-AzSecurityPricing -Exactly 1
+            }
+        }
+
+        Context -Name 'ReverseDSC Tests' -Fixture {
+            BeforeAll {
+                $Global:CurrentModeIsExport = $true
+                $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
+                $testParams = @{
+                    Credential = $Credential
+                }
+
+                Mock -CommandName Search-AzGraph -MockWith {
+                    return @{
+                        Data = @(
+                            @{
+                                SubscriptionId   = '2974ccf2-1e67-4b74-a102-2d921b595a89'
+                                SubscriptionName = 'MySubscription'
+                                PlanName         = 'VirtualMachines'
+                                SubPlanName      = 'P2'
+                                PricingTier      = 'Standard'
+                                Extensions       = $null
+                            }
+                        )
+                    }
+                }
+            }
+
+            It 'Should Reverse Engineer resource from the Export method' {
+                $result = Export-TargetResource @testParams
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}
+
+Invoke-Command -ScriptBlock $Global:DscHelper.CleanupScript -NoNewScope

--- a/Tests/Unit/Stubs/Microsoft365.psm1
+++ b/Tests/Unit/Stubs/Microsoft365.psm1
@@ -67,6 +67,77 @@ function Get-AzSubscription
     )
 }
 
+function Get-AzSecurityPricing
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.String]
+        $Name
+    )
+}
+
+function Set-AzSecurityPricing
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.String]
+        $Name,
+
+        [Parameter()]
+        [System.String]
+        $PricingTier,
+
+        [Parameter()]
+        [System.String]
+        $SubPlan,
+
+        [Parameter()]
+        [System.String]
+        $Extension
+    )
+}
+
+function Get-AzContext
+{
+    [CmdletBinding()]
+    param()
+}
+
+function Set-AzContext
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.String]
+        $Subscription
+    )
+}
+
+function Search-AzGraph
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.String]
+        $Query,
+
+        [Parameter()]
+        [System.Int32]
+        $First,
+
+        [Parameter()]
+        [System.String]
+        $SkipToken,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UseTenantScope
+    )
+}
+
+
 function Enable-ATPProtectionPolicyRule
 {
     [CmdletBinding()]


### PR DESCRIPTION
#### Pull Request (PR) description
Adding MdcSubscriptionDefenderPlan DSC resource.
Which allows to enable or disable Microsoft Defender plans for a subscription in Microsoft Defender for Cloud.
For more information about the available Defender plans, sub plans and plan extensions refer to Defender for Cloud onboarding API documentation.
https://learn.microsoft.com/en-us/rest/api/defenderforcloud/pricings/update?view=rest-defenderforcloud-2024-01-01&tabs=HTTP

Important things to note in this resource:
1. Since this tool runs in tenant scope while Azure Powershell runs in subscription scope, Export-TargetResource is being implemented by querying Azure Resource Graph on the tenant scope
2. To allow users to actually export configuration and use it on another tenant, the subscription name is used as a key, and not the subscription ID (similar to AzureSubscription DSC resource which was used for inspiration)
3. The underlying Defender for Cloud commands (Set-AzSecurityPricing and Get-AzSecurityPricing doesnt accept a subscription ID as parameters, the subscription ID being used is the subscription of the logged-on Az Powershell session, therefore the subscription ID of the session is being set in Get-TargetResource and Set-TargetResource using Set-AzContext
4. Need to make sure that all Az Powershell is a dependency of this tool? or a specific Az Powershell modules? If its specific modules and **not** all Az Powershell, then Az.Security and Az.ResourceGraph should be included as well (how do I add them?)
