### PR TITLE
Fixes #5390

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   * Fixed bug where an empty value was passed in the request for the
     insiderRiskLevels parameter, which throws an error.
     FIXES [#5389](https://github.com/microsoft/Microsoft365DSC/issues/5389)
+  * Fixes a bug where 3P apps could not be assigned by DisplayName for both
+    IncludeApplications and ExcludeApplications
+    FIXES [#5390](https://github.com/microsoft/Microsoft365DSC/issues/5390)
 * EXOATPBuiltInProtectionRule, EXOEOPProtectionRule
   * Fixed issue where empty arrays were being compared incorrectly to null
     strings

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -1031,11 +1031,54 @@ function Set-TargetResource
         Write-Verbose -Message 'Set-Targetresource: create Application Condition object'
         if ($currentParameters.ContainsKey('IncludeApplications'))
         {
-            $conditions.Applications.Add('includeApplications', $IncludeApplications)
+            $IncludeApplicationsValue = @()
+            foreach ($app in $IncludeApplications)
+            {
+                $ObjectGuid = [System.Guid]::empty
+                if ([System.Guid]::TryParse($app, [System.Management.Automation.PSReference]$ObjectGuid))
+                {
+                    $IncludeApplicationsValue += $app
+                }
+                else
+                {
+                    $appInfo = Get-MgApplication -Filter "DisplayName eq '$app'" -ErrorAction SilentlyContinue
+                    if ($null -ne $appInfo)
+                    {
+                        $IncludeApplicationsValue += $appInfo.AppId
+                    }
+                    else
+                    {
+                        $IncludeApplicationsValue += $app
+                    }
+                }
+            }
+
+            $conditions.Applications.Add('includeApplications', $IncludeApplicationsValue)
         }
         if ($currentParameters.ContainsKey('excludeApplications'))
         {
-            $conditions.Applications.Add('excludeApplications', $ExcludeApplications)
+            $ExcludeApplicationsValue = @()
+            foreach ($app in $ExcludeApplications)
+            {
+                $ObjectGuid = [System.Guid]::empty
+                if ([System.Guid]::TryParse($app, [System.Management.Automation.PSReference]$ObjectGuid))
+                {
+                    $ExcludeApplicationsValue += $app
+                }
+                else
+                {
+                    $appInfo = Get-MgApplication -Filter "DisplayName eq '$app'" -ErrorAction SilentlyContinue
+                    if ($null -ne $appInfo)
+                    {
+                        $ExcludeApplicationsValue += $appInfo.AppId
+                    }
+                    else
+                    {
+                        $ExcludeApplicationsValue += $app
+                    }
+                }
+            }
+            $conditions.Applications.Add('excludeApplications', $ExcludeApplicationsValue)
         }
         if ($ApplicationsFilter -and $ApplicationsFilterMode)
         {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOrgWideAppSettings/MSFT_TeamsOrgWideAppSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOrgWideAppSettings/MSFT_TeamsOrgWideAppSettings.psm1
@@ -25,7 +25,7 @@ function Get-TargetResource
         [Switch]
         $ManagedIdentity
     )
-    Write-Verbose -Message 'Checking the Teams Upgrade Configuration'
+    Write-Verbose -Message 'Checking the Teams Org Wide App Settings'
 
     $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftTeams' `
         -InboundParameters $PSBoundParameters
@@ -105,7 +105,7 @@ function Set-TargetResource
         $ManagedIdentity
     )
 
-    Write-Verbose -Message 'Setting Teams Upgrade Configuration'
+    Write-Verbose -Message 'Setting the Teams Org Wide App Settings'
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
@@ -169,7 +169,7 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    Write-Verbose -Message 'Testing configuration of Team Upgrade Settings'
+    Write-Verbose -Message 'Testing configuration for the Teams Org Wide App Settings'
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
 


### PR DESCRIPTION
#### Pull Request (PR) description
* AADConditionalAccessPolicy
   * Fixes a bug where 3P apps could not be assigned by DisplayName for both
    IncludeApplications and ExcludeApplications
    FIXES [#5390](https://github.com/microsoft/Microsoft365DSC/issues/5390)

#### This Pull Request (PR) fixes the following issues
* FIXES #5390 
