### PR TITLE
Remove property from merge conflict

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.schema.mof
@@ -57,12 +57,12 @@ class MSFT_IntuneMobileAppsMacOSLobApp : OMI_BaseResource
     [Write, Description("The owner of the app. Inherited from mobileApp.")] String Owner;
     [Write, Description("The privacy statement Url. Inherited from mobileApp.")] String PrivacyInformationUrl;
     [Write, Description("The publisher of the app. Inherited from mobileApp.")] String Publisher;
-    [Write, Description("The publishing state for the app. The app cannot be assigned unless the app is published. Inherited from mobileApp."), ValueMap{"notPublished", "processing","published"}, Values{"notPublished", "processing", "published"}] String PublishingState;
     [Write, Description("The bundleId of the app.")] String BundleId;
     [Write, Description("The build number of the app.")] String BuildNumber;
     [Write, Description("The version number of the app.")] String VersionNumber;
     [Write, Description("List of Scope Tag IDs for mobile app.")] String RoleScopeTagIds[];
     [Write, Description("Whether to ignore the version of the app or not.")] Boolean IgnoreVersionDetection;
+    [Write, Description("Install the app as managed. Requires macOS 11.0.")] Boolean InstallAsManaged;
     [Write, Description("The icon for this app."), EmbeddedInstance("MSFT_DeviceManagementMimeContent")] String LargeIcon;
     [Write, Description("The minimum supported operating system to install the app."), EmbeddedInstance("MSFT_DeviceManagementMinimumOperatingSystem")] String MinimumSupportedOperatingSystem;
     [Write, Description("The list of categories for this app."), EmbeddedInstance("MSFT_DeviceManagementMobileAppCategory")] String Categories[];

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsMacOSLobApp/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsMacOSLobApp/2-Update.ps1
@@ -38,7 +38,6 @@ Configuration Example
             Owner                 = "";
             PrivacyInformationUrl = "";
             Publisher             = "Contoso";
-            PublishingState       = "published";
             Assignments           = @(
                     MSFT_DeviceManagementMobileAppAssignment {
                         groupDisplayName = 'All devices'

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsMacOSLobApp.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsMacOSLobApp.Tests.ps1
@@ -138,7 +138,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         Owner                 = ""
                         PrivacyInformationUrl = ""
                         Publisher             = "Contoso"
-                        PublishingState       = "published"
                         RoleScopeTagIds       = @()
                         IgnoreVersionDetection = $True
                         AdditionalProperties   = @{
@@ -204,7 +203,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         Owner                 = ""
                         PrivacyInformationUrl = ""
                         Publisher             = "Contoso"
-                        PublishingState       = "published"
                         RoleScopeTagIds       = @()
                         AdditionalProperties   = @{
                             '@odata.type' = '#microsoft.graph.macOSLobApp'
@@ -260,7 +258,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         Owner                 = ""
                         PrivacyInformationUrl = ""
                         Publisher             = "Contoso"
-                        PublishingState       = "published"
                         AdditionalProperties   = @{
                             '@odata.type' = '#microsoft.graph.macOSLobApp'
                             minimumSupportedOperatingSystem = @{
@@ -307,7 +304,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         Owner                 = ""
                         PrivacyInformationUrl = ""
                         Publisher             = "Contoso"
-                        PublishingState       = "published"
                         RoleScopeTagIds       = @()
                         AdditionalProperties   = @{
                             '@odata.type' = '#microsoft.graph.macOSLobApp'


### PR DESCRIPTION
#### Pull Request (PR) description
This PR removes a read-only property from the `IntuneMobileAppsMacOSLobApp` resource which got caught in a merge conflict and was readded, although I removed it in https://github.com/microsoft/Microsoft365DSC/commit/88ad08eec67e12816386e546274f88f90cc210ab. No changelog because compiling a configuration with that property would not have worked. 

#### This Pull Request (PR) fixes the following issues
None.
