### PR TITLE
Fix autofromconnector type for Intune EDR Windows10 policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   * Initial release.
 * AADSocialIdentityProvider
   * Fixed missing permissions in settings.json
+* IntuneEndpointDetectionAndResponsePolicyWindows10
+  * Fixes an issue with `AutoFromConnector` as the Configuration package type.
+    FIXES [#5246](https://github.com/microsoft/Microsoft365DSC/issues/5246)
 * Intune workload
   * Fixed missing permissions in settings.json
 * SentinelAlertRule

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
@@ -286,7 +286,7 @@ function Set-TargetResource
 
     if ($ConfigurationType -ne 'AutoFromConnector' -and [System.String]::IsNullOrEmpty($ConfigurationBlob))
     {
-        throw "ConfigurationBlob is required for configurationType '$($DSCParams.ConfigurationType)'"
+        throw "ConfigurationBlob is required for configurationType '$($ConfigurationType)'"
     }
     $BoundParameters.Remove('ConfigurationType') | Out-Null
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
@@ -267,7 +267,7 @@ function Set-TargetResource
         'AutoFromConnector'
         {
             $BoundParameters.Add('ClientConfigurationPackageType', 'autofromconnector')
-            $BoundParameters.Add('autofromconnector', 'autoConnectPlaceholder')
+            $BoundParameters.Add('onboarding_fromconnector', 'autoConnectPlaceholder')
             $BoundParameters.Remove('ConfigurationBlob') | Out-Null
         }
         'Onboard'

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
@@ -126,18 +126,11 @@ function Get-TargetResource
 
         $policySettings = @{}
         $policySettings = Export-IntuneSettingCatalogPolicySettings -Settings $settings -ReturnHashtable $policySettings
-        if ($policySettings.ClientConfigurationPackageType -eq 'onboarding_fromconnector')
-        {
-            $policySettings.Add('ConfigurationType', 'AutoFromConnector')
-        }
-        else
-        {
-            $policySettings.Add('ConfigurationType', $policySettings.ClientConfigurationPackageType)
-        }
+        $policySettings.Add('ConfigurationType', $policySettings.ClientConfigurationPackageType)
         $policySettings.Remove('ClientConfigurationPackageType')
         $policySettings.Remove('onboarding')
         $policySettings.Remove('offboarding')
-        $policySettings.Remove('onboarding_fromconnector')
+        $policySettings.Remove('autofromconnector')
 
         # Removing TelemetryReportingFrequency because it's deprecated and doesn't need to be evaluated and enforced
         $policySettings.Remove('telemetryreportingfrequency')
@@ -273,8 +266,8 @@ function Set-TargetResource
     {
         'AutoFromConnector'
         {
-            $BoundParameters.Add('ClientConfigurationPackageType', 'onboarding_fromconnector')
-            $BoundParameters.Add('onboarding_fromconnector', $ConfigurationBlob)
+            $BoundParameters.Add('ClientConfigurationPackageType', 'autofromconnector')
+            $BoundParameters.Add('autofromconnector', 'autoConnectPlaceholder')
             $BoundParameters.Remove('ConfigurationBlob') | Out-Null
         }
         'Onboard'
@@ -291,7 +284,7 @@ function Set-TargetResource
         }
     }
 
-    if ([System.String]::IsNullOrEmpty($ConfigurationBlob))
+    if ($ConfigurationType -ne 'AutoFromConnector' -and [System.String]::IsNullOrEmpty($ConfigurationBlob))
     {
         throw "ConfigurationBlob is required for configurationType '$($DSCParams.ConfigurationType)'"
     }


### PR DESCRIPTION
#### Pull Request (PR) description
This PR aims to address an issue with the `AutoFromConnector` value for the `ConfigurationPackageType` in the `IntuneEndpointDetectionAndResponsePolicyWindows10` resource. It throws an error for the empty configuration blob, although that blob must be empty because it will be populated by the Graph endpoint. 

#### This Pull Request (PR) fixes the following issues
- Fixes #5246 