### PR TITLE
Fix export of changed property name in EDR Windows10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 * IntuneAntivirusPolicyWindows10SettingCatalog
   * Update properties to be upper-case.
     Fixes [#5373](https://github.com/microsoft/Microsoft365DSC/issues/5373)
+* IntuneEndpointDetectionAndResponsePolicyWindows10
+  * Remove changed property name from export.
+    FIXES [#5300](https://github.com/microsoft/Microsoft365DSC/issues/5300)
 * IntuneSecurityBaselineMicrosoftEdge
   * Deprecate property `authschemes` and replace with `AuthSchemes_AuthSchemes`
 * M365DSCDRGUtil

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
@@ -122,6 +122,7 @@ function Get-TargetResource
         [array]$settings = Get-MgBetaDeviceManagementConfigurationPolicySetting `
             -DeviceManagementConfigurationPolicyId $Identity `
             -ExpandProperty 'settingDefinitions' `
+            -All `
             -ErrorAction Stop
 
         $policySettings = @{}
@@ -130,7 +131,7 @@ function Get-TargetResource
         $policySettings.Remove('ClientConfigurationPackageType')
         $policySettings.Remove('onboarding')
         $policySettings.Remove('offboarding')
-        $policySettings.Remove('autofromconnector')
+        $policySettings.Remove('onboarding_fromconnector')
 
         # Removing TelemetryReportingFrequency because it's deprecated and doesn't need to be evaluated and enforced
         $policySettings.Remove('telemetryreportingfrequency')


### PR DESCRIPTION
#### Pull Request (PR) description
This PR removes the property `onboarding_onboarding_fromconnector` from the export. Due to changes in the settings catalog property generation, this one slipped by. 

#### This Pull Request (PR) fixes the following issues
- Fixes #5300 