### PR TITLE
Add Intune Group.Read.All permissions to generated permissions

### DIFF
--- a/ResourceGenerator/M365DSCResourceGenerator.psm1
+++ b/ResourceGenerator/M365DSCResourceGenerator.psm1
@@ -967,7 +967,15 @@ class MSFT_DeviceManagementConfigurationPolicyAssignments
             -Workload $Workload `
             -CmdLetNoun $CmdLetNoun `
             -ApiVersion $ApiVersion `
-            -UpdateVerb $updateVerb).permissions | ConvertTo-Json -Depth 20
+            -UpdateVerb $updateVerb).permissions
+        if ($ResourceName -like "Intune*")
+        {
+            $resourcePermissions.application.read += @{ name = 'Group.Read.All' }
+            $resourcePermissions.application.update += @{ name = 'Group.Read.All' }
+            $resourcePermissions.delegated.read += @{ name = 'Group.Read.All' }
+            $resourcePermissions.delegated.update += @{ name = 'Group.Read.All' }
+        }
+        $resourcePermissions = $resourcePermissions | ConvertTo-Json -Depth 20
         $resourcePermissions = '    ' + $resourcePermissions
         Write-TokenReplacement -Token '<ResourceFriendlyName>' -Value $ResourceName -FilePath $settingsFilePath
         Write-TokenReplacement -Token '<ResourceDescription>' -Value $resourceDescription -FilePath $settingsFilePath


### PR DESCRIPTION
#### Pull Request (PR) description
As suggested in #5232, the DRG now includes the `Group.Read.All` permission for Intune resources on generation.

#### This Pull Request (PR) fixes the following issues
None.
