### PR TITLE
Warn on lowercase method name during script analyze

### DIFF
--- a/.vscode/CustomRules/UseCorrectMethodCasing.psm1
+++ b/.vscode/CustomRules/UseCorrectMethodCasing.psm1
@@ -1,0 +1,67 @@
+﻿<#
+.SYNOPSIS
+    Use correct method casing in the method name.
+.DESCRIPTION
+    Methods called on an object should use the correct casing (PascalCase) for the method name.
+.EXAMPLE
+    $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $MyInvocation.MyCommand.ModuleName.replace('MSFT_', '')
+    The first example is correct, the second example is incorrect.
+#>
+
+function Use-CorrectMethodCasing {
+    [CmdletBinding()]
+    [OutputType([Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.ScriptBlockAst]
+        $ScriptBlockAst
+    )
+
+    Process
+    {
+        $results = @()
+        try
+        {
+            [System.Management.Automation.Language.InvokeMemberExpressionAst[]]$memberAst = $ScriptBlockAst.FindAll({$Args[0].GetType().Name -eq 'InvokeMemberExpressionAst'}, $true)
+            
+            foreach ($member in $memberAst)
+            {
+                if ($member.Member.Value -cmatch '^[a-z]') {
+                    [int]$startLineNumber =  $member.Extent.StartLineNumber
+                    [int]$endLineNumber = $member.Extent.EndLineNumber
+                    [int]$startColumnNumber = $member.Extent.StartColumnNumber
+                    [int]$endColumnNumber = $member.Extent.EndColumnNumber
+                    [string]$file = $MyInvocation.MyCommand.Definition
+
+                    $correctedString = $member.Member.Value.Substring(0, 1).ToUpper() + $member.Member.Value.Substring(1)
+                    [string]$correction = $member.Extent.Text.Replace($member.Member.Value, $correctedString)
+                    [string]$optionalDescription = "Replace '$($member.Member.Value)' with '$($member.Member.Value.Substring(0, 1).ToUpper() + $member.Member.Value.Substring(1))'."
+                    $objParams = @{
+                        TypeName = 'Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent'
+                        ArgumentList = $startLineNumber, $endLineNumber, $startColumnNumber,
+                                       $endColumnNumber, $correction, $file, $optionalDescription
+                    }
+                    $correctionExtent = New-Object @objParams
+                    $suggestedCorrections = New-Object System.Collections.ObjectModel.Collection[$($objParams.TypeName)]
+                    $suggestedCorrections.Add($correctionExtent) | Out-Null
+                    
+                    $results += [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
+                        Message = 'Use correct method casing in the method name.'
+                        Extent = $member.Extent
+                        RuleName = $PSCmdlet.MyInvocation.InvocationName
+                        Severity = 'Warning'
+                        SuggestedCorrections = $suggestedCorrections
+                    }
+                }
+            }
+        }
+        catch
+        {
+            $PSCmdlet.ThrowTerminatingError( $_ )
+        }
+
+        return $results
+    }
+}

--- a/.vscode/ScriptAnalyzerSettings.psd1
+++ b/.vscode/ScriptAnalyzerSettings.psd1
@@ -1,8 +1,16 @@
 @{
-    Severity     = @('Error',
-        'Warning')
-    ExcludeRules = @('PSMissingModuleManifestField',
+    Severity = @(
+        'Error',
+        'Warning'
+    )
+    ExcludeRules = @(
+        'PSMissingModuleManifestField',
         'PSUseShouldProcessForStateChangingFunctions',
         'PSAvoidGlobalVars',
-        'PSAvoidUsingWriteHost')
+        'PSAvoidUsingWriteHost'
+    )
+    CustomRulePath = @(
+        '.vscode\CustomRules\UseCorrectMethodCasing.psm1'
+    )
+    IncludeDefaultRules = $true
 }


### PR DESCRIPTION
#### Pull Request (PR) description
@ykuijs This PR starts to warn developers and maintainers of DSC resources inside Microsoft365DSC if a lowercase method name is used instead of the correct PascalCase version. Method names in C# are per-design in PascalCase, but because PowerShell is case insensitive, those method names can be written in lower case as well. The new rule `UseCorrectMethodCasing` warns if an invalid method name is detected and suggests a fix for it. 

#### This Pull Request (PR) fixes the following issues
None. 

#### Task list
- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
