### PR TITLE
EXOTenantAllowBlockListItems: Fix Test-TargetResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   * Fixed missing permissions in settings.json
 * EXOMailboxAuditBypassAssociation
   * Initial release.
+* EXOTenantAllowBlockListItems
+  * Fixed `Test-TargetResource` to correctly mark when this resource is removed
 * IntuneDerivedCredential
   * Fixed export and deployment when `NotificationType` had more than one option
     selected

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTenantAllowBlockListItems/MSFT_EXOTenantAllowBlockListItems.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTenantAllowBlockListItems/MSFT_EXOTenantAllowBlockListItems.psm1
@@ -378,17 +378,20 @@ function Test-TargetResource
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
-    $ValuesToCheck.Remove('Entries') | Out-Null
+
+    if ($CurrentValues.Ensure -ne $Ensure)
+    {
+        Write-Verbose -Message "Test-TargetResource returned $false"
+        return $false
+    }
+
     if ($null -ne $ValuesToCheck.ExpirationDate -and $ValuesToCheck.ExpirationDate.Kind -eq 'Local')
     {
         $ValuesToCheck.ExpirationDate = $ValuesToCheck.ExpirationDate.ToUniversalTime().ToString()
     }
 
-    if ($CurrentValues.Ensure -eq 'Absent')
-    {
-        Write-Verbose -Message "Test-TargetResource returned $false"
-        return $false
-    }
+    $ValuesToCheck = Remove-M365DSCAuthenticationParameter -BoundParameters $ValuesToCheck
+    $ValuesToCheck.Remove('Entries') | Out-Null
 
     Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $ValuesToCheck)"


### PR DESCRIPTION
#### Pull Request (PR) description

When an *EXOTenantAllowBlockListItems* is removed it works correctly but the test in *Test-TargetResource* always returns false even if the resource is not in the tenant anymore, this PR fix the test condition.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
