### PR TITLE
MSFT_AADFilteringPolicyRuleDestination Fix for Export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * AAD
   * Added ApplicationSecret auth method to multiple resources
+* AADFilteringPolicyRule
+  * Fixed an issue with the export of the Destinations property where
+    the CIMInstance array object was malformed.
 * EXOEOPProtectionPolicyRule
   * Added support for AccessTokens.
 * EXOExternalInOutlook

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADFilteringPolicyRule/MSFT_AADFilteringPolicyRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADFilteringPolicyRule/MSFT_AADFilteringPolicyRule.psm1
@@ -520,7 +520,7 @@ function Export-TargetResource
 
                 if ($Results.Destinations)
                 {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Destinations' -IsCIMArray:$false
+                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Destinations' -IsCIMArray:$true
                 }
                 $dscContent += $currentDSCBlock
                 Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyiOS/MSFT_IntuneAppProtectionPolicyiOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyiOS/MSFT_IntuneAppProtectionPolicyiOS.psm1
@@ -769,7 +769,6 @@ function Set-TargetResource
         }
         $createParameters.ExemptedAppProtocols = $myExemptedAppProtocols
 
-
         $policy = New-MgBetaDeviceAppManagementiOSManagedAppProtection -BodyParameter $createParameters
 
         Update-IntuneAppProtectionPolicyiOSApp -IosManagedAppProtectionId $policy.id -Apps $myApps
@@ -812,7 +811,6 @@ function Set-TargetResource
             }
         }
         $updateParameters.ExemptedAppProtocols = $myExemptedAppProtocols
-
 
         Update-MgBetaDeviceAppManagementiOSManagedAppProtection -IosManagedAppProtectionId $Identity -BodyParameter $updateParameters
 


### PR DESCRIPTION
#### Pull Request (PR) description
* AADFilteringPolicyRule
  * Fixed an issue with the export of the Destinations property where
    the CIMInstance array object was malformed.

#### This Pull Request (PR) fixes the following issues
* N/A

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
