### PR TITLE
Fix limited result issue with more than 25 results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@
   * Initial release.
 * IntuneSecurityBaselineDefenderForEndpoint
   * Initial release.
+* IntuneSettingCatalogCustomPolicyWindows10
+  * Fixes an issue with limited results when more than 25 results are present.
 * Intune workload
   * Fixed missing permissions in settings.json
 * M365DSCRuleEvaluation

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogCustomPolicyWindows10/MSFT_IntuneSettingCatalogCustomPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogCustomPolicyWindows10/MSFT_IntuneSettingCatalogCustomPolicyWindows10.psm1
@@ -111,6 +111,7 @@ function Get-TargetResource
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
                     -Filter "Name eq '$Name' and Platforms eq 'windows10' and Technologies eq 'mdm' and TemplateReference/TemplateFamily eq 'none'" `
+                    -All `
                     -ErrorAction SilentlyContinue
 
                 if ($getValue.Count -gt 1)
@@ -930,7 +931,7 @@ function Update-IntuneDeviceConfigurationPolicy
     try
     {
         $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/configurationPolicies/$DeviceManagementConfigurationPolicyId"
-        
+
         $policy = @{
             'name'              = $Name
             'description'       = $Description


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue misunderstood in #5088. The query didn't check for more than 25 elements, resulting in no policy found even though it existed in a larger batch (e.g. 30 elements). 

#### This Pull Request (PR) fixes the following issues
None.