### PR TITLE
TeamsComplianceRecordingPolicy: ComplianceRecordingApplications converts $null to empty array

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsComplianceRecordingPolicy/MSFT_TeamsComplianceRecordingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsComplianceRecordingPolicy/MSFT_TeamsComplianceRecordingPolicy.psm1
@@ -83,9 +83,9 @@ function Get-TargetResource
             return $nullResult
         }
 
+        $ComplexComplianceRecordingApplications = @()
         if ($instance.ComplianceRecordingApplications.Count -gt 0)
         {
-            $ComplexComplianceRecordingApplications = @()
             foreach ($CurrentComplianceRecordingApplications in $instance.ComplianceRecordingApplications)
             {
                 $MyComplianceRecordingApplications = @{}


### PR DESCRIPTION
#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
-->
If no ComplianceRecordingApplications are connected to an TeamsComplianceRecordingPolicy, Get-TargetResource now returns an empty array instead of null. 

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
Fixes #5241
