### PR TITLE
Fix export of Firewall policy settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* IntuneFirewallPolicyWindows10
+  * Fix export of properties that appear multiple times in subsections.
+
 # 1.24.1204.1
 
 * All resources

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
@@ -492,12 +492,19 @@ function Get-TargetResource
 
         # Retrieve policy specific settings
         [array]$settings = Get-MgBetaDeviceManagementConfigurationPolicySetting `
+            -All `
             -DeviceManagementConfigurationPolicyId $Id `
             -ExpandProperty 'settingDefinitions' `
             -ErrorAction Stop
+        $policyTemplateId = $getValue.TemplateReference.TemplateId
+        [array]$settingDefinitions = Get-MgBetaDeviceManagementConfigurationPolicyTemplateSettingTemplate `
+            -DeviceManagementConfigurationPolicyTemplateId $policyTemplateId `
+            -ExpandProperty 'settingDefinitions' `
+            -All `
+            -ErrorAction Stop | Select-Object -ExpandProperty SettingDefinitions
 
         $policySettings = @{}
-        $policySettings = Export-IntuneSettingCatalogPolicySettings -Settings $settings -ReturnHashtable $policySettings
+        $policySettings = Export-IntuneSettingCatalogPolicySettings -Settings $settings -ReturnHashtable $policySettings -AllSettingDefinitions $settingDefinitions
 
         $results = @{
             #region resource generator code

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneFirewallPolicyWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneFirewallPolicyWindows10.Tests.ps1
@@ -279,6 +279,150 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 )
             }
 
+            Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicyTemplateSettingTemplate -MockWith {
+                return @(
+                    @{
+                        SettingDefinitions = @(
+                            @{
+                                Id = 'vendor_msft_firewall_mdmstore_global_disablestatefulftp'
+                                Name = 'DisableStatefulFtp'
+                                OffsetUri = '/MdmStore/Global/DisableStatefulFtp'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                }
+                            }
+                        )
+                    },
+                    @{
+                        SettingDefinitions = @(
+                            @{
+                                Id = 'vendor_msft_firewall_mdmstore_domainprofile_enablefirewall'
+                                Name = 'EnableFirewall'
+                                OffsetUri = '/MdmStore/DomainProfile/EnableFirewall'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                }
+                            },
+                            @{
+                                Id = 'vendor_msft_firewall_mdmstore_domainprofile_logfilepath'
+                                Name = 'LogFilePath'
+                                OffsetUri = '/MdmStore/DomainProfile/LogFilePath'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationStringSettingDefinition'
+                                    dependentOn = @(
+                                        @{
+                                            dependentOn = 'vendor_msft_firewall_mdmstore_domainprofile_enablefirewall_true'
+                                            parentSettingId = 'vendor_msft_firewall_mdmstore_domainprofile_enablefirewall'
+                                        }
+                                    )
+                                }
+                            },
+                            @{
+                                Id = 'vendor_msft_firewall_mdmstore_publicprofile_enablefirewall'
+                                Name = 'EnableFirewall'
+                                OffsetUri = '/MdmStore/PublicProfile/EnableFirewall'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                }
+                            },
+                            @{
+                                Id = 'vendor_msft_firewall_mdmstore_publicprofile_logfilepath'
+                                Name = 'LogFilePath'
+                                OffsetUri = '/MdmStore/PublicProfile/LogFilePath'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationStringSettingDefinition'
+                                    dependentOn = @(
+                                        @{
+                                            dependentOn = 'vendor_msft_firewall_mdmstore_publicprofile_enablefirewall_true'
+                                            parentSettingId = 'vendor_msft_firewall_mdmstore_publicprofile_enablefirewall'
+                                        }
+                                    )
+                                }
+                            }
+                        )
+                    },
+                    @{
+                        SettingDefinitions = @(
+                            @{
+                                Id = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_domainprofile_enablefirewall'
+                                Name = 'EnableFirewall'
+                                OffsetUri = '/MdmStore/HyperVVMSettings/{0}/DomainProfile/EnableFirewall'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                    options = @(
+                                        # Only option used in the tests is defined here
+                                        @{
+                                            name = 'Enable Firewall'
+                                            itemId = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_domainprofile_enablefirewall_true'
+                                            dependentOn = @(
+                                                @{
+                                                    dependentOn = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_target_wsl'
+                                                    parentSettingId = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_target'
+                                                }
+                                            )
+                                        }
+                                    )
+                                }
+                            },
+                            @{
+                                Id = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_publicprofile_enablefirewall'
+                                Name = 'EnableFirewall'
+                                OffsetUri = '/MdmStore/HyperVVMSettings/{0}/PublicProfile/EnableFirewall'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                    options = @(
+                                        # Only option used in the tests is defined here
+                                        @{
+                                            name = 'Enable Firewall'
+                                            itemId = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_publicprofile_enablefirewall_true'
+                                            dependentOn = @(
+                                                @{
+                                                    dependentOn = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_target_wsl'
+                                                    parentSettingId = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_target'
+                                                }
+                                            )
+                                        }
+                                    )
+                                }
+                            },
+                            @{
+                                Id = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_target'
+                                Name = 'Target'
+                                OffsetUri = '/MdmStore/HyperVVMSettings/{0}/Target'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                    options = @(
+                                        @{
+                                            dependentOn = @(
+                                                @{
+                                                    dependentOn = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}'
+                                                    parentSettingId = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}'
+                                                }
+                                            )
+                                            name = 'WSL'
+                                            itemId = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_target_wsl'
+                                        }
+                                    )
+                                }
+                            },
+                            @{
+                                Id = 'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}'
+                                Name = '{VMCreatorId}'
+                                OffsetUri = '/MdmStore/HyperVVMSettings/{0}'
+                                AdditionalProperties = @{
+                                    '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSettingGroupCollectionDefinition'
+                                    childIds = @(
+                                        'vendor_msft_firewall_mdmstore_hypervvmsettings_{vmcreatorid}_target'
+                                    )
+                                    maximumCount = 1
+                                    minimumCount = 0
+                                }
+                            }
+                        )
+                    }
+                )
+            }
+
             Mock -CommandName Update-DeviceConfigurationPolicyAssignment -MockWith {
             }
 


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue of export of `IntuneFirewallPolicyWindows10`. Settings like `LogFilePath` could be exported without their prefix for `DomainProfile` if it was only specified one time in the policy.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
