### PR TITLE
Fix non-unique property name generation with parent setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * AADIdentityGovernanceProgram
   * Initial release.
+* M365DSCDRGUtil
+  * Fixes an issue where non-unique properties were not combined
+    properly with their respective parent setting.
 
 # 1.24.1016.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -2576,8 +2576,16 @@ function Export-IntuneSettingCatalogPolicySettings
 
         if ($null -ne $parentSetting)
         {
-            $combinationMatchesWithParent = $settingsWithSameName | Where-Object -FilterScript {
-                "$($parentSetting.Name)_$($_.Name)" -eq "$($parentSetting.Name)_$settingName"
+            $combinationMatchesWithParent = @()
+            $settingsWithSameName | ForEach-Object {
+                $innerParentSetting = Get-ParentSettingDefinition -SettingDefinition $_ -AllSettingDefinitions $AllSettingDefinitions
+                if ($null -ne $innerParentSetting)
+                {
+                    if ("$($innerParentSetting.Name)_$($_.Name)" -eq "$($parentSetting.Name)_$settingName")
+                    {
+                        $combinationMatchesWithParent += $_
+                    }
+                }
             }
 
             # If the combination of parent setting and setting name is unique, add the parent setting name to the setting name

--- a/ResourceGenerator/M365DSCResourceGenerator.psm1
+++ b/ResourceGenerator/M365DSCResourceGenerator.psm1
@@ -3880,8 +3880,16 @@ function New-SettingsCatalogSettingDefinitionSettingsFromTemplate {
         $parentSetting = Get-ParentSettingDefinition -SettingDefinition $SettingDefinition -AllSettingDefinitions $AllSettingDefinitions
         if ($null -ne $parentSetting)
         {
-            $combinationMatchesWithParent = $settingsWithSameName | Where-Object -FilterScript {
-                "$($parentSetting.Name)_$($_.Name)" -eq "$($parentSetting.Name)_$settingName"
+            $combinationMatchesWithParent = @()
+            $settingsWithSameName | ForEach-Object {
+                $innerParentSetting = Get-ParentSettingDefinition -SettingDefinition $_ -AllSettingDefinitions $AllSettingDefinitions
+                if ($null -ne $innerParentSetting)
+                {
+                    if ("$($innerParentSetting.Name)_$($_.Name)" -eq "$($parentSetting.Name)_$settingName")
+                    {
+                        $combinationMatchesWithParent += $_
+                    }
+                }
             }
             # If the combination of parent setting and setting name is unique, add the parent setting name to the setting name
             if ($combinationMatchesWithParent.Count -eq 1)

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneFirewallPolicyWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneFirewallPolicyWindows10.Tests.ps1
@@ -118,6 +118,14 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                 }
                             },
                             @{
+                                Id = 'vendor_msft_firewall_mdmstore_publicprofile_enablefirewall'
+                                Name = 'EnableFirewall'
+                                OffsetUri = '/MdmStore/PublicProfile/EnableFirewall'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                }
+                            },
+                            @{
                                 Id = 'vendor_msft_firewall_mdmstore_publicprofile_logfilepath'
                                 Name = 'LogFilePath'
                                 OffsetUri = '/MdmStore/PublicProfile/LogFilePath'
@@ -175,7 +183,27 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                                     parentSettingId = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_target'
                                                 }
                                             )
-
+                                        }
+                                    )
+                                }
+                            },
+                            @{
+                                Id = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_publicprofile_enablefirewall'
+                                Name = 'EnableFirewall'
+                                OffsetUri = '/MdmStore/HyperVVMSettings/{0}/PublicProfile/EnableFirewall'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                    options = @(
+                                        # Only option used in the tests is defined here
+                                        @{
+                                            name = 'Enable Firewall'
+                                            itemId = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_publicprofile_enablefirewall_true'
+                                            dependentOn = @(
+                                                @{
+                                                    dependentOn = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_target_wsl'
+                                                    parentSettingId = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_target'
+                                                }
+                                            )
                                         }
                                     )
                                 }
@@ -348,7 +376,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
             }
 
-            It 'Should return true from the Test method' {
+            It 'Should return false from the Test method' {
                 Test-TargetResource @testParams | Should -Be $false
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneSettingCatalogASRRulesPolicyWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneSettingCatalogASRRulesPolicyWindows10.Tests.ps1
@@ -59,103 +59,167 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
 
             Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicySetting -MockWith {
-                return @{
-                    Id                   = '0'
-                    SettingDefinitions   = @(
-                        @{
-                            Id = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules'
-                            Name = 'AttackSurfaceReductionRules'
-                            AdditionalProperties = @{
-                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSettingGroupCollectionDefinition'
-                                childIds = @(
-                                    'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockadobereaderfromcreatingchildprocesses',
-                                    'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros',
-                                    'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockcredentialstealingfromwindowslocalsecurityauthoritysubsystem',
-                                    'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockallofficeapplicationsfromcreatingchildprocesses'
-                                )
-                                maximumCount = 1
-                                minimumCount = 0
-                            }
-                        },
-                        @{
-                            Id = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockadobereaderfromcreatingchildprocesses'
-                            Name = 'BlockAdobeReaderFromCreatingChildProcesses'
-                            AdditionalProperties = @{
-                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
-                            }
-                        },
-                        @{
-                            Id = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros'
-                            Name = 'BlockWin32APICallsFromOfficeMacros'
-                            AdditionalProperties = @{
-                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
-                            }
-                        },
-                        @{
-                            Id = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockcredentialstealingfromwindowslocalsecurityauthoritysubsystem'
-                            Name = 'BlockCredentialStealingFromWindowsLocalSecurityAuthoritySubsystem'
-                            AdditionalProperties = @{
-                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
-                            }
-                        },
-                        @{
-                            Id = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockallofficeapplicationsfromcreatingchildprocesses'
-                            Name = 'BlockAllOfficeApplicationsFromCreatingChildProcesses'
-                            AdditionalProperties = @{
-                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
-                            }
-                        }
-                    )
-                    SettingInstance      = @{
-                        SettingDefinitionId              = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules'
-                        SettingInstanceTemplateReference = @{
-                            SettingInstanceTemplateId = '19600663-e264-4c02-8f55-f2983216d6d7'
-                        }
-                        AdditionalProperties             = @(
+                return @(
+                    @{
+                        Id                   = '0'
+                        SettingDefinitions   = @(
                             @{
-                                '@odata.type'               = '#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance'
-                                groupSettingCollectionValue = @(
-                                    @{
-                                        children = @(
-                                            @{
-                                                '@odata.type'       = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
-                                                settingDefinitionId = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockadobereaderfromcreatingchildprocesses'
-                                                choiceSettingValue  = @{
-                                                    children = @()
-                                                    value = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockadobereaderfromcreatingchildprocesses_audit'
-                                                }
-                                            },
-                                            @{
-                                                '@odata.type'       = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
-                                                settingDefinitionId = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros'
-                                                choiceSettingValue  = @{
-                                                    children = @()
-                                                    value = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros_block'
-                                                }
-                                            },
-                                            @{
-                                                '@odata.type'       = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
-                                                settingDefinitionId = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockcredentialstealingfromwindowslocalsecurityauthoritysubsystem'
-                                                choiceSettingValue  = @{
-                                                    children = @()
-                                                    value = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockcredentialstealingfromwindowslocalsecurityauthoritysubsystem_warn'
-                                                }
-                                            },
-                                            @{
-                                                '@odata.type'       = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
-                                                settingDefinitionId = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockallofficeapplicationsfromcreatingchildprocesses'
-                                                choiceSettingValue  = @{
-                                                    children = @()
-                                                    value = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockallofficeapplicationsfromcreatingchildprocesses_warn'
-                                                }
-                                            }
-                                        )
-                                    }
-                                )
+                                Id = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules'
+                                Name = 'AttackSurfaceReductionRules'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSettingGroupCollectionDefinition'
+                                    childIds = @(
+                                        'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockadobereaderfromcreatingchildprocesses',
+                                        'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros',
+                                        'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockcredentialstealingfromwindowslocalsecurityauthoritysubsystem',
+                                        'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockallofficeapplicationsfromcreatingchildprocesses'
+                                    )
+                                    maximumCount = 1
+                                    minimumCount = 0
+                                }
+                            },
+                            @{
+                                Id = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockadobereaderfromcreatingchildprocesses'
+                                Name = 'BlockAdobeReaderFromCreatingChildProcesses'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                }
+                            },
+                            @{
+                                Id = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockadobereaderfromcreatingchildprocesses_perruleexclusions'
+                                Name = 'ASROnlyPerRuleExclusions'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionDefinition'
+                                    maximumCount = 600
+                                    minimumCount = 0
+                                    dependentOn = @(
+                                        @{
+                                            dependentOn = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockadobereaderfromcreatingchildprocesses_block'
+                                            parentSettingId = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockadobereaderfromcreatingchildprocesses'
+                                        }
+                                    )
+                                }
+                                OffsetUri = '/Configuration/ASROnlyPerRuleExclusions'
+                            },
+                            @{
+                                Id = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros'
+                                Name = 'BlockWin32APICallsFromOfficeMacros'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                }
+                            },
+                            @{
+                                Id = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros_perruleexclusions'
+                                Name = 'ASROnlyPerRuleExclusions'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionDefinition'
+                                    maximumCount = 600
+                                    minimumCount = 0
+                                    dependentOn = @(
+                                        @{
+                                            dependentOn = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros_block'
+                                            parentSettingId = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros'
+                                        }
+                                    )
+                                }
+                                OffsetUri = '/Configuration/ASROnlyPerRuleExclusions'
+                            }
+                            @{
+                                Id = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockcredentialstealingfromwindowslocalsecurityauthoritysubsystem'
+                                Name = 'BlockCredentialStealingFromWindowsLocalSecurityAuthoritySubsystem'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                }
+                            },
+                            @{
+                                Id = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockallofficeapplicationsfromcreatingchildprocesses'
+                                Name = 'BlockAllOfficeApplicationsFromCreatingChildProcesses'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                }
                             }
                         )
+                        SettingInstance      = @{
+                            SettingDefinitionId              = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules'
+                            SettingInstanceTemplateReference = @{
+                                SettingInstanceTemplateId = '19600663-e264-4c02-8f55-f2983216d6d7'
+                            }
+                            AdditionalProperties             = @(
+                                @{
+                                    '@odata.type'               = '#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance'
+                                    groupSettingCollectionValue = @(
+                                        @{
+                                            children = @(
+                                                @{
+                                                    '@odata.type'       = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                                    settingDefinitionId = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockadobereaderfromcreatingchildprocesses'
+                                                    choiceSettingValue  = @{
+                                                        children = @(
+                                                            @{
+                                                                '@odata.type'       = '#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionInstance'
+                                                                settingDefinitionId = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockadobereaderfromcreatingchildprocesses_perruleexclusions'
+                                                                simpleSettingCollectionValue = @(
+                                                                    @{
+                                                                        '@odata.type'       = '#microsoft.graph.deviceManagementConfigurationStringSettingValue'
+                                                                        value = 'Adobe Reader Exclusion'
+                                                                    }
+                                                                )
+                                                            }
+                                                        )
+                                                        value = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockadobereaderfromcreatingchildprocesses_audit'
+                                                    }
+                                                },
+                                                @{
+                                                    '@odata.type'       = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                                    settingDefinitionId = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros'
+                                                    choiceSettingValue  = @{
+                                                        children = @(
+                                                            @{
+                                                                '@odata.type'       = '#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionInstance'
+                                                                settingDefinitionId = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros_perruleexclusions'
+                                                                simpleSettingCollectionValue = @(
+                                                                    @{
+                                                                        '@odata.type'       = '#microsoft.graph.deviceManagementConfigurationStringSettingValue'
+                                                                        value = 'Win32 API Calls Exclusion'
+                                                                    }
+                                                                )
+                                                            }
+                                                        )
+                                                        value = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros_block'
+                                                    }
+                                                },
+                                                @{
+                                                    '@odata.type'       = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                                    settingDefinitionId = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockcredentialstealingfromwindowslocalsecurityauthoritysubsystem'
+                                                    choiceSettingValue  = @{
+                                                        children = @()
+                                                        value = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockcredentialstealingfromwindowslocalsecurityauthoritysubsystem_warn'
+                                                    }
+                                                },
+                                                @{
+                                                    '@odata.type'       = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                                    settingDefinitionId = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockallofficeapplicationsfromcreatingchildprocesses'
+                                                    choiceSettingValue  = @{
+                                                        children = @()
+                                                        value = 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockallofficeapplicationsfromcreatingchildprocesses_warn'
+                                                    }
+                                                }
+                                            )
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                        AdditionalProperties = @{}
                     }
-                    AdditionalProperties = @{}
+                )
+            }
+
+            Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+                return @{
+                    Id          = '12345-12345-12345-12345-12345'
+                    Description = 'My Test'
+                    Name        = 'asdfads'
                 }
             }
 
@@ -194,15 +258,17 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             deviceAndAppManagementAssignmentFilterType = 'none'
                         } -ClientOnly)
                     )
-                    BlockAdobeReaderFromCreatingChildProcesses                        = 'audit'
-                    BlockAllOfficeApplicationsFromCreatingChildProcesses              = 'warn'
-                    BlockCredentialStealingFromWindowsLocalSecurityAuthoritySubsystem = 'warn'
-                    BlockWin32APICallsFromOfficeMacros                                = 'block'
-                    Credential                                                        = $Credential
-                    Description                                                       = 'My Test'
-                    DisplayName                                                       = 'asdfads'
-                    Ensure                                                            = 'Present'
-                    Identity                                                          = 'a90ca9bc-8a68-4901-a991-dafaa633b034'
+                    BlockAdobeReaderFromCreatingChildProcesses                          = 'audit'
+                    BlockAdobeReaderFromCreatingChildProcesses_ASROnlyPerRuleExclusions = @('Adobe Reader Exclusion')
+                    BlockAllOfficeApplicationsFromCreatingChildProcesses                = 'warn'
+                    BlockCredentialStealingFromWindowsLocalSecurityAuthoritySubsystem   = 'warn'
+                    BlockWin32APICallsFromOfficeMacros                                  = 'block'
+                    BlockWin32APICallsFromOfficeMacros_ASROnlyPerRuleExclusions         = @('Win32 API Calls Exclusion')
+                    Credential                                                          = $Credential
+                    Description                                                         = 'My Test'
+                    DisplayName                                                         = 'asdfads'
+                    Ensure                                                              = 'Present'
+                    Identity                                                           = '12345-12345-12345-12345-12345'
                 }
 
                 Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicy -MockWith {
@@ -234,23 +300,17 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             deviceAndAppManagementAssignmentFilterType = 'none'
                         } -ClientOnly)
                     )
-                    BlockAdobeReaderFromCreatingChildProcesses                        = 'audit'
-                    BlockAllOfficeApplicationsFromCreatingChildProcesses              = 'warn'
-                    BlockCredentialStealingFromWindowsLocalSecurityAuthoritySubsystem = 'warn'
-                    BlockWin32APICallsFromOfficeMacros                                = 'block' #drift
-                    Credential                                                        = $Credential
-                    Description                                                       = 'test'
-                    DisplayName                                                       = 'asdfads'
-                    Ensure                                                            = 'Present'
-                    Identity                                                          = '12345-12345-12345-12345-12345'
-                }
-
-                Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicy -MockWith {
-                    return @{
-                        Id          = '12345-12345-12345-12345-12345'
-                        Description = 'My Test'
-                        Name        = 'asdfads'
-                    }
+                    BlockAdobeReaderFromCreatingChildProcesses                          = 'audit'
+                    BlockAdobeReaderFromCreatingChildProcesses_ASROnlyPerRuleExclusions = @('Adobe Reader Exclusion')
+                    BlockAllOfficeApplicationsFromCreatingChildProcesses                = 'warn'
+                    BlockCredentialStealingFromWindowsLocalSecurityAuthoritySubsystem   = 'block' # Drift
+                    BlockWin32APICallsFromOfficeMacros                                  = 'block'
+                    BlockWin32APICallsFromOfficeMacros_ASROnlyPerRuleExclusions         = @('Win32 API Calls Exclusion')
+                    Credential                                                          = $Credential
+                    Description                                                         = 'My Test'
+                    DisplayName                                                         = 'asdfads'
+                    Ensure                                                              = 'Present'
+                    Identity                                                            = '12345-12345-12345-12345-12345'
                 }
             }
 
@@ -278,23 +338,17 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             deviceAndAppManagementAssignmentFilterType = 'none'
                         } -ClientOnly)
                     )
-                    BlockAdobeReaderFromCreatingChildProcesses                        = 'audit'
-                    BlockAllOfficeApplicationsFromCreatingChildProcesses              = 'warn'
-                    BlockCredentialStealingFromWindowsLocalSecurityAuthoritySubsystem = 'warn'
-                    BlockWin32APICallsFromOfficeMacros                                = 'block'
-                    Credential                                                        = $Credential
-                    Description                                                       = 'My Test'
-                    DisplayName                                                       = 'asdfads'
-                    Ensure                                                            = 'Present'
-                    Identity                                                          = '12345-12345-12345-12345-12345'
-                }
-
-                Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicy -MockWith {
-                    return @{
-                        Id          = '12345-12345-12345-12345-12345'
-                        Description = 'My Test'
-                        Name        = 'asdfads'
-                    }
+                    BlockAdobeReaderFromCreatingChildProcesses                          = 'audit'
+                    BlockAdobeReaderFromCreatingChildProcesses_ASROnlyPerRuleExclusions = @('Adobe Reader Exclusion')
+                    BlockAllOfficeApplicationsFromCreatingChildProcesses                = 'warn'
+                    BlockCredentialStealingFromWindowsLocalSecurityAuthoritySubsystem   = 'warn'
+                    BlockWin32APICallsFromOfficeMacros                                  = 'block'
+                    BlockWin32APICallsFromOfficeMacros_ASROnlyPerRuleExclusions         = @('Win32 API Calls Exclusion')
+                    Credential                                                          = $Credential
+                    Description                                                         = 'My Test'
+                    DisplayName                                                         = 'asdfads'
+                    Ensure                                                              = 'Present'
+                    Identity                                                            = '12345-12345-12345-12345-12345'
                 }
             }
 
@@ -313,23 +367,17 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             deviceAndAppManagementAssignmentFilterType = 'none'
                         } -ClientOnly)
                     )
-                    BlockAdobeReaderFromCreatingChildProcesses                        = 'audit'
-                    BlockAllOfficeApplicationsFromCreatingChildProcesses              = 'warn'
-                    BlockCredentialStealingFromWindowsLocalSecurityAuthoritySubsystem = 'warn'
-                    BlockWin32APICallsFromOfficeMacros                                = 'block'
-                    Credential                                                        = $Credential
-                    Description                                                       = 'test'
-                    DisplayName                                                       = 'asdfads'
-                    Ensure                                                            = 'Absent'
-                    Identity                                                          = '12345-12345-12345-12345-12345'
-                }
-
-                Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicy -MockWith {
-                    return @{
-                        Id          = '12345-12345-12345-12345-12345'
-                        Description = 'My Test'
-                        Name        = 'asdfads'
-                    }
+                    BlockAdobeReaderFromCreatingChildProcesses                          = 'audit'
+                    BlockAdobeReaderFromCreatingChildProcesses_ASROnlyPerRuleExclusions = @('Adobe Reader Exclusion')
+                    BlockAllOfficeApplicationsFromCreatingChildProcesses                = 'warn'
+                    BlockCredentialStealingFromWindowsLocalSecurityAuthoritySubsystem   = 'warn'
+                    BlockWin32APICallsFromOfficeMacros                                  = 'block'
+                    BlockWin32APICallsFromOfficeMacros_ASROnlyPerRuleExclusions         = @('Win32 API Calls Exclusion')
+                    Credential                                                          = $Credential
+                    Description                                                         = 'My Test'
+                    DisplayName                                                         = 'asdfads'
+                    Ensure                                                              = 'Absent'
+                    Identity                                                            = '12345-12345-12345-12345-12345'
                 }
             }
 


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue in the Settings Catalog part where non-unique properties were not correctly checked and combined with their respective parent setting. The implementation lacked a reevaluation of the parent setting for the currently checked setting, leading to a name conflict for settings with the same name (which should have been fixed by this loop). 

The updated implementation grabs the parent setting for the current setting and combines the name with its corresponding parent setting, effectively mitigating the issue (and should have been its task to begin with). 

#### This Pull Request (PR) fixes the following issues
None.
