### PR TITLE
fix BadRequest error when trying to remove AADUser group memberships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   * Initial release.
 * M365DSCDRGUtil
   * Improve CIM instance detection for specific Intune resources.
+* AADUser
+  * Fixed issue updating user group membership when looking for the group by DisplayName.
 
 # 1.24.1113.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * Improve CIM instance detection for specific Intune resources.
 * AADUser
   * Fixed issue updating user group membership when looking for the group by DisplayName.
+  * Fixed missing User Id when changing  group membership in Set-TargetResource function.
 
 # 1.24.1113.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/MSFT_AADUser.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/MSFT_AADUser.psm1
@@ -619,7 +619,6 @@ function Set-TargetResource
                 # user is a member of some groups, ensure that user is only a member of groups listed in MemberOf
                 Compare-Object -ReferenceObject $MemberOf -DifferenceObject $user.MemberOf | ForEach-Object {
                     $group = Get-MgGroup -Filter "DisplayName eq '$($_.InputObject)'" -Property Id, GroupTypes
-
                     if ($_.SideIndicator -eq '<=')
                     {
                         # Group in MemberOf not present in groups that user is a member of, add user to group

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/MSFT_AADUser.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/MSFT_AADUser.psm1
@@ -223,6 +223,7 @@ function Get-TargetResource
         }
 
         $results = @{
+            Id                    = $user.id
             UserPrincipalName     = $UserPrincipalName
             DisplayName           = $user.DisplayName
             FirstName             = $user.GivenName
@@ -618,7 +619,7 @@ function Set-TargetResource
             {
                 # user is a member of some groups, ensure that user is only a member of groups listed in MemberOf
                 Compare-Object -ReferenceObject $MemberOf -DifferenceObject $user.MemberOf | ForEach-Object {
-                    $group = Get-MgGroup -Filter "DisplayName eq '$($_.InputObject)" -Property Id, GroupTypes
+                    $group = Get-MgGroup -Filter "DisplayName eq '$($_.InputObject)'" -Property Id, GroupTypes
                     if ($_.SideIndicator -eq '<=')
                     {
                         # Group in MemberOf not present in groups that user is a member of, add user to group

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/MSFT_AADUser.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/MSFT_AADUser.psm1
@@ -611,7 +611,7 @@ function Set-TargetResource
 
                         throw "Cannot add user $UserPrincipalName to group '$memberOfGroup' because it is a dynamic group"
                     }
-                    New-MgGroupMember -GroupId $group.Id -DirectoryObjectId $user.Id
+                    New-MgGroupMember -GroupId $group.Id -DirectoryObjectId (Get-MgUser -UserId $UserPrincipalName).Id
                 }
             }
             else


### PR DESCRIPTION
#### Pull Request (PR) description
<!--
    This pull request is fixing an error that I have found in my test environment. Where I have some changes on users group membership and DSC needs to remove a user group membership and it generates an error like this: [BadRequest] : Invalid filter clause: There is an unterminated string literal at position 27 in 'DisplayName eq 'TEST1-Group'.
    Looking at the code, I found that the error is caused by the missing closing quote in the DisplayName filter clause in line 621.
    Then, I added the missing quote to fix the issue but I get another error on line 651 as Id was not part of the returned object for function Get-TargetResource, this has been solved by getting the ID in a similar way that is done in RoleAssignments.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    - Fixes #5417 
-->
