### PR TITLE
AAD/Intune: Fix permissions in settings.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@
 
 * AADAccessReviewDefinition
   * Initial release.
+* AADCustomSecurityAttributeDefinition
+  * Fixed missing permissions in settings.json
 * AADIdentityGovernanceProgram
   * Initial release.
+* AADSocialIdentityProvider
+  * Fixed missing permissions in settings.json
+* Intune workload
+  * Fixed missing permissions in settings.json
 * SPOTenantSettings
   * Added support for AllowSelectSGsInODBListInTenant,
     DenySelectSGsInODBListInTenant, DenySelectSecurityGroupsInSPSitesList,

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/settings.json
@@ -12,8 +12,16 @@
     "permissions": {
         "graph": {
             "delegated": {
-                "read": [],
-                "update": []
+                "read": [
+                    {
+                        "name": "CustomSecAttributeDefinition.Read.All"
+                    }
+                ],
+                "update": [
+                    {
+                        "name": "CustomSecAttributeDefinition.ReadWrite.All"
+                    }
+                ]
             },
             "application": {
                 "read": [

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADSocialIdentityProvider/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADSocialIdentityProvider/settings.json
@@ -13,8 +13,14 @@
         "graph": {
             "delegated": {
                 "read": [
+                    {
+                        "name": "IdentityProvider.Read.All"
+                    }
                 ],
                 "update": [
+                    {
+                        "name": "IdentityProvider.ReadWrite.All"
+                    }
                 ]
             },
             "application": {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneASRRulesPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneASRRulesPolicyWindows10/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicy/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated":{
                 "read":[
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name":"DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update":[
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name":"DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application":{
                 "read":[
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name":"DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update":[
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name":"DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
     "application": {
       "read": [
         {
+          "name": "Group.Read.All"
+        },
+        {
           "name": "DeviceManagementConfiguration.Read.All"
         }
       ],
       "update": [
+        {
+          "name": "Group.Read.All"
+        },
         {
           "name": "DeviceManagementConfiguration.ReadWrite.All"
         }
@@ -18,10 +24,16 @@
     "delegated": {
       "read": [
         {
+          "name": "Group.Read.All"
+        },
+        {
           "name": "DeviceManagementConfiguration.Read.All"
         }
       ],
       "update": [
+        {
+          "name": "Group.Read.All"
+        },
         {
           "name": "DeviceManagementConfiguration.ReadWrite.All"
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationDevicePolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationDevicePolicy/settings.json
@@ -6,10 +6,16 @@
     "delegated": {
       "read": [
         {
+          "name": "Group.Read.All"
+        },
+        {
           "name": "DeviceManagementApps.Read.All"
         }
       ],
       "update": [
+        {
+          "name": "Group.Read.All"
+        },
         {
           "name": "DeviceManagementApps.ReadWrite.All"
         }
@@ -18,10 +24,16 @@
     "application": {
       "read": [
         {
+          "name": "Group.Read.All"
+        },
+        {
           "name": "DeviceManagementApps.Read.All"
         }
       ],
       "update": [
+        {
+          "name": "Group.Read.All"
+        },
         {
           "name": "DeviceManagementApps.ReadWrite.All"
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationPolicy/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementApps.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementApps.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyAndroid/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyAndroid/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementApps.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementApps.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyiOS/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyiOS/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementApps.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementApps.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneApplicationControlPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneApplicationControlPolicyWindows10/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAttackSurfaceReductionRulesPolicyWindows10ConfigManager/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAttackSurfaceReductionRulesPolicyWindows10ConfigManager/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroid/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroid/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyMacOS/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyMacOS/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyWindows10/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyiOs/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyiOs/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/settings.json
@@ -14,6 +14,9 @@
                                              ],
                                     "update":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
                                                ]
@@ -28,6 +31,9 @@
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10/settings.json
@@ -14,6 +14,9 @@
                                              ],
                                     "update":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
                                                ]
@@ -28,6 +31,9 @@
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDefenderForEndpointOnboardingPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDefenderForEndpointOnboardingPolicyWindows10/settings.json
@@ -14,6 +14,9 @@
                                              ],
                                     "update":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
                                                ]
@@ -28,6 +31,9 @@
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDeliveryOptimizationPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDeliveryOptimizationPolicyWindows10/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDomainJoinPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDomainJoinPolicyWindows10/settings.json
@@ -29,6 +29,9 @@
                                                ],
                                       "update":  [
                                                      {
+                                                         "name": "Group.Read.All"
+                                                     },
+                                                     {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }
                                                  ]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEndpointProtectionPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEndpointProtectionPolicyWindows10/settings.json
@@ -14,6 +14,9 @@
                 ],
                 "update": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
                 ]
@@ -28,6 +31,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationFirmwareInterfacePolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationFirmwareInterfacePolicyWindows10/settings.json
@@ -6,10 +6,16 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
                                                    {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
@@ -18,10 +24,16 @@
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationIdentityProtectionPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationIdentityProtectionPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationImportedPfxCertificatePolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationImportedPfxCertificatePolicyWindows10/settings.json
@@ -6,10 +6,16 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
                                                    {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
@@ -18,10 +24,16 @@
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationKioskPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationKioskPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
                                                    {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
@@ -18,10 +24,16 @@
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationNetworkBoundaryPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationNetworkBoundaryPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPkcsCertificatePolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPkcsCertificatePolicyWindows10/settings.json
@@ -6,10 +6,16 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
                                                    {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
@@ -18,10 +24,16 @@
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/settings.json
@@ -6,6 +6,9 @@
     "delegated": {
       "read": [
         {
+          "name": "Group.Read.All"
+        },
+        {
           "name": "DeviceManagementConfiguration.Read.All"
         },
         {
@@ -13,6 +16,9 @@
         }
       ],
       "update": [
+        {
+          "name": "Group.Read.All"
+        },
         {
           "name": "DeviceManagementConfiguration.ReadWrite.All"
         },
@@ -24,6 +30,9 @@
     "application": {
       "read": [
         {
+          "name": "Group.Read.All"
+        },
+        {
           "name": "DeviceManagementConfiguration.Read.All"
         },
         {
@@ -31,6 +40,9 @@
         }
       ],
       "update": [
+        {
+          "name": "Group.Read.All"
+        },
         {
           "name": "DeviceManagementConfiguration.ReadWrite.All"
         },

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceOwner/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceOwner/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidWorkProfile/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidWorkProfile/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyiOS/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyiOS/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/settings.json
@@ -6,10 +6,16 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
                                                    {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
@@ -18,10 +24,16 @@
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSecureAssessmentPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSecureAssessmentPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
                                                    {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
@@ -18,10 +24,16 @@
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSharedMultiDevicePolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSharedMultiDevicePolicyWindows10/settings.json
@@ -6,10 +6,16 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
                                                    {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
@@ -18,10 +24,16 @@
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationTrustedCertificatePolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationTrustedCertificatePolicyWindows10/settings.json
@@ -6,10 +6,16 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
                                                    {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
@@ -18,10 +24,16 @@
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationVpnPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationVpnPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
                                                    {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
@@ -18,10 +24,16 @@
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWindowsTeamPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWindowsTeamPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
                                                    {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
@@ -18,10 +24,16 @@
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
                                                    {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
@@ -18,10 +24,16 @@
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
           "delegated":{
               "read":[
                   {
+                      "name": "Group.Read.All"
+                  },
+                  {
                       "name":"DeviceManagementConfiguration.Read.All"
                   }
               ],
               "update":[
+                  {
+                      "name": "Group.Read.All"
+                  },
                   {
                       "name":"DeviceManagementConfiguration.ReadWrite.All"
                   }
@@ -18,10 +24,16 @@
           "application":{
               "read":[
                   {
+                      "name": "Group.Read.All"
+                  },
+                  {
                       "name":"DeviceManagementConfiguration.Read.All"
                   }
               ],
               "update":[
+                  {
+                      "name": "Group.Read.All"
+                  },
                   {
                       "name":"DeviceManagementConfiguration.ReadWrite.All"
                   }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentPlatformRestriction/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentPlatformRestriction/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementServiceConfig.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementServiceConfig.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementServiceConfig.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementServiceConfig.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/settings.json
@@ -6,6 +6,9 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     },
                     {
@@ -16,6 +19,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     },
@@ -30,6 +36,9 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     },
                     {
@@ -40,6 +49,9 @@
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     },

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceRemediation/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceRemediation/settings.json
@@ -6,10 +6,16 @@
     "application": {
       "read": [
         {
+          "name": "Group.Read.All"
+        },
+        {
           "name": "DeviceManagementConfiguration.Read.All"
         }
       ],
       "update": [
+        {
+          "name": "Group.Read.All"
+        },
         {
           "name": "DeviceManagementConfiguration.Read.All"
         },
@@ -21,10 +27,16 @@
     "delegated": {
       "read": [
         {
+          "name": "Group.Read.All"
+        },
+        {
           "name": "DeviceManagementConfiguration.Read.All"
         }
       ],
       "update": [
+        {
+          "name": "Group.Read.All"
+        },
         {
           "name": "DeviceManagementConfiguration.Read.All"
         },

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/settings.json
@@ -6,10 +6,16 @@
       "delegated": {
         "read": [
           {
+            "name": "Group.Read.All"
+          },
+          {
             "name": "DeviceManagementConfiguration.Read.All"
           }
         ],
         "update": [
+          {
+            "name": "Group.Read.All"
+          },
           {
             "name": "DeviceManagementConfiguration.ReadWrite.All"
           }
@@ -18,10 +24,16 @@
       "application": {
         "read": [
           {
+            "name": "Group.Read.All"
+          },
+          {
             "name": "DeviceManagementConfiguration.Read.All"
           }
         ],
         "update": [
+          {
+            "name": "Group.Read.All"
+          },
           {
             "name": "DeviceManagementConfiguration.ReadWrite.All"
           }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated":{
                 "read":[
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name":"DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update":[
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name":"DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application":{
                 "read":[
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name":"DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update":[
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name":"DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/settings.json
@@ -6,10 +6,16 @@
           "delegated":{
               "read":[
                   {
+                      "name": "Group.Read.All"
+                  },
+                  {
                       "name":"DeviceManagementConfiguration.Read.All"
                   }
               ],
               "update":[
+                  {
+                      "name": "Group.Read.All"
+                  },
                   {
                       "name":"DeviceManagementConfiguration.ReadWrite.All"
                   }
@@ -18,10 +24,16 @@
           "application":{
               "read":[
                   {
+                      "name": "Group.Read.All"
+                  },
+                  {
                       "name":"DeviceManagementConfiguration.Read.All"
                   }
               ],
               "update":[
+                  {
+                      "name": "Group.Read.All"
+                  },
                   {
                       "name":"DeviceManagementConfiguration.ReadWrite.All"
                   }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/settings.json
@@ -6,10 +6,16 @@
           "delegated":{
               "read":[
                   {
+                      "name": "Group.Read.All"
+                  },
+                  {
                       "name":"DeviceManagementConfiguration.Read.All"
                   }
               ],
               "update":[
+                  {
+                      "name": "Group.Read.All"
+                  },
                   {
                       "name":"DeviceManagementConfiguration.ReadWrite.All"
                   }
@@ -18,10 +24,16 @@
           "application":{
               "read":[
                   {
+                      "name": "Group.Read.All"
+                  },
+                  {
                       "name":"DeviceManagementConfiguration.Read.All"
                   }
               ],
               "update":[
+                  {
+                      "name": "Group.Read.All"
+                  },
                   {
                       "name":"DeviceManagementConfiguration.ReadWrite.All"
                   }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneExploitProtectionPolicyWindows10SettingCatalog/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneExploitProtectionPolicyWindows10SettingCatalog/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
     "delegated": {
       "update": [
         {
+          "name": "Group.Read.All"
+        },
+        {
           "name": "DeviceManagementConfiguration.ReadWrite.All"
         }
       ],
       "read": [
+        {
+          "name": "Group.Read.All"
+        },
         {
           "name": "DeviceManagementConfiguration.Read.All"
         }
@@ -18,10 +24,16 @@
     "application": {
       "update": [
         {
+          "name": "Group.Read.All"
+        },
+        {
           "name": "DeviceManagementConfiguration.ReadWrite.All"
         }
       ],
       "read": [
+        {
+          "name": "Group.Read.All"
+        },
         {
           "name": "DeviceManagementConfiguration.Read.All"
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementApps.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementApps.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementApps.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementApps.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementApps.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementApps.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementApps.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementApps.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntunePolicySets/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntunePolicySets/settings.json
@@ -6,21 +6,37 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
-
+                                                 {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
+                                                     "name":  "DeviceManagementConfiguration.ReadWrite.All"
+                                                 }
                                                ]
                                 },
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
-
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
+                                                       "name":  "DeviceManagementConfiguration.ReadWrite.All"
+                                                   }
                                                  ]
                                   }
               }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleAssignment/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleAssignment/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementRBAC.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementRBAC.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementRBAC.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementRBAC.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoft365AppsForEnterprise/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoft365AppsForEnterprise/settings.json
@@ -6,10 +6,16 @@
             "delegated":{
                 "read":[
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name":"DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update":[
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name":"DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application":{
                 "read":[
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name":"DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update":[
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name":"DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/settings.json
@@ -6,10 +6,16 @@
     "application": {
       "read": [
         {
+          "name": "Group.Read.All"
+        },
+        {
           "name": "DeviceManagementConfiguration.Read.All"
         }
       ],
       "update": [
+        {
+          "name": "Group.Read.All"
+        },
         {
           "name": "DeviceManagementConfiguration.ReadWrite.All"
         }
@@ -18,10 +24,16 @@
     "delegated": {
       "read": [
         {
+          "name": "Group.Read.All"
+        },
+        {
           "name": "DeviceManagementConfiguration.Read.All"
         }
       ],
       "update": [
+        {
+          "name": "Group.Read.All"
+        },
         {
           "name": "DeviceManagementConfiguration.ReadWrite.All"
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogCustomPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogCustomPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
                   "delegated":  {
                                     "read":  [
                                                  {
+                                                     "name": "Group.Read.All"
+                                                 },
+                                                 {
                                                      "name":  "DeviceManagementConfiguration.Read.All"
                                                  }
                                              ],
                                     "update":  [
+                                                   {
+                                                       "name": "Group.Read.All"
+                                                   },
                                                    {
                                                        "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                    }
@@ -18,10 +24,16 @@
                   "application":  {
                                       "read":  [
                                                    {
+                                                       "name": "Group.Read.All"
+                                                   },
+                                                   {
                                                        "name":  "DeviceManagementConfiguration.Read.All"
                                                    }
                                                ],
                                       "update":  [
+                                                     {
+                                                         "name": "Group.Read.All"
+                                                     },
                                                      {
                                                          "name":  "DeviceManagementConfiguration.ReadWrite.All"
                                                      }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministrator/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministrator/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseDeviceOwner/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseDeviceOwner/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidForWork/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidForWork/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidOpenSourceProject/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidOpenSourceProject/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyIOS/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyIOS/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyMacOS/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyMacOS/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementServiceConfig.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementServiceConfig.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementServiceConfig.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementServiceConfig.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementServiceConfig.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementServiceConfig.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementServiceConfig.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementServiceConfig.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsInformationProtectionPolicyWindows10MdmEnrolled/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsInformationProtectionPolicyWindows10MdmEnrolled/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementApps.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementApps.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementApps.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementApps.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessDriverUpdateProfileWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessDriverUpdateProfileWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessQualityUpdateProfileWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessQualityUpdateProfileWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated":{
                 "read":[
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name":"DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update":[
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name":"DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application":{
                 "read":[
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name":"DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update":[
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name":"DeviceManagementConfiguration.ReadWrite.All"
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10/settings.json
@@ -6,10 +6,16 @@
             "delegated": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }
@@ -18,10 +24,16 @@
             "application": {
                 "read": [
                     {
+                        "name": "Group.Read.All"
+                    },
+                    {
                         "name": "DeviceManagementConfiguration.Read.All"
                     }
                 ],
                 "update": [
+                    {
+                        "name": "Group.Read.All"
+                    },
                     {
                         "name": "DeviceManagementConfiguration.ReadWrite.All"
                     }


### PR DESCRIPTION
#### Pull Request (PR) description

*AADCustomSecurityAttributeDefinition* and *AADIdentityGovernanceProgram* were missing the delegated permissions, this PR fixes this but the bulk of the change was to add *Group.Read.All* to almost all Intune resources, where assignments are used, this has been like this since ever so I always have to add it manually to every customer and they keep me asking about this additional permission.

#### This Pull Request (PR) fixes the following issues
