### PR TITLE
Fixed the -Uri string concatenation for Invoke-MgGraphRequest calls

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyExternal/MSFT_AADAuthenticationMethodPolicyExternal.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyExternal/MSFT_AADAuthenticationMethodPolicyExternal.psm1
@@ -96,7 +96,7 @@ function Get-TargetResource
             }
             else
             {
-                $response = Invoke-MgGraphRequest -Method Get -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/policies/authenticationMethodsPolicy/"
+                $response = Invoke-MgGraphRequest -Method Get -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/policies/authenticationMethodsPolicy/")
                 $getValue = $response.authenticationMethodConfigurations | Where-Object -FilterScript {$_.DisplayName -eq $DisplayName}
             }
         }
@@ -300,7 +300,7 @@ function Set-TargetResource
     {
         Write-Verbose -Message "Updating the Azure AD Authentication Method Policy External with name {$($currentInstance.displayName)}"
 
-        $response = Invoke-MgGraphRequest -Method Get -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/policies/authenticationMethodsPolicy/"
+        $response = Invoke-MgGraphRequest -Method Get -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/policies/authenticationMethodsPolicy/")
         $getValue = $response.authenticationMethodConfigurations | Where-Object -FilterScript {$_.displayName -eq $currentInstance.displayName}
 
         $params.Remove('displayName') | Out-Null
@@ -313,7 +313,7 @@ function Set-TargetResource
     {
         Write-Verbose -Message "Removing the Azure AD Authentication Method Policy External with Id {$($currentInstance.displayName)}"
 
-        $response = Invoke-MgGraphRequest -Method Get -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/policies/authenticationMethodsPolicy/"
+        $response = Invoke-MgGraphRequest -Method Get -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/policies/authenticationMethodsPolicy/")
         $getValue = $response.authenticationMethodConfigurations | Where-Object -FilterScript {$_.displayName -eq $currentInstance.displayName}
 
         Remove-MgBetaPolicyAuthenticationMethodPolicyAuthenticationMethodConfiguration -AuthenticationMethodConfigurationId $getValue.Id
@@ -505,7 +505,7 @@ function Export-TargetResource
     {
         #region resource generator code
         $desiredType = "#microsoft.graph.externalAuthenticationMethodConfiguration"
-        $getPolicy = Invoke-MgGraphRequest -Method Get -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/policies/authenticationMethodsPolicy/"
+        $getPolicy = Invoke-MgGraphRequest -Method Get -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/policies/authenticationMethodsPolicy/")
         $getValue = $getPolicy.AuthenticationMethodConfigurations | Where-Object -FilterScript {$_.'@odata.type' -eq $desiredType}
         #endregion
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -1410,7 +1410,7 @@ function Set-TargetResource
         if ($currentParameters.ContainsKey('ServicePrincipalFilterMode') -and $currentParameters.ContainsKey('ServicePrincipalFilterRule'))
         {
             #check if the custom attribute exist.
-            $customattribute = Invoke-MgGraphRequest -Method GET -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directory/customSecurityAttributeDefinitions"
+            $customattribute = Invoke-MgGraphRequest -Method GET -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directory/customSecurityAttributeDefinitions")
             $ServicePrincipalFilterRule -match "CustomSecurityAttribute.(?<attribute>.*) -.*"
             $attrinrule = $matches.attribute
             if ($customattribute.value.id -contains $attrinrule){

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEnrichedAuditLogs/MSFT_AADEnrichedAuditLogs.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEnrichedAuditLogs/MSFT_AADEnrichedAuditLogs.psm1
@@ -167,7 +167,7 @@ function Set-TargetResource
         }
     }
     $body = ConvertTo-Json $values -Depth 10 -Compress
-    Invoke-MgGraphRequest -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/networkAccess/settings/enrichedAuditLogs' -Method PATCH -Body $body
+    Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/networkAccess/settings/enrichedAuditLogs') -Method PATCH -Body $body
 }
 
 function Test-TargetResource

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNetworkAccessForwardingPolicy/MSFT_AADNetworkAccessForwardingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNetworkAccessForwardingPolicy/MSFT_AADNetworkAccessForwardingPolicy.psm1
@@ -202,7 +202,7 @@ function Set-TargetResource
             rules = $rulesParam
         }
 
-        Invoke-MgGraphRequest -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/networkAccess/forwardingPolicies/$($currentPolicy.ID)/updatePolicyRules" -Method Post -Body $updateParams
+        Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/networkAccess/forwardingPolicies/$($currentPolicy.ID)/updatePolicyRules") -Method Post -Body $updateParams
     }
     else {
         Write-Verbose "Can not modify the list of poilicy rules for the forwarding policy with name: $($setParameters.Name)"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADOrganizationCertificateBasedAuthConfiguration/MSFT_AADOrganizationCertificateBasedAuthConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADOrganizationCertificateBasedAuthConfiguration/MSFT_AADOrganizationCertificateBasedAuthConfiguration.psm1
@@ -201,7 +201,7 @@ function Set-TargetResource
 
     # Delete the old configuration
     Write-Verbose -Message "Removing the current Azure AD Organization Certificate Based Auth Configuration."
-    Invoke-MgGraphRequest -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/organization/$OrganizationId/certificateBasedAuthConfiguration/$CertificateBasedAuthConfigurationId" -Method DELETE
+    Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/organization/$OrganizationId/certificateBasedAuthConfiguration/$CertificateBasedAuthConfigurationId") -Method DELETE
 
     if ($Ensure -eq 'Present')
     {
@@ -225,7 +225,7 @@ function Set-TargetResource
             certificateAuthorities = $createCertAuthorities
         }
 
-        $policy = Invoke-MgGraphRequest -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/organization/$OrganizationId/certificateBasedAuthConfiguration/" -Method POST -Body $params
+        $policy = Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/organization/$OrganizationId/certificateBasedAuthConfiguration/") -Method POST -Body $params
     }
 }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
@@ -593,7 +593,7 @@ function Set-TargetResource
             $CSAParams = @{
                 customSecurityAttributes = $currentAADServicePrincipal.CustomSecurityAttributes
             }
-            Invoke-MgGraphRequest -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/servicePrincipals(appId='$($currentParameters.AppId)')" -Method Patch -Body $CSAParams
+            Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/servicePrincipals(appId='$($currentParameters.AppId)')") -Method Patch -Body $CSAParams
         }
 
         Update-MgServicePrincipal -ServicePrincipalId $currentAADServicePrincipal.ObjectID @currentParameters
@@ -1223,7 +1223,7 @@ function Get-CustomSecurityAttributes {
         [String]$ServicePrincipalId
     )
 
-    $customSecurityAttributes = Invoke-MgGraphRequest -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/servicePrincipals/$($ServicePrincipalId)`?`$select=customSecurityAttributes" -Method Get
+    $customSecurityAttributes = Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/servicePrincipals/$($ServicePrincipalId)`?`$select=customSecurityAttributes") -Method Get
     $customSecurityAttributes = $customSecurityAttributes.customSecurityAttributes
     $newCustomSecurityAttributes = @()
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppleMDMPushNotificationCertificate/MSFT_IntuneAppleMDMPushNotificationCertificate.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppleMDMPushNotificationCertificate/MSFT_IntuneAppleMDMPushNotificationCertificate.psm1
@@ -222,7 +222,7 @@ function Set-TargetResource
         # so first check if it is $false, then make a post call to agree to the consent, this set the DataSharingConsetGranted to $true.
         $consentInstance = Get-MgBetaDeviceManagementDataSharingConsent -DataSharingConsentId "appleMDMPushCertificate"
         If($consentInstance.Granted -eq $False) {
-            Invoke-MgGraphRequest -Method POST -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/dataSharingConsents/appleMDMPushCertificate/consentToDataSharing" -Headers @{ "Content-Type" = "application/json" }
+            Invoke-MgGraphRequest -Method POST -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/dataSharingConsents/appleMDMPushCertificate/consentToDataSharing") -Headers @{ "Content-Type" = "application/json" }
         }
         else {
             Write-Host "Data sharing conset is already granted, so it can't be revoked."

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay.psm1
@@ -225,7 +225,7 @@ function Set-TargetResource
         if ($dataSharingConsent.granted -eq $false)
         {
             Write-Verbose -Message "Consent not granted, requesting consent..."
-            $consentResult = Invoke-MgGraphRequest -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/dataSharingConsents/androidManagedStore/consentToDataSharing" -Method 'POST' -Body @{
+            $consentResult = Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/dataSharingConsents/androidManagedStore/consentToDataSharing") -Method 'POST' -Body @{
                 DataSharingConsentId = "androidManagedStore"
             } -ContentType "application/json"
         }
@@ -238,7 +238,7 @@ function Set-TargetResource
         #         hostName = "intune.microsoft.com"
         #     }
 
-        #     $signupUrl = Invoke-MgGraphRequest -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/androidManagedStoreAccountEnterpriseSettings/requestSignupUrl" -Method 'POST' -Body @{
+        #     $signupUrl = Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/androidManagedStoreAccountEnterpriseSettings/requestSignupUrl") -Method 'POST' -Body @{
         #         hostName = "intune.microsoft.com"
         #     } -ContentType "application/json"
 
@@ -248,7 +248,7 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
     {
             Write-Host "Remove the Intune Device Management Android Google Play Enrollment with Id {$($currentInstance.Id)}"
-        $unbindResult = Invoke-MgGraphRequest -Uri $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/androidManagedStoreAccountEnterpriseSettings/unbind" -Method 'POST' -Body @{} -ContentType "application/json"
+        $unbindResult = Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/androidManagedStoreAccountEnterpriseSettings/unbind") -Method 'POST' -Body @{} -ContentType "application/json"
     }
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description

Fixed the `-Uri` string concatenation for `Invoke-MgGraphRequest` calls

#### This Pull Request (PR) fixes the following issues

Fixes the `Invoke-MgGraphRequest -Uri` string concatenation bug introduced in #5341


