### PR TITLE
Add Intune Antivirus Exclusions Policy for Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* IntuneAntivirusExclusionsPolicyLinux
+  * Initial release.
+
 # 1.24.1106.1
 
 * AADAccessReviewDefinition

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusExclusionsPolicyLinux/MSFT_IntuneAntivirusExclusionsPolicyLinux.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusExclusionsPolicyLinux/MSFT_IntuneAntivirusExclusionsPolicyLinux.schema.mof
@@ -1,0 +1,39 @@
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementConfigurationPolicyAssignments
+{
+    [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}] String dataType;
+    [Write, Description("The type of filter of the target assignment i.e. Exclude or Include. Possible values are:none, include, exclude."), ValueMap{"none","include","exclude"}, Values{"none","include","exclude"}] String deviceAndAppManagementAssignmentFilterType;
+    [Write, Description("The Id of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterId;
+    [Write, Description("The group Id that is the target of the assignment.")] String groupId;
+    [Write, Description("The group Display Name that is the target of the assignment.")] String groupDisplayName;
+    [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions
+{
+    [Write, Description("Type - Depends on exclusions (0: Path, 1: File extension, 2: Process name)"), ValueMap{"0", "1", "2"}, Values{"0", "1", "2"}] String exclusions_item_type;
+    [Write, Description("File extension - Depends on exclusions_item_type=1")] String exclusions_item_extension;
+    [Write, Description("File name - exclusions_item_type=2")] String exclusions_item_name;
+    [Write, Description("Path - exclusions_item_type=0")] String exclusions_item_path;
+    [Write, Description("Is directory (false: Disabled, true: Enabled) - Depends on exclusions_item_type=0"), ValueMap{"false", "true"}, Values{"false", "true"}] String exclusions_item_isDirectory;
+};
+
+[ClassVersion("1.0.0.0"), FriendlyName("IntuneAntivirusExclusionsPolicyLinux")]
+class MSFT_IntuneAntivirusExclusionsPolicyLinux : OMI_BaseResource
+{
+    [Write, Description("Policy description")] String Description;
+    [Key, Description("Policy name")] String DisplayName;
+    [Write, Description("List of Scope Tags for this Entity instance.")] String RoleScopeTagIds[];
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
+    [Write, Description("Scan exclusions"), EmbeddedInstance("MSFT_MicrosoftGraphIntuneSettingsCatalogexclusions")] String Exclusions[];
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
+    [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
+    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
+    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
+    [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
+    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Access token used for authentication.")] String AccessTokens[];
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusExclusionsPolicyLinux/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusExclusionsPolicyLinux/readme.md
@@ -1,0 +1,6 @@
+
+# IntuneAntivirusExclusionsPolicyLinux
+
+## Description
+
+Intune Antivirus Exclusions Policy Linux

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusExclusionsPolicyLinux/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusExclusionsPolicyLinux/settings.json
@@ -1,0 +1,39 @@
+{
+    "resourceName": "IntuneAntivirusExclusionsPolicyLinux",
+    "description": "This resource configures an Intune Antivirus Exclusions Policy Linux.",
+    "permissions":    {
+  "graph": {
+    "application": {
+      "update": [
+        {
+          "name": "Group.Read.All"
+        }
+      ],
+      "read": [
+        {
+          "name": "DeviceManagementConfiguration.Read.All"
+        },
+        {
+          "name": "Group.Read.All"
+        }
+      ]
+    },
+    "delegated": {
+      "update": [
+        {
+          "name": "Group.Read.All"
+        }
+      ],
+      "read": [
+        {
+          "name": "DeviceManagementConfiguration.Read.All"
+        },
+        {
+          "name": "Group.Read.All"
+        }
+      ]
+    }
+  }
+}
+
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneAntivirusExclusionsPolicyLinux/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneAntivirusExclusionsPolicyLinux/1-Create.ps1
@@ -1,0 +1,47 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneAntivirusExclusionsPolicyLinux 'myIntuneAntivirusExclusionsPolicyLinux'
+        {
+            Assignments = @();
+            Description = "";
+            DisplayName = "Test";
+            Ensure      = "Present";
+            Exclusions  = @(
+                MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions{
+                    Exclusions_item_extension = '.exe'
+                    Exclusions_item_type = '1'
+                }
+                MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions{
+                    Exclusions_item_name = 'process1'
+                    Exclusions_item_type = '2'
+                }
+            );
+            RoleScopeTagIds                    = @("0");
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneAntivirusExclusionsPolicyLinux/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneAntivirusExclusionsPolicyLinux/2-Update.ps1
@@ -1,0 +1,47 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneAntivirusExclusionsPolicyLinux 'myIntuneAntivirusExclusionsPolicyLinux'
+        {
+            Assignments = @();
+            Description = "";
+            DisplayName = "Test";
+            Ensure      = "Present";
+            Exclusions  = @(
+                MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions{
+                    Exclusions_item_extension = '.bat' # Updated property
+                    Exclusions_item_type = '1'
+                }
+                MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions{
+                    Exclusions_item_name = 'process1'
+                    Exclusions_item_type = '2'
+                }
+            );
+            RoleScopeTagIds                    = @("0");
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneAntivirusExclusionsPolicyLinux/3-Remove.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneAntivirusExclusionsPolicyLinux/3-Remove.ps1
@@ -1,0 +1,34 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneAntivirusExclusionsPolicyLinux 'myIntuneAntivirusExclusionsPolicyLinux'
+        {
+            DisplayName           = 'test'
+            Ensure                = 'Absent'
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAntivirusExclusionsPolicyLinux.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAntivirusExclusionsPolicyLinux.Tests.ps1
@@ -1,0 +1,407 @@
+[CmdletBinding()]
+param(
+)
+$M365DSCTestFolder = Join-Path -Path $PSScriptRoot `
+                        -ChildPath '..\..\Unit' `
+                        -Resolve
+$CmdletModule = (Join-Path -Path $M365DSCTestFolder `
+            -ChildPath '\Stubs\Microsoft365.psm1' `
+            -Resolve)
+$GenericStubPath = (Join-Path -Path $M365DSCTestFolder `
+    -ChildPath '\Stubs\Generic.psm1' `
+    -Resolve)
+Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\UnitTestHelper.psm1' `
+        -Resolve)
+
+$Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
+    -DscResource "IntuneAntivirusExclusionsPolicyLinux" -GenericStubModule $GenericStubPath
+Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
+        BeforeAll {
+
+            $secpasswd = ConvertTo-SecureString (New-Guid | Out-String) -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
+
+            Mock -CommandName Confirm-M365DSCDependencies -MockWith {
+            }
+
+            Mock -CommandName Get-PSSession -MockWith {
+            }
+
+            Mock -CommandName Remove-PSSession -MockWith {
+            }
+
+            Mock -CommandName Update-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+            }
+
+            Mock -CommandName New-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+                return @{
+                    Id = '12345-12345-12345-12345-12345'
+                }
+            }
+
+            Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+                return @{
+                    Id              = '12345-12345-12345-12345-12345'
+                    Description     = 'My Test'
+                    Name            = 'My Test'
+                    RoleScopeTagIds = @("FakeStringValue")
+                    TemplateReference = @{
+                        TemplateId = '8a17a1e5-3df4-4e07-9d20-3878267a79b8_1'
+                    }
+                }
+            }
+
+            Mock -CommandName Remove-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+            }
+
+            Mock -CommandName Remove-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+            }
+
+            Mock -CommandName Update-IntuneDeviceConfigurationPolicy -MockWith {
+            }
+
+            Mock -CommandName Get-IntuneSettingCatalogPolicySetting -MockWith {
+            }
+
+            Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicySetting -MockWith {
+                return @(
+                    @{
+                        Id = 0
+                        SettingDefinitions = @(
+                            @{
+                                Id = 'linux_mdatp_managed_antivirusengine_exclusions'
+                                Name = 'exclusions'
+                                OffsetUri = 'exclusions'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSettingGroupCollectionDefinition'
+                                    maximumCount = 600
+                                    minimumCount = 0
+                                    childIds = @(
+                                        'linux_mdatp_managed_antivirusengine_exclusions_item_$type',
+                                        'linux_mdatp_managed_antivirusengine_exclusions_item_extension'
+                                    )
+                                }
+                            },
+                            @{
+                                Id = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type'
+                                Name = 'exclusions_item_$type'
+                                OffsetUri = 'exclusions_item_$type'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                    options = @(
+                                        @{
+                                            itemId = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type_1'
+                                            name = 'Path'
+                                            dependentOn = @(
+                                                @{
+                                                    dependentOn = 'linux_mdatp_managed_antivirusengine_exclusions'
+                                                    parentSettingId = 'linux_mdatp_managed_antivirusengine_exclusions'
+                                                }
+                                            )
+                                        }
+                                    )
+                                }
+                            },
+                            @{
+                                Id = 'linux_mdatp_managed_antivirusengine_exclusions_item_extension'
+                                Name = 'exclusions_item_extension'
+                                OffsetUri = 'exclusions/[{0}]/extension'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSimpleSettingDefinition'
+                                    dependentOn = @(
+                                        @{
+                                            dependentOn = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type_1'
+                                            parentSettingId = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type'
+                                        }
+                                    )
+                                }
+                            },
+                            @{
+                                Id = 'linux_mdatp_managed_antivirusengine_exclusions_item_name'
+                                Name = 'exclusions_item_name'
+                                OffsetUri = 'exclusions/[{0}]/name'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSimpleSettingDefinition'
+                                    dependentOn = @(
+                                        @{
+                                            dependentOn = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type_2'
+                                            parentSettingId = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type'
+                                        }
+                                    )
+                                }
+                            }
+                        )
+                        SettingInstance = @{
+                            SettingDefinitionId = 'linux_mdatp_managed_antivirusengine_exclusions'
+                            SettingInstanceTemplateReference = @{
+                                SettingInstanceTemplateId = 'e2d557ab-357e-4727-978e-0d655facbb23'
+                            }
+                            AdditionalProperties = @{
+                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance'
+                                groupSettingCollectionValue = @(
+                                    @{
+                                        children = @(
+                                            @{
+                                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                                settingDefinitionId = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type'
+                                                choiceSettingValue = @{
+                                                    children = @(
+                                                        @{
+                                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance'
+                                                            settingDefinitionId = 'linux_mdatp_managed_antivirusengine_exclusions_item_extension'
+                                                            simpleSettingValue = @{
+                                                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationStringSettingValue'
+                                                                value = '.exe'
+                                                            }
+                                                        }
+                                                    )
+                                                    value = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type_1'
+                                                }
+                                            }
+                                        )
+                                    },
+                                    @{
+                                        children = @(
+                                            @{
+                                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                                settingDefinitionId = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type'
+                                                choiceSettingValue = @{
+                                                    children = @(
+                                                        @{
+                                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance'
+                                                            settingDefinitionId = 'linux_mdatp_managed_antivirusengine_exclusions_item_name'
+                                                            simpleSettingValue = @{
+                                                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationStringSettingValue'
+                                                                value = 'Test'
+                                                            }
+                                                        }
+                                                    )
+                                                    value = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type_2'
+                                                }
+                                            }
+                                        )
+                                    }
+                                )
+                            }
+                        }
+                    }
+                )
+            }
+
+            Mock -CommandName Update-DeviceConfigurationPolicyAssignment -MockWith {
+            }
+
+            Mock -CommandName New-M365DSCConnection -MockWith {
+                return "Credentials"
+            }
+
+            # Mock Write-Host to hide output during the tests
+            Mock -CommandName Write-Host -MockWith {
+            }
+            $Script:exportedInstances =$null
+            $Script:ExportMode = $false
+
+            Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicyAssignment -MockWith {
+                return @(@{
+                    Id       = '12345-12345-12345-12345-12345'
+                    Source   = 'direct'
+                    SourceId = '12345-12345-12345-12345-12345'
+                    Target   = @{
+                        DeviceAndAppManagementAssignmentFilterId   = '12345-12345-12345-12345-12345'
+                        DeviceAndAppManagementAssignmentFilterType = 'none'
+                        AdditionalProperties                       = @(
+                            @{
+                                '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                                groupId       = '26d60dd1-fab6-47bf-8656-358194c1a49d'
+                            }
+                        )
+                    }
+                })
+            }
+
+        }
+        # Test contexts
+        Context -Name "The IntuneAntivirusExclusionsPolicyLinux should exist but it DOES NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Assignments = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_DeviceManagementConfigurationPolicyAssignments -Property @{
+                            DataType     = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                            groupId = '26d60dd1-fab6-47bf-8656-358194c1a49d'
+                            deviceAndAppManagementAssignmentFilterType = 'none'
+                        } -ClientOnly)
+                    )
+                    Description = "My Test"
+                    Exclusions = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
+                            Exclusions_item_extension = '.exe'
+                            Exclusions_item_type = '1'
+                        } -ClientOnly)
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
+                            Exclusions_item_name = 'Test'
+                            Exclusions_item_type = '2'
+                        } -ClientOnly)
+                    );
+                    Id = "12345-12345-12345-12345-12345"
+                    DisplayName = "My Test"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+
+                Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+                    return $null
+                }
+            }
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
+            }
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+            It 'Should Create the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName New-MgBetaDeviceManagementConfigurationPolicy -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneAntivirusExclusionsPolicyLinux exists but it SHOULD NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Assignments = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_DeviceManagementConfigurationPolicyAssignments -Property @{
+                            DataType     = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                            groupId = '26d60dd1-fab6-47bf-8656-358194c1a49d'
+                            deviceAndAppManagementAssignmentFilterType = 'none'
+                        } -ClientOnly)
+                    )
+                    Description = "My Test"
+                    Exclusions = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
+                            Exclusions_item_extension = '.exe'
+                            Exclusions_item_type = '1'
+                        } -ClientOnly)
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
+                            Exclusions_item_name = 'Test'
+                            Exclusions_item_type = '2'
+                        } -ClientOnly)
+                    );
+                    Id = "12345-12345-12345-12345-12345"
+                    DisplayName = "My Test"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Absent"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should Remove the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Remove-MgBetaDeviceManagementConfigurationPolicy -Exactly 1
+            }
+        }
+        Context -Name "The IntuneAntivirusExclusionsPolicyLinux Exists and Values are already in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Assignments = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_DeviceManagementConfigurationPolicyAssignments -Property @{
+                            DataType     = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                            groupId = '26d60dd1-fab6-47bf-8656-358194c1a49d'
+                            deviceAndAppManagementAssignmentFilterType = 'none'
+                        } -ClientOnly)
+                    )
+                    Description = "My Test"
+                    Exclusions = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
+                            Exclusions_item_extension = '.exe'
+                            Exclusions_item_type = '1'
+                        } -ClientOnly)
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
+                            Exclusions_item_name = 'Test'
+                            Exclusions_item_type = '2'
+                        } -ClientOnly)
+                    );
+                    Id = "12345-12345-12345-12345-12345"
+                    DisplayName = "My Test"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+        }
+
+        Context -Name "The IntuneAntivirusExclusionsPolicyLinux exists and values are NOT in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Assignments = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_DeviceManagementConfigurationPolicyAssignments -Property @{
+                            DataType     = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                            groupId = '26d60dd1-fab6-47bf-8656-358194c1a49d'
+                            deviceAndAppManagementAssignmentFilterType = 'none'
+                        } -ClientOnly)
+                    )
+                    Description = "My Test"
+                    Exclusions = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
+                            Exclusions_item_extension = '.bat' # Drift
+                            Exclusions_item_type = '1'
+                        } -ClientOnly)
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
+                            Exclusions_item_name = 'Test'
+                            Exclusions_item_type = '2'
+                        } -ClientOnly)
+                    );
+                    Id = "12345-12345-12345-12345-12345"
+                    DisplayName = "My Test"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Update-IntuneDeviceConfigurationPolicy -Exactly 1
+            }
+        }
+
+        Context -Name 'ReverseDSC Tests' -Fixture {
+            BeforeAll {
+                $Global:CurrentModeIsExport = $true
+                $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
+                $testParams = @{
+                    Credential = $Credential
+                }
+            }
+
+            It 'Should Reverse Engineer resource from the Export method' {
+                $result = Export-TargetResource @testParams
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}
+
+Invoke-Command -ScriptBlock $Global:DscHelper.CleanupScript -NoNewScope

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAntivirusPolicyLinux.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAntivirusPolicyLinux.Tests.ps1
@@ -171,6 +171,20 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                         }
                                     )
                                 }
+                            },
+                            @{
+                                Id = 'linux_mdatp_managed_antivirusengine_exclusions_item_name'
+                                Name = 'exclusions_item_name'
+                                OffsetUri = 'exclusions/[{0}]/name'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSimpleSettingDefinition'
+                                    dependentOn = @(
+                                        @{
+                                            dependentOn = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type_2'
+                                            parentSettingId = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type'
+                                        }
+                                    )
+                                }
                             }
                         )
                         SettingInstance = @{
@@ -198,6 +212,27 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                                         }
                                                     )
                                                     value = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type_1'
+                                                }
+                                            }
+                                        )
+                                    },
+                                    @{
+                                        children = @(
+                                            @{
+                                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                                settingDefinitionId = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type'
+                                                choiceSettingValue = @{
+                                                    children = @(
+                                                        @{
+                                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance'
+                                                            settingDefinitionId = 'linux_mdatp_managed_antivirusengine_exclusions_item_name'
+                                                            simpleSettingValue = @{
+                                                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationStringSettingValue'
+                                                                value = 'Test'
+                                                            }
+                                                        }
+                                                    )
+                                                    value = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type_2'
                                                 }
                                             }
                                         )
@@ -383,6 +418,20 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                         }
                                     )
                                 }
+                            },
+                            @{
+                                Id = 'linux_mdatp_managed_antivirusengine_exclusions_item_name'
+                                Name = 'exclusions_item_name'
+                                OffsetUri = 'exclusions/[{0}]/name'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSimpleSettingDefinition'
+                                    dependentOn = @(
+                                        @{
+                                            dependentOn = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type_2'
+                                            parentSettingId = 'linux_mdatp_managed_antivirusengine_exclusions_item_$type'
+                                        }
+                                    )
+                                }
                             }
                         )
                         SettingInstance = @{
@@ -503,6 +552,10 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             Exclusions_item_extension = '.exe'
                             Exclusions_item_type = '1'
                         } -ClientOnly)
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
+                            Exclusions_item_name = 'Test'
+                            Exclusions_item_type = '2'
+                        } -ClientOnly)
                     );
                     Id = "12345-12345-12345-12345-12345"
                     DisplayName = "My Test"
@@ -551,6 +604,10 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             Exclusions_item_extension = '.exe'
                             Exclusions_item_type = '1'
                         } -ClientOnly)
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
+                            Exclusions_item_name = 'Test'
+                            Exclusions_item_type = '2'
+                        } -ClientOnly)
                     );
                     Id = "12345-12345-12345-12345-12345"
                     DisplayName = "My Test"
@@ -597,6 +654,10 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             Exclusions_item_extension = '.exe'
                             Exclusions_item_type = '1'
                         } -ClientOnly)
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
+                            Exclusions_item_name = 'Test'
+                            Exclusions_item_type = '2'
+                        } -ClientOnly)
                     );
                     Id = "12345-12345-12345-12345-12345"
                     DisplayName = "My Test"
@@ -635,6 +696,10 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             Exclusions_item_extension = '.pdf' # Drift
                             Exclusions_item_type = '1'
                         } -ClientOnly)
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
+                            Exclusions_item_name = 'Test'
+                            Exclusions_item_type = '2'
+                        } -ClientOnly)
                     );
                     Id = "12345-12345-12345-12345-12345"
                     DisplayName = "My Test"
@@ -672,6 +737,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Credential = $Credential
                 }
             }
+            
             It 'Should Reverse Engineer resource from the Export method' {
                 $result = Export-TargetResource @testParams
                 $result | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds the `IntuneAntivirusExclusionsPolicyLinux` resource. Additionally, it adds extended test cases to the `IntuneAntivirusPolicyLinux` resource with a slightly improved export behavior in `Get-TargetResource`. 

#### This Pull Request (PR) fixes the following issues
None.