### PR TITLE
Fix limited Microsoft Graph results on Get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   * Added support for AccessTokens.
 * EXOExternalInOutlook
   * Added support for AccessTokens.
+* INTUNE
+  * Add parameter `-All` to Graph requests to fetch all policies on Get.
 * IntuneAndroidManagedStoreAppConfiguration
   * Initial release.
 * MISC

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneASRRulesPolicyWindows10/MSFT_IntuneASRRulesPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneASRRulesPolicyWindows10/MSFT_IntuneASRRulesPolicyWindows10.psm1
@@ -193,7 +193,7 @@ function Get-TargetResource
             Write-Verbose -Message "No Endpoint Protection Attack Surface Protection rules Policy with identity {$Identity} was found"
             if (-not [String]::IsNullOrEmpty($DisplayName))
             {
-                $policy = Get-MgBetaDeviceManagementIntent -Filter "DisplayName eq '$DisplayName'" -ErrorAction SilentlyContinue
+                $policy = Get-MgBetaDeviceManagementIntent -All -Filter "DisplayName eq '$DisplayName'" -ErrorAction SilentlyContinue
             }
 
             if(([array]$policy).count -gt 1)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy.psm1
@@ -90,7 +90,7 @@ function Get-TargetResource
             Write-Verbose -Message "No Account Protection Local User Group Membership Policy with identity {$Identity} was found"
             if (-not [String]::IsNullOrEmpty($DisplayName))
             {
-                $policy = Get-MgBetaDeviceManagementConfigurationPolicy -Filter "Name eq '$DisplayName'" -ErrorAction SilentlyContinue
+                $policy = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'" -ErrorAction SilentlyContinue
 
                 if(([array]$devicePolicy).Count -gt 1)
                 {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/MSFT_IntuneAccountProtectionPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/MSFT_IntuneAccountProtectionPolicyWindows10.psm1
@@ -99,6 +99,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyLinux/MSFT_IntuneAntivirusPolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyLinux/MSFT_IntuneAntivirusPolicyLinux.psm1
@@ -206,6 +206,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
@@ -454,6 +454,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $policy = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10.psm1
@@ -179,6 +179,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }
@@ -199,7 +200,7 @@ function Get-TargetResource
             -ErrorAction Stop
 
         $policySettings = @{}
-        $policySettings = Export-IntuneSettingCatalogPolicySettings -Settings $settings -ReturnHashtable $policySettings 
+        $policySettings = Export-IntuneSettingCatalogPolicySettings -Settings $settings -ReturnHashtable $policySettings
 
         $results = @{
             #region resource generator code

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10ConfigMgr/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10ConfigMgr.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10ConfigMgr/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10ConfigMgr.psm1
@@ -179,6 +179,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppCategory/MSFT_IntuneAppCategory.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppCategory/MSFT_IntuneAppCategory.psm1
@@ -87,6 +87,7 @@ function Get-TargetResource
                 if (-Not [string]::IsNullOrEmpty($DisplayName))
                 {
                     $instance = Get-MgBetaDeviceAppManagementMobileAppCategory `
+                        -All `
                         -Filter "DisplayName eq '$DisplayName'" `
                         -ErrorAction SilentlyContinue
                 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationDevicePolicy/MSFT_IntuneAppConfigurationDevicePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationDevicePolicy/MSFT_IntuneAppConfigurationDevicePolicy.psm1
@@ -126,6 +126,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceAppManagementMobileAppConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationPolicy/MSFT_IntuneAppConfigurationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationPolicy/MSFT_IntuneAppConfigurationPolicy.psm1
@@ -93,7 +93,7 @@ function Get-TargetResource
 
             try
             {
-                $configPolicy = Get-MgBetaDeviceAppManagementTargetedManagedAppConfiguration -Filter "displayName eq '$DisplayName'" `
+                $configPolicy = Get-MgBetaDeviceAppManagementTargetedManagedAppConfiguration -All -Filter "displayName eq '$DisplayName'" `
                     -ErrorAction Stop
             }
             catch

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyiOS/MSFT_IntuneAppProtectionPolicyiOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyiOS/MSFT_IntuneAppProtectionPolicyiOS.psm1
@@ -279,7 +279,7 @@ function Get-TargetResource
         if ($policy.Length -eq 0)
         {
             Write-Verbose -Message "No iOS App Protection Policy {$Identity} was found by Identity. Trying to retrieve by DisplayName"
-            [Array]$policy = Get-MgBetaDeviceAppManagementiOSManagedAppProtection -Filter "DisplayName eq '$DisplayName'" -ErrorAction SilentlyContinue
+            [Array]$policy = Get-MgBetaDeviceAppManagementiOSManagedAppProtection -All -Filter "DisplayName eq '$DisplayName'" -ErrorAction SilentlyContinue
         }
 
         if ($policy.Length -gt 1)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneApplicationControlPolicyWindows10/MSFT_IntuneApplicationControlPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneApplicationControlPolicyWindows10/MSFT_IntuneApplicationControlPolicyWindows10.psm1
@@ -86,7 +86,7 @@ function Get-TargetResource
     try
     {
         #Retrieve policy general settings
-        $policy = Get-MgBetaDeviceManagementIntent -Filter "displayName eq '$DisplayName'" -ErrorAction Stop | Where-Object -FilterScript { $_.TemplateId -eq '63be6324-e3c9-4c97-948a-e7f4b96f0f20' }
+        $policy = Get-MgBetaDeviceManagementIntent -All -Filter "displayName eq '$DisplayName'" -ErrorAction Stop | Where-Object -FilterScript { $_.TemplateId -eq '63be6324-e3c9-4c97-948a-e7f4b96f0f20' }
 
         if(([array]$policy).count -gt 1)
         {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAttackSurfaceReductionRulesPolicyWindows10ConfigManager/MSFT_IntuneAttackSurfaceReductionRulesPolicyWindows10ConfigManager.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAttackSurfaceReductionRulesPolicyWindows10ConfigManager/MSFT_IntuneAttackSurfaceReductionRulesPolicyWindows10ConfigManager.psm1
@@ -190,6 +190,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $policy = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName' and templateReference/TemplateId eq '$templateReferenceId'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDerivedCredential/MSFT_IntuneDerivedCredential.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDerivedCredential/MSFT_IntuneDerivedCredential.psm1
@@ -105,6 +105,7 @@ function Get-TargetResource {
                 if (-Not [string]::IsNullOrEmpty($DisplayName))
                 {
                     $instance = Get-MgBetaDeviceManagementDerivedCredential `
+                        -All `
                         -Filter "DisplayName eq '$DisplayName'" `
                         -ErrorAction SilentlyContinue
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCategory/MSFT_IntuneDeviceCategory.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCategory/MSFT_IntuneDeviceCategory.psm1
@@ -67,7 +67,7 @@ function Get-TargetResource
 
     try
     {
-        $category = Get-MgBetaDeviceManagementDeviceCategory -Filter "displayName eq '$DisplayName'"
+        $category = Get-MgBetaDeviceManagementDeviceCategory -Filter "displayName eq '$DisplayName'" -All
 
         if ($null -eq $category)
         {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroid/MSFT_IntuneDeviceCompliancePolicyAndroid.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroid/MSFT_IntuneDeviceCompliancePolicyAndroid.psm1
@@ -185,7 +185,7 @@ function Get-TargetResource
     $nullResult.Ensure = 'Absent'
     try
     {
-        $devicePolicy = Get-MgBetaDeviceManagementDeviceCompliancePolicy `
+        $devicePolicy = Get-MgBetaDeviceManagementDeviceCompliancePolicy -All `
             -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidCompliancePolicy' -and `
                 $_.displayName -eq $($DisplayName) }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner.psm1
@@ -138,6 +138,7 @@ function Get-TargetResource
     try
     {
         $devicePolicy = Get-MgBetaDeviceManagementDeviceCompliancePolicy `
+            -All `
             -ErrorAction Stop | Where-Object `
             -FilterScript {
             $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidDeviceOwnerCompliancePolicy' -and `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile.psm1
@@ -176,6 +176,7 @@ function Get-TargetResource
     try
     {
         $devicePolicy = Get-MgBetaDeviceManagementDeviceCompliancePolicy `
+            -All `
             -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidWorkProfileCompliancePolicy' -and `
                 $_.displayName -eq $($DisplayName) }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyMacOS/MSFT_IntuneDeviceCompliancePolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyMacOS/MSFT_IntuneDeviceCompliancePolicyMacOS.psm1
@@ -159,6 +159,7 @@ function Get-TargetResource
     try
     {
         $devicePolicy = Get-MgBetaDeviceManagementDeviceCompliancePolicy `
+            -All `
             -ErrorAction Stop | Where-Object `
             -FilterScript { $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.macOSCompliancePolicy' -and `
                 $_.displayName -eq $($DisplayName) }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyWindows10/MSFT_IntuneDeviceCompliancePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyWindows10/MSFT_IntuneDeviceCompliancePolicyWindows10.psm1
@@ -201,6 +201,7 @@ function Get-TargetResource
     try
     {
         $devicePolicy = Get-MgBetaDeviceManagementDeviceCompliancePolicy `
+            -All `
             -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.windows10CompliancePolicy' -and `
                 $_.displayName -eq $($DisplayName) }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyiOs/MSFT_IntuneDeviceCompliancePolicyiOs.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyiOs/MSFT_IntuneDeviceCompliancePolicyiOs.psm1
@@ -150,6 +150,7 @@ function Get-TargetResource
     try
     {
         $devicePolicy = Get-MgBetaDeviceManagementDeviceCompliancePolicy `
+            -All `
             -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.iosCompliancePolicy' -and `
                 $_.displayName -eq $($DisplayName) }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.psm1
@@ -96,6 +96,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementGroupPolicyConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
                 if ($null -eq $getValue)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10.psm1
@@ -95,6 +95,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDefenderForEndpointOnboardingPolicyWindows10/MSFT_IntuneDeviceConfigurationDefenderForEndpointOnboardingPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDefenderForEndpointOnboardingPolicyWindows10/MSFT_IntuneDeviceConfigurationDefenderForEndpointOnboardingPolicyWindows10.psm1
@@ -115,6 +115,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDeliveryOptimizationPolicyWindows10/MSFT_IntuneDeviceConfigurationDeliveryOptimizationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDeliveryOptimizationPolicyWindows10/MSFT_IntuneDeviceConfigurationDeliveryOptimizationPolicyWindows10.psm1
@@ -162,6 +162,7 @@ function Get-TargetResource
             if (-not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDomainJoinPolicyWindows10/MSFT_IntuneDeviceConfigurationDomainJoinPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDomainJoinPolicyWindows10/MSFT_IntuneDeviceConfigurationDomainJoinPolicyWindows10.psm1
@@ -107,6 +107,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10.psm1
@@ -145,6 +145,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEndpointProtectionPolicyWindows10/MSFT_IntuneDeviceConfigurationEndpointProtectionPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEndpointProtectionPolicyWindows10/MSFT_IntuneDeviceConfigurationEndpointProtectionPolicyWindows10.psm1
@@ -1056,6 +1056,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationFirmwareInterfacePolicyWindows10/MSFT_IntuneDeviceConfigurationFirmwareInterfacePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationFirmwareInterfacePolicyWindows10/MSFT_IntuneDeviceConfigurationFirmwareInterfacePolicyWindows10.psm1
@@ -196,6 +196,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `
@@ -377,7 +378,7 @@ function Get-TargetResource
             AccessTokens                   = $AccessTokens
             #endregion
         }
-        
+
         $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10.psm1
@@ -105,6 +105,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }
@@ -152,7 +153,7 @@ function Get-TargetResource
             AccessTokens                            = $AccessTokens
             #endregion
         }
-        
+
         $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationIdentityProtectionPolicyWindows10/MSFT_IntuneDeviceConfigurationIdentityProtectionPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationIdentityProtectionPolicyWindows10/MSFT_IntuneDeviceConfigurationIdentityProtectionPolicyWindows10.psm1
@@ -150,6 +150,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationImportedPfxCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationImportedPfxCertificatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationImportedPfxCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationImportedPfxCertificatePolicyWindows10.psm1
@@ -120,6 +120,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `
@@ -190,7 +191,7 @@ function Get-TargetResource
             AccessTokens                   = $AccessTokens
             #endregion
         }
-        
+
         $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationKioskPolicyWindows10/MSFT_IntuneDeviceConfigurationKioskPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationKioskPolicyWindows10/MSFT_IntuneDeviceConfigurationKioskPolicyWindows10.psm1
@@ -127,6 +127,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `
@@ -342,7 +343,7 @@ function Get-TargetResource
             AccessTokens                           = $AccessTokens
             #endregion
         }
-        
+
         $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationNetworkBoundaryPolicyWindows10/MSFT_IntuneDeviceConfigurationNetworkBoundaryPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationNetworkBoundaryPolicyWindows10/MSFT_IntuneDeviceConfigurationNetworkBoundaryPolicyWindows10.psm1
@@ -95,6 +95,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object -FilterScript {
                         $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.windows10NetworkBoundaryConfiguration'
@@ -170,7 +171,7 @@ function Get-TargetResource
             AccessTokens                  = $AccessTokens
             #endregion
         }
-        
+
         $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPkcsCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationPkcsCertificatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPkcsCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationPkcsCertificatePolicyWindows10.psm1
@@ -148,6 +148,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `
@@ -254,7 +255,7 @@ function Get-TargetResource
             AccessTokens                       = $AccessTokens
             #endregion
         }
-        
+
         $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.psm1
@@ -119,6 +119,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceShellScript `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ExpandProperty "assignments" `
                     -ErrorAction SilentlyContinue

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
@@ -112,6 +112,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementScript `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
                 if ($null -ne $getValue)
@@ -159,7 +160,7 @@ function Get-TargetResource
             AccessTokens          = $AccessTokens
             #endregion
         }
-        
+
         $assignmentsValues = Get-MgBetaDeviceManagementScriptAssignment -DeviceManagementScriptId $Id
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator.psm1
@@ -298,7 +298,7 @@ function Get-TargetResource
 
         if ($null -eq $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidGeneralDeviceConfiguration' `
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceOwner/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceOwner.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceOwner/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceOwner.psm1
@@ -650,7 +650,7 @@ function Get-TargetResource
 
         if (-not $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidDeviceOwnerGeneralDeviceConfiguration' `
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject.psm1
@@ -151,7 +151,7 @@ function Get-TargetResource
         #region resource generator code
         if ($null -eq $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.aospDeviceOwnerDeviceConfiguration' `
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidWorkProfile/MSFT_IntuneDeviceConfigurationPolicyAndroidWorkProfile.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidWorkProfile/MSFT_IntuneDeviceConfigurationPolicyAndroidWorkProfile.psm1
@@ -263,7 +263,7 @@ function Get-TargetResource
 
     try
     {
-        $policy = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "displayName eq '$DisplayName'" `
+        $policy = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "displayName eq '$DisplayName'" `
             -ErrorAction Stop | Where-Object -FilterScript { $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidWorkProfileGeneralDeviceConfiguration' }
 
         if ($null -eq $policy)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
@@ -339,7 +339,7 @@ function Get-TargetResource
         #region resource generator code
         if ($null -eq $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.macOSGeneralDeviceConfiguration' `
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationPolicyWindows10.psm1
@@ -1271,6 +1271,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyiOS/MSFT_IntuneDeviceConfigurationPolicyiOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyiOS/MSFT_IntuneDeviceConfigurationPolicyiOS.psm1
@@ -843,7 +843,7 @@ function Get-TargetResource
 
         if (-not $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.iosGeneralDeviceConfiguration' `
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.psm1
@@ -163,6 +163,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSecureAssessmentPolicyWindows10/MSFT_IntuneDeviceConfigurationSecureAssessmentPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSecureAssessmentPolicyWindows10/MSFT_IntuneDeviceConfigurationSecureAssessmentPolicyWindows10.psm1
@@ -120,6 +120,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSharedMultiDevicePolicyWindows10/MSFT_IntuneDeviceConfigurationSharedMultiDevicePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSharedMultiDevicePolicyWindows10/MSFT_IntuneDeviceConfigurationSharedMultiDevicePolicyWindows10.psm1
@@ -166,6 +166,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `
@@ -286,7 +287,7 @@ function Get-TargetResource
             AccessTokens                 = $AccessTokens
             #endregion
         }
-        
+
         $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)
@@ -776,7 +777,7 @@ function Export-TargetResource
         [Parameter()]
         [Switch]
         $ManagedIdentity,
-        
+
         [Parameter()]
         [System.String[]]
         $AccessTokens

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationTrustedCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationTrustedCertificatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationTrustedCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationTrustedCertificatePolicyWindows10.psm1
@@ -100,6 +100,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `
@@ -142,7 +143,7 @@ function Get-TargetResource
             AccessTokens           = $AccessTokens
             #endregion
         }
-        
+
         $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationVpnPolicyWindows10/MSFT_IntuneDeviceConfigurationVpnPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationVpnPolicyWindows10/MSFT_IntuneDeviceConfigurationVpnPolicyWindows10.psm1
@@ -198,6 +198,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `
@@ -470,7 +471,7 @@ function Get-TargetResource
             AccessTokens                               = $AccessTokens
             #endregion
         }
-        
+
         $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWindowsTeamPolicyWindows10/MSFT_IntuneDeviceConfigurationWindowsTeamPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWindowsTeamPolicyWindows10/MSFT_IntuneDeviceConfigurationWindowsTeamPolicyWindows10.psm1
@@ -173,6 +173,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10.psm1
@@ -208,6 +208,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
@@ -265,6 +265,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentLimitRestriction/MSFT_IntuneDeviceEnrollmentLimitRestriction.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentLimitRestriction/MSFT_IntuneDeviceEnrollmentLimitRestriction.psm1
@@ -72,7 +72,7 @@ function Get-TargetResource
 
     try
     {
-        $config = Get-MgBetaDeviceManagementDeviceEnrollmentConfiguration -Filter "displayName eq '$DisplayName'" `
+        $config = Get-MgBetaDeviceManagementDeviceEnrollmentConfiguration -All -Filter "displayName eq '$DisplayName'" `
         | Where-Object -FilterScript { $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.deviceEnrollmentLimitConfiguration' }
 
         if ($null -eq $config)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentPlatformRestriction/MSFT_IntuneDeviceEnrollmentPlatformRestriction.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentPlatformRestriction/MSFT_IntuneDeviceEnrollmentPlatformRestriction.psm1
@@ -139,7 +139,7 @@ function Get-TargetResource
         if ($null -eq $config)
         {
             Write-Verbose -Message "Could not find an Intune Device Enrollment Platform Restriction with Id {$Identity}"
-            $config = Get-MgBetaDeviceManagementDeviceEnrollmentConfiguration -Filter "DisplayName eq '$DisplayName'" `
+            $config = Get-MgBetaDeviceManagementDeviceEnrollmentConfiguration -All -Filter "DisplayName eq '$DisplayName'" `
                 -ErrorAction SilentlyContinue | Where-Object -FilterScript {
                     $_.AdditionalProperties.'@odata.type' -like "#microsoft.graph.deviceEnrollmentPlatformRestriction*Configuration" -and
                     $(if ($null -ne $_.AdditionalProperties.platformType) { $_.AdditionalProperties.platformType -eq $PlatformType } else { $true })

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1
@@ -151,6 +151,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceEnrollmentConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagmentAndroidDeviceOwnerEnrollmentProfile/MSFT_IntuneDeviceManagmentAndroidDeviceOwnerEnrollmentProfile.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagmentAndroidDeviceOwnerEnrollmentProfile/MSFT_IntuneDeviceManagmentAndroidDeviceOwnerEnrollmentProfile.psm1
@@ -146,6 +146,7 @@ function Get-TargetResource
         {
             Write-Verbose -Message "Trying to retrieve profile by DisplayName"
             $androidDeviceOwnerEnrollmentProfile = Get-MgBetaDeviceManagementAndroidDeviceOwnerEnrollmentProfile `
+                -All `
                 -Filter "displayName eq '$DisplayName'" `
                 -ErrorAction SilentlyContinue
         }
@@ -346,7 +347,7 @@ function Set-TargetResource
     # UPDATE
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
     {
-        Write-Verbose -Message "Updating AndroidDeviceOwnerEnrollmentProfile: $DisplayName"        
+        Write-Verbose -Message "Updating AndroidDeviceOwnerEnrollmentProfile: $DisplayName"
         Remove-MgBetaDeviceManagementAndroidDeviceOwnerEnrollmentProfile -AndroidDeviceOwnerEnrollmentProfileId $currentInstance.Id -Confirm:$false
         $response = New-MgBetaDeviceManagementAndroidDeviceOwnerEnrollmentProfile @setParameters
     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceRemediation/MSFT_IntuneDeviceRemediation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceRemediation/MSFT_IntuneDeviceRemediation.psm1
@@ -133,6 +133,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceHealthScript `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/MSFT_IntuneDiskEncryptionMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/MSFT_IntuneDiskEncryptionMacOS.psm1
@@ -126,6 +126,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementIntent `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionWindows10/MSFT_IntuneDiskEncryptionWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionWindows10/MSFT_IntuneDiskEncryptionWindows10.psm1
@@ -367,6 +367,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName' and templateReference/TemplateId eq '$templateReferenceId'" `
                     -ErrorAction SilentlyContinue
             }
@@ -387,7 +388,7 @@ function Get-TargetResource
             -ErrorAction Stop
 
         $policySettings = @{}
-        $policySettings = Export-IntuneSettingCatalogPolicySettings -Settings $settings -ReturnHashtable $policySettings 
+        $policySettings = Export-IntuneSettingCatalogPolicySettings -Settings $settings -ReturnHashtable $policySettings
 
         $results = @{
             #region resource generator code

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
@@ -100,6 +100,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
@@ -100,6 +100,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
@@ -105,8 +105,9 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $policy = Get-MgBetaDeviceManagementConfigurationPolicy `
-                -Filter "Name eq '$DisplayName'" `
-                -ErrorAction SilentlyContinue
+                    -All `
+                    -Filter "Name eq '$DisplayName'" `
+                    -ErrorAction SilentlyContinue
             }
         }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneExploitProtectionPolicyWindows10SettingCatalog/MSFT_IntuneExploitProtectionPolicyWindows10SettingCatalog.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneExploitProtectionPolicyWindows10SettingCatalog/MSFT_IntuneExploitProtectionPolicyWindows10SettingCatalog.psm1
@@ -98,6 +98,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $policy = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName' and templateReference/TemplateId eq '$templateReferenceId'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
@@ -476,6 +476,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallRulesHyperVPolicyWindows10/MSFT_IntuneFirewallRulesHyperVPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallRulesHyperVPolicyWindows10/MSFT_IntuneFirewallRulesHyperVPolicyWindows10.psm1
@@ -95,6 +95,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppConfigurationPolicyIOS/MSFT_IntuneMobileAppConfigurationPolicyIOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppConfigurationPolicyIOS/MSFT_IntuneMobileAppConfigurationPolicyIOS.psm1
@@ -90,18 +90,18 @@ function Get-TargetResource
         -Parameters $PSBoundParameters
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
-    
+
 
     $nullResult = $PSBoundParameters
     $nullResult.Ensure = 'Absent'
     try
     {
         if (-not [string]::IsNullOrWhiteSpace($id)){ $getValue = Get-MgBetaDeviceAppManagementMobileAppConfiguration -ManagedDeviceMobileAppConfigurationId $id -ErrorAction SilentlyContinue }
-        
+
         #region resource generator code
         if ($null -eq $getValue)
         {
-            $getValue = Get-MgBetaDeviceAppManagementMobileAppConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceAppManagementMobileAppConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.iosMobileAppConfiguration' `
             }
@@ -124,7 +124,7 @@ function Get-TargetResource
             $mySettings.Add('appConfigKey', $setting['appConfigKey'])
             $mySettings.Add('appConfigKeyType', $setting['appConfigKeyType'])
             $mySettings.Add('appConfigKeyValue', $setting['appConfigKeyValue'])
-            
+
             if ($mySettings.values.Where({$null -ne $_}).count -gt 0)
             {
                 $complexSettings += $mySettings
@@ -135,7 +135,7 @@ function Get-TargetResource
             #region resource generator code
             Id                             = $getValue.Id
             Description                    = $getValue.Description
-            DisplayName                    = $getValue.DisplayName   
+            DisplayName                    = $getValue.DisplayName
             targetedMobileApps             = $getValue.TargetedMobileApps
             settings                       = $complexSettings #$getValue.AdditionalProperties.settings
             encodedSettingXml              = $getValue.AdditionalProperties.encodedSettingXml
@@ -150,7 +150,7 @@ function Get-TargetResource
             version                        = $getValue.AdditionalProperties.version
 
         }
-                                          
+
         $assignmentsValues = Get-MgBetaDeviceAppManagementMobileAppConfigurationAssignment -ManagedDeviceMobileAppConfigurationId $Results.Id
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)
@@ -307,7 +307,7 @@ function Set-TargetResource
         }
 
         $CreateParameters.add('AdditionalProperties', $AdditionalProperties)
-           
+
         #region resource generator code
         $policy = New-MgBetaDeviceAppManagementMobileAppConfiguration @CreateParameters
         $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
@@ -668,7 +668,7 @@ function Export-TargetResource
                 }
                 $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
             }
-           
+
             if ($Results.settings)
             {
                 $isCIMArray = $false
@@ -685,7 +685,7 @@ function Export-TargetResource
             $i++
             Write-Host $Global:M365DSCEmojiGreenCheckMark
         }
-        
+
         return $dscContent
     }
     catch

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.psm1
@@ -156,6 +156,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $instance = Get-MgBetaDeviceAppManagementMobileApp `
+                    -All `
                     -Filter "(isof('microsoft.graph.macOSLobApp') and displayName eq '$DisplayName')" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp.psm1
@@ -173,6 +173,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $instance = Get-MgBetaDeviceAppManagementMobileApp `
+                    -All `
                     -Filter "(isof('microsoft.graph.officeSuiteApp') and displayName eq '$DisplayName')" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntunePolicySets/MSFT_IntunePolicySets.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntunePolicySets/MSFT_IntunePolicySets.psm1
@@ -92,7 +92,7 @@ function Get-TargetResource
         #region resource generator code
         if ($id -ne $null)
         {
-            $getValue = Get-MgbetaDeviceAppManagementPolicySet -PolicySetId $Id -ExpandProperty * -ErrorAction SilentlyContinue
+            $getValue = Get-MgBetaDeviceAppManagementPolicySet -PolicySetId $Id -ExpandProperty * -ErrorAction SilentlyContinue
         }
 
         if ($null -eq $getValue)
@@ -101,23 +101,24 @@ function Get-TargetResource
 
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
-                [array]$getValue = Get-MgbetaDeviceAppManagementPolicySet `
-                -Filter "DisplayName eq '$DisplayName'"
+                [array]$getValue = Get-MgBetaDeviceAppManagementPolicySet `
+                    -All `
+                    -Filter "DisplayName eq '$DisplayName'"
 
-                if ($getValue -eq $null)
+                if ($null -eq $getValue)
                 {
                     Write-verbose -Message "Could not find an Intune Policy Sets with DisplayName {$DisplayName}"
                     return $nullResult
                 }
                 else
                 {
-                    if ($getValue.count -gt 1)
+                    if ($getValue.Count -gt 1)
                     {
-                        Write-verbose -Message "Multiple Intune Policy Sets with DisplayName {$DisplayName} - unable to continue"
+                        Write-Verbose -Message "Multiple Intune Policy Sets with DisplayName {$DisplayName} - unable to continue"
                         return $nullResult
                     }
                     else {
-                        $getValue = Get-MgbetaDeviceAppManagementPolicySet -PolicySetId $getValue.Id -ExpandProperty * -ErrorAction SilentlyContinue
+                        $getValue = Get-MgBetaDeviceAppManagementPolicySet -PolicySetId $getValue.Id -ExpandProperty * -ErrorAction SilentlyContinue
 
                         }
                 }
@@ -150,7 +151,7 @@ function Get-TargetResource
             #endregion
         }
 
-        if ($getValue.GuidedDeploymentTags -eq $null)
+        if ($null -eq $getValue.GuidedDeploymentTags)
         {
             $results.GuidedDeploymentTags = @()
         }
@@ -301,7 +302,7 @@ function Set-TargetResource
             }
         }
 
-        # set assignments and items to work with New-MgbetaDeviceAppManagementPolicySet command
+        # set assignments and items to work with New-MgBetaDeviceAppManagementPolicySet command
         $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
         $CreateParameters.Add("Assignments", $assignmentsHash)
 
@@ -317,7 +318,7 @@ function Set-TargetResource
         $CreateParameters.Add("Items", $itemsHash)
 
         write-verbose -Message ($CreateParameters | out-string)
-        $policy = New-MgbetaDeviceAppManagementPolicySet @CreateParameters
+        $policy = New-MgBetaDeviceAppManagementPolicySet @CreateParameters
 
     }
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
@@ -343,8 +344,8 @@ function Set-TargetResource
         #region resource generator code
         $UpdateParameters.Add("PolicySetId", $currentInstance.Id)
 
-        Update-MgbetaDeviceAppManagementPolicySet  @UpdateParameters
-        
+        Update-MgBetaDeviceAppManagementPolicySet  @UpdateParameters
+
         $Url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceAppManagement/policySets/$($currentInstance.Id)/update"
         if ($null -ne ($itemamendments = Get-ItemsAmendmentsObject -currentObjectItems $currentInstance.Items -targetObjectItems $items))
         {
@@ -359,7 +360,7 @@ function Set-TargetResource
     {
         Write-Verbose -Message "Removing the Intune Policy Sets with Id {$($currentInstance.Id)}"
         #region resource generator code
-        Remove-MgbetaDeviceAppManagementPolicySet -PolicySetId $currentInstance.Id
+        Remove-MgBetaDeviceAppManagementPolicySet -PolicySetId $currentInstance.Id
         #endregion
     }
 }
@@ -554,7 +555,7 @@ function Export-TargetResource
     try
     {
         #region resource generator code
-        [array]$getValue = Get-MgbetaDeviceAppManagementPolicySet -Filter $Filter -All -ErrorAction Stop
+        [array]$getValue = Get-MgBetaDeviceAppManagementPolicySet -Filter $Filter -All -ErrorAction Stop
         #endregion
 
         $i = 1

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleAssignment/MSFT_IntuneRoleAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleAssignment/MSFT_IntuneRoleAssignment.psm1
@@ -117,7 +117,7 @@ function Get-TargetResource
         {
             Write-Verbose -Message "Nothing with id {$id} was found"
             $Filter = "displayName eq '$DisplayName'"
-            $getValue = Get-MgBetaDeviceManagementRoleAssignment -Filter $Filter -ErrorAction SilentlyContinue
+            $getValue = Get-MgBetaDeviceManagementRoleAssignment -All -Filter $Filter -ErrorAction SilentlyContinue
             if ($null -ne $getValue)
             {
                 Write-Verbose -Message "Found something with displayname {$DisplayName}"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleDefinition/MSFT_IntuneRoleDefinition.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleDefinition/MSFT_IntuneRoleDefinition.psm1
@@ -97,22 +97,22 @@ function Get-TargetResource
             $getValue = Get-MgBetaDeviceManagementRoleDefinition -RoleDefinitionId $id -ErrorAction SilentlyContinue
             if ($null -ne $getValue)
             {
-                Write-Verbose -Message "Found something with id {$id}"
+                Write-Verbose -Message "Found an Intune Role Definition with id {$id}"
             }
         }
 
         if ($null -eq $getValue)
         {
-            Write-Verbose -Message "Nothing with id {$id} was found"
+            Write-Verbose -Message "No Intune Role Definition with id {$id} was found"
             $Filter = "displayName eq '$DisplayName'"
-            $getValue = Get-MgBetaDeviceManagementRoleDefinition -Filter $Filter -ErrorAction SilentlyContinue
+            $getValue = Get-MgBetaDeviceManagementRoleDefinition -All -Filter $Filter -ErrorAction SilentlyContinue
             if ($null -ne $getValue)
             {
-                Write-Verbose -Message "Found something with displayname {$DisplayName}"
+                Write-Verbose -Message "Found an Intune Role Definition with displayname {$DisplayName}"
             }
             else
             {
-                Write-Verbose -Message "Nothing with displayname {$DisplayName} was found"
+                Write-Verbose -Message "No Intune Role Definition with displayname {$DisplayName} was found"
                 return $nullResult
             }
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineDefenderForEndpoint/MSFT_IntuneSecurityBaselineDefenderForEndpoint.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineDefenderForEndpoint/MSFT_IntuneSecurityBaselineDefenderForEndpoint.psm1
@@ -12,7 +12,7 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $DisplayName,
-       
+
         [Parameter()]
         [System.String[]]
         $RoleScopeTagIds,
@@ -99,8 +99,9 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
-                    -ErrorAction SilentlyContinue 
+                    -ErrorAction SilentlyContinue
             }
         }
         #endregion
@@ -524,7 +525,7 @@ function Get-TargetResource
         }
         $policySettings.Remove('UserSettings') | Out-Null
         #endregion
-      
+
         #endregion
 
         $results = @{
@@ -581,7 +582,7 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $DisplayName,
-       
+
         [Parameter()]
         [System.String[]]
         $RoleScopeTagIds,
@@ -738,7 +739,7 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $DisplayName,
-       
+
         [Parameter()]
         [System.String[]]
         $RoleScopeTagIds,

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoft365AppsForEnterprise/MSFT_IntuneSecurityBaselineMicrosoft365AppsForEnterprise.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoft365AppsForEnterprise/MSFT_IntuneSecurityBaselineMicrosoft365AppsForEnterprise.psm1
@@ -99,6 +99,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/MSFT_IntuneSecurityBaselineMicrosoftEdge.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/MSFT_IntuneSecurityBaselineMicrosoftEdge.psm1
@@ -199,6 +199,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10.psm1
@@ -274,6 +274,7 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $policy = Get-MgBetaDeviceManagementConfigurationPolicy `
+                    -All `
                     -Filter "Name eq '$DisplayName' and templateReference/TemplateId eq '$templateReferenceId'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministrator/MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministrator.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministrator/MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministrator.psm1
@@ -108,7 +108,7 @@ function Get-TargetResource
         #region resource generator code
         if ($null -eq $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidWiFiConfiguration' `
             }
@@ -117,11 +117,11 @@ function Get-TargetResource
 
         if ($null -eq $getValue)
         {
-            Write-Verbose -Message "Nothing with id {$id} was found"
+            Write-Verbose -Message "No Intune Wifi Configuration Policy Android Device Administrator with id {$id} was found"
             return $nullResult
         }
 
-        Write-Verbose -Message "Found something with id {$id}"
+        Write-Verbose -Message "Found an Intune Wifi Configuration Policy Android Device Administrator with id {$id}"
         $results = @{
             #region resource generator code
             Id                             = $getValue.Id

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseDeviceOwner/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseDeviceOwner.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseDeviceOwner/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseDeviceOwner.psm1
@@ -137,7 +137,7 @@ function Get-TargetResource
         #region resource generator code
         if ($null -eq $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidDeviceOwnerWiFiConfiguration' `
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile.psm1
@@ -108,7 +108,7 @@ function Get-TargetResource
         #region resource generator code
         if ($null -ne $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidWorkProfileWiFiConfiguration' `
             }
@@ -117,11 +117,11 @@ function Get-TargetResource
 
         if ($null -eq $getValue)
         {
-            Write-Verbose -Message "Nothing with id {$id} was found"
+            Write-Verbose -Message "No Intune Wifi Configuration Policy Android Enterprise Work Profile with id {$id} was found"
             return $nullResult
         }
 
-        Write-Verbose -Message "Found something with id {$id}"
+        Write-Verbose -Message "Found an Intune Wifi Configuration Policy Android Enterprise Work Profile with id {$id}"
         $results = @{
             #region resource generator code
             Id                             = $getValue.Id

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidForWork/MSFT_IntuneWifiConfigurationPolicyAndroidForWork.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidForWork/MSFT_IntuneWifiConfigurationPolicyAndroidForWork.psm1
@@ -108,7 +108,7 @@ function Get-TargetResource
         #region resource generator code
         if ($null -eq $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidForWorkWiFiConfiguration' `
             }
@@ -117,11 +117,11 @@ function Get-TargetResource
 
         if ($null -eq $getValue)
         {
-            Write-Verbose -Message "Nothing with id {$id} was found"
+            Write-Verbose -Message "No Intune Wifi Configuration Policy Android For Work with id {$id} was found"
             return $nullResult
         }
 
-        Write-Verbose -Message "Found something with id {$id}"
+        Write-Verbose -Message "Found an Intune Wifi Configuration Policy Android For Work with id {$id}"
         $results = @{
             #region resource generator code
             Id                             = $getValue.Id

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidOpenSourceProject/MSFT_IntuneWifiConfigurationPolicyAndroidOpenSourceProject.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidOpenSourceProject/MSFT_IntuneWifiConfigurationPolicyAndroidOpenSourceProject.psm1
@@ -116,7 +116,7 @@ function Get-TargetResource
         #region resource generator code
         if ($null -eq $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.aospDeviceOwnerWiFiConfiguration' `
             }
@@ -125,11 +125,11 @@ function Get-TargetResource
 
         if ($null -eq $getValue)
         {
-            Write-Verbose -Message "Nothing with id {$id} was found"
+            Write-Verbose -Message "No Intune Wifi Configuration Policy Android Open Source Project with id {$id} was found"
             return $nullResult
         }
 
-        Write-Verbose -Message "Found something with id {$id}"
+        Write-Verbose -Message "Found an Intune Wifi Configuration Policy Android Open Source Project with id {$id}"
         $results = @{
             #region resource generator code
             Id                             = $getValue.Id

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyIOS/MSFT_IntuneWifiConfigurationPolicyIOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyIOS/MSFT_IntuneWifiConfigurationPolicyIOS.psm1
@@ -133,7 +133,7 @@ function Get-TargetResource
         #region resource generator code
         if ($null -eq $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.iosWiFiConfiguration' `
             }
@@ -142,11 +142,11 @@ function Get-TargetResource
 
         if ($null -eq $getValue)
         {
-            Write-Verbose -Message "Nothing with id {$id} was found"
+            Write-Verbose -Message "No Intune Wifi Configuration Policy for iOS with id {$id} was found"
             return $nullResult
         }
 
-        Write-Verbose -Message "Found something with id {$id}"
+        Write-Verbose -Message "Found an Intune Wifi Configuration Policy for iOS with id {$id}"
         $results = @{
             #region resource generator code
             Id                             = $getValue.Id

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyMacOS/MSFT_IntuneWifiConfigurationPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyMacOS/MSFT_IntuneWifiConfigurationPolicyMacOS.psm1
@@ -129,7 +129,7 @@ function Get-TargetResource
         #region resource generator code
         if ($null -eq $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.macOSWiFiConfiguration' `
             }
@@ -138,11 +138,11 @@ function Get-TargetResource
 
         if ($null -eq $getValue)
         {
-            Write-Verbose -Message "Nothing with id {$id} was found"
+            Write-Verbose -Message "No Intune Wifi Configuration Policy for MacOS with id {$id} was found"
             return $nullResult
         }
 
-        Write-Verbose -Message "Found something with id {$id}"
+        Write-Verbose -Message "Found an Intune Wifi Configuration Policy for MacOS with id {$id}"
         $results = @{
             #region resource generator code
             Id                             = $getValue.Id

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyWindows10/MSFT_IntuneWifiConfigurationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyWindows10/MSFT_IntuneWifiConfigurationPolicyWindows10.psm1
@@ -142,7 +142,7 @@ function Get-TargetResource
         #region resource generator code
         if ($null -eq $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
+            $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$Displayname'" -ErrorAction SilentlyContinue | Where-Object `
             -FilterScript { `
                 $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.windowsWifiConfiguration' `
             }
@@ -151,11 +151,11 @@ function Get-TargetResource
 
         if ($null -eq $getValue)
         {
-            Write-Verbose -Message "Nothing with id {$id} was found"
+            Write-Verbose -Message "No Intune Wifi Configuration Policy for Windows10 with id {$id} was found"
             return $nullResult
         }
 
-        Write-Verbose -Message "Found something with id {$id}"
+        Write-Verbose -Message "Found an Intune Wifi Configuration Policy for Windows10 with id {$id}"
         $results = @{
             #region resource generator code
             Id                             = $getValue.Id

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined.psm1
@@ -124,6 +124,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementWindowsAutopilotDeploymentProfile `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined.psm1
@@ -121,6 +121,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementWindowsAutopilotDeploymentProfile `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue `
                     | Where-Object -FilterScript {$null -ne $_.DisplayName}

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsInformationProtectionPolicyWindows10MdmEnrolled/MSFT_IntuneWindowsInformationProtectionPolicyWindows10MdmEnrolled.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsInformationProtectionPolicyWindows10MdmEnrolled/MSFT_IntuneWindowsInformationProtectionPolicyWindows10MdmEnrolled.psm1
@@ -178,9 +178,10 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceAppManagementMdmWindowsInformationProtectionPolicy `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
-                if ($getValue.count -gt 1)
+                if ($getValue.Count -gt 1)
                 {
                     throw ("Error: Ensure the displayName {$displayName} is unique.")
                 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessDriverUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessDriverUpdateProfileWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessDriverUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessDriverUpdateProfileWindows10.psm1
@@ -100,6 +100,7 @@ function Get-TargetResource
 
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
+                # Potentially add support for -All parameter (@odata.nextLink) if needed
                 $uri = '/beta/deviceManagement/windowsDriverUpdateProfiles'
                 $getValue = (Invoke-MgGraphRequest -Method GET -Uri $uri).value | Where-Object -FilterScript {
                     $_.displayName -eq $DisplayName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10.psm1
@@ -232,6 +232,7 @@ function Get-TargetResource
             if (-Not [string]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementDeviceConfiguration `
+                    -All `
                     -Filter "DisplayName eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
             }

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1544,7 +1544,7 @@ function Confirm-M365DSCDependencies
             {
                 $ErrorMessage += '    * ' + $invalidDependency.ModuleName + "`r`n"
             }
-            $ErrorMessage += 'Please run Update-M365DSCDependencies as Administrator.'
+            $ErrorMessage += 'Please run Update-M365DSCDependencies as Administrator. '
             $ErrorMessage += 'Please run Uninstall-M365DSCOutdatedDependencies.'
             $Script:M365DSCDependenciesValidated = $false
             Add-M365DSCEvent -Message $ErrorMessage -EntryType 'Error' `


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes the issue where filtering by display name in Microsoft Graph did not return the policy when there are more than 25 policies of the same type. Filtering seems to occur after fetching the first 25 policies from the database, leading to no policy found, even though it did exist. 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
