### PR TITLE
Add separate module handling for PowerShell Core

### DIFF
--- a/.github/workflows/CodeCoverage.yml
+++ b/.github/workflows/CodeCoverage.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Install Modules
         shell: pwsh
         run: |
-          Install-Module ReverseDSC -Force -Scope AllUsers
-          Install-Module DSCParser -Force -Scope AllUsers
-          Install-Module PSDesiredStateConfiguration -Force -Scope AllUsers
-          Install-Module Pester -Force -SkipPublisherCheck -Scope AllUsers
+          Install-PSResource -Name ReverseDSC -Scope AllUsers -TrustRepository
+          Install-PSResource -Name DSCParser -Scope AllUsers -TrustRepository
+          Install-PSResource -Name PSDesiredStateConfiguration -Scope AllUsers -TrustRepository
+          Install-PSResource -Name Pester -Scope AllUsers -TrustRepository
           [System.Environment]::SetEnvironmentVariable('M365DSCTelemetryEnabled', $false, [System.EnvironmentVariableTarget]::Machine);
       - name: Run Quality Checks
         shell: pwsh

--- a/.github/workflows/Unit Tests.yml
+++ b/.github/workflows/Unit Tests.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Install Modules
         shell: pwsh
         run: |
-          Install-Module ReverseDSC -Force -Scope AllUsers
-          Install-Module DSCParser -Force -Scope AllUsers
-          Install-Module PSDesiredStateConfiguration -Force -Scope AllUsers
-          Install-Module Pester -Force -SkipPublisherCheck -Scope AllUsers
+          Install-PSResource -Name ReverseDSC -Scope AllUsers -TrustRepository
+          Install-PSResource -Name DSCParser -Scope AllUsers -TrustRepository
+          Install-PSResource -Name PSDesiredStateConfiguration -Scope AllUsers -TrustRepository
+          Install-PSResource -Name Pester -Scope AllUsers -TrustRepository
           [System.Environment]::SetEnvironmentVariable('M365DSCTelemetryEnabled', $false, [System.EnvironmentVariableTarget]::Machine);
       - name: Run Quality Checks
         shell: pwsh

--- a/.vscode/GetTestCoverage.ps1
+++ b/.vscode/GetTestCoverage.ps1
@@ -10,7 +10,7 @@ $minVersion = '5.5.0'
 
 $module = Get-Module -ListAvailable | Where-Object { $_.Name -eq $moduleName -and $_.Version -ge $minVersion }
 
-if ($module -ne $null)
+if ($null -ne $module)
 {
     Write-Output "Module $moduleName with version greater than or equal to $minVersion found."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   * Initial release.
 * MISC
   * Removed hardcoded Graph urls and replaced by MSCloudLoginAssistant values.
+  * Add separate module handling for PowerShell Core.
 
 # 1.24.1120.1
 

--- a/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
+++ b/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
@@ -127,6 +127,7 @@
         @{
             ModuleName      = 'PnP.PowerShell'
             RequiredVersion = '1.12.0'
+            InstallLocation = 'WindowsPowerShell'
         },
         @{
             ModuleName      = 'PSDesiredStateConfiguration'


### PR DESCRIPTION
#### Pull Request (PR) description
This PR removes the dependency that all PowerShell modules need to be installed under _C:\Program Files\WindowsPowerShell\Modules\*_ and massively improves the installation speed if the `Microsoft.PowerShell.PSResourceGet` module is installed. This module is installed by default if run from PowerShell 7.4 or greater.

The improvement is inspired from issue #5433 and from my own experience with PowerShell 7. Microsoft365DSC seems to run fine with PowerShell 7, and now it doesn't require a hard dependency on any module except `PnP.PowerShell` to be installed under Windows PowerShell 5.1. 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
