### PR TITLE
Add separate check for strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * IntuneTrustedRootCertificateIOS
   * Initial release
+* M365DSCDRGUtil
+  * Add separate check for strings with ordinal comparison and standardized line breaks.
 
 # 1.24.1127.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Initial release
 * M365DSCDRGUtil
   * Add separate check for strings with ordinal comparison and standardized line breaks.
+* M365DSCUtil
+  * Add separate check for strings with ordinal comparison and standardized line breaks.
 
 # 1.24.1127.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -2349,7 +2349,15 @@ function Export-IntuneSettingCatalogPolicySettings
     {
         '#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance'
         {
-            $settingValue = if ($IsRoot) { $SettingInstance.AdditionalProperties.simpleSettingValue.value } else { $SettingInstance.simpleSettingValue.value }
+            $simpleSetting = if ($IsRoot) { $SettingInstance.AdditionalProperties.simpleSettingValue } else { $SettingInstance.simpleSettingValue }
+            if ($simpleSetting.'@odata.type' -eq '#microsoft.graph.deviceManagementConfigurationIntegerSettingValue')
+            {
+                $settingValue = [int]$simpleSetting.value
+            }
+            else
+            {
+                $settingValue = $simpleSetting.value
+            }
         }
         '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
         {
@@ -2439,16 +2447,30 @@ function Export-IntuneSettingCatalogPolicySettings
         '#microsoft.graph.deviceManagementConfigurationSimpleSettingCollectionInstance'
         {
             $values = @()
-            $childValues = if ($IsRoot) { $SettingInstance.AdditionalProperties.simpleSettingCollectionValue.value } else { $SettingInstance.simpleSettingCollectionValue.value }
+            $childValues = if ($IsRoot) { $SettingInstance.AdditionalProperties.simpleSettingCollectionValue } else { $SettingInstance.simpleSettingCollectionValue }
             foreach ($value in $childValues)
             {
-                $values += $value
+                if ($value.'@odata.type' -eq '#microsoft.graph.deviceManagementConfigurationIntegerSettingValue')
+                {
+                    $values += [int]$value.value
+                }
+                else
+                {
+                    $values += $value.value
+                }
             }
             $settingValue = $values
         }
         Default
         {
-            $settingValue = $SettingInstance.value
+            if ($SettingInstance.'@odata.type' -eq '#microsoft.graph.deviceManagementConfigurationIntegerSettingValue')
+            {
+                $settingValue += [int]$SettingInstance.value
+            }
+            else
+            {
+                $settingValue = $SettingInstance.value
+            }
         }
     }
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -608,7 +608,7 @@ function Compare-M365DSCComplexObject
     {
         if ($Source.Length -ne $Target.Length)
         {
-            Write-Verbose -Message "Configuration drift - The complex array have different number of items: Source {$($Source.Length)} Target {$($Target.Length)}"
+            Write-Verbose -Message "Configuration drift - The complex array have different number of items: Source {$($Source.Length)}, Target {$($Target.Length)}"
             return $false
         }
         if ($Source.Length -eq 0)
@@ -627,7 +627,9 @@ function Compare-M365DSCComplexObject
 
             if (-not $compareResult)
             {
-                Write-Verbose -Message "Configuration drift - Intune Policy Assignment: $key Source {$Source} Target {$Target}"
+                Write-Verbose -Message "Configuration drift - Intune Policy Assignment: $key"
+                Write-Verbose -Message "Source {$Source}"
+                Write-Verbose -Message "Target {$Target}"
                 return $false
             }
 
@@ -724,7 +726,9 @@ function Compare-M365DSCComplexObject
                 $targetValue = 'null'
             }
 
-            Write-Verbose -Message "Configuration drift - key: $key Source {$sourceValue} Target {$targetValue}"
+            Write-Verbose -Message "Configuration drift - key: $key"
+            Write-Verbose -Message "Source {$sourceValue}"
+            Write-Verbose -Message "Target {$targetValue}"
             return $false
         }
 
@@ -753,7 +757,9 @@ function Compare-M365DSCComplexObject
 
                 if (-not $compareResult)
                 {
-                    Write-Verbose -Message "Configuration drift - complex object key: $key Source {$sourceValue} Target {$targetValue}"
+                    Write-Verbose -Message "Configuration drift - complex object key: $key"
+                    Write-Verbose -Message "Source {$sourceValue}"
+                    Write-Verbose -Message "Target {$targetValue}"
                     return $false
                 }
             }
@@ -774,6 +780,18 @@ function Compare-M365DSCComplexObject
                         $compareResult = $null
                     }
                 }
+                elseif ($targetType -eq 'String')
+                {
+                    # Remove carriage return and line feed characters
+                    $referenceObject = $referenceObject.Replace("`r`n", "`n")
+                    $differenceObject = $differenceObject.Replace("`r`n", "`n")
+
+                    $ordinalComparison = [System.String]::Equals($referenceObject, $differenceObject, [System.StringComparison]::Ordinal)
+                    if (-not $ordinalComparison)
+                    {
+                        $compareResult = $true
+                    }
+                }
                 else
                 {
                     $compareResult = Compare-Object `
@@ -783,7 +801,9 @@ function Compare-M365DSCComplexObject
 
                 if ($null -ne $compareResult)
                 {
-                    Write-Verbose -Message "Configuration drift - simple object key: $key Source {$sourceValue} Target {$targetValue}"
+                    Write-Verbose -Message "Configuration drift - simple object key: $key"
+                    Write-Verbose -Message "Source {$sourceValue}"
+                    Write-Verbose -Message "Target {$targetValue}"
                     return $false
                 }
             }

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -782,14 +782,22 @@ function Compare-M365DSCComplexObject
                 }
                 elseif ($targetType -eq 'String')
                 {
-                    # Remove carriage return and line feed characters
-                    $referenceObject = $referenceObject.Replace("`r`n", "`n")
-                    $differenceObject = $differenceObject.Replace("`r`n", "`n")
-
-                    $ordinalComparison = [System.String]::Equals($referenceObject, $differenceObject, [System.StringComparison]::Ordinal)
-                    if (-not $ordinalComparison)
+                    # Align line breaks
+                    if (-not [System.String]::IsNullOrEmpty($referenceObject))
                     {
-                        $compareResult = $true
+                        $referenceObject = $referenceObject.Replace("`r`n", "`n")
+                    }
+
+                    if (-not [System.String]::IsNullOrEmpty($differenceObject))
+                    {
+                        $differenceObject = $differenceObject.Replace("`r`n", "`n")
+                    }
+
+                    $compareResult = $true
+                    $ordinalComparison = [System.String]::Equals($referenceObject, $differenceObject, [System.StringComparison]::Ordinal)
+                    if ($ordinalComparison)
+                    {
+                        $compareResult = $null
                     }
                 }
                 else

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -628,6 +628,7 @@ function Test-M365DSCParameterState
         [System.Collections.Hashtable]
         $IncludedDrifts
     )
+
     $VerbosePreference = 'SilentlyContinue'
     #region Telemetry
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
@@ -840,6 +841,14 @@ function Test-M365DSCParameterState
                             {
                                 if ([string]::IsNullOrEmpty($CurrentValues.$fieldName) `
                                         -and [string]::IsNullOrEmpty($DesiredValues.$fieldName))
+                                {
+                                }
+                                # Align line breaks
+                                elseif (-not [string]::IsNullOrEmpty($CurrentValues.$fieldName) `
+                                        -and -not [string]::IsNullOrEmpty($DesiredValues.$fieldName) `
+                                        -and [string]::Equals($CurrentValues.$fieldName.Replace("`r`n", "`n"), `
+                                        $DesiredValues.$fieldName.Replace("`r`n", "`n"), `
+                                        [System.StringComparison]::Ordinal))
                                 {
                                 }
                                 else

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SPOPropertyBag.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SPOPropertyBag.Tests.ps1
@@ -85,12 +85,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 }
 
                 Mock -CommandName Get-PnPPropertyBag -MockWith {
-                    return @(
-                        @{
-                            Key   = 'MyKey'
-                            Value = 'MyValue'
-                        }
-                    )
+                    'MyValue'
                 }
             }
 


### PR DESCRIPTION
#### Pull Request (PR) description
This PR improves the comparison of strings inside of `Compare-M365DSCComplexObject`. Previously, the comparison did not check for different line breaks (`\r\n` vs `\n`). The comparison was also updated to use `StringComparison.Ordinal`, a byte-wise check which does not take into consideration the current culture. 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
