### PR TITLE
MSFT_TeamsClientConfiguration - Fix RestrictedSenderList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
   * Initial release.
 * PPPowerAppPolicyUrlPatterns
   * Initial release.
+* TeamsClientConfiguration
+  * Fixed bug where RestrictedSenderList was always empty in the MSFT_TeamsClientConfiguration resource
+    FIXES [#5190](https://github.com/microsoft/Microsoft365DSC/issues/5190)
+  * Changed Set-TargetResource to always use semicolon as separator as mentioned in the MS documentation
 * TeamsUpgradePolicy
   * Added support for tenant wide changes using the * value for users.
     FIXES [#5174](https://github.com/microsoft/Microsoft365DSC/issues/5174)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsClientConfiguration/MSFT_TeamsClientConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsClientConfiguration/MSFT_TeamsClientConfiguration.psm1
@@ -140,7 +140,7 @@ function Get-TargetResource
             ManagedIdentity                  = $ManagedIdentity.IsPresent
             AccessTokens                     = $AccessTokens
         }
-        if ([System.String]::IsNullOrEmpty($RestrictedSenderList))
+        if ([System.String]::IsNullOrEmpty($Config.RestrictedSenderList))
         {
             $result.Remove('RestrictedSenderList') | Out-Null
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsClientConfiguration/MSFT_TeamsClientConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsClientConfiguration/MSFT_TeamsClientConfiguration.psm1
@@ -282,12 +282,9 @@ function Set-TargetResource
     }
     else
     {
-        $tempValue = $null
-        foreach ($sender in $SetParams.RestrictedSenderList)
-        {
-            $tempValue += $sender + ','
-        }
-        $tempValue = $tempValue.Substring(0, $tempValue.Length - 1)
+        # https://learn.microsoft.com/en-us/powershell/module/teams/set-csteamsclientconfiguration?view=teams-ps#-restrictedsenderlist
+        # This is a semicolon-separated string of the domains you'd like to allow to send emails to Teams channels
+        $tempValue = $SetParams['RestrictedSenderList'] -join ';'
         $SetParams.RestrictedSenderList = $tempValue
     }
     Set-CsTeamsClientConfiguration @SetParams


### PR DESCRIPTION
#### Pull Request (PR) description
The RestrictedSenderList was always empty in the MSFT_TeamsClientConfiguration resource.

#### This Pull Request (PR) fixes the following issues
Fixes #5190 
