### PR TITLE
IntuneDerivedCredential: Fix export and deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * EXOMailboxAuditBypassAssociation
   * Initial release.
 * IntuneDerivedCredential
-  * Fixed export and deployment when `NotificateType` had more than one option
+  * Fixed export and deployment when `NotificationType` had more than one option
     selected
   * Fixed retrieval of resource when it cannot be found by `Id`
   * Added a few verbose messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
   * Fixed missing permissions in settings.json
 * EXOMailboxAuditBypassAssociation
   * Initial release.
+* IntuneDerivedCredential
+  * Fixed export and deployment when `NotificateType` had more than one option
+    selected
+  * Fixed retrieval of resource when it cannot be found by `Id`
+  * Added a few verbose messages
 * Intune workload
   * Fixed missing permissions in settings.json
 * SentinelAlertRule

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDerivedCredential/MSFT_IntuneDerivedCredential.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDerivedCredential/MSFT_IntuneDerivedCredential.schema.mof
@@ -12,8 +12,8 @@ class MSFT_IntuneDerivedCredential : OMI_BaseResource
         String Issuer;
 
     [Write, Description("Supported values for the notification type to use."),
-        ValueMap{"none", "email", "companyPortal"},
-        Values{"none", "email", "companyPortal"}]
+        ValueMap{"none", "email", "companyPortal", "companyPortal,email"},
+        Values{"none", "email", "companyPortal", "companyPortal,email"}]
         String NotificationType;
 
     [Write, Description("Supported values for the notification type to use."),


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes the retrieval/deployment of the resource if it cannot be found by *Id* by silently continuing as done in other resources.

It also fixes the export and deployment if *NotificationType* has more than one option select, which in this case is always *companyPortal,email*

While here also changed *Test-TargetResource* function to resemble how it's done in several other resources.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
