### PR TITLE
fix for targetedMobileApps

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneVPNConfigurationPolicyIOS/MSFT_IntuneVPNConfigurationPolicyIOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneVPNConfigurationPolicyIOS/MSFT_IntuneVPNConfigurationPolicyIOS.psm1
@@ -281,7 +281,7 @@ function Get-TargetResource
         foreach ($value in $getValue.AdditionalProperties.targetedMobileApps)
         {
             $myTMAdata = @{}
-            $myTMAdata.Add('address', $value.address)
+            $myTMAdata.Add('name', $value.name)
             $myTMAdata.Add('publisher', $value.publisher)
             $myTMAdata.Add('appStoreUrl', $value.appStoreUrl)
             $myTMAdata.Add('appId', $value.appId)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneVPNConfigurationPolicyIOS/MSFT_IntuneVPNConfigurationPolicyIOS.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneVPNConfigurationPolicyIOS/MSFT_IntuneVPNConfigurationPolicyIOS.schema.mof
@@ -38,7 +38,7 @@ class MSFT_MicrosoftvpnProxyServer
 [ClassVersion("1.0.0")]
 class MSFT_targetedMobileApps
 {
-    [Write, Description("The application name.")] String address;
+    [Write, Description("The application name.")] String name;
     [Write, Description("The publisher of the application.")] String publisher;
     [Write, Description("The Store URL of the application.")] String appStoreUrl;
     [Write, Description("The application or bundle identifier of the application.")] String appId;

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneVPNConfigurationPolicyIOS.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneVPNConfigurationPolicyIOS.Tests.ps1
@@ -121,7 +121,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         (New-CimInstance `
                         -ClassName MSFT_targetedMobileApps `
                         -Property @{
-                            address                            = 'FakeStringValue'
+                            name                               = 'FakeStringValue'
                             publisher                          = 'FakeStringValue'
                             appStoreUrl                        = 'FakeStringValue'
                             appId                              = 'FakeStringValue'
@@ -219,7 +219,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         (New-CimInstance `
                         -ClassName MSFT_targetedMobileApps `
                         -Property @{
-                            address                          = 'FakeStringValue'
+                            name                             = 'FakeStringValue'
                             publisher                        = 'FakeStringValue'
                             appStoreUrl                      = 'FakeStringValue'
                             appId                            = 'FakeStringValue'
@@ -285,7 +285,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             )
                             targetedMobileApps                      = @(
                                 @{
-                                    address                         = 'FakeStringValue'
+                                    name                            = 'FakeStringValue'
                                     publisher                       = 'FakeStringValue'
                                     appStoreUrl                     = 'FakeStringValue'
                                     appId                           = 'FakeStringValue'
@@ -375,7 +375,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         (New-CimInstance `
                         -ClassName MSFT_targetedMobileApps `
                         -Property @{
-                            address                         = 'FakeStringValue'
+                            name                            = 'FakeStringValue'
                             publisher                       = 'FakeStringValue'
                             appStoreUrl                     = 'FakeStringValue'
                             appId                           = 'FakeStringValue'
@@ -442,7 +442,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             )
                             targetedMobileApps                    = @(
                                 @{
-                                    address                         = 'FakeStringValue'
+                                    name                            = 'FakeStringValue'
                                     publisher                       = 'FakeStringValue'
                                     appStoreUrl                     = 'FakeStringValue'
                                     appId                           = 'FakeStringValue'


### PR DESCRIPTION
Reviewed documentation on appListItem resource type for targetedMobileApps property and realised one of the properties was not correctly defined in the schema.mof. Corrected mof, psm1 and unit test scripts.

https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceconfig-applistitem?view=graph-rest-beta

#### Pull Request (PR) description
Reviewed documentation on appListItem resource type for targetedMobileApps property and realised one of the properties was not correctly defined in the schema.mof. Corrected mof, psm1 and unit test scripts.

Not updated change log as IntuneVPNConfigurationPolicyIOS is still in # UNRELEASED / initial release.

https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceconfig-applistitem?view=graph-rest-beta
#### This Pull Request (PR) fixes the following issues
None

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
