### PR TITLE
Fix Intune role assignment and cloud login variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   * Fixes an issue where assignment wasn't properly set if the
     groupId was null.
     FIXES [#5430](https://github.com/microsoft/Microsoft365DSC/issues/5430)
+* IntuneRoleAssignment
+  * Improve verbose output and fix copy-pasted variables.
 * IntuneRoleScopeTag
   * Initial release.
 * TeamsUserPolicyAssignment

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -689,7 +689,7 @@ function Set-TargetResource
                 {
                     Write-Verbose -Message "Adding new owner {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
                     $ownerObject = @{
-                        '@odata.id' = $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/{$($directoryObject.Id)}"
+                        '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/{$($directoryObject.Id)}"
                     }
                     try
                     {
@@ -751,7 +751,7 @@ function Set-TargetResource
                 {
                     Write-Verbose -Message "Adding new member {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
                     $memberObject = @{
-                        '@odata.id' = $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/{$($directoryObject.Id)}"
+                        '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/{$($directoryObject.Id)}"
                     }
                     New-MgGroupMemberByRef -GroupId ($currentGroup.Id) -BodyParameter $memberObject | Out-Null
                 }
@@ -759,7 +759,7 @@ function Set-TargetResource
                 {
                     Write-Verbose -Message "Removing new member {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
                     $memberObject = @{
-                        '@odata.id' = $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/{$($directoryObject.Id)}"
+                        '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/{$($directoryObject.Id)}"
                     }
                     Remove-MgGroupMemberDirectoryObjectByRef -GroupId ($currentGroup.Id) -DirectoryObjectId ($directoryObject.Id) | Out-Null
                 }
@@ -809,7 +809,7 @@ function Set-TargetResource
                     {
                         Write-Verbose -Message "Adding AAD group {$($groupAsMember.DisplayName)} as member of AAD group {$($currentGroup.DisplayName)}"
                         $groupAsMemberObject = @{
-                            "@odata.id"= $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/$($groupAsMember.Id)"
+                            "@odata.id"= $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/$($groupAsMember.Id)"
                         }
                         New-MgBetaGroupMemberByRef -GroupId ($currentGroup.Id) -Body $groupAsMemberObject | Out-Null
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityB2XUserFlow/MSFT_AADIdentityB2XUserFlow.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityB2XUserFlow/MSFT_AADIdentityB2XUserFlow.psm1
@@ -269,7 +269,7 @@ function Set-TargetResource
         foreach ($provider in $IdentityProviders)
         {
             $params = @{
-                "@odata.id" = $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "beta/identityProviders/$($provider)"
+                "@odata.id" = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/identityProviders/$($provider)"
             }
 
             Write-Verbose -Message "Adding the Identity Provider with Id {$provider} to the newly created Azure AD Identity B2X User Flow with Id {$($newObj.Id)}"
@@ -318,7 +318,7 @@ function Set-TargetResource
         {
             $getConnector = Get-MgBetaIdentityApiConnector -Filter "DisplayName eq '$($ApiConnectorConfiguration.postFederationSignupConnectorName)'"
             $params = @{
-                "@odata.id" = $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "beta/identity/apiConnectors/$($getConnector.Id)"
+                "@odata.id" = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/identity/apiConnectors/$($getConnector.Id)"
             }
 
             Write-Verbose -Message "Updating the Post Federation Signup connector for Azure AD Identity B2X User Flow with Id {$($currentInstance.Id)}"
@@ -330,7 +330,7 @@ function Set-TargetResource
         {
             $getConnector = Get-MgBetaIdentityApiConnector -Filter "DisplayName eq '$($ApiConnectorConfiguration.postAttributeCollectionConnectorName)'"
             $params = @{
-                "@odata.id" = $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "beta/identity/apiConnectors/$($getConnector.Id)"
+                "@odata.id" = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/identity/apiConnectors/$($getConnector.Id)"
             }
 
             Write-Verbose -Message "Updating the Post Attribute Collection connector for Azure AD Identity B2X User Flow with Id {$($currentInstance.Id)}"
@@ -344,7 +344,7 @@ function Set-TargetResource
         foreach ($provider in $providersToAdd)
         {
             $params = @{
-                "@odata.id" = $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "beta/identityProviders/$($provider)"
+                "@odata.id" = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/identityProviders/$($provider)"
             }
 
             Write-Verbose -Message "Adding the Identity Provider with Id {$provider} to the Azure AD Identity B2X User Flow with Id {$($currentInstance.Id)}"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRemoteNetwork/MSFT_AADRemoteNetwork.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRemoteNetwork/MSFT_AADRemoteNetwork.psm1
@@ -262,7 +262,7 @@ function Set-TargetResource
             "@context" = '#$delta'
             value = @(@{})
         }
-        Invoke-MgGraphRequest -Uri "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/networkAccess/connectivity/remoteNetworks/$($currentInstance.Id)/forwardingProfiles" -Method Patch -Body $params
+        Invoke-MgGraphRequest -Uri "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/networkAccess/connectivity/remoteNetworks/$($currentInstance.Id)/forwardingProfiles" -Method Patch -Body $params
 
         #adding forwarding profiles if required
         if ($forwardingProfilesList.Count -gt 0) {
@@ -270,7 +270,7 @@ function Set-TargetResource
                 "@context" = '#$delta'
                 value = $forwardingProfilesList
             }
-            Invoke-MgGraphRequest -Uri "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/networkAccess/connectivity/remoteNetworks/$($currentInstance.Id)/forwardingProfiles" -Method Patch -Body $params
+            Invoke-MgGraphRequest -Uri "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/networkAccess/connectivity/remoteNetworks/$($currentInstance.Id)/forwardingProfiles" -Method Patch -Body $params
         }
     }
     elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.psm1
@@ -423,7 +423,7 @@ function Set-TargetResource
                 {
                     $value = $presentationValue.clone()
                     $value = Rename-M365DSCCimInstanceParameter -Properties $value -KeyMapping $keyToRename
-                    $value.add('presentation@odata.bind', $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')/presentations('$($presentationValue.presentationDefinitionId)')")
+                    $value.add('presentation@odata.bind', $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')/presentations('$($presentationValue.presentationDefinitionId)')")
                     $value.remove('PresentationDefinitionId')
                     $value.remove('PresentationDefinitionLabel')
                     $value.remove('id')
@@ -431,7 +431,7 @@ function Set-TargetResource
                 }
             }
             $complexDefinitionValue = @{
-                'definition@odata.bind' = $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')"
+                'definition@odata.bind' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')"
                 enabled                 = $definitionValue.Enabled
                 presentationValues      = $complexPresentationValues
             }
@@ -519,7 +519,7 @@ function Set-TargetResource
                 {
                     $value = $presentationValue.clone()
                     $value = Rename-M365DSCCimInstanceParameter -Properties $value -KeyMapping $keyToRename
-                    $value.add('presentation@odata.bind', "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')/presentations('$($presentationValue.presentationDefinitionId)')")
+                    $value.add('presentation@odata.bind', "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')/presentations('$($presentationValue.presentationDefinitionId)')")
                     $value.remove('PresentationDefinitionId')
                     $value.remove('PresentationDefinitionLabel')
                     $value.remove('id')
@@ -527,7 +527,7 @@ function Set-TargetResource
                 }
             }
             $complexDefinitionValue = @{
-                'definition@odata.bind' = $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')"
+                'definition@odata.bind' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')"
                 enabled                 = $definitionValue.Enabled
                 presentationValues      = $complexPresentationValues
             }
@@ -553,7 +553,7 @@ function Set-TargetResource
                     $currentPresentationValue = $currentDefinitionValue.PresentationValues | Where-Object { $_.PresentationDefinitionId -eq $presentationValue.presentationDefinitionId }
                     $value = $presentationValue.clone()
                     $value = Rename-M365DSCCimInstanceParameter -Properties $value -KeyMapping $keyToRename
-                    $value.add('presentation@odata.bind', "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')/presentations('$($presentationValue.presentationDefinitionId)')")
+                    $value.add('presentation@odata.bind', "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')/presentations('$($presentationValue.presentationDefinitionId)')")
                     $value.remove('PresentationDefinitionId')
                     $value.remove('PresentationDefinitionLabel')
                     $value.remove('id')
@@ -563,7 +563,7 @@ function Set-TargetResource
             }
             $complexDefinitionValue = @{
                 id                      = $currentDefinitionValue.Id
-                'definition@odata.bind' = $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')"
+                'definition@odata.bind' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')"
                 enabled                 = $definitionValue.Enabled
                 presentationValues      = $complexPresentationValues
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.psm1
@@ -521,7 +521,7 @@ function Set-TargetResource
         }
 
         #region resource generator code
-        $CreateParameters.Add("rootCertificate@odata.bind", "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$RootCertificateId')")
+        $CreateParameters.Add("rootCertificate@odata.bind", "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$RootCertificateId')")
         $CreateParameters.Add("@odata.type", "#microsoft.graph.windows81SCEPCertificateProfile")
         $policy = New-MgBetaDeviceManagementDeviceConfiguration -BodyParameter $CreateParameters
         $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
@@ -1033,7 +1033,7 @@ function Update-DeviceConfigurationPolicyRootCertificateId
 
     $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/deviceConfigurations('$DeviceConfigurationPolicyId')/microsoft.graph.windows81SCEPCertificateProfile/rootCertificate/`$ref"
     $ref = @{
-        '@odata.id' = $Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/deviceConfigurations('$RootCertificateId')"
+        '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/deviceConfigurations('$RootCertificateId')"
     }
 
     Invoke-MgGraphRequest -Method PUT -Uri $Uri -Body ($ref|ConvertTo-Json) -ErrorAction Stop

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10.psm1
@@ -563,7 +563,7 @@ function Set-TargetResource
                     -CertificateId $RootCertificatesForServerValidationIds[$i] `
                     -CertificateDisplayName $RootCertificatesForServerValidationDisplayNames[$i] `
                     -OdataTypes @('#microsoft.graph.windows81TrustedRootCertificate')
-                $rootCertificatesForServerValidation += "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
+                $rootCertificatesForServerValidation += "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
             }
             $CreateParameters.Add('rootCertificatesForServerValidation@odata.bind', $rootCertificatesForServerValidation)
         }
@@ -578,7 +578,7 @@ function Set-TargetResource
                     '#microsoft.graph.windows81TrustedRootCertificate', `
                     '#microsoft.graph.windows10PkcsCertificateProfile' `
                 )
-            $ref = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
+            $ref = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
             $CreateParameters.Add('identityCertificateForClientAuthentication@odata.bind', $ref)
         }
 
@@ -592,7 +592,7 @@ function Set-TargetResource
                     '#microsoft.graph.windows81TrustedRootCertificate', `
                     '#microsoft.graph.windows10PkcsCertificateProfile' `
                 )
-            $ref = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
+            $ref = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
             $CreateParameters.Add('secondaryIdentityCertificateForClientAuthentication@odata.bind', $ref)
         }
 
@@ -602,7 +602,7 @@ function Set-TargetResource
                 -CertificateId $RootCertificateForClientValidationId `
                 -CertificateDisplayName $RootCertificateForClientValidationDisplayName `
                 -OdataTypes @('#microsoft.graph.windows81TrustedRootCertificate')
-            $ref = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
+            $ref = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
             $CreateParameters.Add('rootCertificateForClientValidation@odata.bind', $ref)
         }
 
@@ -612,7 +612,7 @@ function Set-TargetResource
                 -CertificateId $SecondaryRootCertificateForClientValidationId `
                 -CertificateDisplayName $SecondaryRootCertificateForClientValidationDisplayName `
                 -OdataTypes @('#microsoft.graph.windows81TrustedRootCertificate')
-            $ref = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
+            $ref = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
             $CreateParameters.Add('secondaryRootCertificateForClientValidation@odata.bind', $ref)
         }
 
@@ -1241,7 +1241,7 @@ function Update-DeviceConfigurationPolicyCertificateId
     foreach ($certificateId in $CertificateIds)
     {
         $ref = @{
-            '@odata.id' = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$certificateId')"
+            '@odata.id' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$certificateId')"
         }
 
         Invoke-MgGraphRequest -Method $method -Uri $Uri -Body ($ref | ConvertTo-Json) -ErrorAction Stop 4>$null

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.psm1
@@ -450,8 +450,8 @@ function Set-TargetResource
                 throw "Mobile App Category with DisplayName $($category.DisplayName) not found."
             }
 
-            Invoke-MgGraphRequest -Uri "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileApps/$($app.Id)/categories/`$ref" -Method 'POST' -Body @{
-                '@odata.id' = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
+            Invoke-MgGraphRequest -Uri "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileApps/$($app.Id)/categories/`$ref" -Method 'POST' -Body @{
+                '@odata.id' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
             }
         }
 
@@ -507,7 +507,7 @@ function Set-TargetResource
                 }
 
                 Invoke-MgGraphRequest -Uri "/beta/deviceAppManagement/mobileApps/$($currentInstance.Id)/categories/`$ref" -Method 'POST' -Body @{
-                    '@odata.id' = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
+                    '@odata.id' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
                 }
             }
             else

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp.psm1
@@ -487,7 +487,7 @@ function Set-TargetResource
             }
 
             Invoke-MgGraphRequest -Uri "/beta/deviceAppManagement/mobileApps/$($app.Id)/categories/`$ref" -Method 'POST' -Body @{
-                '@odata.id' = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
+                '@odata.id' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
             }
         }
 
@@ -544,7 +544,7 @@ function Set-TargetResource
                 }
 
                 Invoke-MgGraphRequest -Uri "/beta/deviceAppManagement/mobileApps/$($currentInstance.Id)/categories/`$ref" -Method 'POST' -Body @{
-                    '@odata.id' = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
+                    '@odata.id' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
                 }
             }
             else

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleAssignment/MSFT_IntuneRoleAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleAssignment/MSFT_IntuneRoleAssignment.psm1
@@ -78,58 +78,51 @@ function Get-TargetResource
         $AccessTokens
     )
 
+    Write-Verbose -Message "Getting configuration of the Intune Role Assignment with Id {$Id} and DisplayName {$DisplayName}"
+
     try
     {
         $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
             -InboundParameters $PSBoundParameters
-    }
-    catch
-    {
-        Write-Verbose -Message ($_)
-    }
 
-    #Ensure the proper dependencies are installed in the current environment.
-    Confirm-M365DSCDependencies
+        #Ensure the proper dependencies are installed in the current environment.
+        Confirm-M365DSCDependencies
 
-    #region Telemetry
-    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
-    $CommandName = $MyInvocation.MyCommand
-    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
-        -CommandName $CommandName `
-        -Parameters $PSBoundParameters
-    Add-M365DSCTelemetryEvent -Data $data
-    #endregion
+        #region Telemetry
+        $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+        $CommandName = $MyInvocation.MyCommand
+        $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+            -CommandName $CommandName `
+            -Parameters $PSBoundParameters
+        Add-M365DSCTelemetryEvent -Data $data
+        #endregion
 
-    $nullResult = $PSBoundParameters
-    $nullResult.Ensure = 'Absent'
-    try
-    {
+        $nullResult = $PSBoundParameters
+        $nullResult.Ensure = 'Absent'
+
         $getValue = $null
-        if ($Id -match '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$')
+        $getValue = Get-MgBetaDeviceManagementRoleAssignment -DeviceAndAppManagementRoleAssignmentId $Id -ErrorAction SilentlyContinue
+        
+        if ($null -eq $getValue)
         {
-            $getValue = Get-MgBetaDeviceManagementRoleAssignment -DeviceAndAppManagementRoleAssignmentId $id -ErrorAction SilentlyContinue
-            if ($null -ne $getValue)
-            {
-                Write-Verbose -Message "Found something with id {$id}"
-            }
-        }
-        else
-        {
-            Write-Verbose -Message "Nothing with id {$id} was found"
-            $Filter = "displayName eq '$DisplayName'"
-            $getValue = Get-MgBetaDeviceManagementRoleAssignment -Filter $Filter -ErrorAction SilentlyContinue
-            if ($null -ne $getValue)
-            {
-                Write-Verbose -Message "Found something with displayname {$DisplayName}"
-            }
-            else
-            {
-                Write-Verbose -Message "Nothing with displayname {$DisplayName} was found"
-                return $nullResult
-            }
+            Write-Verbose -Message "Could not find an Intune Role Assignment with Id {$Id}"
+
+            $getValue = Get-MgBetaDeviceManagementRoleAssignment `
+                -All `
+                -Filter "displayName eq '$DisplayName'" `
+                -ErrorAction SilentlyContinue
         }
 
-        #Get Roledefinition first, loop through all roledefinitions and find the assignment match the id
+        if ($null -eq $getValue)
+        {
+            Write-Verbose -Message "Could not find an Intune Role Assignment with DisplayName {$DisplayName}"
+            return $nullResult
+        }
+
+        $Id = $getValue.Id
+        Write-Verbose -Message "An Intune Role Assignment with Id {$Id} and DisplayName {$DisplayName} was found"
+
+        #Get Roledefinition first, loop through all roledefinitions and find the assignment that matches the Id
         $tempRoleDefinitions = Get-MgDeviceManagementRoleDefinition
         foreach ($tempRoleDefinition in $tempRoleDefinitions)
         {
@@ -142,8 +135,6 @@ function Get-TargetResource
             }
         }
 
-        #$RoleDefinitionid = Get-MgDeviceManagementRoleAssignment -DeviceAndAppManagementRoleAssignmentId $getvalue.Id -ExpandProperty *
-
         $ResourceScopesDisplayNames = @()
         foreach ($ResourceScope in $getValue.ResourceScopes)
         {
@@ -155,8 +146,6 @@ function Get-TargetResource
         {
             $MembersDisplayNames += (Get-MgGroup -GroupId $tempMember).DisplayName
         }
-
-        Write-Verbose -Message "Found something with id {$id}"
 
         $scopeTypeValue = $null
         if (-not ([System.String]::IsNullOrEmpty($getValue.ScopeType)))
@@ -188,26 +177,12 @@ function Get-TargetResource
     }
     catch
     {
-        try
-        {
-            Write-Verbose -Message $_
-            $tenantIdValue = ''
-            if (-not [System.String]::IsNullOrEmpty($TenantId))
-            {
-                $tenantIdValue = $TenantId
-            }
-            elseif ($null -ne $Credential)
-            {
-                $tenantIdValue = $Credential.UserName.Split('@')[1]
-            }
-            Add-M365DSCEvent -Message $_ -EntryType 'Error' `
-                -EventID 1 -Source $($MyInvocation.MyCommand.Source) `
-                -TenantId $tenantIdValue
-        }
-        catch
-        {
-            Write-Verbose -Message $_
-        }
+        New-M365DSCLogEntry -Message 'Error retrieving data:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
         return $nullResult
     }
 }
@@ -314,28 +289,20 @@ function Set-TargetResource
     #endregion
 
     $currentInstance = Get-TargetResource @PSBoundParameters
-
-    $PSBoundParameters.Remove('Ensure') | Out-Null
-    $PSBoundParameters.Remove('Credential') | Out-Null
-    $PSBoundParameters.Remove('ApplicationId') | Out-Null
-    $PSBoundParameters.Remove('ApplicationSecret') | Out-Null
-    $PSBoundParameters.Remove('TenantId') | Out-Null
-    $PSBoundParameters.Remove('CertificateThumbprint') | Out-Null
-    $PSBoundParameters.Remove('ManagedIdentity') | Out-Null
-    $PSBoundParameters.Remove('AccessTokens') | Out-Null
+    $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
 
     if (!($RoleDefinition -match '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'))
     {
         [string]$roleDefinition = $null
         $Filter = "displayName eq '$RoleDefinitionDisplayName'"
-        $RoleDefinitionId = Get-MgDeviceManagementRoleDefinition -Filter $Filter -ErrorAction SilentlyContinue
+        $RoleDefinitionId = Get-MgDeviceManagementRoleDefinition -All -Filter $Filter -ErrorAction SilentlyContinue
         if ($null -ne $RoleDefinitionId)
         {
             $roleDefinition = $RoleDefinitionId.Id
         }
         else
         {
-            Write-Verbose -Message "Nothing with displayname {$RoleDefinitionDisplayName} was found"
+            Write-Verbose -Message "No role definition with DisplayName {$RoleDefinitionDisplayName} was found"
         }
     }
 
@@ -353,7 +320,7 @@ function Set-TargetResource
         }
         else
         {
-            Write-Verbose -Message "Nothing with displayname {$MembersDisplayName} was found"
+            Write-Verbose -Message "No member of type group with DisplayName {$MembersDisplayName} was found"
         }
     }
 
@@ -371,7 +338,7 @@ function Set-TargetResource
         }
         else
         {
-            Write-Verbose -Message "Nothing with displayname {$ResourceScopesDisplayName} was found"
+            Write-Verbose -Message "No resource scope of type group with DisplayName {$ResourceScopesDisplayName} was found"
         }
     }
     if ($ScopeType -match 'AllDevices|AllLicensedUsers|AllDevicesAndLicensedUsers')
@@ -385,7 +352,7 @@ function Set-TargetResource
     }
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {
-        Write-Verbose -Message "Creating {$DisplayName}"
+        Write-Verbose -Message "Creating an Intune Role Assignment with DisplayName {$DisplayName}"
 
         $CreateParameters = @{
             description                 = $Description
@@ -394,14 +361,13 @@ function Set-TargetResource
             scopeType                   = $ScopeType
             members                     = $Members
             '@odata.type'               = '#microsoft.graph.deviceAndAppManagementRoleAssignment'
-            'roleDefinition@odata.bind' = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceManagement/roleDefinitions('$roleDefinition')"
+            'roleDefinition@odata.bind' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/roleDefinitions('$roleDefinition')"
         }
-        $policy = New-MgBetaDeviceManagementRoleAssignment -BodyParameter $CreateParameters
-
+        $null = New-MgBetaDeviceManagementRoleAssignment -BodyParameter $CreateParameters
     }
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
     {
-        Write-Verbose -Message "Updating {$DisplayName}"
+        Write-Verbose -Message "Updating the Intune Role Assignment with Id {$($currentInstance.Id)} and DisplayName {$DisplayName}"
 
         $UpdateParameters = @{
             description                 = $Description
@@ -410,16 +376,15 @@ function Set-TargetResource
             scopeType                   = $ScopeType
             members                     = $Members
             '@odata.type'               = '#microsoft.graph.deviceAndAppManagementRoleAssignment'
-            'roleDefinition@odata.bind' = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)beta/deviceManagement/roleDefinitions('$roleDefinition')"
+            'roleDefinition@odata.bind' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/roleDefinitions('$roleDefinition')"
         }
 
         Update-MgBetaDeviceManagementRoleAssignment -BodyParameter $UpdateParameters `
             -DeviceAndAppManagementRoleAssignmentId $currentInstance.Id
-
     }
     elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
     {
-        Write-Verbose -Message "Removing {$DisplayName}"
+        Write-Verbose -Message "Removing the Intune Role Assignment with Id {$($currentInstance.Id)} and DisplayName {$DisplayName}"
         Remove-MgBetaDeviceManagementRoleAssignment -DeviceAndAppManagementRoleAssignmentId $currentInstance.Id
     }
 }
@@ -516,16 +481,16 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    Write-Verbose -Message "Testing configuration of {$id - $displayName}"
+    Write-Verbose -Message "Testing configuration of {$Id - $displayName}"
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
-    $ValuesToCheck = ([Hashtable]$PSBoundParameters).clone()
+    $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
 
-    if (!($RoleDefinition -match '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'))
+    if (-not ($RoleDefinition -match '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'))
     {
         [string]$roleDefinition = $null
         $Filter = "displayName eq '$RoleDefinitionDisplayName'"
-        $RoleDefinitionId = Get-MgDeviceManagementRoleDefinition -Filter $Filter -ErrorAction SilentlyContinue
+        $RoleDefinitionId = Get-MgDeviceManagementRoleDefinition -All -Filter $Filter -ErrorAction SilentlyContinue
         if ($null -ne $RoleDefinitionId)
         {
             $roleDefinition = $RoleDefinitionId.Id
@@ -533,7 +498,7 @@ function Test-TargetResource
         }
         else
         {
-            Write-Verbose -Message "Nothing with displayname {$RoleDefinitionDisplayName} was found"
+            Write-Verbose -Message "No role definition with DisplayName {$RoleDefinitionDisplayName} was found"
         }
     }
 
@@ -550,7 +515,7 @@ function Test-TargetResource
         }
         else
         {
-            Write-Verbose -Message "Nothing with displayname {$RoleDefinitionDisplayName} was found"
+            Write-Verbose -Message "No member of type group with DisplayName {$MembersDisplayName} was found"
         }
     }
     $PSBoundParameters.Set_Item('Members', $Members)
@@ -568,7 +533,7 @@ function Test-TargetResource
         }
         else
         {
-            Write-Verbose -Message "Nothing with displayname {$RoleDefinitionDisplayName} was found"
+            Write-Verbose -Message "No resource scope of type group with DisplayName {$ResourceScopesDisplayName} was found"
         }
     }
     $PSBoundParameters.Set_Item('ResourceScopes', $ResourceScopes)
@@ -691,14 +656,14 @@ function Export-TargetResource
                 $Global:M365DSCExportResourceInstancesCount++
             }
 
-            $displayedKey = $config.id
+            $displayedKey = $config.Id
             if (-not [String]::IsNullOrEmpty($config.displayName))
             {
                 $displayedKey = $config.displayName
             }
             Write-Host "    |---[$i/$($getValue.Count)] $displayedKey" -NoNewline
             $params = @{
-                id                    = $config.id
+                Id                    = $config.Id
                 DisplayName           = $config.displayName
                 Ensure                = 'Present'
                 Credential            = $Credential
@@ -749,3 +714,5 @@ function Export-TargetResource
         return ''
     }
 }
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleScopeTag/MSFT_IntuneRoleScopeTag.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleScopeTag/MSFT_IntuneRoleScopeTag.psm1
@@ -119,6 +119,7 @@ function Get-TargetResource
             ApplicationSecret     = $ApplicationSecret
             CertificateThumbprint = $CertificateThumbprint
             ManagedIdentity       = $ManagedIdentity.IsPresent
+            AccessTokens          = $AccessTokens
             #endregion
         }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365Group/MSFT_O365Group.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365Group/MSFT_O365Group.psm1
@@ -352,7 +352,7 @@ function Set-TargetResource
                     $userId = (Get-MgUser -UserId $member).Id
 
                     # There are no cmldet to remove members from group available at the time of writing this resource (March 8th 2022)
-                    $url = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)v1.0/groups/$($ADGroup[0].Id)/members/$userId/`$ref"
+                    $url = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/groups/$($ADGroup[0].Id)/members/$userId/`$ref"
                     Invoke-MgGraphRequest -Method DELETE -Uri $url | Out-Null
                 }
             }
@@ -398,7 +398,7 @@ function Set-TargetResource
                     Write-Verbose -Message "Adding Owner {$owner}"
                     $userId = (Get-MgUser -UserId $owner).Id
                     $newGroupOwner = @{
-                        '@odata.id' = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)v1.0/users/{$userId}"
+                        '@odata.id' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/users/{$userId}"
                     }
 
                     New-MgGroupOwnerByRef -GroupId $ADGroup[0].Id -BodyParameter $newGroupOwner
@@ -410,7 +410,7 @@ function Set-TargetResource
                     $userId = (Get-MgUser -UserId $owner).Id
 
                     # There are no cmldet to remove members from group available at the time of writing this resource (March 8th 2022)
-                    $url = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)v1.0/groups/$($ADGroup[0].Id)/owners/$userId/`$ref"
+                    $url = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/groups/$($ADGroup[0].Id)/owners/$userId/`$ref"
                     Invoke-MgGraphRequest -Method DELETE -Uri $url | Out-Null
                 }
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerTask/MSFT_PlannerTask.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerTask/MSFT_PlannerTask.psm1
@@ -492,7 +492,7 @@ function Set-TargetResource
         Write-Verbose -Message "Updating Task with:`r`n$JSONDetails"
         # Need to continue to rely on Invoke-MgGraphRequest
         Invoke-MgGraphRequest -Method PATCH `
-            -Uri "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)v1.0/planner/tasks/$taskId" `
+            -Uri "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/planner/tasks/$taskId" `
             -Headers $Headers `
             -Body $JSONDetails
 
@@ -504,7 +504,7 @@ function Set-TargetResource
         $JSONDetails = (ConvertTo-Json $details)
         Write-Verbose -Message "Updating Task's details with:`r`n$JSONDetails"
         Invoke-MgGraphRequest -Method PATCH `
-            -Uri "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)v1.0/planner/tasks/$taskId/details" `
+            -Uri "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/planner/tasks/$taskId/details" `
             -Headers $Headers `
             -Body $JSONDetails
 
@@ -940,7 +940,7 @@ function Get-M365DSCPlannerTasksFromPlan
         $Credential
     )
     $results = @()
-    $uri = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)v1.0/planner/plans/$PlanId/tasks"
+    $uri = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/planner/plans/$PlanId/tasks"
     $taskResponse = Invoke-MSCloudLoginMicrosoftGraphAPI -Credential $Credential `
         -Uri $uri `
         -Method Get

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelTab/MSFT_TeamsChannelTab.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelTab/MSFT_TeamsChannelTab.psm1
@@ -368,7 +368,7 @@ function Set-TargetResource
         Write-Verbose -Message "Params: $($CurrentParameters | Out-String)"
 
         $additionalProperties = @{
-            'teamsApp@odata.bind' = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)v1.0/appCatalogs/teamsApps/$TeamsApp"
+            'teamsApp@odata.bind' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/appCatalogs/teamsApps/$TeamsApp"
         }
         $CurrentParameters.Add('AdditionalProperties', $additionalProperties)
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -443,7 +443,7 @@ function Set-TargetResource
 
             Write-Verbose -Message "Retrieving Group Owner {$currentOwner}"
             $ownerUser = Get-MgUser -Search $currentOwner -ConsistencyLevel eventual
-            $ownerOdataID = "$($Global:MSCloudLoginAssistant.MicrosoftGraph.ResourceUrl)v1.0/directoryObjects/$($ownerUser.Id)"
+            $ownerOdataID = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/directoryObjects/$($ownerUser.Id)"
 
             Write-Verbose -Message "Adding Owner {$($ownerUser.Id)} to Group {$($group.Id)}"
             try


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes three things: 
* First, it improves the overall output of `IntuneRoleAssignment` and some copy-pasted variables
* Secondly, it fixes the incorrect variable `$Global:MSCloudLoginAssistant` to `$Global:MSCloudLoginConnectionProfile`
* Thirdly, it adds the `AccessTokens` property to the output of the Get method

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
