### PR TITLE
MSFT_AADConditionalAccessPolicy [BUG] Prevent null objects, allow IncludePlatforms without Exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # UNRELEASED
 
+* AADConditionalAccessPolicy
+  * Fixed bug where a null value was passed in the request for the
+    excludePlatforms parameter when just values were assigned to includePlatforms, which throws an error.
+  * Fixed bug where a null value was passed in the request for the
+    sessionControl parameter when there are no session controls, which throws an error.
+  * Fixed bug where a null value was passed in the request for the
+    applicationEnforcedRestrictions parameter when value was set to false, which throws an error.
 * AADRoleEligibilityScheduleRequest
   * Adds support for custom role assignments at app scope.
 


### PR DESCRIPTION
#### Pull Request (PR) description
The PR solves adding null objects to the $NewParameter when not applicable for $sessioncontrols and $sessioncontrols.applicationEnforcedRestrictions, which causes errors on deployment. Next to that it provides the possibility to include platforms without excluding but expects included platforms when excluding.

#### This Pull Request (PR) fixes the following issues
None
