### PR TITLE
IntuneAppCategory: Fix retrieval of resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   * Fixed missing permissions in settings.json
 * EXOMailboxAuditBypassAssociation
   * Initial release.
+* IntuneAppCategory
+  * Fixed retrieval of resource which could then result in multiple categories
+    being created with same name
+  * Added a few verbose messages
 * Intune workload
   * Fixed missing permissions in settings.json
 * SentinelAlertRule


### PR DESCRIPTION
#### Pull Request (PR) description

This PR calls the correct cmdlet when searching by DisplayName, if the resource cannot be retrieved by Id, since the result could be null it would always create new categories with the same name.

Additionally since there was no feedback of what the code was doing I also added a few verbose messages and while here also changed *Test-TargetResource* a bit to resemble other resources.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
