### PR TITLE
AADFeatureRolloutPolicy: Fix policy retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* AADFeatureRolloutPolicy
+  * Fixed policy retrieval
+    FIXES [#5521](https://github.com/microsoft/Microsoft365DSC/issues/5521)
 * IntuneDeviceManagementAndroidDeviceOwnerEnrollmentProfile
   * Fixing issue with the way the QrCodeImage property was exported and handled.
 * IntuneFirewallPolicyWindows10

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADFeatureRolloutPolicy/MSFT_AADFeatureRolloutPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADFeatureRolloutPolicy/MSFT_AADFeatureRolloutPolicy.psm1
@@ -98,10 +98,7 @@ function Get-TargetResource
             {
                 $getValue = Get-MgBetaPolicyFeatureRolloutPolicy `
                     -Filter "DisplayName eq '$DisplayName'" `
-                    -ErrorAction SilentlyContinue | Where-Object `
-                    -FilterScript {
-                    $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.FeatureRolloutPolicy'
-                }
+                    -ErrorAction SilentlyContinue
             }
         }
         #endregion


### PR DESCRIPTION
#### Pull Request (PR) description
After policy is created currently is not possible to retrieve it, this is because policies are being created without AdditionalProperties field and @odata.type is therefore not available which leads to when trying retrieve the policies and filter them by @odata.type it won't find any.

This PR fixes this by removing the filter by @odata.type since is not required.

#### This Pull Request (PR) fixes the following issues
- Fixes #5521

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
