### PR TITLE
[BUG] Fix duplicate policy creation bug & dynamic group compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,38 @@
 
 # UNRELEASED
 
+* AADGroup
+  * Only get Members & GroupAsMembers when a static group is defined.
+* IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneAccountProtectionPolicyWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneAntivirusPolicyLinux
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneAntivirusPolicyMacOS
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneAntivirusPolicyWindows10SettingCatalog
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneAppAndBrowserIsolationPolicyWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneDeviceControlPolicyWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneDiskEncryptionMacOS
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneDiskEncryptionWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneEndpointDetectionAndResponsePolicyLinux
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneEndpointDetectionAndResponsePolicyMacOS
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneEndpointDetectionAndResponsePolicyWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneSettingCatalogASRRulesPolicyWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
 * IntuneDeviceManagementAndroidDeviceOwnerEnrollmentProfile
   * Fixing issue with the way the QrCodeImage property was exported and handled.
 * IntuneFirewallPolicyWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
   * Fix export of properties that appear multiple times in subsections.
 
 # 1.24.1204.1

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -216,6 +216,7 @@ function Get-TargetResource
             }
 
             $MembersValues = $null
+            $result = @{}
             if ($Group.MembershipRuleProcessingState -ne 'On')
             {
                 # Members
@@ -237,6 +238,8 @@ function Get-TargetResource
                         $GroupAsMembersValues += $member.AdditionalProperties.displayName
                     }
                 }
+                $result.Add('Members', $MembersValues)
+                $result.Add('GroupAsMembers', $GroupAsMembersValues)
             }
 
             # MemberOf
@@ -273,15 +276,12 @@ function Get-TargetResource
             if ($assignedLicensesRequest.value.Length -gt 0)
             {
                 $assignedLicensesValues = Get-M365DSCAzureADGroupLicenses -AssignedLicenses $assignedLicensesRequest.value
-
             }
 
-            $result = @{
+            $policySettings = @{
                 DisplayName                   = $Group.DisplayName
                 Id                            = $Group.Id
                 Owners                        = $OwnersValues
-                Members                       = $MembersValues
-                GroupAsMembers                = $GroupAsMembersValues
                 MemberOf                      = $MemberOfValues
                 Description                   = $Group.Description
                 GroupTypes                    = [System.String[]]$Group.GroupTypes
@@ -303,6 +303,7 @@ function Get-TargetResource
                 Managedidentity               = $ManagedIdentity.IsPresent
                 AccessTokens                  = $AccessTokens
             }
+            $result += $policySettings
 
             return $result
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy.psm1
@@ -160,7 +160,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($policy.id))
+        if ([String]::IsNullOrEmpty($policy.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy.psm1
@@ -145,7 +145,7 @@ function Get-TargetResource
                 $policy = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName' and templateReference/TemplateId eq '$templateReferenceId'"
                 if ($policy.Length -gt 1)
                 {
-                    throw "Duplicate Account Protection LAPS Policyy named $DisplayName exist in tenant"
+                    throw "Duplicate Account Protection LAPS Policy named $DisplayName exist in tenant"
                 }
             }
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy.psm1
@@ -141,7 +141,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Identity}"
+                Write-Verbose -Message "No Account Protection LAPS Policy with Id {$Identity} was found"
                 $policy = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName' and templateReference/TemplateId eq '$templateReferenceId'"
                 if ($policy.Length -gt 1)
                 {
@@ -162,7 +162,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($policy.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Account Protection LAPS Policy with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/MSFT_IntuneAccountProtectionPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/MSFT_IntuneAccountProtectionPolicyWindows10.psm1
@@ -85,31 +85,42 @@ function Get-TargetResource
         Add-M365DSCTelemetryEvent -Data $data
         #endregion
 
-        $nullResult = $PSBoundParameters
-        $nullResult.Ensure = 'Absent'
-
-        $getValue = $null
-        #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
-
-        if ($null -eq $getValue)
+        if ($PSBoundParameters.ContainsKey('Id'))
         {
-            Write-Verbose -Message "Could not find an Intune Account Protection Policy for Windows10 with Id {$Id}"
-
-            if (-not [System.String]::IsNullOrEmpty($DisplayName))
+            Write-Verbose -Message 'PolicyID was specified'
+            try
             {
-                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
-                    -All `
-                    -Filter "Name eq '$DisplayName'" `
-                    -ErrorAction SilentlyContinue
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction Stop
+            }
+            catch
+            {
+                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Account Protection Policy for Windows10 named $DisplayName exist in tenant"
+                }
             }
         }
-        #endregion
-        if ($null -eq $getValue)
+        else
         {
-            Write-Verbose -Message "Could not find an Intune Account Protection Policy for Windows10 with Name {$DisplayName}."
-            return $nullResult
+            Write-Verbose -Message 'Id was NOT specified'
+            ## Can retreive multiple Intune Policies since displayname is not unique
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+            if ($getValue.Length -gt 1)
+            {
+                throw "Duplicate Intune Account Protection Policy for Windows10 named $DisplayName exist in tenant"
+            }
         }
+
+        if ([String]::IsNullOrEmpty($getValue.id))
+        {
+            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            $currentValues = $PSBoundParameters
+            $currentValues.Ensure = 'Absent'
+            return $currentValues
+        }
+
         $Id = $getValue.Id
         Write-Verbose -Message "An Intune Account Protection Policy for Windows10 with Id {$Id} and Name {$DisplayName} was found"
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/MSFT_IntuneAccountProtectionPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/MSFT_IntuneAccountProtectionPolicyWindows10.psm1
@@ -94,7 +94,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                Write-Verbose -Message "No Account Protection Policy for Windows10 with Id {$Id} was found"
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
                 if ($getValue.Length -gt 1)
                 {
@@ -115,7 +115,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($getValue.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Account Protection Policy for Windows10 with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/MSFT_IntuneAccountProtectionPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/MSFT_IntuneAccountProtectionPolicyWindows10.psm1
@@ -113,7 +113,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($getValue.id))
+        if ([String]::IsNullOrEmpty($getValue.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyLinux/MSFT_IntuneAntivirusPolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyLinux/MSFT_IntuneAntivirusPolicyLinux.psm1
@@ -192,31 +192,42 @@ function Get-TargetResource
         Add-M365DSCTelemetryEvent -Data $data
         #endregion
 
-        $nullResult = $PSBoundParameters
-        $nullResult.Ensure = 'Absent'
-
-        $getValue = $null
-        #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
-
-        if ($null -eq $getValue)
+        if ($PSBoundParameters.ContainsKey('Id'))
         {
-            Write-Verbose -Message "Could not find an Intune Antivirus Policy for Linux with Id {$Id}"
-
-            if (-not [System.String]::IsNullOrEmpty($DisplayName))
+            Write-Verbose -Message 'PolicyID was specified'
+            try
             {
-                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
-                    -All `
-                    -Filter "Name eq '$DisplayName'" `
-                    -ErrorAction SilentlyContinue
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction Stop
+            }
+            catch
+            {
+                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Antivirus Policy for Linux named $DisplayName exist in tenant"
+                }
             }
         }
-        #endregion
-        if ($null -eq $getValue)
+        else
         {
-            Write-Verbose -Message "Could not find an Intune Antivirus Policy for Linux with Name {$DisplayName}."
-            return $nullResult
+            Write-Verbose -Message 'Id was NOT specified'
+            ## Can retreive multiple Intune Policies since displayname is not unique
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+            if ($getValue.Length -gt 1)
+            {
+                throw "Duplicate Intune Antivirus Policy for Linux named $DisplayName exist in tenant"
+            }
         }
+
+        if ([String]::IsNullOrEmpty($getValue.id))
+        {
+            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            $currentValues = $PSBoundParameters
+            $currentValues.Ensure = 'Absent'
+            return $currentValues
+        }
+
         $Id = $getValue.Id
         Write-Verbose -Message "An Intune Antivirus Policy for Linux with Id {$Id} and Name {$DisplayName} was found"
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyLinux/MSFT_IntuneAntivirusPolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyLinux/MSFT_IntuneAntivirusPolicyLinux.psm1
@@ -220,7 +220,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($getValue.id))
+        if ([String]::IsNullOrEmpty($getValue.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyLinux/MSFT_IntuneAntivirusPolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyLinux/MSFT_IntuneAntivirusPolicyLinux.psm1
@@ -201,7 +201,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                Write-Verbose -Message "No Intune Antivirus Policy for Linux with Id {$Id} was found"
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
                 if ($getValue.Length -gt 1)
                 {
@@ -222,7 +222,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($getValue.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Intune Antivirus Policy for Linux with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyMacOS/MSFT_IntuneAntivirusPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyMacOS/MSFT_IntuneAntivirusPolicyMacOS.psm1
@@ -223,7 +223,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($getValue.id))
+        if ([String]::IsNullOrEmpty($getValue.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyMacOS/MSFT_IntuneAntivirusPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyMacOS/MSFT_IntuneAntivirusPolicyMacOS.psm1
@@ -195,31 +195,42 @@ function Get-TargetResource
         Add-M365DSCTelemetryEvent -Data $data
         #endregion
 
-        $nullResult = $PSBoundParameters
-        $nullResult.Ensure = 'Absent'
-
-        $getValue = $null
-        #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
-
-        if ($null -eq $getValue)
+        if ($PSBoundParameters.ContainsKey('Id'))
         {
-            Write-Verbose -Message "Could not find an Intune Antivirus Policy for macOS with Id {$Id}"
-
-            if (-not [System.String]::IsNullOrEmpty($DisplayName))
+            Write-Verbose -Message 'PolicyID was specified'
+            try
             {
-                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
-                    -Filter "Name eq '$DisplayName'" `
-                    -All `
-                    -ErrorAction SilentlyContinue
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction Stop
+            }
+            catch
+            {
+                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Antivirus Policy for macOS named $DisplayName exist in tenant"
+                }
             }
         }
-        #endregion
-        if ($null -eq $getValue)
+        else
         {
-            Write-Verbose -Message "Could not find an Intune Antivirus Policy for macOS with Name {$DisplayName}."
-            return $nullResult
+            Write-Verbose -Message 'Id was NOT specified'
+            ## Can retreive multiple Intune Policies since displayname is not unique
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+            if ($getValue.Length -gt 1)
+            {
+                throw "Duplicate Intune Antivirus Policy for macOS named $DisplayName exist in tenant"
+            }
         }
+
+        if ([String]::IsNullOrEmpty($getValue.id))
+        {
+            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            $currentValues = $PSBoundParameters
+            $currentValues.Ensure = 'Absent'
+            return $currentValues
+        }
+
         $Id = $getValue.Id
         Write-Verbose -Message "An Intune Antivirus Policy for macOS with Id {$Id} and Name {$DisplayName} was found"
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyMacOS/MSFT_IntuneAntivirusPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyMacOS/MSFT_IntuneAntivirusPolicyMacOS.psm1
@@ -204,7 +204,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                Write-Verbose -Message "No Intune Antivirus Policy for macOS with Id {$Id} was found"
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
                 if ($getValue.Length -gt 1)
                 {
@@ -225,7 +225,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($getValue.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Intune Antivirus Policy for macOS with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
@@ -450,7 +450,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Identity}"
+                Write-Verbose -Message "No Intune Antivirus Policy for Windows10 Setting Catalog with Id {$Identity} was found"
                 $policy = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'" | Where-Object -FilterScript {$_.TemplateReference.TemplateId -in $templateReferences}
                 if ($policy.Length -gt 1)
                 {
@@ -471,7 +471,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($policy.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Intune Antivirus Policy for Windows10 Setting Catalog with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10.psm1
@@ -174,7 +174,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                Write-Verbose -Message "No Intune App And Browser Isolation Policy for Windows10 with Id {$Id} was found"
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
                 if ($getValue.Length -gt 1)
                 {
@@ -195,7 +195,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($getValue.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Intune App And Browser Isolation Policy for Windows10 with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10.psm1
@@ -193,7 +193,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($getValue.id))
+        if ([String]::IsNullOrEmpty($getValue.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
@@ -279,7 +279,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($getValue.id))
+        if ([String]::IsNullOrEmpty($getValue.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
@@ -260,7 +260,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                Write-Verbose -Message "No Intune Device Control Policy for Windows10 with Id {$Id} was found"
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
                 if ($getValue.Length -gt 1)
                 {
@@ -281,7 +281,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($getValue.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Intune Device Control Policy for Windows10 with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
@@ -251,31 +251,42 @@ function Get-TargetResource
         Add-M365DSCTelemetryEvent -Data $data
         #endregion
 
-        $nullResult = $PSBoundParameters
-        $nullResult.Ensure = 'Absent'
-
-        $getValue = $null
-        #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
-
-        if ($null -eq $getValue)
+        if ($PSBoundParameters.ContainsKey('Id'))
         {
-            Write-Verbose -Message "Could not find an Intune Device Control Policy for Windows10 with Id {$Id}"
-
-            if (-not [System.String]::IsNullOrEmpty($DisplayName))
+            Write-Verbose -Message 'PolicyID was specified'
+            try
             {
-                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
-                    -All `
-                    -Filter "Name eq '$DisplayName'" `
-                    -ErrorAction SilentlyContinue
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction Stop
+            }
+            catch
+            {
+                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Device Control Policy for Windows10 named $DisplayName exist in tenant"
+                }
             }
         }
-        #endregion
-        if ($null -eq $getValue)
+        else
         {
-            Write-Verbose -Message "Could not find an Intune Device Control Policy for Windows10 with Name {$DisplayName}."
-            return $nullResult
+            Write-Verbose -Message 'Id was NOT specified'
+            ## Can retreive multiple Intune Policies since displayname is not unique
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+            if ($getValue.Length -gt 1)
+            {
+                throw "Duplicate Intune Device Control Policy for Windows10 named $DisplayName exist in tenant"
+            }
         }
+
+        if ([String]::IsNullOrEmpty($getValue.id))
+        {
+            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            $currentValues = $PSBoundParameters
+            $currentValues.Ensure = 'Absent'
+            return $currentValues
+        }
+
         $Id = $getValue.Id
         Write-Verbose -Message "An Intune Device Control Policy for Windows10 with Id {$Id} and Name {$DisplayName} was found"
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/MSFT_IntuneDiskEncryptionMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/MSFT_IntuneDiskEncryptionMacOS.psm1
@@ -140,7 +140,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($getValue.id))
+        if ([String]::IsNullOrEmpty($getValue.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/MSFT_IntuneDiskEncryptionMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/MSFT_IntuneDiskEncryptionMacOS.psm1
@@ -121,7 +121,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                Write-Verbose -Message "No Intune Disk Encryption for macOS with Id {$Id} was found"
                 $getValue = Get-MgBetaDeviceManagementIntent -All -Filter "DisplayName eq '$DisplayName'" | Where-Object -FilterScript {$_.TemplateId -eq 'a239407c-698d-4ef8-b314-e3ae409204b8'}
                 if ($getValue.Length -gt 1)
                 {
@@ -142,7 +142,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($getValue.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Intune Disk Encryption for macOS with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionWindows10/MSFT_IntuneDiskEncryptionWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionWindows10/MSFT_IntuneDiskEncryptionWindows10.psm1
@@ -382,7 +382,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($getValue.id))
+        if ([String]::IsNullOrEmpty($getValue.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionWindows10/MSFT_IntuneDiskEncryptionWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionWindows10/MSFT_IntuneDiskEncryptionWindows10.psm1
@@ -352,32 +352,44 @@ function Get-TargetResource
         Add-M365DSCTelemetryEvent -Data $data
         #endregion
 
-        $nullResult = $PSBoundParameters
-        $nullResult.Ensure = 'Absent'
-
         $templateReferenceId = '46ddfc50-d10f-4867-b852-9434254b3bff_1'
-        $getValue = $null
-        #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
 
-        if ($null -eq $getValue)
+        if ($PSBoundParameters.ContainsKey('Id'))
         {
-            Write-Verbose -Message "Could not find an Intune Disk Encryption for Windows10 with Id {$Id}"
-
-            if (-not [System.String]::IsNullOrEmpty($DisplayName))
+            Write-Verbose -Message 'PolicyID was specified'
+            try
             {
-                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
-                    -All `
-                    -Filter "Name eq '$DisplayName' and templateReference/TemplateId eq '$templateReferenceId'" `
-                    -ErrorAction SilentlyContinue
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction Stop
+            }
+            catch
+            {
+                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName' and templateReference/TemplateId eq '$templateReferenceId'"
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Disk Encryption for Windows10 named $DisplayName exist in tenant"
+                }
             }
         }
-        #endregion
-        if ($null -eq $getValue)
+        else
         {
-            Write-Verbose -Message "Could not find an Intune Disk Encryption for Windows10 with Name {$DisplayName}."
-            return $nullResult
+            Write-Verbose -Message 'Id was NOT specified'
+            ## Can retreive multiple Intune Policies since displayname is not unique
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName' and templateReference/TemplateId eq '$templateReferenceId'"
+            if ($getValue.Length -gt 1)
+            {
+                throw "Duplicate Intune Disk Encryption for Windows10 named $DisplayName exist in tenant"
+            }
         }
+
+        if ([String]::IsNullOrEmpty($getValue.id))
+        {
+            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            $currentValues = $PSBoundParameters
+            $currentValues.Ensure = 'Absent'
+            return $currentValues
+        }
+
         $Id = $getValue.Id
         Write-Verbose -Message "An Intune Disk Encryption for Windows10 with Id {$Id} and Name {$DisplayName} was found"
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionWindows10/MSFT_IntuneDiskEncryptionWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionWindows10/MSFT_IntuneDiskEncryptionWindows10.psm1
@@ -363,7 +363,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                Write-Verbose -Message "No Intune Disk Encryption for Windows10 with Id {$Id} was found"
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName' and templateReference/TemplateId eq '$templateReferenceId'"
                 if ($getValue.Length -gt 1)
                 {
@@ -384,7 +384,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($getValue.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Intune Disk Encryption for Windows10 with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
@@ -95,7 +95,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                Write-Verbose -Message "No Intune Endpoint Detection And Response Policy Linux with Id {$Id} was found"
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
                 if ($getValue.Length -gt 1)
                 {
@@ -116,7 +116,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($getValue.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Intune Endpoint Detection And Response Policy Linux with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
@@ -114,7 +114,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($getValue.id))
+        if ([String]::IsNullOrEmpty($getValue.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
@@ -86,31 +86,42 @@ function Get-TargetResource
         Add-M365DSCTelemetryEvent -Data $data
         #endregion
 
-        $nullResult = $PSBoundParameters
-        $nullResult.Ensure = 'Absent'
-
-        $getValue = $null
-        #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
-
-        if ($null -eq $getValue)
+        if ($PSBoundParameters.ContainsKey('Id'))
         {
-            Write-Verbose -Message "Could not find an Intune Endpoint Detection And Response Policy Linux with Id {$Id}"
-
-            if (-not [System.String]::IsNullOrEmpty($DisplayName))
+            Write-Verbose -Message 'PolicyID was specified'
+            try
             {
-                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
-                    -All `
-                    -Filter "Name eq '$DisplayName'" `
-                    -ErrorAction SilentlyContinue
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction Stop
+            }
+            catch
+            {
+                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Endpoint Detection And Response Policy Linux named $DisplayName exist in tenant"
+                }
             }
         }
-        #endregion
-        if ($null -eq $getValue)
+        else
         {
-            Write-Verbose -Message "Could not find an Intune Endpoint Detection And Response Policy Linux with Name {$DisplayName}."
-            return $nullResult
+            Write-Verbose -Message 'Id was NOT specified'
+            ## Can retreive multiple Intune Policies since displayname is not unique
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+            if ($getValue.Length -gt 1)
+            {
+                throw "Duplicate Intune Endpoint Detection And Response Policy Linux named $DisplayName exist in tenant"
+            }
         }
+
+        if ([String]::IsNullOrEmpty($getValue.id))
+        {
+            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            $currentValues = $PSBoundParameters
+            $currentValues.Ensure = 'Absent'
+            return $currentValues
+        }
+
         $Id = $getValue.Id
         Write-Verbose -Message "An Intune Endpoint Detection And Response Policy Linux with Id {$Id} and Name {$DisplayName} was found"
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
@@ -95,7 +95,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                Write-Verbose -Message "No Intune Endpoint Detection And Response Policy MacOS with Id {$Id} was found"
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
                 if ($getValue.Length -gt 1)
                 {
@@ -116,7 +116,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($getValue.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Intune Endpoint Detection And Response Policy MacOS with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
@@ -86,31 +86,42 @@ function Get-TargetResource
         Add-M365DSCTelemetryEvent -Data $data
         #endregion
 
-        $nullResult = $PSBoundParameters
-        $nullResult.Ensure = 'Absent'
-
-        $getValue = $null
-        #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
-
-        if ($null -eq $getValue)
+        if ($PSBoundParameters.ContainsKey('Id'))
         {
-            Write-Verbose -Message "Could not find an Intune Endpoint Detection And Response Policy MacOS with Id {$Id}"
-
-            if (-not [System.String]::IsNullOrEmpty($DisplayName))
+            Write-Verbose -Message 'PolicyID was specified'
+            try
             {
-                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
-                    -All `
-                    -Filter "Name eq '$DisplayName'" `
-                    -ErrorAction SilentlyContinue
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction Stop
+            }
+            catch
+            {
+                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Endpoint Detection And Response Policy MacOS named $DisplayName exist in tenant"
+                }
             }
         }
-        #endregion
-        if ($null -eq $getValue)
+        else
         {
-            Write-Verbose -Message "Could not find an Intune Endpoint Detection And Response Policy MacOS with Name {$DisplayName}."
-            return $nullResult
+            Write-Verbose -Message 'Id was NOT specified'
+            ## Can retreive multiple CA Policies since displayname is not unique
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+            if ($getValue.Length -gt 1)
+            {
+                throw "Duplicate Intune Endpoint Detection And Response Policy MacOS named $DisplayName exist in tenant"
+            }
         }
+
+        if ([String]::IsNullOrEmpty($getValue.id))
+        {
+            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            $currentValues = $PSBoundParameters
+            $currentValues.Ensure = 'Absent'
+            return $currentValues
+        }
+
         $Id = $getValue.Id
         Write-Verbose -Message "An Intune Endpoint Detection And Response Policy MacOS with Id {$Id} and Name {$DisplayName} was found"
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
@@ -114,7 +114,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($getValue.id))
+        if ([String]::IsNullOrEmpty($getValue.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
@@ -102,7 +102,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Identity}"
+                Write-Verbose -Message "No Intune Endpoint Detection And Response Policy for Windows10 with Id {$Identity} was found"
                 $policy = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
                 if ($policy.Length -gt 1)
                 {
@@ -123,7 +123,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($policy.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Intune Endpoint Detection And Response Policy for Windows10 with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
@@ -121,7 +121,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($policy.id))
+        if ([String]::IsNullOrEmpty($policy.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
@@ -490,7 +490,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($getValue.id))
+        if ([String]::IsNullOrEmpty($getValue.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
@@ -471,7 +471,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                Write-Verbose -Message "No Intune Firewall Policy for Windows10 with Id {$Id} was found"
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
                 if ($getValue.Length -gt 1)
                 {
@@ -492,7 +492,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($getValue.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Intune Firewall Policy for Windows10 with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
@@ -462,31 +462,42 @@ function Get-TargetResource
         Add-M365DSCTelemetryEvent -Data $data
         #endregion
 
-        $nullResult = $PSBoundParameters
-        $nullResult.Ensure = 'Absent'
-
-        $getValue = $null
-        #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
-
-        if ($null -eq $getValue)
+        if ($PSBoundParameters.ContainsKey('Id'))
         {
-            Write-Verbose -Message "Could not find an Intune Firewall Policy for Windows10 with Id {$Id}"
-
-            if (-not [System.String]::IsNullOrEmpty($DisplayName))
+            Write-Verbose -Message 'PolicyID was specified'
+            try
             {
-                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
-                    -All `
-                    -Filter "Name eq '$DisplayName'" `
-                    -ErrorAction SilentlyContinue
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction Stop
+            }
+            catch
+            {
+                Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
+                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Firewall Policy for Windows10 named $DisplayName exist in tenant"
+                }
             }
         }
-        #endregion
-        if ($null -eq $getValue)
+        else
         {
-            Write-Verbose -Message "Could not find an Intune Firewall Policy for Windows10 with Name {$DisplayName}."
-            return $nullResult
+            Write-Verbose -Message 'Id was NOT specified'
+            ## Can retreive multiple Intune Policies since displayname is not unique
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName'"
+            if ($getValue.Length -gt 1)
+            {
+                throw "Duplicate Intune Firewall Policy for Windows10 named $DisplayName exist in tenant"
+            }
         }
+
+        if ([String]::IsNullOrEmpty($getValue.id))
+        {
+            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            $currentValues = $PSBoundParameters
+            $currentValues.Ensure = 'Absent'
+            return $currentValues
+        }
+
         $Id = $getValue.Id
         Write-Verbose -Message "An Intune Firewall Policy for Windows10 with Id {$Id} and Name {$DisplayName} was found"
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10.psm1
@@ -269,7 +269,7 @@ function Get-TargetResource
             }
             catch
             {
-                Write-Verbose -Message "Couldn't find existing policy by ID {$Identity}"
+                Write-Verbose -Message "No Endpoint Protection Attack Surface Reduction Rules Policy with Id {$Identity} was found"
                 $policy = Get-MgBetaDeviceManagementConfigurationPolicy -All -Filter "Name eq '$DisplayName' and templateReference/TemplateId eq '$templateReferenceId'"
                 if ($policy.Length -gt 1)
                 {
@@ -290,7 +290,7 @@ function Get-TargetResource
 
         if ([String]::IsNullOrEmpty($policy.Id))
         {
-            Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
+            Write-Verbose -Message "No Endpoint Protection Attack Surface Reduction Rules Policy with Name {$DisplayName} were found"
             $currentValues = $PSBoundParameters
             $currentValues.Ensure = 'Absent'
             return $currentValues

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10.psm1
@@ -288,7 +288,7 @@ function Get-TargetResource
             }
         }
 
-        if ([String]::IsNullOrEmpty($policy.id))
+        if ([String]::IsNullOrEmpty($policy.Id))
         {
             Write-Verbose -Message "No existing Policy with name {$DisplayName} were found"
             $currentValues = $PSBoundParameters


### PR DESCRIPTION
#### Pull Request (PR) description
- Fix duplicate policy creation bug, when existing policy was found in tenant, still a new policy was created.
- Fix dynamic group compliance, when dynamic group was found, returned incompliant due to empty parameters Members & GroupAsMembers. Edited so that those params are only added to the comparison when it is a static group.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
