### PR TITLE
AADGroup: Fixes #5001 by removing code that purports to assign licenses to a new group but is never executed

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -591,10 +591,6 @@ function Set-TargetResource
                     -Source $MyInvocation.MyCommand.ModuleName
             }
         }
-        if ($assignedLicensesGUIDs.Length -gt 0)
-        {
-            Set-MgGroupLicense -GroupId $currentGroup.Id -AddLicenses $licensesToAdd -RemoveLicenses @()
-        }
     }
     if ($Ensure -eq 'Present')
     {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADGroup.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADGroup.Tests.ps1
@@ -36,8 +36,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             Mock -CommandName Get-MgGroupMember -MockWith {
             }
-            Mock -CommandName Get-MgBetaGroupMember -MockWith {
-            }
 
             Mock -CommandName Get-MgGroup -MockWith {
             }
@@ -51,12 +49,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
 
             Mock -CommandName Get-MgGroupOwner -MockWith {
-            }
-
-            Mock -CommandName Get-MgBetaGroupMemberOf -MockWith {
-            }
-
-            Mock -CommandName Get-MgBetaGroupOwner -MockWith {
             }
 
             Mock -CommandName Invoke-MgGraphRequest -MockWith {
@@ -74,15 +66,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName New-MgGroupOwnerByRef -MockWith {
             }
 
-            Mock -CommandName New-MgGroupMember -MockWith {        }            
-
-            Mock -CommandName New-MgBetaGroupOwnerByRef -MockWith {
+            Mock -CommandName New-MgGroupMember -MockWith {
             }
-            
-            Mock -CommandName New-MgBetaGroupMemberByRef -MockWith {
-            }
-
-            Mock -CommandName New-MgBetaGroupMember -MockWith {}
 
             Mock -CommandName New-MgBetaDirectoryRoleMemberByRef -MockWith {
             }
@@ -94,6 +79,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
 
             Mock -CommandName Remove-MgBetaDirectoryRoleMemberDirectoryObjectByRef -MockWith {
+            }
+
+            Mock -CommandName Invoke-MgGraphRequest -MockWith {
+            }
+
+            Mock -CommandName Set-MgGroupLicense -MockWith {
             }
 
             # Mock Write-Host to hide output during the tests
@@ -255,7 +246,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         GroupTypes      = @()
                     }
                 }
-                Mock -CommandName Get-MgBetaGroupMemberOf -MockWith {
+                Mock -CommandName Get-MgGroupMemberOf -MockWith {
                     return @{
                         AdditionalProperties = @{
                             '@odata.type' = '#microsoft.graph.group'
@@ -282,7 +273,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
                 Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
-                Should -Invoke -CommandName 'Get-MgBetaGroupMemberOf' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgGroupMemberOf' -Exactly 1
             }
 
             It 'Should return true from the Test method' {
@@ -323,7 +314,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         IsAssignableToRole = $true
                     }
                 }
-                Mock -CommandName Get-MgBetaGroupMemberOf -MockWith {
+                Mock -CommandName Get-MgGroupMemberOf -MockWith {
                     return @{
                         AdditionalProperties = @{
                             '@odata.type' = '#microsoft.graph.directoryRole'
@@ -336,7 +327,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
                 Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
-                Should -Invoke -CommandName 'Get-MgBEtaGroupMemberOf' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgGroupMemberOf' -Exactly 1
             }
 
             It 'Should return true from the Test method' {
@@ -444,7 +435,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
                 Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
-                Should -Invoke -CommandName 'Get-MgBetaGroupMemberOf' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgGroupMemberOf' -Exactly 1
             }
 
             It 'Should return false from the Test method' {
@@ -554,7 +545,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     }
                 }
 
-                Mock -CommandName New-MgBetaGroupMemberByRef -MockWith {
+                Mock -CommandName New-MgGroupMemberByRef -MockWith {
                 }
             }
 
@@ -570,7 +561,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             It 'Should call the Set method' {
                 Set-TargetResource @testParams
                 Should -Invoke -CommandName 'Get-MgGroup' -Exactly 2
-                Should -Invoke -CommandName 'New-MgBetaGroupMemberByRef' -Exactly 1
+                Should -Invoke -CommandName 'New-MgGroupMemberByRef' -Exactly 1
                 #Should -Invoke -CommandName 'Remove-MgGroupMemberDirectoryObjectByRef' -Exactly 1
             }
         }
@@ -608,7 +599,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         IsAssignableToRole = $true
                     }
                 }
-                Mock -CommandName Get-MgBEtaGroupMemberOf -MockWith {
+                Mock -CommandName Get-MgGroupMemberOf -MockWith {
                     return @{
                         AdditionalProperties = @{
                             '@odata.type' = '#microsoft.graph.directoryRole'
@@ -627,7 +618,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
                 Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
-                Should -Invoke -CommandName 'Get-MgBetaGroupMemberOf' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgGroupMemberOf' -Exactly 1
             }
 
             It 'Should return false from the Test method' {
@@ -639,6 +630,352 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
                 Should -Invoke -CommandName 'Get-MgBetaDirectoryRole' -Exactly 1
                 Should -Invoke -CommandName 'Remove-MgBetaDirectoryRoleMemberDirectoryObjectByRef' -Exactly 1
+            }
+        }
+
+        Context -Name "The Group does not exist and must be created and assigned a license. Values are NOT in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    DisplayName        = 'DSCGroup'
+                    ID                 = '12345-12345-12345-12345'
+                    Description        = 'Microsoft DSC Group'
+                    SecurityEnabled    = $True
+                    MailEnabled        = $false
+                    GroupTypes         = @()
+                    MailNickname       = 'M365DSC'
+                    AssignedLicenses   = @(
+                        (New-CimInstance -ClassName MSFT_AADGroupLicense -Property @{
+                            DisabledPlans  = [string[]]@()
+                            SkuId          = 'AAD_PREMIUM_P2'
+                        } -ClientOnly)
+                    )
+                    Ensure             = 'Present'
+                    Credential         = $Credential
+                }
+
+                Mock -CommandName New-M365DSCConnection -MockWith {
+                    return 'Credentials'
+                }
+
+                Mock -CommandName Get-MgGroup -MockWith {
+                }
+
+                Mock -CommandName Get-MgBetaSubscribedSku -MockWith {
+                    return [pscustomobject]@{
+                        ServicePlans         = @(
+                            @{
+                                ServicePlanId   = '56789-56789-56789-56789'
+                                ServicePlanName = 'Something_P2'
+                            }
+                        )
+                        SkuId                = '12345-12345-12345-12345'
+                        SkuPartNumber        = 'AAD_PREMIUM_P2'
+                    }
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                Get-TargetResource @testParams
+                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName 'New-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Set-MgGroupLicense' -Exactly 1
+            }
+        }
+
+        Context -Name "The Group exists and has been assigned the correct license. Values are already in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    DisplayName        = 'DSCGroup'
+                    ID                 = '12345-12345-12345-12345'
+                    Description        = 'Microsoft DSC Group'
+                    SecurityEnabled    = $True
+                    MailEnabled        = $false
+                    GroupTypes         = @()
+                    MailNickname       = 'M365DSC'
+                    AssignedLicenses   = @(
+                        (New-CimInstance -ClassName MSFT_AADGroupLicense -Property @{
+                            DisabledPlans  = [string[]]@()
+                            SkuId          = 'AAD_PREMIUM_P2'
+                        } -ClientOnly)
+                    )
+                    Ensure             = 'Present'
+                    Credential         = $Credential
+                }
+
+                Mock -CommandName New-M365DSCConnection -MockWith {
+                    return 'Credentials'
+                }
+
+                Mock -CommandName Get-MgGroup -MockWith {
+                    return @{
+                        DisplayName        = 'DSCGroup'
+                        ID                 = '12345-12345-12345-12345'
+                        Description        = 'Microsoft DSC Group'
+                        SecurityEnabled    = $True
+                        MailEnabled        = $false
+                        GroupTypes         = @()
+                        MailNickname       = 'M365DSC'
+                        IsAssignableToRole = $false
+                    }
+                }
+
+                Mock -CommandName Invoke-MgGraphRequest -MockWith {
+                    return @{
+                        value = @{
+                            DisabledPlans = @()
+                            SkuId         = '12345-12345-12345'
+                        }
+                    }
+                }
+
+                Mock -CommandName Get-MgBetaSubscribedSku -MockWith {
+                    return [pscustomobject]@{
+                        ServicePlans         = @(
+                            @{
+                                ServicePlanId   = '67890-67890-67890'
+                                ServicePlanName = 'Something_P2'
+                            }
+                        )
+                        SkuId                = '12345-12345-12345'
+                        SkuPartNumber        = 'AAD_PREMIUM_P2'
+                    }
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                Get-TargetResource @testParams
+                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Invoke-MgGraphRequest' -Exactly 1
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+        }
+        Context -Name "The Group exists and has been assigned the correct license but DisabledPlans differ. Values are NOT in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    DisplayName        = 'DSCGroup'
+                    ID                 = '12345-12345-12345-12345'
+                    Description        = 'Microsoft DSC Group'
+                    SecurityEnabled    = $True
+                    MailEnabled        = $false
+                    GroupTypes         = @()
+                    MailNickname       = 'M365DSC'
+                    AssignedLicenses   = @(
+                        (New-CimInstance -ClassName MSFT_AADGroupLicense -Property @{
+                            DisabledPlans  = [string[]]@()
+                            SkuId          = 'AAD_PREMIUM_P2'  # is really the SkuPartNumber
+                        } -ClientOnly)
+                    )
+                    Ensure             = 'Present'
+                    Credential         = $Credential
+                }
+
+                Mock -CommandName New-M365DSCConnection -MockWith {
+                    return 'Credentials'
+                }
+
+                Mock -CommandName Get-MgGroup -MockWith {
+                    return @{
+                        DisplayName        = 'DSCGroup'
+                        ID                 = '12345-12345-12345-12345'
+                        Description        = 'Microsoft DSC Group'
+                        SecurityEnabled    = $True
+                        MailEnabled        = $false
+                        GroupTypes         = @()
+                        MailNickname       = 'M365DSC'
+                        IsAssignableToRole = $false
+                    }
+                }
+
+                Mock -CommandName Invoke-MgGraphRequest -MockWith {
+                    return @{
+                        value = @{
+                            DisabledPlans = @('56789-56789-56789-56789')
+                            SkuId         = '23456-23456-23456-23456'
+                        }
+                    }
+                }
+
+                Mock -CommandName Get-MgBetaSubscribedSku -MockWith {
+                    return [pscustomobject]@{
+                        ServicePlans         = @(
+                            @{
+                                ServicePlanId   = '56789-56789-56789-56789'
+                                ServicePlanName = 'AAD_PREMIUM'
+                            },
+                            @{
+                                ServicePlanId   = '67890-67890-67890-67890'
+                                ServicePlanName = 'AAD_PREMIUM_P2'
+                            }
+                        )
+                        SkuId                = '23456-23456-23456-23456'
+                        SkuPartNumber        = 'AAD_PREMIUM_P2'
+                    }
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                Get-TargetResource @testParams
+                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Invoke-MgGraphRequest' -Exactly 1
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName 'Update-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Set-MgGroupLicense' -Exactly 1
+            }
+        }
+        Context -Name "The Group exists and is not assigned a license but it should be. Values are NOT in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    DisplayName        = 'DSCGroup'
+                    ID                 = '12345-12345-12345-12345'
+                    Description        = 'Microsoft DSC Group'
+                    SecurityEnabled    = $True
+                    MailEnabled        = $false
+                    GroupTypes         = @()
+                    MailNickname       = 'M365DSC'
+                    AssignedLicenses   = @(
+                        (New-CimInstance -ClassName MSFT_AADGroupLicense -Property @{
+                            DisabledPlans  = [string[]]@()
+                            SkuId          = 'AAD_PREMIUM_P2'
+                        } -ClientOnly)
+                    )
+                    Ensure             = 'Present'
+                    Credential         = $Credential
+                }
+
+                Mock -CommandName New-M365DSCConnection -MockWith {
+                    return 'Credentials'
+                }
+
+                Mock -CommandName Get-MgGroup -MockWith {
+                    return @{
+                        DisplayName        = 'DSCGroup'
+                        ID                 = '12345-12345-12345-12345'
+                        Description        = 'Microsoft DSC Group'
+                        SecurityEnabled    = $True
+                        MailEnabled        = $false
+                        GroupTypes         = @()
+                        MailNickname       = 'M365DSC'
+                        IsAssignableToRole = $false
+                    }
+                }
+
+                Mock -CommandName Get-MgBetaSubscribedSku -MockWith {
+                    return [pscustomobject]@{
+                        ServicePlans         = @(
+                            @{
+                                ServicePlanId   = '67890-67890-67890'
+                                ServicePlanName = 'Something_P2'
+                            }
+                        )
+                        SkuId                = '12345-12345-12345'
+                        SkuPartNumber        = 'AAD_PREMIUM_P2'
+                    }
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                Get-TargetResource @testParams
+                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Invoke-MgGraphRequest' -Exactly 1
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Set-MgGroupLicense' -Exactly 1
+            }
+        }
+        Context -Name "The Group Exists and is assigned a license but it shouldn't be. Values are NOT in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    DisplayName        = 'DSCGroup'
+                    ID                 = '12345-12345-12345-12345'
+                    Description        = 'Microsoft DSC Group'
+                    SecurityEnabled    = $True
+                    MailEnabled        = $false
+                    GroupTypes         = @()
+                    MailNickname       = 'M365DSC'
+                    AssignedLicenses   = @()
+                    Ensure             = 'Present'
+                    Credential         = $Credential
+                }
+
+                Mock -CommandName New-M365DSCConnection -MockWith {
+                    return 'Credentials'
+                }
+
+                Mock -CommandName Get-MgGroup -MockWith {
+                    return @{
+                        DisplayName        = 'DSCGroup'
+                        ID                 = '12345-12345-12345-12345'
+                        Description        = 'Microsoft DSC Group'
+                        SecurityEnabled    = $True
+                        MailEnabled        = $false
+                        GroupTypes         = @()
+                        MailNickname       = 'M365DSC'
+                        IsAssignableToRole = $false
+                    }
+                }
+
+                Mock -CommandName Invoke-MgGraphRequest -MockWith {
+                    return @{
+                        value = @{
+                            DisabledPlans = @()
+                            SkuId         = '12345-12345-12345'
+                        }
+                    }
+                }
+
+                Mock -CommandName Get-MgBetaSubscribedSku -MockWith {
+                    return [pscustomobject]@{
+                        ServicePlans         = @(
+                            @{
+                                ServicePlanId   = '67890-67890-67890'
+                                ServicePlanName = 'Something_P2'
+                            }
+                        )
+                        SkuId                = '12345-12345-12345'
+                        SkuPartNumber        = 'AAD_PREMIUM_P2'
+                    }
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                Get-TargetResource @testParams
+                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Invoke-MgGraphRequest' -Exactly 1
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Set-MgGroupLicense' -Exactly 1
             }
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Remove code that purports to assign licenses to a new group but is never executed due to an unassigned variable.
Any licenses are assigned afterwards when Ensure equals 'Present'.
Unit-tests have been expanded to include AssignedLicenses

#### This Pull Request (PR) fixes the following issues
Fixes #5001