### PR TITLE
Add Intune Disk Encryption for Personal Data Encryption Windows 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * AADRoleEligibilityScheduleRequest
   * Adds support for custom role assignments at app scope.
+* IntuneDiskEncryptionPDEPolicyWindows10
+  * Initial release.
 * IntuneFirewallRulesHyperVPolicyWindows10
   * Initial release.
 * M365DSCDRGUtil

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionPDEPolicyWindows10/MSFT_IntuneDiskEncryptionPDEPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionPDEPolicyWindows10/MSFT_IntuneDiskEncryptionPDEPolicyWindows10.psm1
@@ -1,0 +1,653 @@
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $EnablePersonalDataEncryption,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ProtectDesktop,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ProtectPictures,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ProtectDocuments,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    try
+    {
+        $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+            -InboundParameters $PSBoundParameters
+
+        #Ensure the proper dependencies are installed in the current environment.
+        Confirm-M365DSCDependencies
+
+        #region Telemetry
+        $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+        $CommandName = $MyInvocation.MyCommand
+        $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+            -CommandName $CommandName `
+            -Parameters $PSBoundParameters
+        Add-M365DSCTelemetryEvent -Data $data
+        #endregion
+
+        $nullResult = $PSBoundParameters
+        $nullResult.Ensure = 'Absent'
+
+        $getValue = $null
+        #region resource generator code
+        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id  -ErrorAction SilentlyContinue
+
+        if ($null -eq $getValue)
+        {
+            Write-Verbose -Message "Could not find an Intune Disk Encryption PDE Policy for Windows10 with Id {$Id}"
+
+            if (-not [System.String]::IsNullOrEmpty($DisplayName))
+            {
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -Filter "Name eq '$DisplayName'" `
+                    -All `
+                    -ErrorAction SilentlyContinue
+            }
+        }
+        #endregion
+        if ($null -eq $getValue)
+        {
+            Write-Verbose -Message "Could not find an Intune Disk Encryption PDE Policy for Windows10 with Name {$DisplayName}."
+            return $nullResult
+        }
+        $Id = $getValue.Id
+        Write-Verbose -Message "An Intune Disk Encryption PDE Policy for Windows10 with Id {$Id} and Name {$DisplayName} was found"
+
+        # Retrieve policy specific settings
+        [array]$settings = Get-MgBetaDeviceManagementConfigurationPolicySetting `
+            -DeviceManagementConfigurationPolicyId $Id `
+            -ExpandProperty 'settingDefinitions' `
+            -All `
+            -ErrorAction Stop
+
+        $policySettings = @{}
+        $policySettings = Export-IntuneSettingCatalogPolicySettings -Settings $settings -ReturnHashtable $policySettings
+
+        $results = @{
+            #region resource generator code
+            Description           = $getValue.Description
+            DisplayName           = $getValue.Name
+            RoleScopeTagIds       = $getValue.RoleScopeTagIds
+            Id                    = $getValue.Id
+            Ensure                = 'Present'
+            Credential            = $Credential
+            ApplicationId         = $ApplicationId
+            TenantId              = $TenantId
+            ApplicationSecret     = $ApplicationSecret
+            CertificateThumbprint = $CertificateThumbprint
+            ManagedIdentity       = $ManagedIdentity.IsPresent
+            #endregion
+        }
+        $results += $policySettings
+
+        $assignmentsValues = Get-MgBetaDeviceManagementConfigurationPolicyAssignment -DeviceManagementConfigurationPolicyId $Id
+        $assignmentResult = @()
+        if ($assignmentsValues.Count -gt 0)
+        {
+            $assignmentResult += ConvertFrom-IntunePolicyAssignment -Assignments $assignmentsValues -IncludeDeviceFilter $true
+        }
+        $results.Add('Assignments', $assignmentResult)
+
+        return [System.Collections.Hashtable] $results
+    }
+    catch
+    {
+        New-M365DSCLogEntry -Message 'Error retrieving data:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return $nullResult
+    }
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $EnablePersonalDataEncryption,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ProtectDesktop,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ProtectPictures,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ProtectDocuments,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    $currentInstance = Get-TargetResource @PSBoundParameters
+
+    $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+
+    $templateReferenceId = '0b5708d9-9bc2-49a9-b4f7-ec463fcc41e0_1'
+    $platforms = 'windows10'
+    $technologies = 'mdm'
+
+    if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
+    {
+        Write-Verbose -Message "Creating an Intune Disk Encryption PDE Policy for Windows10 with Name {$DisplayName}"
+        $BoundParameters.Remove("Assignments") | Out-Null
+
+        $settings = Get-IntuneSettingCatalogPolicySetting `
+            -DSCParams ([System.Collections.Hashtable]$BoundParameters) `
+            -TemplateId $templateReferenceId
+
+        $createParameters = @{
+            Name              = $DisplayName
+            Description       = $Description
+            TemplateReference = @{ templateId = $templateReferenceId }
+            Platforms         = $platforms
+            Technologies      = $technologies
+            Settings          = $settings
+        }
+
+        #region resource generator code
+        $policy = New-MgBetaDeviceManagementConfigurationPolicy -BodyParameter $createParameters
+
+        if ($policy.Id)
+        {
+            $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
+            Update-DeviceConfigurationPolicyAssignment `
+                -DeviceConfigurationPolicyId $policy.Id `
+                -Targets $assignmentsHash `
+                -Repository 'deviceManagement/configurationPolicies'
+        }
+        #endregion
+    }
+    elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Updating the Intune Disk Encryption PDE Policy for Windows10 with Id {$($currentInstance.Id)}"
+        $BoundParameters.Remove("Assignments") | Out-Null
+
+        $settings = Get-IntuneSettingCatalogPolicySetting `
+            -DSCParams ([System.Collections.Hashtable]$BoundParameters) `
+            -TemplateId $templateReferenceId
+
+        Update-IntuneDeviceConfigurationPolicy `
+            -DeviceConfigurationPolicyId $currentInstance.Id `
+            -Name $DisplayName `
+            -Description $Description `
+            -TemplateReferenceId $templateReferenceId `
+            -Platforms $platforms `
+            -Technologies $technologies `
+            -Settings $settings
+
+        #region resource generator code
+        $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
+        Update-DeviceConfigurationPolicyAssignment `
+            -DeviceConfigurationPolicyId $currentInstance.Id `
+            -Targets $assignmentsHash `
+            -Repository 'deviceManagement/configurationPolicies'
+        #endregion
+    }
+    elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Removing the Intune Disk Encryption PDE Policy for Windows10 with Id {$($currentInstance.Id)}"
+        #region resource generator code
+        Remove-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $currentInstance.Id
+        #endregion
+    }
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $EnablePersonalDataEncryption,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ProtectDesktop,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ProtectPictures,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ProtectDocuments,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    Write-Verbose -Message "Testing configuration of the Intune Disk Encryption PDE Policy for Windows10 with Id {$Id} and Name {$DisplayName}"
+
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+    [Hashtable]$ValuesToCheck = @{}
+    $MyInvocation.MyCommand.Parameters.GetEnumerator() | ForEach-Object {
+        if ($_.Key -notlike '*Variable' -or $_.Key -notin @('Verbose', 'Debug', 'ErrorAction', 'WarningAction', 'InformationAction'))
+        {
+            if ($null -ne $CurrentValues[$_.Key] -or $null -ne $PSBoundParameters[$_.Key])
+            {
+                $ValuesToCheck.Add($_.Key, $null)
+                if (-not $PSBoundParameters.ContainsKey($_.Key))
+                {
+                    $PSBoundParameters.Add($_.Key, $null)
+                }
+            }
+        }
+    }
+
+    if ($CurrentValues.Ensure -ne $Ensure)
+    {
+        Write-Verbose -Message "Test-TargetResource returned $false"
+        return $false
+    }
+    $testResult = $true
+
+    #Compare Cim instances
+    foreach ($key in $PSBoundParameters.Keys)
+    {
+        $source = $PSBoundParameters.$key
+        $target = $CurrentValues.$key
+        if ($null -ne $source -and $source.GetType().Name -like '*CimInstance*')
+        {
+            $testResult = Compare-M365DSCComplexObject `
+                -Source ($source) `
+                -Target ($target)
+
+            if (-not $testResult)
+            {
+                break
+            }
+
+            $ValuesToCheck.Remove($key) | Out-Null
+        }
+    }
+
+    $ValuesToCheck.Remove('Id') | Out-Null
+    $ValuesToCheck = Remove-M365DSCAuthenticationParameter -BoundParameters $ValuesToCheck
+
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
+    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
+
+    if ($testResult)
+    {
+        $testResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -DesiredValues $PSBoundParameters `
+            -ValuesToCheck $ValuesToCheck.Keys
+    }
+
+    Write-Verbose -Message "Test-TargetResource returned $testResult"
+
+    return $testResult
+}
+
+function Export-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+        -InboundParameters $PSBoundParameters
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    try
+    {
+        #region resource generator code
+        $policyTemplateID = "0b5708d9-9bc2-49a9-b4f7-ec463fcc41e0_1"
+        [array]$getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+            -Filter $Filter `
+            -All `
+            -ErrorAction Stop | Where-Object `
+            -FilterScript {
+                $_.TemplateReference.TemplateId -eq $policyTemplateID
+            }
+        #endregion
+
+        $i = 1
+        $dscContent = ''
+        if ($getValue.Length -eq 0)
+        {
+            Write-Host $Global:M365DSCEmojiGreenCheckMark
+        }
+        else
+        {
+            Write-Host "`r`n" -NoNewline
+        }
+        foreach ($config in $getValue)
+        {
+            $displayedKey = $config.Id
+            if (-not [String]::IsNullOrEmpty($config.displayName))
+            {
+                $displayedKey = $config.displayName
+            }
+            elseif (-not [string]::IsNullOrEmpty($config.name))
+            {
+                $displayedKey = $config.name
+            }
+            Write-Host "    |---[$i/$($getValue.Count)] $displayedKey" -NoNewline
+            $params = @{
+                Id = $config.Id
+                DisplayName = $config.Name
+                Ensure = 'Present'
+                Credential = $Credential
+                ApplicationId = $ApplicationId
+                TenantId = $TenantId
+                ApplicationSecret = $ApplicationSecret
+                CertificateThumbprint = $CertificateThumbprint
+                ManagedIdentity = $ManagedIdentity.IsPresent
+                AccessTokens = $AccessTokens
+            }
+
+            $Results = Get-TargetResource @Params
+            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
+                -Results $Results
+
+            if ($Results.Assignments)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
+                if ($complexTypeStringResult)
+                {
+                    $Results.Assignments = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('Assignments') | Out-Null
+                }
+            }
+
+            $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
+                -ConnectionMode $ConnectionMode `
+                -ModulePath $PSScriptRoot `
+                -Results $Results `
+                -Credential $Credential
+
+            if ($Results.Assignments)
+            {
+                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "Assignments" -IsCIMArray:$true
+            }
+
+            $dscContent += $currentDSCBlock
+            Save-M365DSCPartialExport -Content $currentDSCBlock `
+                -FileName $Global:PartialExportFileName
+            $i++
+            Write-Host $Global:M365DSCEmojiGreenCheckMark
+        }
+        return $dscContent
+    }
+    catch
+    {
+        Write-Host $Global:M365DSCEmojiRedX
+
+        New-M365DSCLogEntry -Message 'Error during Export:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return ''
+    }
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionPDEPolicyWindows10/MSFT_IntuneDiskEncryptionPDEPolicyWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionPDEPolicyWindows10/MSFT_IntuneDiskEncryptionPDEPolicyWindows10.schema.mof
@@ -1,0 +1,33 @@
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementConfigurationPolicyAssignments
+{
+    [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}] String dataType;
+    [Write, Description("The type of filter of the target assignment i.e. Exclude or Include. Possible values are:none, include, exclude."), ValueMap{"none","include","exclude"}, Values{"none","include","exclude"}] String deviceAndAppManagementAssignmentFilterType;
+    [Write, Description("The Id of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterId;
+    [Write, Description("The group Id that is the target of the assignment.")] String groupId;
+    [Write, Description("The group Display Name that is the target of the assignment.")] String groupDisplayName;
+    [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
+};
+
+
+[ClassVersion("1.0.0.0"), FriendlyName("IntuneDiskEncryptionPDEPolicyWindows10")]
+class MSFT_IntuneDiskEncryptionPDEPolicyWindows10 : OMI_BaseResource
+{
+    [Write, Description("Policy description")] String Description;
+    [Key, Description("Policy name")] String DisplayName;
+    [Write, Description("List of Scope Tags for this Entity instance.")] String RoleScopeTagIds[];
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
+    [Write, Description("Enable Personal Data Encryption (User) (0: Disable Personal Data Encryption., 1: Enable Personal Data Encryption.)"), ValueMap{"0", "1"}, Values{"0", "1"}] String EnablePersonalDataEncryption;
+    [Write, Description("Protect Desktop (User) (Windows Insiders only) - Depends on EnablePersonalDataEncryption (0: Disable PDE on the folder. If the folder is currently protected by PDE, this will result in unprotecting the folder., 1: Enable PDE on the folder.)"), ValueMap{"0", "1"}, Values{"0", "1"}] String ProtectDesktop;
+    [Write, Description("Protect Pictures (User) (Windows Insiders only) - Depends on EnablePersonalDataEncryption (0: Disable PDE on the folder. If the folder is currently protected by PDE, this will result in unprotecting the folder., 1: Enable PDE on the folder.)"), ValueMap{"0", "1"}, Values{"0", "1"}] String ProtectPictures;
+    [Write, Description("Protect Documents (User) (Windows Insiders only) - Depends on EnablePersonalDataEncryption (0: Disable PDE on the folder. If the folder is currently protected by PDE, this will result in unprotecting the folder., 1: Enable PDE on the folder.)"), ValueMap{"0", "1"}, Values{"0", "1"}] String ProtectDocuments;
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
+    [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
+    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
+    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
+    [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
+    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Access token used for authentication.")] String AccessTokens[];
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionPDEPolicyWindows10/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionPDEPolicyWindows10/readme.md
@@ -1,0 +1,6 @@
+
+# IntuneDiskEncryptionPDEPolicyWindows10
+
+## Description
+
+Intune Disk Encryption Personal Data Encryption Policy for Windows10

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionPDEPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionPDEPolicyWindows10/settings.json
@@ -1,0 +1,44 @@
+{
+  "resourceName":"IntuneDiskEncryptionPDEPolicyWindows10",
+  "description":"This resource configures an Intune Disk Encryption P D E Policy for Windows10.",
+  "permissions":{
+      "graph":{
+          "application":{
+              "update":[
+                  {
+                      "name":"DeviceManagementConfiguration.ReadWrite.All"
+                  },
+                  {
+                      "name":"Group.Read.All"
+                  }
+              ],
+              "read":[
+                  {
+                      "name":"DeviceManagementConfiguration.Read.All"
+                  },
+                  {
+                      "name":"Group.Read.All"
+                  }
+              ]
+          },
+          "delegated":{
+              "update":[
+                  {
+                      "name":"DeviceManagementConfiguration.ReadWrite.All"
+                  },
+                  {
+                      "name":"Group.Read.All"
+                  }
+              ],
+              "read":[
+                  {
+                      "name":"DeviceManagementConfiguration.Read.All"
+                  },
+                  {
+                      "name":"Group.Read.All"
+                  }
+              ]
+          }
+      }
+  }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneDiskEncryptionPDEPolicyWindows10/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneDiskEncryptionPDEPolicyWindows10/1-Create.ps1
@@ -1,0 +1,41 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneDiskEncryptionPDEPolicyWindows10 "IntuneDiskEncryptionPDEPolicyWindows10"
+        {
+            Assignments                  = @();
+            Description                  = "test";
+            DisplayName                  = "test";
+            Ensure                       = "Present";
+            EnablePersonalDataEncryption = "1";
+            ProtectDesktop               = "0";
+            ProtectDocuments             = "0";
+            ProtectPictures              = "0";
+            RoleScopeTagIds              = @("0");
+            ApplicationId                = $ApplicationId;
+            TenantId                     = $TenantId;
+            CertificateThumbprint        = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneDiskEncryptionPDEPolicyWindows10/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneDiskEncryptionPDEPolicyWindows10/2-Update.ps1
@@ -1,0 +1,41 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneDiskEncryptionPDEPolicyWindows10 "IntuneDiskEncryptionPDEPolicyWindows10"
+        {
+            Assignments                  = @();
+            Description                  = "test";
+            DisplayName                  = "test";
+            Ensure                       = "Present";
+            EnablePersonalDataEncryption = "1";
+            ProtectDesktop               = "0";
+            ProtectDocuments             = "1"; # Updated property
+            ProtectPictures              = "1"; # Updated property
+            RoleScopeTagIds              = @("0");
+            ApplicationId                = $ApplicationId;
+            TenantId                     = $TenantId;
+            CertificateThumbprint        = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneDiskEncryptionPDEPolicyWindows10/3-Remove.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneDiskEncryptionPDEPolicyWindows10/3-Remove.ps1
@@ -1,0 +1,34 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneDiskEncryptionPDEPolicyWindows10 "IntuneDiskEncryptionPDEPolicyWindows10"
+        {
+            DisplayName           = "test";
+            Ensure                = "Absent";
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDiskEncryptionPDEPolicyWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDiskEncryptionPDEPolicyWindows10.Tests.ps1
@@ -1,0 +1,379 @@
+[CmdletBinding()]
+param(
+)
+$M365DSCTestFolder = Join-Path -Path $PSScriptRoot `
+                        -ChildPath '..\..\Unit' `
+                        -Resolve
+$CmdletModule = (Join-Path -Path $M365DSCTestFolder `
+            -ChildPath '\Stubs\Microsoft365.psm1' `
+            -Resolve)
+$GenericStubPath = (Join-Path -Path $M365DSCTestFolder `
+    -ChildPath '\Stubs\Generic.psm1' `
+    -Resolve)
+Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\UnitTestHelper.psm1' `
+        -Resolve)
+
+$Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
+    -DscResource "IntuneDiskEncryptionPDEPolicyWindows10" -GenericStubModule $GenericStubPath
+Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
+        BeforeAll {
+
+            $secpasswd = ConvertTo-SecureString (New-Guid | Out-String) -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
+
+            Mock -CommandName Confirm-M365DSCDependencies -MockWith {
+            }
+
+            Mock -CommandName Get-PSSession -MockWith {
+            }
+
+            Mock -CommandName Remove-PSSession -MockWith {
+            }
+
+            Mock -CommandName Update-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+            }
+
+            Mock -CommandName New-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+                return @{
+                    Id = '12345-12345-12345-12345-12345'
+                }
+            }
+
+            Mock -CommandName Remove-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+            }
+
+            Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+                return @{
+                    Id              = '12345-12345-12345-12345-12345'
+                    Description     = 'My Test'
+                    Name            = 'My Test'
+                    RoleScopeTagIds = @("FakeStringValue")
+                    TemplateReference = @{
+                        TemplateId = '0b5708d9-9bc2-49a9-b4f7-ec463fcc41e0_1'
+                    }
+                }
+            }
+
+            Mock -CommandName Update-IntuneDeviceConfigurationPolicy -MockWith {
+            }
+
+            Mock -CommandName Get-IntuneSettingCatalogPolicySetting -MockWith {
+            }
+
+            Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicySetting -MockWith {
+                return @(
+                    @{
+                        Id = '0'
+                        SettingDefinitions = @(
+                            @{
+                                Id = 'user_vendor_msft_pde_enablepersonaldataencryption'
+                                Name = 'EnablePersonalDataEncryption'
+                                OffsetUri = '/EnablePersonalDataEncryption'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                    options = @(
+                                        @{
+                                            name = 'Enable Personal Data Encryption.'
+                                            itemId = 'user_vendor_msft_pde_enablepersonaldataencryption_1'
+                                        }
+                                    )
+                                }
+                            },
+                            @{
+                                Id = 'user_vendor_msft_pde_protectfolders_protectdesktop'
+                                Name = 'ProtectDesktop'
+                                OffsetUri = '/ProtectFolders/ProtectDesktop'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                    options = @(
+                                        @{
+                                            name = 'Disable PDE on the folder. If the folder is currently protected by PDE, this will result in unprotecting the folder.'
+                                            itemId = 'user_vendor_msft_pde_protectfolders_protectdesktop_0'
+                                            dependentOn = @(
+                                                @{
+                                                    dependentOn = 'user_vendor_msft_pde_enablepersonaldataencryption_1'
+                                                    parentSettingId = 'user_vendor_msft_pde_enablepersonaldataencryption'
+                                                }
+                                            )
+                                        }
+                                    )
+                                }
+                            },
+                            @{
+                                Id = 'user_vendor_msft_pde_protectfolders_protectpictures'
+                                Name = 'ProtectPictures'
+                                OffsetUri = '/ProtectFolders/ProtectPictures'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                    options = @(
+                                        @{
+                                            name = 'Disable PDE on the folder. If the folder is currently protected by PDE, this will result in unprotecting the folder.'
+                                            itemId = 'user_vendor_msft_pde_protectfolders_protectpictures_0'
+                                            dependentOn = @(
+                                                @{
+                                                    dependentOn = 'user_vendor_msft_pde_enablepersonaldataencryption_1'
+                                                    parentSettingId = 'user_vendor_msft_pde_enablepersonaldataencryption'
+                                                }
+                                            )
+                                        }
+                                    )
+                                }
+                            },
+                            @{
+                                Id = 'user_vendor_msft_pde_protectfolders_protectdocuments'
+                                Name = 'ProtectDocuments'
+                                OffsetUri = '/ProtectFolders/ProtectDocuments'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                    options = @(
+                                        @{
+                                            name = 'Disable PDE on the folder. If the folder is currently protected by PDE, this will result in unprotecting the folder.'
+                                            itemId = 'user_vendor_msft_pde_protectfolders_protectdocuments_1'
+                                            dependentOn = @(
+                                                @{
+                                                    dependentOn = 'user_vendor_msft_pde_enablepersonaldataencryption_1'
+                                                    parentSettingId = 'user_vendor_msft_pde_enablepersonaldataencryption'
+                                                }
+                                            )
+                                        }
+                                    )
+                                }
+                            }
+                        )
+                        SettingInstance = @{
+                            SettingDefinitionId = 'user_vendor_msft_pde_enablepersonaldataencryption'
+                            SettingInstanceTemplateReference = @{
+                                SettingInstanceTemplateId = '1ba5dce6-3ba0-40f3-bde3-811ed766c14a'
+                            }
+                            AdditionalProperties = @{
+                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                choiceSettingValue = @{
+                                    value = 'user_vendor_msft_pde_enablepersonaldataencryption_1'
+                                    children = @(
+                                        @{
+                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                            settingDefinitionId = 'user_vendor_msft_pde_protectfolders_protectdesktop'
+                                            choiceSettingValue = @{
+                                                children = @()
+                                                value = 'user_vendor_msft_pde_protectfolders_protectdesktop_0'
+                                            }
+                                        },
+                                        @{
+                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                            settingDefinitionId = 'user_vendor_msft_pde_protectfolders_protectpictures'
+                                            choiceSettingValue = @{
+                                                children = @()
+                                                value = 'user_vendor_msft_pde_protectfolders_protectpictures_0'
+                                            }
+                                        },
+                                        @{
+                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                            settingDefinitionId = 'user_vendor_msft_pde_protectfolders_protectdocuments'
+                                            choiceSettingValue = @{
+                                                children = @()
+                                                value = 'user_vendor_msft_pde_protectfolders_protectdocuments_0'
+                                            }
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+                )
+            }
+
+            Mock -CommandName Update-DeviceConfigurationPolicyAssignment -MockWith {
+            }
+
+            Mock -CommandName New-M365DSCConnection -MockWith {
+                return "Credentials"
+            }
+
+            # Mock Write-Host to hide output during the tests
+            Mock -CommandName Write-Host -MockWith {
+            }
+            $Script:exportedInstances =$null
+            $Script:ExportMode = $false
+
+            Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicyAssignment -MockWith {
+                return @(@{
+                    Id       = '12345-12345-12345-12345-12345'
+                    Source   = 'direct'
+                    SourceId = '12345-12345-12345-12345-12345'
+                    Target   = @{
+                        DeviceAndAppManagementAssignmentFilterId   = '12345-12345-12345-12345-12345'
+                        DeviceAndAppManagementAssignmentFilterType = 'none'
+                        AdditionalProperties                       = @(
+                            @{
+                                '@odata.type' = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                                groupId       = '26d60dd1-fab6-47bf-8656-358194c1a49d'
+                            }
+                        )
+                    }
+                })
+            }
+
+        }
+
+        # Test contexts
+        Context -Name "The IntuneDiskEncryptionPDEPolicyWindows10 should exist but it DOES NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Assignments = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_DeviceManagementConfigurationPolicyAssignments -Property @{
+                            DataType = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                            groupId = '26d60dd1-fab6-47bf-8656-358194c1a49d'
+                            deviceAndAppManagementAssignmentFilterType = 'none'
+                        } -ClientOnly)
+                    )
+                    Description = "My Test"
+                    Id = "12345-12345-12345-12345-12345"
+                    DisplayName = "My Test"
+                    EnablePersonalDataEncryption = "1";
+                    ProtectDesktop               = "0";
+                    ProtectDocuments             = "0";
+                    ProtectPictures              = "0";
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+
+                Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+                    return $null
+                }
+            }
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
+            }
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+            It 'Should Create the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName New-MgBetaDeviceManagementConfigurationPolicy -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneDiskEncryptionPDEPolicyWindows10 exists but it SHOULD NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Assignments = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_DeviceManagementConfigurationPolicyAssignments -Property @{
+                            DataType = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                            groupId = '26d60dd1-fab6-47bf-8656-358194c1a49d'
+                            deviceAndAppManagementAssignmentFilterType = 'none'
+                        } -ClientOnly)
+                    )
+                    Description = "My Test"
+                    Id = "12345-12345-12345-12345-12345"
+                    DisplayName = "My Test"
+                    EnablePersonalDataEncryption = "1";
+                    ProtectDesktop               = "0";
+                    ProtectDocuments             = "0";
+                    ProtectPictures              = "0";
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Absent"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should Remove the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Remove-MgBetaDeviceManagementConfigurationPolicy -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneDiskEncryptionPDEPolicyWindows10 Exists and Values are already in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Assignments = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_DeviceManagementConfigurationPolicyAssignments -Property @{
+                            DataType = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                            groupId = '26d60dd1-fab6-47bf-8656-358194c1a49d'
+                            deviceAndAppManagementAssignmentFilterType = 'none'
+                        } -ClientOnly)
+                    )
+                    Description = "My Test"
+                    Id = "12345-12345-12345-12345-12345"
+                    DisplayName = "My Test"
+                    EnablePersonalDataEncryption = "1";
+                    ProtectDesktop               = "0";
+                    ProtectDocuments             = "0";
+                    ProtectPictures              = "0";
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+        }
+
+        Context -Name "The IntuneDiskEncryptionPDEPolicyWindows10 exists and values are NOT in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Assignments = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_DeviceManagementConfigurationPolicyAssignments -Property @{
+                            DataType = '#microsoft.graph.exclusionGroupAssignmentTarget'
+                            groupId = '26d60dd1-fab6-47bf-8656-358194c1a49d'
+                            deviceAndAppManagementAssignmentFilterType = 'none'
+                        } -ClientOnly)
+                    )
+                    Description = "My Test"
+                    Id = "12345-12345-12345-12345-12345"
+                    DisplayName = "My Test"
+                    EnablePersonalDataEncryption = "1";
+                    ProtectDesktop               = "0";
+                    ProtectDocuments             = "1"; # Drift
+                    ProtectPictures              = "0";
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Update-IntuneDeviceConfigurationPolicy -Exactly 1
+            }
+        }
+
+        Context -Name 'ReverseDSC Tests' -Fixture {
+            BeforeAll {
+                $Global:CurrentModeIsExport = $true
+                $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
+                $testParams = @{
+                    Credential = $Credential
+                }
+            }
+
+            It 'Should Reverse Engineer resource from the Export method' {
+                $result = Export-TargetResource @testParams
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}
+
+Invoke-Command -ScriptBlock $Global:DscHelper.CleanupScript -NoNewScope


### PR DESCRIPTION
#### Pull Request (PR) description
This PR completes the Disk encryption part in Intune. It adds the `IntuneDiskEncryptionPDEPolicyWindows10`, the policy for `Personal Data Encryption`. This is an additional policy to Bitlocker, aimed for personal data and not on the operating system layer. 

#### This Pull Request (PR) fixes the following issues
None.
