### PR TITLE
M365DSCUtil: Fix generation of instance names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 * TeamsUpgradePolicy
   * DEPRECATED: Users properties. Use the TeamsUserPolicyAssignment resource
     instead.
+* M365DSCUtil
+  * When exporting generate the instance names of resources with their mandatory
+    keys instead of random GUIDs , this makes exports idempotent again
+    FIXES [#5469](https://github.com/microsoft/Microsoft365DSC/issues/5469)
 * MISC
   * Removed hardcoded Graph urls and replaced by MSCloudLoginAssistant values.
   * Add separate module handling for PowerShell Core.

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -3204,13 +3204,10 @@ function Update-M365DSCDependencies
         [Parameter()]
         [Switch]
         $ValidateOnly,
-
         [Parameter()]
         [ValidateSet("CurrentUser", "AllUsers")]
         $Scope = "AllUsers"
     )
-
-    $isPSResourceGetInstalled = Get-Module -Name Microsoft.PowerShell.PSResourceGet -ListAvailable
 
     try
     {
@@ -3261,14 +3258,14 @@ function Update-M365DSCDependencies
                     }
                     if (-not $errorFound)
                     {
-                        if (($dependency.PowerShellCore -eq $false -or $dependency.InstallLocation -eq "WindowsPowerShell") -and $Script:IsPowerShellCore)
+                        if (-not $dependency.PowerShellCore -and $Script:IsPowerShellCore)
                         {
-                            Write-Warning "The dependency {$($dependency.ModuleName)} requires Windows PowerShell for installation. Please run Update-M365DSCDependencies in Windows PowerShell."
+                            Write-Warning "The dependency {$($dependency.ModuleName)} does not support PowerShell Core. Please run Update-M365DSCDependencies in Windows PowerShell."
                             continue
                         }
                         elseif ($dependency.PowerShellCore -and -not $Script:IsPowerShellCore)
                         {
-                            Write-Warning "The dependency {$($dependency.ModuleName)} requires PowerShell Core for installation. Please run Update-M365DSCDependencies in PowerShell Core."
+                            Write-Warning "The dependency {$($dependency.ModuleName)} requires PowerShell Core. Please run Update-M365DSCDependencies in PowerShell Core."
                             continue
                         }
 
@@ -3279,15 +3276,7 @@ function Update-M365DSCDependencies
                             Remove-Module 'Microsoft.Graph.Authentication' -Force -ErrorAction SilentlyContinue
                         }
                         Remove-Module $dependency.ModuleName -Force -ErrorAction SilentlyContinue
-
-                        if ($null -eq $isPSResourceGetInstalled)
-                        {
-                            Install-Module $dependency.ModuleName -RequiredVersion $dependency.RequiredVersion -AllowClobber -Force -Scope $Scope
-                        }
-                        else
-                        {
-                            Install-PSResource -Name $dependency.ModuleName -Version $dependency.RequiredVersion -AcceptLicense -Scope $Scope -Reinstall -TrustRepository
-                        }
+                        Install-Module $dependency.ModuleName -RequiredVersion $dependency.RequiredVersion -AllowClobber -Force -Scope "$Scope"
                     }
                 }
 
@@ -3787,13 +3776,13 @@ function Get-M365DSCExportContentForResource
             Import-Module $Resource.Path -Force
             $moduleInfo = Get-Command -Module $ModuleFullName -ErrorAction SilentlyContinue
             $cmdInfo = $moduleInfo | Where-Object -FilterScript {$_.Name -eq 'Get-TargetResource'}
-            $Keys = $cmdInfo.Parameters.Keys
+            $Keys = $cmdInfo.Parameters.Values.Where({ $_.ParameterSets.Values.IsMandatory }).Name
         }
     }
     else
     {
         $cmdInfo = $moduleInfo | Where-Object -FilterScript {$_.Name -eq 'Get-TargetResource'}
-        $Keys = $cmdInfo.Parameters.Keys
+        $Keys = $cmdInfo.Parameters.Values.Where({ $_.ParameterSets.Values.IsMandatory }).Name
     }
 
     if ($Keys.Contains('IsSingleInstance'))
@@ -3840,19 +3829,20 @@ function Get-M365DSCExportContentForResource
     {
         $primaryKey = $Results.UserPrincipalName
     }
-    elseif ($Keys.Contains('User'))
+
+    if ([String]::IsNullOrEmpty($primaryKey) -and `
+        -not $Keys.Contains('IsSingleInstance'))
     {
-        $primaryKey = $Results.User
+        foreach ($Key in $Keys)
+        {
+            $primaryKey += $Results.$Key
+        }
     }
 
     $instanceName = $ResourceName
     if (-not [System.String]::IsNullOrEmpty($primaryKey))
     {
         $instanceName += "-$primaryKey"
-    }
-    elseif (-not $Keys.Contains('IsSingleInstance'))
-    {
-        $instanceName += "-" + (New-Guid).ToString()
     }
 
     if ($Results.ContainsKey('Workload'))


### PR DESCRIPTION
#### Pull Request (PR) description

When resources are exported their instance names are generated through cmdlet *Get-M365DSCExportContentForResource* and currently if the primary key of each resource doesn't appear in all the conditions present in the code it will just assign a random GUID to it.

This PR fixes this by actually looking into the mandatory key of the resources so even if it doesn't appear in that list it will assign that mandatory key to the instance name, and in case it has more than one key it will just concatenate them all together.

#### This Pull Request (PR) fixes the following issues

- Fixes #5469
