### PR TITLE
Fix property naming and settings catalog handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,22 @@
 
 # UNRELEASED
 
+* IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy
+  * Update property `PasswordAgeDays_AAD` to be lower-case.
+    FIXES [#5378](https://github.com/microsoft/Microsoft365DSC/issues/5378) (1/2)
 * IntuneAntivirusExclusionsPolicyMacOS
   * Initial release.
 * IntuneAntivirusPolicyWindows10SettingCatalog
   * Update properties to be upper-case.
     Fixes [#5373](https://github.com/microsoft/Microsoft365DSC/issues/5373)
+* IntuneSecurityBaselineMicrosoftEdge
+  * Deprecate property `authschemes` and replace with `AuthSchemes_AuthSchemes`
 * M365DSCDRGUtil
   * Restrict CIM instance access to properties that appear multiple times.
   * Switch log type for not found Intune assignments to `Warning`.
+* M365DSCIntuneSettingsCatalogUtil
+  * Add ADMX handling for `edge~httpauthentication_`.
+    FIXES [#5378](https://github.com/microsoft/Microsoft365DSC/issues/5378) (2/2)
 * DEPENDENCIES
   * Updated DSCParser to version 2.0.0.12.
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy.psm1
@@ -24,7 +24,7 @@ function Get-TargetResource
         [Parameter()]
         [System.Int32]
         [ValidateRange(7, 365)]
-        $PasswordAgeDays_AAD,
+        $passwordagedays_aad,
 
         [Parameter()]
         [System.Int32]
@@ -118,7 +118,7 @@ function Get-TargetResource
             -ErrorAction Stop
 
         #Ensure the proper dependencies are installed in the current environment.
-        Confirm-M365DSCDependencies
+        #Confirm-M365DSCDependencies
 
         #region Telemetry
         $ResourceName = $MyInvocation.MyCommand.ModuleName -replace 'MSFT_', ''
@@ -237,7 +237,7 @@ function Set-TargetResource
         [Parameter()]
         [System.Int32]
         [ValidateRange(7, 365)]
-        $PasswordAgeDays_AAD,
+        $passwordagedays_aad,
 
         [Parameter()]
         [System.Int32]
@@ -324,7 +324,7 @@ function Set-TargetResource
     )
 
     #Ensure the proper dependencies are installed in the current environment.
-    Confirm-M365DSCDependencies
+    #Confirm-M365DSCDependencies
 
     #region Telemetry
     $ResourceName = $MyInvocation.MyCommand.ModuleName -replace 'MSFT_', ''
@@ -433,7 +433,7 @@ function Test-TargetResource
         [Parameter()]
         [System.Int32]
         [ValidateRange(7, 365)]
-        $PasswordAgeDays_AAD,
+        $passwordagedays_aad,
 
         [Parameter()]
         [System.Int32]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy.schema.mof
@@ -17,7 +17,7 @@ class MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy : OMI
     [Write, Description("Description of the account protection local administrator password solution policy.")] String Description;
     [Write, Description("Assignments of the account protection local administrator password solution policy."), EmbeddedInstance("MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicyAssignments")] String Assignments[];
     [Write, Description("Configures which directory the local admin account password is backed up to. 0 - Disabled, 1 - Azure AD, 2 - AD"), ValueMap{"0", "1", "2"}, Values{"0", "1", "2"}] UInt32 BackupDirectory;
-    [Write, Description("Configures the maximum password age of the managed local administrator account for Azure AD. Minimum - 7, Maximum - 365")] UInt32 PasswordAgeDays_AAD;
+    [Write, Description("Configures the maximum password age of the managed local administrator account for Azure AD. Minimum - 7, Maximum - 365")] UInt32 passwordagedays_aad;
     [Write, Description("Configures the maximum password age of the managed local administrator account for Active Directory. Minimum - 1, Maximum - 365")] UInt32 PasswordAgeDays;
     [Write, Description("Configures additional enforcement of maximum password age for the managed local administrator account.")] Boolean PasswordExpirationProtectionEnabled;
     [Write, Description("Configures how many previous encrypted passwords will be remembered in Active Directory. Minimum - 0, Maximum - 12")] UInt32 AdEncryptedPasswordHistorySize;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/MSFT_IntuneSecurityBaselineMicrosoftEdge.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/MSFT_IntuneSecurityBaselineMicrosoftEdge.psm1
@@ -81,6 +81,10 @@ function Get-TargetResource
         $authschemes,
 
         [Parameter()]
+        [System.String]
+        $AuthSchemes_AuthSchemes,
+
+        [Parameter()]
         [ValidateSet('0', '1')]
         [System.String]
         $NativeMessagingUserLevelHosts,
@@ -339,6 +343,10 @@ function Set-TargetResource
         $authschemes,
 
         [Parameter()]
+        [System.String]
+        $AuthSchemes_AuthSchemes,
+
+        [Parameter()]
         [ValidateSet('0', '1')]
         [System.String]
         $NativeMessagingUserLevelHosts,
@@ -440,6 +448,13 @@ function Set-TargetResource
     $templateReferenceId = 'c66347b7-8325-4954-a235-3bf2233dfbfd_2'
     $platforms = 'windows10'
     $technologies = 'mdm'
+
+    if ($BoundParameters.ContainsKey('authschemes'))
+    {
+        Write-Warning -Message "The parameter 'authschemes' is deprecated. Please use 'AuthSchemes_AuthSchemes' instead."
+        $BoundParameters['AuthSchemes_AuthSchemes'] = $BoundParameters['authschemes']
+        $BoundParameters.Remove('authschemes') | Out-Null
+    }
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {
@@ -590,6 +605,10 @@ function Test-TargetResource
         $authschemes,
 
         [Parameter()]
+        [System.String]
+        $AuthSchemes_AuthSchemes,
+
+        [Parameter()]
         [ValidateSet('0', '1')]
         [System.String]
         $NativeMessagingUserLevelHosts,
@@ -728,6 +747,17 @@ function Test-TargetResource
 
             $ValuesToCheck.Remove($key) | Out-Null
         }
+    }
+
+    if ($PSBoundParameters.ContainsKey('authschemes'))
+    {
+        Write-Warning -Message "The parameter 'authschemes' is deprecated. Please use 'AuthSchemes_AuthSchemes' instead."
+        if ($PSBoundParameters['authschemes'] -ne $CurrentValues['AuthSchemes_AuthSchemes'])
+        {
+            $testResult = $false
+        }
+        $ValuesToCheck.Remove('authschemes') | Out-Null
+        $ValuesToCheck.Remove('AuthSchemes_AuthSchemes') | Out-Null
     }
 
     $ValuesToCheck.Remove('Id') | Out-Null

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/MSFT_IntuneSecurityBaselineMicrosoftEdge.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/MSFT_IntuneSecurityBaselineMicrosoftEdge.schema.mof
@@ -28,7 +28,8 @@ class MSFT_IntuneSecurityBaselineMicrosoftEdge : OMI_BaseResource
     [Write, Description("Force WebSQL to be enabled (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String WebSQLAccess;
     [Write, Description("Allow Basic authentication for HTTP (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String BasicAuthOverHttpEnabled;
     [Write, Description("Supported authentication schemes (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String MicrosoftEdge_HTTPAuthentication_AuthSchemes;
-    [Write, Description("Supported authentication schemes (Device) - Depends on MicrosoftEdge_HTTPAuthentication_AuthSchemes")] String authschemes;
+    [Write, Description("(Deprecated) - Supported authentication schemes (Device) - Depends on MicrosoftEdge_HTTPAuthentication_AuthSchemes")] String authschemes;
+    [Write, Description("Supported authentication schemes (Device) - Depends on MicrosoftEdge_HTTPAuthentication_AuthSchemes")] String AuthSchemes_AuthSchemes;
     [Write, Description("Allow user-level native messaging hosts (installed without admin permissions) (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String NativeMessagingUserLevelHosts;
     [Write, Description("Specifies whether to allow insecure websites to make requests to more-private network endpoints (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String InsecurePrivateNetworkRequestsAllowed;
     [Write, Description("Show the Reload in Internet Explorer mode button in the toolbar (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String InternetExplorerModeToolbarButtonEnabled;

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/1-Create.ps1
@@ -34,7 +34,7 @@ Configuration Example
                 }
             );
             BackupDirectory          = "1";
-            PasswordAgeDays_AAD      = 10;
+            passwordagedays_aad      = 10;
             AdministratorAccountName = "Administrator";
             PasswordAgeDays          = 20;
             ApplicationId         = $ApplicationId;

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/2-Update.ps1
@@ -34,7 +34,7 @@ Configuration Example
                 }
             );
             BackupDirectory          = "1";
-            PasswordAgeDays_AAD      = 15; # Updated Property
+            passwordagedays_aad      = 15; # Updated Property
             AdministratorAccountName = "Administrator";
             PasswordAgeDays          = 20;
             ApplicationId         = $ApplicationId;

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -2480,7 +2480,7 @@ function Update-IntuneDeviceConfigurationPolicy
             'settings'          = $Settings
         }
         $body = $policy | ConvertTo-Json -Depth 20
-        Write-Verbose -Message $body -Verbose
+        # Write-Verbose -Message $body -Verbose
         Invoke-MgGraphRequest -Method PUT -Uri $Uri -Body $body -ErrorAction Stop
     }
     catch

--- a/Modules/Microsoft365DSC/Modules/M365DSCIntuneSettingsCatalogUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCIntuneSettingsCatalogUtil.psm1
@@ -67,7 +67,7 @@
         }
 
         # When there is no parent, we can't use the parent setting name to make the setting name unique
-        # Instead, we traverse up the OffsetUri. 
+        # Instead, we traverse up the OffsetUri.
         if ($null -eq $parentSetting)
         {
             $settingResult = Get-UniqueSettingDefinitionNameFromMultipleMatches -SettingDefinition $SettingDefinition -SettingName $settingName -SettingsWithSameName $settingsWithSameName
@@ -98,6 +98,7 @@
             'pub16v2~Policy~L_MicrosoftOfficePublisher~*' { $settingName = $settingName.Replace('pub16v2~Policy~L_MicrosoftOfficePublisher', 'MicrosoftPublisherV2_') }
             'pub16v3~Policy~L_MicrosoftOfficePublisher~*' { $settingName = $settingName.Replace('pub16v3~Policy~L_MicrosoftOfficePublisher', 'MicrosoftPublisherV3_') }
             'microsoft_edge~Policy~microsoft_edge~*' { $settingName = $settingName.Replace('microsoft_edge~Policy~microsoft_edge', 'MicrosoftEdge_') }
+            'edge~httpauthentication*' { $settingName = $settingName.Replace('edge~httpauthentication', 'MicrosoftEdge_HTTPAuthentication') }
             '*~L_Security~*' { $settingName = $settingName.Replace('~L_Security', 'Security') }
             '*~L_TrustCenter*' { $settingName = $settingName.Replace('~L_TrustCenter', '_TrustCenter') }
             '*~L_ProtectedView_*' { $settingName = $settingName.Replace('~L_ProtectedView', 'ProtectedView') }


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes three issues with the settings catalog: One was a not handled case of a property name simplification, the second one in the same resource was an incorrectly generated property name, and the last issue in the second resource was a upper vs lower-case property name. 

#### This Pull Request (PR) fixes the following issues
- Fixes #5378 