### PR TITLE
M365DSCRuleEvaluation - Renaming Key Property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,12 @@
   * Initial release.
 * Intune workload
   * Fixed missing permissions in settings.json
+* M365DSCRuleEvaluation
+  * Changed the name of the Key property from ResourceName to ResourceTypeName.
+    While this is considered a breaking change, the old property name was
+    breaking the DSCParser process. The impact of this breaking the parsing
+    process is important enough to justify an out-of-band breaking change of
+    this resource.
 * SCPolicyConfig
   * Initial release.
 * SCSensitivityLabel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,8 @@
    IntuneDeviceEnrollmentStatusPageWindows10, IntuneDiskEncryptionMacOS, IntunePolicySets,
    IntuneSettingCatalogCustomPolicyWindows10, M365DSCRGUtil
   * Exponential performance improvements by reducing complexity and roundtrips.
+  * Changed the logic that appends GUID in the resource name when primary key is not found during an
+    export. We will only append a GUID if the IsSingleInstance property is not found on the resource.
 * DEPENDENCIES
   * Updated Microsoft.Graph to version 2.24.0.
   * Updated Microsoft.PowerApps.Administration.PowerShell to version 2.0.199.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
@@ -6,7 +6,7 @@ function Get-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [System.String]
-        $ResourceName,
+        $ResourceTypeName,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -54,7 +54,7 @@ function Set-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [System.String]
-        $ResourceName,
+        $ResourceTypeName,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -103,7 +103,7 @@ function Test-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [System.String]
-        $ResourceName,
+        $ResourceTypeName,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -153,7 +153,7 @@ function Test-TargetResource
     Write-Verbose -Message 'Testing configuration of AzureAD Tenant Details'
 
     $Global:PartialExportFileName = "$((New-Guid).ToString()).partial"
-    $module = Join-Path -Path $PSScriptRoot -ChildPath "..\MSFT_$ResourceName\MSFT_$ResourceName.psm1" -Resolve
+    $module = Join-Path -Path $PSScriptRoot -ChildPath "..\MSFT_$ResourceTypeName\MSFT_$ResourceTypeName.psm1" -Resolve
     if ($null -ne $module)
     {
         $params = @{
@@ -172,7 +172,7 @@ function Test-TargetResource
 
         Write-Verbose -Message "Importing module from Path {$($module)}"
         Import-Module $module -Force -Function 'Export-TargetResource' | Out-Null
-        $cmdName = "MSFT_$ResourceName\Export-TargetResource"
+        $cmdName = "MSFT_$ResourceTypeName\Export-TargetResource"
 
         [Array]$instances = &$cmdName @params
 
@@ -220,7 +220,7 @@ function Test-TargetResource
 
         $message = [System.Text.StringBuilder]::New()
         [void]$message.AppendLine("<M365DSCRuleEvaluation>")
-        [void]$message.AppendLine("  <ResourceName>$ResourceName</ResourceName>")
+        [void]$message.AppendLine("  <ResourceName>$ResourceTypeName</ResourceName>")
         [void]$message.AppendLine("  <RuleDefinition>$RuleDefinition</RuleDefinition>")
 
         if ($instances.Length -eq 0)
@@ -252,7 +252,7 @@ function Test-TargetResource
                         [void]$message.AppendLine("  <Match>")
                         foreach ($validInstance in $validInstances)
                         {
-                            [void]$message.AppendLine("    <ResourceInstanceName>[$ResourceName]$validInstance</ResourceInstanceName>")
+                            [void]$message.AppendLine("    <ResourceInstanceName>[$ResourceTypeName]$validInstance</ResourceInstanceName>")
                         }
                         [void]$message.AppendLine("  </Match>")
                     }
@@ -268,7 +268,7 @@ function Test-TargetResource
                     [void]$message.AppendLine("  <Match>")
                     foreach ($validInstance in $validInstances)
                     {
-                        [void]$message.AppendLine("    <ResourceInstanceName>[$ResourceName]$validInstance</ResourceInstanceName>")
+                        [void]$message.AppendLine("    <ResourceInstanceName>[$ResourceTypeName]$validInstance</ResourceInstanceName>")
                     }
                     [void]$message.AppendLine("  </Match>")
                 }
@@ -295,7 +295,7 @@ function Test-TargetResource
                     [void]$message.AppendLine("  <Match>")
                     foreach ($validInstance in $validInstances)
                     {
-                        [void]$message.AppendLine("    <ResourceInstanceName>[$ResourceName]$validInstance</ResourceInstanceName>")
+                        [void]$message.AppendLine("    <ResourceInstanceName>[$ResourceTypeName]$validInstance</ResourceInstanceName>")
                     }
                     [void]$message.AppendLine("  </Match>")
                 }
@@ -312,7 +312,7 @@ function Test-TargetResource
             [void]$message.AppendLine("  <NotMatch>")
             foreach ($invalidInstance in $invalidInstances)
             {
-                [void]$message.AppendLine("    <ResourceInstanceName>[$ResourceName]$invalidInstance</ResourceInstanceName>")
+                [void]$message.AppendLine("    <ResourceInstanceName>[$ResourceTypeName]$invalidInstance</ResourceInstanceName>")
             }
             [void]$message.AppendLine("  </NotMatch>")
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("M365DSCRuleEvaluation")]
 class MSFT_M365DSCRuleEvaluation : OMI_BaseResource
 {
-    [Key, Description("Name of the resource to monitor")] String ResourceName;
+    [Key, Description("Name of the resource to monitor")] String ResourceTypeName;
     [Required, Description("Specify the rules to monitor the resource for.")] String RuleDefinition;
     [Write, Description("Query to check how many instances exist, using PowerShell format")] String AfterRuleCountQuery;
     [Write, Description("Credentials of the Azure Active Directory Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;

--- a/Modules/Microsoft365DSC/Examples/Resources/M365DSCRuleEvaluation/1-Evaluate a rule.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/M365DSCRuleEvaluation/1-Evaluate a rule.ps1
@@ -16,9 +16,9 @@ Configuration Example
     {
         M365DSCRuleEvaluation 'AllowAnonymousUsersToJoinMeetingAllPolicies'
         {
-            ResourceName   = 'TeamsMeetingPolicy'
-            RuleDefinition = "`$_.AllowAnonymousUsersToJoinMeeting -eq `$true"
-            Credential     = $CredsCredential
+            ResourceTypeName = 'TeamsMeetingPolicy'
+            RuleDefinition   = "`$_.AllowAnonymousUsersToJoinMeeting -eq `$true"
+            Credential       = $CredsCredential
         }
     }
 }

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -3835,7 +3835,7 @@ function Get-M365DSCExportContentForResource
     {
         $instanceName += "-$primaryKey"
     }
-    else
+    elseif (-not $Keys.Contains('IsSingleInstance'))
     {
         $instanceName += "-" + (New-Guid).ToString()
     }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.M365DSCRuleEvaluation.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.M365DSCRuleEvaluation.Tests.ps1
@@ -46,7 +46,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The Rules are successfully evaluated.' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    ResourceName        = 'AADConditionalAccessPolicy'
+                    ResourceTypeName    = 'AADConditionalAccessPolicy'
                     RuleDefinition      = "`$_.State -eq 'Enabled'"
                     AfterRuleCountQuery = '-eq 1'
                     Credential          = $Credential
@@ -61,7 +61,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The Rules are NOT successfully evaluated.' -Fixture {
             BeforeAll {
                 $testParams = @{
-                    ResourceName        = 'AADConditionalAccessPolicy'
+                    ResourceTypeName    = 'AADConditionalAccessPolicy'
                     RuleDefinition      = "`$_.State -eq 'Enabled'"
                     Credential          = $Credential
                 }


### PR DESCRIPTION
#### Pull Request (PR) description
* M365DSCRuleEvaluation
  * Changed the name of the Key property from ResourceName to ResourceTypeName.
    While this is considered a breaking change, the old property name was
    breaking the DSCParser process. The impact of this breaking the parsing
    process is important enough to justify an out-of-band breaking change of
    this resource.
  * Changed the logic that appends GUID in the resource name when primary key is not found during an
    export. We will only append a GUID if the IsSingleInstance property is not found on the resource.


#### This Pull Request (PR) fixes the following issues
* FIXES #5237
