### PR TITLE
AADAccessReviewDefinition - Fixing Accepted Odata.Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 * All resources
   * Applying project default formatting on all files, to improve
-    reading and troubleshooting
+    reading and troubleshooting.
+* AADAccessReviewDefinition
+  * Added support for #microsoft.graph.accessReviewInactiveUsersQueryScope in odatatype.
 * AADRoleManagementPolicyRule
   * Added the logic to handle filters in the Export logic flow.
 * EXOTeamsProtectionPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAccessReviewDefinition/MSFT_AADAccessReviewDefinition.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAccessReviewDefinition/MSFT_AADAccessReviewDefinition.schema.mof
@@ -6,7 +6,7 @@ class MSFT_MicrosoftGraphAccessReviewScope
     [Write, Description("Indicates the type of query. Types include MicrosoftGraph and ARM.")] String QueryType;
     [Write, Description("Defines the scopes of the principals for which access to resources are reviewed in the access review."), EmbeddedInstance("MSFT_MicrosoftGraphAccessReviewScope")] String PrincipalScopes[];
     [Write, Description("Defines the scopes of the resources for which access is reviewed."), EmbeddedInstance("MSFT_MicrosoftGraphAccessReviewScope")] String ResourceScopes[];
-    [Write, Description("The type of the entity."), ValueMap{"#microsoft.graph.accessReviewQueryScope","#microsoft.graph.accessReviewReviewerScope","#microsoft.graph.principalResourceMembershipsScope"}, Values{"#microsoft.graph.accessReviewQueryScope","#microsoft.graph.accessReviewReviewerScope","#microsoft.graph.principalResourceMembershipsScope"}] String odataType;
+    [Write, Description("The type of the entity."), ValueMap{"#microsoft.graph.accessReviewQueryScope","#microsoft.graph.accessReviewReviewerScope","#microsoft.graph.principalResourceMembershipsScope","#microsoft.graph.accessReviewInactiveUsersQueryScope"}, Values{"#microsoft.graph.accessReviewQueryScope","#microsoft.graph.accessReviewReviewerScope","#microsoft.graph.principalResourceMembershipsScope","#microsoft.graph.accessReviewInactiveUsersQueryScope"}] String odataType;
 };
 [ClassVersion("1.0.0")]
 class MSFT_MicrosoftGraphAccessReviewScheduleSettings


### PR DESCRIPTION
#### Pull Request (PR) description
* AADAccessReviewDefinition
  * Added support for #microsoft.graph.accessReviewInactiveUsersQueryScope in odatatype.

#### This Pull Request (PR) fixes the following issues
* N/A

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
