### PR TITLE
Fixed issue in AADConditionalAccessPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+* AADConditionalAccessPolicy
+  * Fixed bug where an empty value was passed in the request for the
+    insiderRiskLevels parameter, which throws an error.
+    FIXES [#5389](https://github.com/microsoft/Microsoft365DSC/issues/5389)
 * IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy
   * Update property `PasswordAgeDays_AAD` to be lower-case.
     FIXES [#5378](https://github.com/microsoft/Microsoft365DSC/issues/5378) (1/2)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -220,6 +220,7 @@ function Get-TargetResource
         $TransferMethods,
 
         [Parameter()]
+        [ValidateSet('minor', 'moderate', 'elevated', 'unknownFutureValue')]
         [System.String]
         $InsiderRiskLevels,
 
@@ -949,6 +950,7 @@ function Set-TargetResource
         $TransferMethods,
 
         [Parameter()]
+        [ValidateSet('minor', 'moderate', 'elevated', 'unknownFutureValue')]
         [System.String]
         $InsiderRiskLevels,
 
@@ -1586,7 +1588,7 @@ function Set-TargetResource
             }
         }
 
-        if ($null -ne $InsiderRiskLevels)
+        if ([String]::IsNullOrEmpty($InsiderRiskLevels) -eq $false)
         {
             $conditions.Add("insiderRiskLevels", $InsiderRiskLevels)
         }
@@ -2059,6 +2061,7 @@ function Test-TargetResource
         $TransferMethods,
 
         [Parameter()]
+        [ValidateSet('minor', 'moderate', 'elevated', 'unknownFutureValue')]
         [System.String]
         $InsiderRiskLevels,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.schema.mof
@@ -50,7 +50,7 @@ class MSFT_AADConditionalAccessPolicy : OMI_BaseResource
     [Write, Description("Name of the associated authentication strength policy.")] String AuthenticationStrength;
     [Write, Description("Names of the associated authentication flow transfer methods. Possible values are '', 'deviceCodeFlow', 'authenticationTransfer', or 'deviceCodeFlow,authenticationTransfer'.")] String TransferMethods;
     [Write, Description("Authentication context class references.")] String AuthenticationContexts[];
-    [Write, Description("Insider risk levels conditions.")] String InsiderRiskLevels;
+    [Write, Description("Insider risk levels conditions."), ValueMap{"minor", "moderate", "elevated", "unknownFutureValue"}, Values{"minor", "moderate", "elevated", "unknownFutureValue"}] String InsiderRiskLevels;
     [Write, Description("Specify if the Azure AD CA Policy should exist or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Credentials for the Microsoft Graph delegated permissions."), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
@@ -60,3 +60,4 @@ class MSFT_AADConditionalAccessPolicy : OMI_BaseResource
     [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
     [Write, Description("Access token used for authentication.")] String AccessTokens[];
 };
+


### PR DESCRIPTION
#### Pull Request (PR) description
Fixed bug where an empty value was passed in the request for the insiderRiskLevels parameter, which throws an error.

#### This Pull Request (PR) fixes the following issues
- Fixes #5389

