### PR TITLE
Fixed #5266 and issue in NamedLocationPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   * Initial release.
 * AADIdentityProtectionPolicySettings
   * Initial release.
+* AADNamedLocationPolicy
+  * Fixed issue where duplicate names were not detected correctly.
 * AADNetworkAccessForwardingProfile
   * Initial release.
 * AADOrganizationCertificateBasedAuthConfiguration
@@ -66,6 +68,9 @@
   * Fixed missing permissions in settings.json
 * SCPolicyConfig
   * Initial release.
+* SCSensitivityLabel
+  * Fixed issue with setting label priority
+    FIXES [#5266](https://github.com/microsoft/Microsoft365DSC/issues/5266)
 * SentinelAlertRule
   * Initial release.
 * SentinelThreatIntelligenceIndicator

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
@@ -121,6 +121,8 @@ function Get-TargetResource
                     -Source $($MyInvocation.MyCommand.Source) `
                     -TenantId $TenantId `
                     -Credential $Credential
+
+                return $nullReturn
             }
         }
         if ($null -eq $NamedLocation)
@@ -251,6 +253,26 @@ function Set-TargetResource
         -Parameters $PSBoundParameters
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
+
+    try
+    {
+        if ($Id)
+        {
+            $NamedLocation = Get-MgBetaIdentityConditionalAccessNamedLocation -NamedLocationId $Id -ErrorAction Stop
+        }
+    }
+    catch
+    {
+        Write-Verbose -Message "Could not retrieve AAD Named Location by ID {$Id}"
+    }
+    if ($null -eq $NamedLocation)
+    {
+        $NamedLocation = Get-MgBetaIdentityConditionalAccessNamedLocation -ErrorAction SilentlyContinue | Where-Object -FilterScript { $_.DisplayName -eq $DisplayName }
+        if ($NamedLocation.Length -gt 1)
+        {
+            throw "More than one instance of a Named Location Policy with name {$DisplayName} was found. Please provide the ID parameter."
+        }
+    }
 
     $currentAADNamedLocation = Get-TargetResource @PSBoundParameters
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
@@ -1133,14 +1133,14 @@ function Set-TargetResource
         try
         {
             Write-Verbose -Message "Creating Label {$Name}"
-            New-Label @CreationParams -ErrorAction Stop
+            $newLabel = New-Label @CreationParams -ErrorAction Stop
 
             ## Can't set priority until label created
-            if ($PSBoundParameters.ContainsKey('Priority'))
+            if ($PSBoundParameters.ContainsKey('Priority') -and $Priority -lt $newLabel.Priority)
             {
                 Start-Sleep 5
                 Write-Verbose -Message "Updating the priority for newly created label {$Name}"
-                Set-label -Identity $Name -priority $Priority -ErrorAction Stop
+                Set-Label -Identity $Name -priority $Priority -ErrorAction Stop
             }
         }
         catch
@@ -1705,7 +1705,7 @@ function Convert-StringToAdvancedSettings
         $settingString = $setting.Replace('[', '').Replace(']', '')
         $settingKey = $settingString.Split(',')[0]
 
-        if ($settingKey -notin @('displayname', 'contenttype', 'tooltip'))
+        if ($settingKey -notin @('displayname', 'contenttype', 'tooltip', 'parentid'))
         {
             $startPos = $settingString.IndexOf(',', 0) + 1
             $valueString = $settingString.Substring($startPos, $settingString.Length - $startPos).Trim()


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue in SCSensitivityLabel where setting the same priority on a newly created label resulted in an error and in AADNamedLocationPolicy where multiple locations with the same name was not detected properly.

#### This Pull Request (PR) fixes the following issues
- Fixes #5266 
