### PR TITLE
PRIORITY / URGENT - Migrate MSCloudLoginAssistant authentication context access to cmdlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
 # 1.24.1211.1
 
 * AADApplication
@@ -16,6 +18,8 @@
   * Improve settings catalog handling for nested objects.
 * M365DSCResourceGenerator
   * Fixes an issue with nested object creation.
+* MISC
+  * Migrate `MSCloudLoginAssistant` authentication context access to cmdlets.
 * DEPENDENCIES
   * Updated MSCloudLoginAssistant to version 1.1.29.
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdminConsentRequestPolicy/MSFT_AADAdminConsentRequestPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdminConsentRequestPolicy/MSFT_AADAdminConsentRequestPolicy.psm1
@@ -272,7 +272,7 @@ function Set-TargetResource
 
     $updateJSON = ConvertTo-Json $updateParameters
     Write-Verbose -Message "Updating the Entra Id Admin Consent Request Policy with values: $updateJSON"
-    $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/policies/adminConsentRequestPolicy'
+    $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/policies/adminConsentRequestPolicy'
     Invoke-MgGraphRequest -Method 'PUT' `
         -Uri $Uri `
         -Body $updateJSON | Out-Null

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
@@ -188,7 +188,7 @@ function Get-TargetResource
                 foreach ($auMember in $auMembers)
                 {
                     $member = @{}
-                    $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directoryobjects/$($auMember.Id)"
+                    $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/directoryobjects/$($auMember.Id)"
                     $memberObject = Invoke-MgGraphRequest -Uri $url
                     if ($memberObject.'@odata.type' -match 'user')
                     {
@@ -233,7 +233,7 @@ function Get-TargetResource
                     }
                 }
                 Write-Verbose -Message "AU {$DisplayName} verify RoleMemberInfo.Id {$($auScopedRoleMember.RoleMemberInfo.Id)}"
-                $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directoryobjects/$($auScopedRoleMember.RoleMemberInfo.Id)"
+                $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/directoryobjects/$($auScopedRoleMember.RoleMemberInfo.Id)"
                 $memberObject = Invoke-MgGraphRequest -Uri $url
                 Write-Verbose -Message "AU {$DisplayName} @odata.Type={$($memberObject.'@odata.type')}"
                 if (($memberObject.'@odata.type') -match 'user')
@@ -563,7 +563,7 @@ function Set-TargetResource
             foreach ($member in $memberSpecification)
             {
                 Write-Verbose -Message "Adding new dynamic member {$($member.Id)}"
-                $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/$($member.Type)/$($member.Id)"
+                $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/$($member.Type)/$($member.Id)"
                 $memberBodyParam = @{
                     '@odata.id' = $url
                 }
@@ -657,7 +657,7 @@ function Set-TargetResource
                     {
                         Write-Verbose -Message "AdministrativeUnit {$DisplayName} Adding member {$($diff.Identity)}, type {$($diff.Type)}"
 
-                        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/$memberType/$($memberObject.Id)"
+                        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/$memberType/$($memberObject.Id)"
                         $memberBodyParam = @{
                             '@odata.id' = $url
                         }
@@ -789,7 +789,7 @@ function Set-TargetResource
         Write-Verbose -Message "Removing AU {$DisplayName}"
         # Workaround since Remove-MgBetaDirectoryAdministrativeUnit is not working with 2.11.1
         # https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/2529
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/administrativeUnits/$($currentInstance.Id)"
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/administrativeUnits/$($currentInstance.Id)"
         Invoke-MgGraphRequest -Method DELETE -Uri $url | Out-Null
         #Remove-MgBetaDirectoryAdministrativeUnit -AdministrativeUnitId $currentInstance.Id
     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -391,7 +391,7 @@ function Get-TargetResource
 
             try
             {
-                $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/applications/$($AADBetaApp.Id)/onPremisesPublishing"
+                $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/applications/$($AADBetaApp.Id)/onPremisesPublishing"
                 $oppInfo = Invoke-MgGraphRequest -Method GET `
                     -Uri $Uri `
                     -ErrorAction SilentlyContinue
@@ -931,7 +931,7 @@ function Set-TargetResource
                 {
                     $Type = 'directoryObjects'
                 }
-                $ObjectUri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'v1.0/{0}/{1}' -f $Type, $diff.InputObject
+                $ObjectUri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'v1.0/{0}/{1}' -f $Type, $diff.InputObject
                 $ownerObject = @{
                     '@odata.id' = $ObjectUri
                 }
@@ -1152,7 +1152,7 @@ function Set-TargetResource
         $onPremisesPayload = ConvertTo-Json $onPremisesPublishingValue -Depth 10 -Compress
         Write-Verbose -Message "Updating the OnPremisesPublishing settings for application {$($currentAADApp.DisplayName)} with payload: $onPremisesPayload"
 
-        $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/applications/$($currentAADApp.Id)/onPremisesPublishing"
+        $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/applications/$($currentAADApp.Id)/onPremisesPublishing"
         Invoke-MgGraphRequest -Method 'PATCH' `
             -Uri $Uri `
             -Body $onPremisesPayload

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyExternal/MSFT_AADAuthenticationMethodPolicyExternal.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyExternal/MSFT_AADAuthenticationMethodPolicyExternal.psm1
@@ -96,7 +96,7 @@ function Get-TargetResource
             }
             else
             {
-                $response = Invoke-MgGraphRequest -Method Get -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/policies/authenticationMethodsPolicy/')
+                $response = Invoke-MgGraphRequest -Method Get -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/policies/authenticationMethodsPolicy/')
                 $getValue = $response.authenticationMethodConfigurations | Where-Object -FilterScript { $_.DisplayName -eq $DisplayName }
             }
         }
@@ -334,7 +334,7 @@ function Set-TargetResource
     {
         Write-Verbose -Message "Updating the Azure AD Authentication Method Policy External with name {$($currentInstance.displayName)}"
 
-        $response = Invoke-MgGraphRequest -Method Get -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/policies/authenticationMethodsPolicy/')
+        $response = Invoke-MgGraphRequest -Method Get -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/policies/authenticationMethodsPolicy/')
         $getValue = $response.authenticationMethodConfigurations | Where-Object -FilterScript { $_.displayName -eq $currentInstance.displayName }
 
         $params.Remove('displayName') | Out-Null
@@ -347,7 +347,7 @@ function Set-TargetResource
     {
         Write-Verbose -Message "Removing the Azure AD Authentication Method Policy External with Id {$($currentInstance.displayName)}"
 
-        $response = Invoke-MgGraphRequest -Method Get -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/policies/authenticationMethodsPolicy/')
+        $response = Invoke-MgGraphRequest -Method Get -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/policies/authenticationMethodsPolicy/')
         $getValue = $response.authenticationMethodConfigurations | Where-Object -FilterScript { $_.displayName -eq $currentInstance.displayName }
 
         Remove-MgBetaPolicyAuthenticationMethodPolicyAuthenticationMethodConfiguration -AuthenticationMethodConfigurationId $getValue.Id
@@ -539,7 +539,7 @@ function Export-TargetResource
     {
         #region resource generator code
         $desiredType = '#microsoft.graph.externalAuthenticationMethodConfiguration'
-        $getPolicy = Invoke-MgGraphRequest -Method Get -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/policies/authenticationMethodsPolicy/')
+        $getPolicy = Invoke-MgGraphRequest -Method Get -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/policies/authenticationMethodsPolicy/')
         $getValue = $getPolicy.AuthenticationMethodConfigurations | Where-Object -FilterScript { $_.'@odata.type' -eq $desiredType }
         #endregion
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationRequirement/MSFT_AADAuthenticationRequirement.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationRequirement/MSFT_AADAuthenticationRequirement.psm1
@@ -62,7 +62,7 @@ function Get-TargetResource
         $nullResult = $PSBoundParameters
 
         $getValue = $null
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/users/$UserPrincipalName/authentication/requirements"
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/users/$UserPrincipalName/authentication/requirements"
         $getValue = Invoke-MgGraphRequest -Method Get -Uri $url
 
         if ($null -eq $getValue)
@@ -155,7 +155,7 @@ function Set-TargetResource
     #endregion
 
     $currentInstance = Get-TargetResource @PSBoundParameters
-    $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/users/$UserPrincipalName/authentication/requirements"
+    $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/users/$UserPrincipalName/authentication/requirements"
 
     $params = @{}
     if ($PerUserMfaState -eq 'enabled' -and $currentInstance.PerUserMfaState -eq 'disabled')

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -1457,7 +1457,7 @@ function Set-TargetResource
         if ($currentParameters.ContainsKey('ServicePrincipalFilterMode') -and $currentParameters.ContainsKey('ServicePrincipalFilterRule'))
         {
             #check if the custom attribute exist.
-            $customattribute = Invoke-MgGraphRequest -Method GET -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'v1.0/directory/customSecurityAttributeDefinitions')
+            $customattribute = Invoke-MgGraphRequest -Method GET -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'v1.0/directory/customSecurityAttributeDefinitions')
             $ServicePrincipalFilterRule -match 'CustomSecurityAttribute.(?<attribute>.*) -.*'
             $attrinrule = $matches.attribute
             if ($customattribute.value.id -contains $attrinrule)
@@ -1817,7 +1817,7 @@ function Set-TargetResource
         {
             Write-Verbose -Message "Updating existing policy with values: $(Convert-M365DscHashtableToString -Hashtable $NewParameters)"
 
-            $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/identity/conditionalAccess/policies/$($currentPolicy.Id)"
+            $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/identity/conditionalAccess/policies/$($currentPolicy.Id)"
             Invoke-MgGraphRequest -Method PATCH -Uri $Uri -Body $NewParameters
         }
         catch
@@ -1841,7 +1841,7 @@ function Set-TargetResource
         {
             try
             {
-                $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/identity/conditionalAccess/policies'
+                $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/identity/conditionalAccess/policies'
                 Invoke-MgGraphRequest -Method POST -Uri $Uri -Body $NewParameters
             }
             catch

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADDeviceRegistrationPolicy/MSFT_AADDeviceRegistrationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADDeviceRegistrationPolicy/MSFT_AADDeviceRegistrationPolicy.psm1
@@ -428,7 +428,7 @@ function Set-TargetResource
             }
         }
     }
-    $uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/policies/deviceRegistrationPolicy'
+    $uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/policies/deviceRegistrationPolicy'
     Write-Verbose -Message "Updating Device Registration Policy with payload:`r`n$(ConvertTo-Json $updateParameters -Depth 10)"
     Invoke-MgGraphRequest -Method PUT -Uri $uri -Body $updateParameters
 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEnrichedAuditLogs/MSFT_AADEnrichedAuditLogs.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEnrichedAuditLogs/MSFT_AADEnrichedAuditLogs.psm1
@@ -176,7 +176,7 @@ function Set-TargetResource
         }
     }
     $body = ConvertTo-Json $values -Depth 10 -Compress
-    Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/networkAccess/settings/enrichedAuditLogs') -Method PATCH -Body $body
+    Invoke-MgGraphRequest -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/networkAccess/settings/enrichedAuditLogs') -Method PATCH -Body $body
 }
 
 function Test-TargetResource

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackage/MSFT_AADEntitlementManagementAccessPackage.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackage/MSFT_AADEntitlementManagementAccessPackage.psm1
@@ -355,7 +355,7 @@ function Set-TargetResource
         foreach ($incompatibleAccessPackage in $IncompatibleAccessPackages)
         {
             $ref = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/identityGovernance/entitlementManagement/accessPackages/$incompatibleAccessPackage"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/identityGovernance/entitlementManagement/accessPackages/$incompatibleAccessPackage"
             }
 
             New-MgBetaEntitlementManagementAccessPackageIncompatibleAccessPackageByRef `
@@ -368,7 +368,7 @@ function Set-TargetResource
         foreach ($IncompatibleGroup in $IncompatibleGroups)
         {
             $ref = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/groups/$IncompatibleGroup"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/groups/$IncompatibleGroup"
             }
 
             New-MgBetaEntitlementManagementAccessPackageIncompatibleGroupByRef `
@@ -485,7 +485,7 @@ function Set-TargetResource
         foreach ($incompatibleAccessPackage in $toBeAdded.InputObject)
         {
             $ref = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/identityGovernance/entitlementManagement/accessPackages/$incompatibleAccessPackage"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/identityGovernance/entitlementManagement/accessPackages/$incompatibleAccessPackage"
             }
 
             New-MgBetaEntitlementManagementAccessPackageIncompatibleAccessPackageByRef `
@@ -522,7 +522,7 @@ function Set-TargetResource
         {
 
             $ref = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/groups/$incompatibleGroup"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/groups/$incompatibleGroup"
             }
 
             New-MgBetaEntitlementManagementAccessPackageIncompatibleGroupByRef `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementConnectedOrganization/MSFT_AADEntitlementManagementConnectedOrganization.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementConnectedOrganization/MSFT_AADEntitlementManagementConnectedOrganization.psm1
@@ -436,7 +436,7 @@ function Set-TargetResource
         }
         Write-Verbose -Message "Create Parameters: $(Convert-M365DscHashtableToString -Hashtable $CreateParameters)"
         $TenantIdValue = $CreateParameters.IdentitySources.TenantId
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/tenantRelationships/microsoft.graph.findTenantInformationByTenantId(tenantId='$TenantIdValue')"
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/tenantRelationships/microsoft.graph.findTenantInformationByTenantId(tenantId='$TenantIdValue')"
         $DomainName = (Invoke-MgGraphRequest -Method 'GET' -Uri $url).defaultDomainName
         $newConnectedOrganization = New-MgBetaEntitlementManagementConnectedOrganization -Description $CreateParameters.Description -DisplayName $CreateParameters.DisplayName -State $CreateParameters.State -DomainName $DomainName
 
@@ -446,7 +446,7 @@ function Set-TargetResource
             $directoryObjectType = $directoryObject.AdditionalProperties.'@odata.type'
             $directoryObjectType = ($directoryObject.AdditionalProperties.'@odata.type').split('.') | Select-Object -Last 1
             $directoryObjectRef = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/$($directoryObjectType)s/$($sponsor)"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/$($directoryObjectType)s/$($sponsor)"
             }
 
             New-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorByRef `
@@ -459,7 +459,7 @@ function Set-TargetResource
             $directoryObject = Get-MgBetaDirectoryObject -DirectoryObjectId $sponsor
             $directoryObjectType = ($directoryObject.AdditionalProperties.'@odata.type').split('.') | Select-Object -Last 1
             $directoryObjectRef = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/$($directoryObjectType)s/$($sponsor)"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/$($directoryObjectType)s/$($sponsor)"
             }
 
             New-MgBetaEntitlementManagementConnectedOrganizationInternalSponsorByRef `
@@ -515,7 +515,7 @@ function Set-TargetResource
             $directoryObjectType = $directoryObject.AdditionalProperties.'@odata.type'
             $directoryObjectType = ($directoryObject.AdditionalProperties.'@odata.type').split('.') | Select-Object -Last 1
             $directoryObjectRef = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/$($directoryObjectType)s/$($sponsor)"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/$($directoryObjectType)s/$($sponsor)"
             }
 
             New-MgBetaEntitlementManagementConnectedOrganizationExternalSponsorByRef `
@@ -553,7 +553,7 @@ function Set-TargetResource
             $directoryObjectType = $directoryObject.AdditionalProperties.'@odata.type'
             $directoryObjectType = ($directoryObject.AdditionalProperties.'@odata.type').split('.') | Select-Object -Last 1
             $directoryObjectRef = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/$($directoryObjectType)s/$($sponsor)"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/$($directoryObjectType)s/$($sponsor)"
             }
 
             New-MgBetaEntitlementManagementConnectedOrganizationInternalSponsorByRef `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADFederationConfiguration/MSFT_AADFederationConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADFederationConfiguration/MSFT_AADFederationConfiguration.psm1
@@ -102,7 +102,7 @@ function Get-TargetResource
         }
         else
         {
-            $uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/directory/federationConfigurations/microsoft.graph.samlOrWsFedExternalDomainFederation'
+            $uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/directory/federationConfigurations/microsoft.graph.samlOrWsFedExternalDomainFederation'
             $instances = Invoke-MgGraphRequest $uri -Method Get
             if (-not [System.String]::IsNullOrEmpty($Id))
             {
@@ -256,7 +256,7 @@ function Set-TargetResource
     # CREATE
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {
-        $uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/directory/federationConfigurations/microsoft.graph.samlOrWsFedExternalDomainFederation'
+        $uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/directory/federationConfigurations/microsoft.graph.samlOrWsFedExternalDomainFederation'
         Write-Verbose -Message "Creating federation configuration {$DisplayName}"
         $body = ConvertTo-Json $instanceParams -Depth 10 -Compress
         Invoke-MgGraphRequest -Uri $uri -Method POST -Body $body
@@ -264,7 +264,7 @@ function Set-TargetResource
     # UPDATE
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
     {
-        $uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/directory/federationConfigurations/microsoft.graph.samlOrWsFedExternalDomainFederation/$currentInstance.Id'
+        $uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/directory/federationConfigurations/microsoft.graph.samlOrWsFedExternalDomainFederation/$currentInstance.Id'
         Write-Verbose -Message "Updating federation configuration {$DisplayName}"
         $body = ConvertTo-Json $instanceParams -Depth 10 -Compress
         Invoke-MgGraphRequest -Uri $uri -Method PATCH -Body $body
@@ -272,7 +272,7 @@ function Set-TargetResource
     # REMOVE
     elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
     {
-        $uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/directory/federationConfigurations/microsoft.graph.samlOrWsFedExternalDomainFederation/$currentInstance.Id'
+        $uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/directory/federationConfigurations/microsoft.graph.samlOrWsFedExternalDomainFederation/$currentInstance.Id'
         Write-Verbose -Message "Removing federation configuration {$DisplayName}"
         Invoke-MgGraphRequest -Uri $uri -Method DELETE
     }
@@ -431,7 +431,7 @@ function Export-TargetResource
     try
     {
         $Script:ExportMode = $true
-        $uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/directory/federationConfigurations/microsoft.graph.samlOrWsFedExternalDomainFederation'
+        $uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/directory/federationConfigurations/microsoft.graph.samlOrWsFedExternalDomainFederation'
         [array] $Script:exportedInstances = Invoke-MgGraphRequest $uri -Method Get
 
         $i = 1

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -266,7 +266,7 @@ function Get-TargetResource
 
             # Licenses
             $assignedLicensesValues = $null
-            $uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/groups/$($Group.Id)/assignedLicenses"
+            $uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/groups/$($Group.Id)/assignedLicenses"
             $assignedLicensesRequest = Invoke-MgGraphRequest -Method 'GET' `
                 -Uri $uri
 
@@ -689,7 +689,7 @@ function Set-TargetResource
                 {
                     Write-Verbose -Message "Adding new owner {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
                     $ownerObject = @{
-                        '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/{$($directoryObject.Id)}"
+                        '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/directoryObjects/{$($directoryObject.Id)}"
                     }
                     try
                     {
@@ -751,7 +751,7 @@ function Set-TargetResource
                 {
                     Write-Verbose -Message "Adding new member {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
                     $memberObject = @{
-                        '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/{$($directoryObject.Id)}"
+                        '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/directoryObjects/{$($directoryObject.Id)}"
                     }
                     New-MgGroupMemberByRef -GroupId ($currentGroup.Id) -BodyParameter $memberObject | Out-Null
                 }
@@ -759,7 +759,7 @@ function Set-TargetResource
                 {
                     Write-Verbose -Message "Removing new member {$($diff.InputObject)} to AAD Group {$($currentGroup.DisplayName)}"
                     $memberObject = @{
-                        '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/{$($directoryObject.Id)}"
+                        '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/directoryObjects/{$($directoryObject.Id)}"
                     }
                     Remove-MgGroupMemberDirectoryObjectByRef -GroupId ($currentGroup.Id) -DirectoryObjectId ($directoryObject.Id) | Out-Null
                 }
@@ -809,7 +809,7 @@ function Set-TargetResource
                     {
                         Write-Verbose -Message "Adding AAD group {$($groupAsMember.DisplayName)} as member of AAD group {$($currentGroup.DisplayName)}"
                         $groupAsMemberObject = @{
-                            '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/$($groupAsMember.Id)"
+                            '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/directoryObjects/$($groupAsMember.Id)"
                         }
                         New-MgBetaGroupMemberByRef -GroupId ($currentGroup.Id) -Body $groupAsMemberObject | Out-Null
                     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityB2XUserFlow/MSFT_AADIdentityB2XUserFlow.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityB2XUserFlow/MSFT_AADIdentityB2XUserFlow.psm1
@@ -269,7 +269,7 @@ function Set-TargetResource
         foreach ($provider in $IdentityProviders)
         {
             $params = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/identityProviders/$($provider)"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/identityProviders/$($provider)"
             }
 
             Write-Verbose -Message "Adding the Identity Provider with Id {$provider} to the newly created Azure AD Identity B2X User Flow with Id {$($newObj.Id)}"
@@ -318,7 +318,7 @@ function Set-TargetResource
         {
             $getConnector = Get-MgBetaIdentityApiConnector -Filter "DisplayName eq '$($ApiConnectorConfiguration.postFederationSignupConnectorName)'"
             $params = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/identity/apiConnectors/$($getConnector.Id)"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/identity/apiConnectors/$($getConnector.Id)"
             }
 
             Write-Verbose -Message "Updating the Post Federation Signup connector for Azure AD Identity B2X User Flow with Id {$($currentInstance.Id)}"
@@ -330,7 +330,7 @@ function Set-TargetResource
         {
             $getConnector = Get-MgBetaIdentityApiConnector -Filter "DisplayName eq '$($ApiConnectorConfiguration.postAttributeCollectionConnectorName)'"
             $params = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/identity/apiConnectors/$($getConnector.Id)"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/identity/apiConnectors/$($getConnector.Id)"
             }
 
             Write-Verbose -Message "Updating the Post Attribute Collection connector for Azure AD Identity B2X User Flow with Id {$($currentInstance.Id)}"
@@ -344,7 +344,7 @@ function Set-TargetResource
         foreach ($provider in $providersToAdd)
         {
             $params = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/identityProviders/$($provider)"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/identityProviders/$($provider)"
             }
 
             Write-Verbose -Message "Adding the Identity Provider with Id {$provider} to the Azure AD Identity B2X User Flow with Id {$($currentInstance.Id)}"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityProtectionPolicySettings/MSFT_AADIdentityProtectionPolicySettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityProtectionPolicySettings/MSFT_AADIdentityProtectionPolicySettings.psm1
@@ -59,7 +59,7 @@ function Get-TargetResource
     $nullResult = $PSBoundParameters
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/identityProtection/policy'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/identityProtection/policy'
         $instance = Invoke-MgGraphRequest -Method Get -Uri $url
 
         if ($null -eq $instance)
@@ -153,7 +153,7 @@ function Set-TargetResource
 
     $updateJSON = ConvertTo-Json $updateParameters
     Write-Verbose -Message "Updating the AAD Identity Protection Policy settings with values: $updateJSON"
-    $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/identityProtection/policy'
+    $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/identityProtection/policy'
 
     Invoke-MgGraphRequest -Method PATCH -Uri $url -Body $updateJSON
 }
@@ -283,7 +283,7 @@ function Export-TargetResource
     {
         $Script:ExportMode = $true
 
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/identityProtection/policy'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/identityProtection/policy'
         [array] $Script:exportedInstances = Invoke-MgGraphRequest -Method Get -Uri $url
 
         $i = 1

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
@@ -315,7 +315,7 @@ function Set-TargetResource
         Write-Verbose -Message "Creating New AAD Named Location {$Displayname)} with attributes: $VerboseAttributes"
         $JSONValue = ConvertTo-Json $desiredValues | Out-String
         Write-Verbose -Message "JSON: $JSONValue"
-        $APIUrl = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'v1.0/identity/conditionalAccess/namedLocations'
+        $APIUrl = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'v1.0/identity/conditionalAccess/namedLocations'
         Invoke-MgGraphRequest -Method POST `
             -Uri $APIUrl `
             -Body $JSONValue | Out-Null
@@ -330,7 +330,7 @@ function Set-TargetResource
         Write-Verbose -Message "Updating AAD Named Location {$Displayname)} with attributes: $VerboseAttributes"
         $JSONValue = ConvertTo-Json $desiredValues | Out-String
         Write-Verbose -Message "JSON: $JSONValue"
-        $APIUrl = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/identity/conditionalAccess/namedLocations/$($currentAADNamedLocation.Id)"
+        $APIUrl = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/identity/conditionalAccess/namedLocations/$($currentAADNamedLocation.Id)"
         Invoke-MgGraphRequest -Method PATCH `
             -Uri $APIUrl `
             -Body $JSONValue | Out-Null

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNetworkAccessForwardingPolicy/MSFT_AADNetworkAccessForwardingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNetworkAccessForwardingPolicy/MSFT_AADNetworkAccessForwardingPolicy.psm1
@@ -221,7 +221,7 @@ function Set-TargetResource
             rules = $rulesParam
         }
 
-        Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/networkAccess/forwardingPolicies/$($currentPolicy.ID)/updatePolicyRules") -Method Post -Body $updateParams
+        Invoke-MgGraphRequest -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/networkAccess/forwardingPolicies/$($currentPolicy.ID)/updatePolicyRules") -Method Post -Body $updateParams
     }
     else
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADOnPremisesPublishingProfilesSettings/MSFT_AADOnPremisesPublishingProfilesSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADOnPremisesPublishingProfilesSettings/MSFT_AADOnPremisesPublishingProfilesSettings.psm1
@@ -59,7 +59,7 @@ function Get-TargetResource
     $nullResult = $PSBoundParameters
     try
     {
-        $uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/onPremisesPublishingProfiles('applicationProxy')"
+        $uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/onPremisesPublishingProfiles('applicationProxy')"
         $instance = Invoke-MgGraphRequest -Uri $uri -Method Get
         if ($null -eq $instance)
         {
@@ -151,7 +151,7 @@ function Set-TargetResource
         isEnabled = $IsEnabled
     }
     $body = ConvertTo-Json $settings
-    $uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/onPremisesPublishingProfiles('applicationProxy')"
+    $uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/onPremisesPublishingProfiles('applicationProxy')"
     Invoke-MgGraphRequest -Uri $uri -Method PATCH -Body $Body | Out-Null
 }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADOrganizationCertificateBasedAuthConfiguration/MSFT_AADOrganizationCertificateBasedAuthConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADOrganizationCertificateBasedAuthConfiguration/MSFT_AADOrganizationCertificateBasedAuthConfiguration.psm1
@@ -201,7 +201,7 @@ function Set-TargetResource
 
     # Delete the old configuration
     Write-Verbose -Message 'Removing the current Azure AD Organization Certificate Based Auth Configuration.'
-    Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/organization/$OrganizationId/certificateBasedAuthConfiguration/$CertificateBasedAuthConfigurationId") -Method DELETE
+    Invoke-MgGraphRequest -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/organization/$OrganizationId/certificateBasedAuthConfiguration/$CertificateBasedAuthConfigurationId") -Method DELETE
 
     if ($Ensure -eq 'Present')
     {
@@ -225,7 +225,7 @@ function Set-TargetResource
             certificateAuthorities = $createCertAuthorities
         }
 
-        $policy = Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/organization/$OrganizationId/certificateBasedAuthConfiguration/") -Method POST -Body $params
+        $policy = Invoke-MgGraphRequest -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/organization/$OrganizationId/certificateBasedAuthConfiguration/") -Method POST -Body $params
     }
 }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRemoteNetwork/MSFT_AADRemoteNetwork.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRemoteNetwork/MSFT_AADRemoteNetwork.psm1
@@ -267,7 +267,7 @@ function Set-TargetResource
             '@context' = '#$delta'
             value      = @(@{})
         }
-        Invoke-MgGraphRequest -Uri "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/networkAccess/connectivity/remoteNetworks/$($currentInstance.Id)/forwardingProfiles" -Method Patch -Body $params
+        Invoke-MgGraphRequest -Uri "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/networkAccess/connectivity/remoteNetworks/$($currentInstance.Id)/forwardingProfiles" -Method Patch -Body $params
 
         #adding forwarding profiles if required
         if ($forwardingProfilesList.Count -gt 0)
@@ -276,7 +276,7 @@ function Set-TargetResource
                 '@context' = '#$delta'
                 value      = $forwardingProfilesList
             }
-            Invoke-MgGraphRequest -Uri "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/networkAccess/connectivity/remoteNetworks/$($currentInstance.Id)/forwardingProfiles" -Method Patch -Body $params
+            Invoke-MgGraphRequest -Uri "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/networkAccess/connectivity/remoteNetworks/$($currentInstance.Id)/forwardingProfiles" -Method Patch -Body $params
         }
     }
     elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
@@ -237,7 +237,7 @@ function Get-TargetResource
             }
 
             [Array]$complexDelegatedPermissionClassifications = @()
-            $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/servicePrincipals/$($AADServicePrincipal.Id)/delegatedPermissionClassifications"
+            $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/servicePrincipals/$($AADServicePrincipal.Id)/delegatedPermissionClassifications"
             $permissionClassifications = Invoke-MgGraphRequest -Uri $Uri -Method Get
             foreach ($permissionClassification in $permissionClassifications.Value)
             {
@@ -553,7 +553,7 @@ function Set-TargetResource
         {
             $userInfo = Get-MgUser -UserId $owner
             $body = @{
-                '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/$($userInfo.Id)"
+                '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/directoryObjects/$($userInfo.Id)"
             }
             Write-Verbose -Message "Adding new owner {$owner}"
             $newOwner = New-MgServicePrincipalOwnerByRef -ServicePrincipalId $newSP.Id -BodyParameter $body
@@ -568,7 +568,7 @@ function Set-TargetResource
                     classification = $permissionClassification.Classification
                     permissionName = $permissionClassification.permissionName
                 }
-                $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/servicePrincipals(appId='$($currentParameters.AppId)')/delegatedPermissionClassifications"
+                $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/servicePrincipals(appId='$($currentParameters.AppId)')/delegatedPermissionClassifications"
                 Invoke-MgGraphRequest -Uri $Uri -Method Post -Body $params
             }
         }
@@ -601,7 +601,7 @@ function Set-TargetResource
             $CSAParams = @{
                 customSecurityAttributes = $currentAADServicePrincipal.CustomSecurityAttributes
             }
-            Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/servicePrincipals(appId='$($currentParameters.AppId)')") -Method Patch -Body $CSAParams
+            Invoke-MgGraphRequest -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/servicePrincipals(appId='$($currentParameters.AppId)')") -Method Patch -Body $CSAParams
         }
 
         Update-MgServicePrincipal -ServicePrincipalId $currentAADServicePrincipal.ObjectID @currentParameters
@@ -709,7 +709,7 @@ function Set-TargetResource
             if ($diff.SideIndicator -eq '=>')
             {
                 $body = @{
-                    '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/directoryObjects/$($userInfo.Id)"
+                    '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/directoryObjects/$($userInfo.Id)"
                 }
                 Write-Verbose -Message "Adding owner {$($userInfo.Id)}"
                 New-MgServicePrincipalOwnerByRef -ServicePrincipalId $currentAADServicePrincipal.ObjectId `
@@ -728,7 +728,7 @@ function Set-TargetResource
         if ($null -ne $DelegatedPermissionClassifications)
         {
             # removing old perm classifications
-            $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "v1.0/servicePrincipals(appId='$($currentParameters.AppId)')/delegatedPermissionClassifications"
+            $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/servicePrincipals(appId='$($currentParameters.AppId)')/delegatedPermissionClassifications"
             $permissionClassificationList = Invoke-MgGraphRequest -Uri $Uri -Method Get
             foreach ($permissionClassification in $permissionClassificationList.Value)
             {
@@ -1250,7 +1250,7 @@ function Get-CustomSecurityAttributes
         [String]$ServicePrincipalId
     )
 
-    $customSecurityAttributes = Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/servicePrincipals/$($ServicePrincipalId)`?`$select=customSecurityAttributes") -Method Get
+    $customSecurityAttributes = Invoke-MgGraphRequest -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/servicePrincipals/$($ServicePrincipalId)`?`$select=customSecurityAttributes") -Method Get
     $customSecurityAttributes = $customSecurityAttributes.customSecurityAttributes
     $newCustomSecurityAttributes = @()
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADVerifiedIdAuthority/MSFT_AADVerifiedIdAuthority.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADVerifiedIdAuthority/MSFT_AADVerifiedIdAuthority.psm1
@@ -568,7 +568,7 @@ function Invoke-M365DSCVerifiedIdWebRequest
     )
 
     $headers = @{
-        Authorization  = $Global:MSCloudLoginConnectionProfile.AdminAPI.AccessToken
+        Authorization  = (Get-MSCloudLoginConnectionProfile -Workload AdminAPI).AccessToken
         'Content-Type' = 'application/json'
     }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADVerifiedIdAuthorityContract/MSFT_AADVerifiedIdAuthorityContract.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADVerifiedIdAuthorityContract/MSFT_AADVerifiedIdAuthorityContract.psm1
@@ -915,7 +915,7 @@ function Invoke-M365DSCVerifiedIdWebRequest
     )
 
     $headers = @{
-        Authorization  = $Global:MSCloudLoginConnectionProfile.AdminAPI.AccessToken
+        Authorization  = (Get-MSCloudLoginConnectionProfile -Workload AdminAPI).AccessToken
         'Content-Type' = 'application/json'
     }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AzureVerifiedIdFaceCheck/MSFT_AzureVerifiedIdFaceCheck.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AzureVerifiedIdFaceCheck/MSFT_AzureVerifiedIdFaceCheck.psm1
@@ -342,7 +342,7 @@ function Export-TargetResource
     try
     {
         $headers = @{
-            Authorization = $Global:MSCloudLoginConnectionProfile.AdminAPI.AccessToken
+            Authorization = (Get-MSCloudLoginConnectionProfile -Workload AdminAPI).AccessToken
         }
         $uri = 'https://verifiedid.did.msidentity.com/v1.0/verifiableCredentials/authorities'
         $response = Invoke-WebRequest -Uri $uri -Method Get -Headers $headers

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/MSFT_EXOManagementRoleAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/MSFT_EXOManagementRoleAssignment.psm1
@@ -382,12 +382,12 @@ function Set-TargetResource
     } while (-not $testResults -and $retries -gt 0)
 
     # Need to force reconnect to Exchange for the new permissions to kick in.
-    if ($null -ne $Global:MSCloudLoginConnectionProfile.ExchangeOnline)
+    if ($null -ne (Get-MSCloudLoginConnectionProfile -Workload ExchangeOnline))
     {
         Write-Verbose -Message 'Waiting for 20 seconds for new permissions to be effective.'
         Start-Sleep 20
         Write-Verbose -Message 'Disconnecting from Exchange Online'
-        $Global:MSCloudLoginConnectionProfile.ExchangeOnline.Disconnect()
+        Reset-MSCloudLoginConnectionProfileContext
     }
 }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_FabricAdminTenantSettings/MSFT_FabricAdminTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_FabricAdminTenantSettings/MSFT_FabricAdminTenantSettings.psm1
@@ -574,7 +574,7 @@ function Get-TargetResource
         }
         else
         {
-            $uri = $global:MsCloudLoginConnectionProfile.Fabric.HostUrl + '/v1/admin/tenantsettings'
+            $uri = (Get-MSCloudLoginConnectionProfile -Workload Fabric).HostUrl + '/v1/admin/tenantsettings'
             $instance = Invoke-M365DSCFabricWebRequest -Uri $uri -Method 'GET'
         }
         if ($null -eq $instance)
@@ -1941,7 +1941,7 @@ function Export-TargetResource
     try
     {
         $Script:ExportMode = $true
-        $uri = $global:MsCloudLoginConnectionProfile.Fabric.HostUrl + '/v1/admin/tenantsettings'
+        $uri = (Get-MSCloudLoginConnectionProfile -Workload Fabric).HostUrl + '/v1/admin/tenantsettings'
         [array] $Script:exportedInstances = Invoke-M365DSCFabricWebRequest -Uri $uri -Method 'GET'
 
         if ($null -ne $Global:M365DSCExportResourceInstancesCount)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneASRRulesPolicyWindows10/MSFT_IntuneASRRulesPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneASRRulesPolicyWindows10/MSFT_IntuneASRRulesPolicyWindows10.psm1
@@ -551,7 +551,7 @@ function Set-TargetResource
         #Update-MgBetaDeviceManagementIntent does not support updating the property settings
         #Update-MgBetaDeviceManagementIntentSetting only support updating a single setting at a time
         #Using Rest to reduce the number of calls
-        $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/intents/$($currentPolicy.Identity)/updateSettings"
+        $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/intents/$($currentPolicy.Identity)/updateSettings"
         $body = @{'settings' = $settings }
         Invoke-MgGraphRequest -Method POST -Uri $Uri -Body ($body | ConvertTo-Json -Depth 20) -ContentType 'application/json' 4> $null
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicy/MSFT_IntuneAccountProtectionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicy/MSFT_IntuneAccountProtectionPolicy.psm1
@@ -452,7 +452,7 @@ function Set-TargetResource
         #Update-MgBetaDeviceManagementIntentSetting only support updating a single setting at a time
         #Using Rest to reduce the number of calls
 
-        $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/intents/$($currentPolicy.Identity)/updateSettings"
+        $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/intents/$($currentPolicy.Identity)/updateSettings"
         $body = @{'settings' = $settings }
         Invoke-MgGraphRequest -Method POST -Uri $Uri -Body ($body | ConvertTo-Json -Depth 20) -ContentType 'application/json' 4> $null
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyiOS/MSFT_IntuneAppProtectionPolicyiOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyiOS/MSFT_IntuneAppProtectionPolicyiOS.psm1
@@ -1336,7 +1336,7 @@ function Get-IntuneAppProtectionPolicyiOSAssignment
 
     try
     {
-        $Url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceAppManagement/iosManagedAppProtections('$IosManagedAppProtectionId')/assignments"
+        $Url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceAppManagement/iosManagedAppProtections('$IosManagedAppProtectionId')/assignments"
         $response = Invoke-MgGraphRequest -Method Get `
             -Uri $Url
         return $response.value
@@ -1367,7 +1367,7 @@ function Update-IntuneAppProtectionPolicyiOSAssignment
     )
     try
     {
-        $Url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceAppManagement/iosManagedAppProtections('$IosManagedAppProtectionId')/assign"
+        $Url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceAppManagement/iosManagedAppProtections('$IosManagedAppProtectionId')/assign"
         $body = ($Assignments | ConvertTo-Json -Depth 20 -Compress)
         Write-Verbose -Message "Group Assignment for iOS App Protection policy with JSON payload {$Url}: `r`n$body"
         Invoke-MgGraphRequest -Method POST `
@@ -1401,7 +1401,7 @@ function Update-IntuneAppProtectionPolicyiOSApp
 
     try
     {
-        $Url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceAppManagement/iosManagedAppProtections('$IosManagedAppProtectionId')/targetApps"
+        $Url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceAppManagement/iosManagedAppProtections('$IosManagedAppProtectionId')/targetApps"
         # Write-Verbose -Message "Group Assignment for iOS App Protection policy with JSON payload: `r`n$JSONContent"
         Invoke-MgGraphRequest -Method POST `
             -Uri $Url `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppleMDMPushNotificationCertificate/MSFT_IntuneAppleMDMPushNotificationCertificate.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppleMDMPushNotificationCertificate/MSFT_IntuneAppleMDMPushNotificationCertificate.psm1
@@ -225,7 +225,7 @@ function Set-TargetResource
         $consentInstance = Get-MgBetaDeviceManagementDataSharingConsent -DataSharingConsentId 'appleMDMPushCertificate'
         If ($consentInstance.Granted -eq $False)
         {
-            Invoke-MgGraphRequest -Method POST -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/deviceManagement/dataSharingConsents/appleMDMPushCertificate/consentToDataSharing') -Headers @{ 'Content-Type' = 'application/json' }
+            Invoke-MgGraphRequest -Method POST -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/deviceManagement/dataSharingConsents/appleMDMPushCertificate/consentToDataSharing') -Headers @{ 'Content-Type' = 'application/json' }
         }
         else
         {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCleanupRule/MSFT_IntuneDeviceCleanupRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCleanupRule/MSFT_IntuneDeviceCleanupRule.psm1
@@ -78,7 +78,7 @@ function Get-TargetResource
 
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/deviceManagement/managedDeviceCleanupSettings'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/deviceManagement/managedDeviceCleanupSettings'
         $cleanupRule = Invoke-MgGraphRequest -Method GET -Uri $url -ErrorAction Stop
 
         $return = @{
@@ -188,7 +188,7 @@ function Set-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/deviceManagement/managedDeviceCleanupSettings'
+    $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/deviceManagement/managedDeviceCleanupSettings'
     $body = @{
         DeviceInactivityBeforeRetirementInDays = "$(if ($Enabled) { $DeviceInactivityBeforeRetirementInDays } else { 0 })"
     }
@@ -340,7 +340,7 @@ function Export-TargetResource
 
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/deviceManagement/managedDeviceCleanupSettings'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/deviceManagement/managedDeviceCleanupSettings'
         [array]$cleanupRules = Invoke-MgGraphRequest -Method GET -Uri $url -ErrorAction Stop
         $i = 1
         $dscContent = ''

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.psm1
@@ -424,7 +424,7 @@ function Set-TargetResource
                 {
                     $value = $presentationValue.clone()
                     $value = Rename-M365DSCCimInstanceParameter -Properties $value -KeyMapping $keyToRename
-                    $value.add('presentation@odata.bind', $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')/presentations('$($presentationValue.presentationDefinitionId)')")
+                    $value.add('presentation@odata.bind', (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')/presentations('$($presentationValue.presentationDefinitionId)')")
                     $value.remove('PresentationDefinitionId')
                     $value.remove('PresentationDefinitionLabel')
                     $value.remove('id')
@@ -432,7 +432,7 @@ function Set-TargetResource
                 }
             }
             $complexDefinitionValue = @{
-                'definition@odata.bind' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')"
+                'definition@odata.bind' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')"
                 enabled                 = $definitionValue.Enabled
                 presentationValues      = $complexPresentationValues
             }
@@ -520,7 +520,7 @@ function Set-TargetResource
                 {
                     $value = $presentationValue.clone()
                     $value = Rename-M365DSCCimInstanceParameter -Properties $value -KeyMapping $keyToRename
-                    $value.add('presentation@odata.bind', "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')/presentations('$($presentationValue.presentationDefinitionId)')")
+                    $value.add('presentation@odata.bind', "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')/presentations('$($presentationValue.presentationDefinitionId)')")
                     $value.remove('PresentationDefinitionId')
                     $value.remove('PresentationDefinitionLabel')
                     $value.remove('id')
@@ -528,7 +528,7 @@ function Set-TargetResource
                 }
             }
             $complexDefinitionValue = @{
-                'definition@odata.bind' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')"
+                'definition@odata.bind' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')"
                 enabled                 = $definitionValue.Enabled
                 presentationValues      = $complexPresentationValues
             }
@@ -554,7 +554,7 @@ function Set-TargetResource
                     $currentPresentationValue = $currentDefinitionValue.PresentationValues | Where-Object { $_.PresentationDefinitionId -eq $presentationValue.presentationDefinitionId }
                     $value = $presentationValue.clone()
                     $value = Rename-M365DSCCimInstanceParameter -Properties $value -KeyMapping $keyToRename
-                    $value.add('presentation@odata.bind', "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')/presentations('$($presentationValue.presentationDefinitionId)')")
+                    $value.add('presentation@odata.bind', "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')/presentations('$($presentationValue.presentationDefinitionId)')")
                     $value.remove('PresentationDefinitionId')
                     $value.remove('PresentationDefinitionLabel')
                     $value.remove('id')
@@ -564,7 +564,7 @@ function Set-TargetResource
             }
             $complexDefinitionValue = @{
                 id                      = $currentDefinitionValue.Id
-                'definition@odata.bind' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')"
+                'definition@odata.bind' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/groupPolicyDefinitions('$($definitionValue.Definition.Id)')"
                 enabled                 = $definitionValue.Enabled
                 presentationValues      = $complexPresentationValues
             }
@@ -993,7 +993,7 @@ function Update-DeviceConfigurationGroupPolicyDefinitionValue
     )
     try
     {
-        $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/groupPolicyConfigurations/$DeviceConfigurationPolicyId/updateDefinitionValues"
+        $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/groupPolicyConfigurations/$DeviceConfigurationPolicyId/updateDefinitionValues"
 
         $body = @{}
         $DefinitionValueToRemoveIds = @()

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.psm1
@@ -522,7 +522,7 @@ function Set-TargetResource
         }
 
         #region resource generator code
-        $CreateParameters.Add('rootCertificate@odata.bind', "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$RootCertificateId')")
+        $CreateParameters.Add('rootCertificate@odata.bind', "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/deviceConfigurations('$RootCertificateId')")
         $CreateParameters.Add('@odata.type', '#microsoft.graph.windows81SCEPCertificateProfile')
         $policy = New-MgBetaDeviceManagementDeviceConfiguration -BodyParameter $CreateParameters
         $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
@@ -1012,7 +1012,7 @@ function Get-DeviceConfigurationPolicyRootCertificate
         [System.String]
         $DeviceConfigurationPolicyId
     )
-    $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/deviceConfigurations('$DeviceConfigurationPolicyId')/microsoft.graph.windows81SCEPCertificateProfile/rootCertificate"
+    $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/deviceConfigurations('$DeviceConfigurationPolicyId')/microsoft.graph.windows81SCEPCertificateProfile/rootCertificate"
     $result = Invoke-MgGraphRequest -Method Get -Uri $Uri -ErrorAction Stop
 
     return $result
@@ -1032,9 +1032,9 @@ function Update-DeviceConfigurationPolicyRootCertificateId
         $RootCertificateId
     )
 
-    $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/deviceConfigurations('$DeviceConfigurationPolicyId')/microsoft.graph.windows81SCEPCertificateProfile/rootCertificate/`$ref"
+    $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/deviceConfigurations('$DeviceConfigurationPolicyId')/microsoft.graph.windows81SCEPCertificateProfile/rootCertificate/`$ref"
     $ref = @{
-        '@odata.id' = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/deviceConfigurations('$RootCertificateId')"
+        '@odata.id' = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/deviceConfigurations('$RootCertificateId')"
     }
 
     Invoke-MgGraphRequest -Method PUT -Uri $Uri -Body ($ref | ConvertTo-Json) -ErrorAction Stop

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10.psm1
@@ -564,7 +564,7 @@ function Set-TargetResource
                     -CertificateId $RootCertificatesForServerValidationIds[$i] `
                     -CertificateDisplayName $RootCertificatesForServerValidationDisplayNames[$i] `
                     -OdataTypes @('#microsoft.graph.windows81TrustedRootCertificate')
-                $rootCertificatesForServerValidation += "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
+                $rootCertificatesForServerValidation += "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
             }
             $CreateParameters.Add('rootCertificatesForServerValidation@odata.bind', $rootCertificatesForServerValidation)
         }
@@ -579,7 +579,7 @@ function Set-TargetResource
                     '#microsoft.graph.windows81TrustedRootCertificate', `
                     '#microsoft.graph.windows10PkcsCertificateProfile' `
             )
-            $ref = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
+            $ref = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
             $CreateParameters.Add('identityCertificateForClientAuthentication@odata.bind', $ref)
         }
 
@@ -593,7 +593,7 @@ function Set-TargetResource
                     '#microsoft.graph.windows81TrustedRootCertificate', `
                     '#microsoft.graph.windows10PkcsCertificateProfile' `
             )
-            $ref = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
+            $ref = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
             $CreateParameters.Add('secondaryIdentityCertificateForClientAuthentication@odata.bind', $ref)
         }
 
@@ -603,7 +603,7 @@ function Set-TargetResource
                 -CertificateId $RootCertificateForClientValidationId `
                 -CertificateDisplayName $RootCertificateForClientValidationDisplayName `
                 -OdataTypes @('#microsoft.graph.windows81TrustedRootCertificate')
-            $ref = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
+            $ref = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
             $CreateParameters.Add('rootCertificateForClientValidation@odata.bind', $ref)
         }
 
@@ -613,7 +613,7 @@ function Set-TargetResource
                 -CertificateId $SecondaryRootCertificateForClientValidationId `
                 -CertificateDisplayName $SecondaryRootCertificateForClientValidationDisplayName `
                 -OdataTypes @('#microsoft.graph.windows81TrustedRootCertificate')
-            $ref = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
+            $ref = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/deviceConfigurations('$checkedCertId')"
             $CreateParameters.Add('secondaryRootCertificateForClientValidation@odata.bind', $ref)
         }
 
@@ -1189,7 +1189,7 @@ function Get-DeviceConfigurationPolicyCertificate
         [System.String]
         $CertificateName
     )
-    $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/deviceConfigurations('$DeviceConfigurationPolicyId')/microsoft.graph.windowsWiredNetworkConfiguration/$CertificateName"
+    $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/deviceConfigurations('$DeviceConfigurationPolicyId')/microsoft.graph.windowsWiredNetworkConfiguration/$CertificateName"
     try
     {
         $result = Invoke-MgGraphRequest -Method Get -Uri $Uri 4>$null
@@ -1228,7 +1228,7 @@ function Update-DeviceConfigurationPolicyCertificateId
         [System.String]
         $CertificateName
     )
-    $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/deviceConfigurations('$DeviceConfigurationPolicyId')/microsoft.graph.windowsWiredNetworkConfiguration/$CertificateName/`$ref"
+    $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/deviceConfigurations('$DeviceConfigurationPolicyId')/microsoft.graph.windowsWiredNetworkConfiguration/$CertificateName/`$ref"
 
     if ($CertificateName -eq 'rootCertificatesForServerValidation')
     {
@@ -1242,7 +1242,7 @@ function Update-DeviceConfigurationPolicyCertificateId
     foreach ($certificateId in $CertificateIds)
     {
         $ref = @{
-            '@odata.id' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/deviceConfigurations('$certificateId')"
+            '@odata.id' = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/deviceConfigurations('$certificateId')"
         }
 
         Invoke-MgGraphRequest -Method $method -Uri $Uri -Body ($ref | ConvertTo-Json) -ErrorAction Stop 4>$null
@@ -1270,7 +1270,7 @@ function Remove-DeviceConfigurationPolicyCertificateId
 
     foreach ($certificateId in $CertificateIds)
     {
-        $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/deviceConfigurations('$DeviceConfigurationPolicyId')/microsoft.graph.windowsWiredNetworkConfiguration/$CertificateName/$certificateId/`$ref"
+        $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/deviceConfigurations('$DeviceConfigurationPolicyId')/microsoft.graph.windowsWiredNetworkConfiguration/$CertificateName/$certificateId/`$ref"
         Invoke-MgGraphRequest -Method DELETE -Uri $Uri -Body ($ref | ConvertTo-Json) -ErrorAction Stop 4>$null
     }
 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1
@@ -411,7 +411,7 @@ function Set-TargetResource
             $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
         }
         $body = @{'enrollmentConfigurationAssignments' = $intuneAssignments } | ConvertTo-Json -Depth 100
-        $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/deviceEnrollmentConfigurations/$($policy.Id)/assign"
+        $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/deviceEnrollmentConfigurations/$($policy.Id)/assign"
         Invoke-MgGraphRequest -Method POST -Uri $Uri -Body $body -ErrorAction Stop
 
         Update-DeviceEnrollmentConfigurationPriority `
@@ -449,7 +449,7 @@ function Set-TargetResource
                 $intuneAssignments += ConvertTo-IntunePolicyAssignment -Assignments $Assignments
             }
             $body = @{'enrollmentConfigurationAssignments' = $intuneAssignments } | ConvertTo-Json -Depth 100
-            $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/deviceEnrollmentConfigurations/$($currentInstance.Id)/assign"
+            $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/deviceEnrollmentConfigurations/$($currentInstance.Id)/assign"
             Invoke-MgGraphRequest -Method POST -Uri $Uri -Body $body -ErrorAction Stop
 
             if ($PSBoundParameters.ContainsKey('Priority') -and $Priority -ne $currentInstance.Priority)
@@ -827,7 +827,7 @@ function Update-DeviceEnrollmentConfigurationPriority
     )
     try
     {
-        $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/deviceEnrollmentConfigurations/$DeviceEnrollmentConfigurationId/setpriority"
+        $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/deviceEnrollmentConfigurations/$DeviceEnrollmentConfigurationId/setpriority"
         $body = @{'priority' = $Priority } | ConvertTo-Json -Depth 100
         #write-verbose -Message $body
         Invoke-MgGraphRequest `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementComplianceSettings/MSFT_IntuneDeviceManagementComplianceSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementComplianceSettings/MSFT_IntuneDeviceManagementComplianceSettings.psm1
@@ -65,7 +65,7 @@ function Get-TargetResource
     $nullResult = $PSBoundParameters
     try
     {
-        $uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/deviceManagement/settings'
+        $uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/deviceManagement/settings'
         $settings = Invoke-MgGraphRequest -Method 'GET' -Uri $uri
         $results = @{
             IsSingleInstance                     = 'Yes'

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay.psm1
@@ -226,7 +226,7 @@ function Set-TargetResource
         if ($dataSharingConsent.granted -eq $false)
         {
             Write-Verbose -Message 'Consent not granted, requesting consent...'
-            $consentResult = Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/deviceManagement/dataSharingConsents/androidManagedStore/consentToDataSharing') -Method 'POST' -Body @{
+            $consentResult = Invoke-MgGraphRequest -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/deviceManagement/dataSharingConsents/androidManagedStore/consentToDataSharing') -Method 'POST' -Body @{
                 DataSharingConsentId = 'androidManagedStore'
             } -ContentType 'application/json'
         }
@@ -239,7 +239,7 @@ function Set-TargetResource
         #         hostName = "intune.microsoft.com"
         #     }
 
-        #     $signupUrl = Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/androidManagedStoreAccountEnterpriseSettings/requestSignupUrl") -Method 'POST' -Body @{
+        #     $signupUrl = Invoke-MgGraphRequest -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/androidManagedStoreAccountEnterpriseSettings/requestSignupUrl") -Method 'POST' -Body @{
         #         hostName = "intune.microsoft.com"
         #     } -ContentType "application/json"
 
@@ -249,7 +249,7 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
     {
         Write-Host "Remove the Intune Device Management Android Google Play Enrollment with Id {$($currentInstance.Id)}"
-        $unbindResult = Invoke-MgGraphRequest -Uri ($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/deviceManagement/androidManagedStoreAccountEnterpriseSettings/unbind') -Method 'POST' -Body @{} -ContentType 'application/json'
+        $unbindResult = Invoke-MgGraphRequest -Uri ((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/deviceManagement/androidManagedStoreAccountEnterpriseSettings/unbind') -Method 'POST' -Body @{} -ContentType 'application/json'
     }
 }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/MSFT_IntuneDiskEncryptionMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/MSFT_IntuneDiskEncryptionMacOS.psm1
@@ -378,7 +378,7 @@ function Set-TargetResource
         Update-MgBetaDeviceManagementIntent -DeviceManagementIntentId $currentInstance.Id -BodyParameter $UpdateParameters
 
         #region resource generator code
-        $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/intents/$($currentInstance.Id)/updateSettings"
+        $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/intents/$($currentInstance.Id)/updateSettings"
         $body = @{'settings' = $settings }
         Invoke-MgGraphRequest -Method POST -Uri $Uri -Body ($body | ConvertTo-Json -Depth 20) -ContentType 'application/json' 4> $null
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.psm1
@@ -451,8 +451,8 @@ function Set-TargetResource
                 throw "Mobile App Category with DisplayName $($category.DisplayName) not found."
             }
 
-            Invoke-MgGraphRequest -Uri "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileApps/$($app.Id)/categories/`$ref" -Method 'POST' -Body @{
-                '@odata.id' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
+            Invoke-MgGraphRequest -Uri "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceAppManagement/mobileApps/$($app.Id)/categories/`$ref" -Method 'POST' -Body @{
+                '@odata.id' = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
             }
         }
 
@@ -522,7 +522,7 @@ function Set-TargetResource
                 }
 
                 Invoke-MgGraphRequest -Uri "/beta/deviceAppManagement/mobileApps/$($currentInstance.Id)/categories/`$ref" -Method 'POST' -Body @{
-                    '@odata.id' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
+                    '@odata.id' = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
                 }
             }
             else

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp.psm1
@@ -490,7 +490,7 @@ function Set-TargetResource
             }
 
             Invoke-MgGraphRequest -Uri "/beta/deviceAppManagement/mobileApps/$($app.Id)/categories/`$ref" -Method 'POST' -Body @{
-                '@odata.id' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
+                '@odata.id' = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
             }
         }
 
@@ -561,7 +561,7 @@ function Set-TargetResource
                 }
 
                 Invoke-MgGraphRequest -Uri "/beta/deviceAppManagement/mobileApps/$($currentInstance.Id)/categories/`$ref" -Method 'POST' -Body @{
-                    '@odata.id' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
+                    '@odata.id' = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceAppManagement/mobileAppCategories/$($currentCategory.Id)"
                 }
             }
             else

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntunePolicySets/MSFT_IntunePolicySets.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntunePolicySets/MSFT_IntunePolicySets.psm1
@@ -347,7 +347,7 @@ function Set-TargetResource
 
         Update-MgBetaDeviceAppManagementPolicySet @UpdateParameters
 
-        $Url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceAppManagement/policySets/$($currentInstance.Id)/update"
+        $Url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceAppManagement/policySets/$($currentInstance.Id)/update"
         if ($null -ne ($itemamendments = Get-ItemsAmendmentsObject -currentObjectItems $currentInstance.Items -targetObjectItems $items))
         {
             Invoke-MgGraphRequest -Method POST -Uri $url -Body $itemamendments

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleAssignment/MSFT_IntuneRoleAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleAssignment/MSFT_IntuneRoleAssignment.psm1
@@ -361,7 +361,7 @@ function Set-TargetResource
             scopeType                   = $ScopeType
             members                     = $Members
             '@odata.type'               = '#microsoft.graph.deviceAndAppManagementRoleAssignment'
-            'roleDefinition@odata.bind' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/roleDefinitions('$roleDefinition')"
+            'roleDefinition@odata.bind' = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/roleDefinitions('$roleDefinition')"
         }
         $null = New-MgBetaDeviceManagementRoleAssignment -BodyParameter $CreateParameters
     }
@@ -376,7 +376,7 @@ function Set-TargetResource
             scopeType                   = $ScopeType
             members                     = $Members
             '@odata.type'               = '#microsoft.graph.deviceAndAppManagementRoleAssignment'
-            'roleDefinition@odata.bind' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)beta/deviceManagement/roleDefinitions('$roleDefinition')"
+            'roleDefinition@odata.bind' = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/roleDefinitions('$roleDefinition')"
         }
 
         Update-MgBetaDeviceManagementRoleAssignment -BodyParameter $UpdateParameters `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogCustomPolicyWindows10/MSFT_IntuneSettingCatalogCustomPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogCustomPolicyWindows10/MSFT_IntuneSettingCatalogCustomPolicyWindows10.psm1
@@ -930,7 +930,7 @@ function Update-IntuneDeviceConfigurationPolicy
     )
     try
     {
-        $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/configurationPolicies/$DeviceManagementConfigurationPolicyId"
+        $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/configurationPolicies/$DeviceManagementConfigurationPolicyId"
 
         $policy = @{
             'name'              = $Name

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365Group/MSFT_O365Group.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365Group/MSFT_O365Group.psm1
@@ -352,7 +352,7 @@ function Set-TargetResource
                     $userId = (Get-MgUser -UserId $member).Id
 
                     # There are no cmldet to remove members from group available at the time of writing this resource (March 8th 2022)
-                    $url = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/groups/$($ADGroup[0].Id)/members/$userId/`$ref"
+                    $url = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)v1.0/groups/$($ADGroup[0].Id)/members/$userId/`$ref"
                     Invoke-MgGraphRequest -Method DELETE -Uri $url | Out-Null
                 }
             }
@@ -398,7 +398,7 @@ function Set-TargetResource
                     Write-Verbose -Message "Adding Owner {$owner}"
                     $userId = (Get-MgUser -UserId $owner).Id
                     $newGroupOwner = @{
-                        '@odata.id' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/users/{$userId}"
+                        '@odata.id' = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)v1.0/users/{$userId}"
                     }
 
                     New-MgGroupOwnerByRef -GroupId $ADGroup[0].Id -BodyParameter $newGroupOwner
@@ -410,7 +410,7 @@ function Set-TargetResource
                     $userId = (Get-MgUser -UserId $owner).Id
 
                     # There are no cmldet to remove members from group available at the time of writing this resource (March 8th 2022)
-                    $url = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/groups/$($ADGroup[0].Id)/owners/$userId/`$ref"
+                    $url = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)v1.0/groups/$($ADGroup[0].Id)/owners/$userId/`$ref"
                     Invoke-MgGraphRequest -Method DELETE -Uri $url | Out-Null
                 }
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
@@ -162,11 +162,10 @@ function Get-TargetResource
 
     # Workaround for issue when if connected to S+C prior to calling cmdlet, an error about an invalid token is thrown.
     # If connected to S+C, then we need to re-initialize the connection to EXO.
-    if ($Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Connected -and `
-            $Global:MSCloudLoginConnectionProfile.ExchangeOnline.Connected)
+    if ((Get-MSCloudLoginConnectionProfile -Workload SecurityComplianceCenter).Connected -and `
+            (Get-MSCloudLoginConnectionProfile -Workload ExchangeOnline).Connected)
     {
-        $Global:MSCloudLoginConnectionProfile.ExchangeOnline.Disconnect()
-        $Global:MSCloudLoginConnectionProfile.SecurityComplianceCenter.Connected = $false
+        Reset-MSCloudLoginConnectionProfileContext
     }
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
         -InboundParameters $PSBoundParameters
@@ -1139,10 +1138,10 @@ function Get-M365DSCO365OrgSettingsPlannerConfig
 
     try
     {
-        $Uri = $Global:MSCloudLoginConnectionProfile.Tasks.HostUrl + '/taskAPI/tenantAdminSettings/Settings'
+        $Uri = (Get-MSCloudLoginConnectionProfile -Workload Tasks).HostUrl + '/taskAPI/tenantAdminSettings/Settings'
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
         $results = Invoke-RestMethod -ContentType 'application/json;odata.metadata=full' `
-            -Headers @{'Accept' = 'application/json'; 'Authorization' = $Global:MSCloudLoginConnectionProfile.Tasks.AccessToken; 'Accept-Charset' = 'UTF-8'; 'OData-Version' = '4.0;NetFx'; 'OData-MaxVersion' = '4.0;NetFx' } `
+            -Headers @{'Accept' = 'application/json'; 'Authorization' = (Get-MSCloudLoginConnectionProfile -Workload Tasks).AccessToken; 'Accept-Charset' = 'UTF-8'; 'OData-Version' = '4.0;NetFx'; 'OData-MaxVersion' = '4.0;NetFx' } `
             -Method GET `
             $Uri -ErrorAction Stop
         return $results
@@ -1182,9 +1181,9 @@ function Set-M365DSCO365OrgSettingsPlannerConfig
     }
 
     $requestBody = $flags | ConvertTo-Json
-    $Uri = $Global:MSCloudLoginConnectionProfile.Tasks.HostUrl + '/taskAPI/tenantAdminSettings/Settings'
+    $Uri = (Get-MSCloudLoginConnectionProfile -Workload Tasks).HostUrl + '/taskAPI/tenantAdminSettings/Settings'
     $results = Invoke-RestMethod -ContentType 'application/json;odata.metadata=full' `
-        -Headers @{'Accept' = 'application/json'; 'Authorization' = $Global:MSCloudLoginConnectionProfile.Tasks.AccessToken; 'Accept-Charset' = 'UTF-8'; 'OData-Version' = '4.0;NetFx'; 'OData-MaxVersion' = '4.0;NetFx' } `
+        -Headers @{'Accept' = 'application/json'; 'Authorization' = (Get-MSCloudLoginConnectionProfile -Workload Tasks).AccessToken; 'Accept-Charset' = 'UTF-8'; 'OData-Version' = '4.0;NetFx'; 'OData-MaxVersion' = '4.0;NetFx' } `
         -Method PATCH `
         -Body $requestBody `
         $Uri
@@ -1203,7 +1202,7 @@ function Get-M365DSCOrgSettingsInstallationOptions
 
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/admin/microsoft365Apps/installationOptions'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/admin/microsoft365Apps/installationOptions'
         $results = Invoke-MgGraphRequest -Method GET -Uri $url
         return $results
     }
@@ -1231,7 +1230,7 @@ function Update-M365DSCOrgSettingsInstallationOptions
 
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/admin/microsoft365Apps/installationOptions'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/admin/microsoft365Apps/installationOptions'
         Invoke-MgGraphRequest -Method PATCH -Uri $url -Body $Options | Out-Null
     }
     catch
@@ -1258,7 +1257,7 @@ function Get-M365DSCOrgSettingsForms
 
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/admin/forms/settings'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/admin/forms/settings'
         $results = Invoke-MgGraphRequest -Method GET -Uri $url -ErrorAction Stop
         return $results
     }
@@ -1283,7 +1282,7 @@ function Update-M365DSCOrgSettingsForms
     try
     {
         Write-Verbose -Message 'Updating Forms Settings'
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/admin/forms/settings'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/admin/forms/settings'
         Invoke-MgGraphRequest -Method PATCH -Uri $url -Body $Options | Out-Null
     }
     catch
@@ -1305,7 +1304,7 @@ function Get-M365DSCOrgSettingsDynamicsCustomerVoice
 
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/admin/dynamics/customerVoice'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/admin/dynamics/customerVoice'
         $results = Invoke-MgGraphRequest -Method GET -Uri $url -ErrorAction Stop
         return $results
     }
@@ -1329,7 +1328,7 @@ function Update-M365DSCOrgSettingsDynamicsCustomerVoice
 
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/admin/dynamics/customerVoice'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/admin/dynamics/customerVoice'
         Invoke-MgGraphRequest -Method PATCH -Uri $url -Body $Options | Out-Null
     }
     catch
@@ -1351,7 +1350,7 @@ function Get-M365DSCOrgSettingsAppsAndServices
 
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/admin/appsAndServices/settings'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/admin/appsAndServices/settings'
         $results = Invoke-MgGraphRequest -Method GET -Uri $url -ErrorAction Stop
         return $results
     }
@@ -1375,7 +1374,7 @@ function Update-M365DSCOrgSettingsAppsAndServices
 
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/admin/appsAndServices/settings'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/admin/appsAndServices/settings'
         Invoke-MgGraphRequest -Method PATCH -Uri $url -Body $Options | Out-Null
     }
     catch
@@ -1396,7 +1395,7 @@ function Get-M365DSCOrgSettingsToDo
 
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/admin/todo/settings'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/admin/todo/settings'
         $results = Invoke-MgGraphRequest -Method GET -Uri $url -ErrorAction Stop
         return $results
     }
@@ -1420,7 +1419,7 @@ function Update-M365DSCOrgSettingsToDo
 
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/admin/todo/settings'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/admin/todo/settings'
         Invoke-MgGraphRequest -Method PATCH -Uri $url -Body $Options | Out-Null
     }
     catch
@@ -1443,7 +1442,7 @@ function Get-M365DSCOrgSettingsAdminCenterReport
 
     try
     {
-        $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/admin/reportSettings'
+        $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/admin/reportSettings'
         $results = Invoke-MgGraphRequest -Method GET -Uri $url -ErrorAction Stop
         return $results
     }
@@ -1464,9 +1463,9 @@ function Update-M365DSCOrgSettingsAdminCenterReport
         $DisplayConcealedNames
     )
     $VerbosePreference = 'SilentlyContinue'
-    $url = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/admin/reportSettings'
+    $url = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/admin/reportSettings'
     $body = @{
-        '@odata.context'      = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'beta/$metadata#admin/reportSettings/$entity'
+        '@odata.context'      = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'beta/$metadata#admin/reportSettings/$entity'
         displayConcealedNames = $DisplayConcealedNames
     }
     Invoke-MgGraphRequest -Method PATCH -Uri $url -Body $body | Out-Null

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerTask/MSFT_PlannerTask.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerTask/MSFT_PlannerTask.psm1
@@ -492,7 +492,7 @@ function Set-TargetResource
         Write-Verbose -Message "Updating Task with:`r`n$JSONDetails"
         # Need to continue to rely on Invoke-MgGraphRequest
         Invoke-MgGraphRequest -Method PATCH `
-            -Uri "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/planner/tasks/$taskId" `
+            -Uri "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)v1.0/planner/tasks/$taskId" `
             -Headers $Headers `
             -Body $JSONDetails
 
@@ -504,7 +504,7 @@ function Set-TargetResource
         $JSONDetails = (ConvertTo-Json $details)
         Write-Verbose -Message "Updating Task's details with:`r`n$JSONDetails"
         Invoke-MgGraphRequest -Method PATCH `
-            -Uri "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/planner/tasks/$taskId/details" `
+            -Uri "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)v1.0/planner/tasks/$taskId/details" `
             -Headers $Headers `
             -Body $JSONDetails
 
@@ -940,7 +940,7 @@ function Get-M365DSCPlannerTasksFromPlan
         $Credential
     )
     $results = @()
-    $uri = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/planner/plans/$PlanId/tasks"
+    $uri = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)v1.0/planner/plans/$PlanId/tasks"
     $taskResponse = Invoke-MSCloudLoginMicrosoftGraphAPI -Credential $Credential `
         -Uri $uri `
         -Method Get

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
@@ -212,7 +212,7 @@ function Get-TargetResource
             'AllowSelectSecurityGroupsInSPSitesList')
 
         $response = Invoke-PnPSPRestMethod -Method Get `
-            -Url "$($Global:MSCloudLoginConnectionProfile.PnP.AdminUrl)/_api/SPO.Tenant?`$select=$($parametersToRetrieve -join ',')"
+            -Url "$((Get-MSCloudLoginConnectionProfile -Workload PnP).AdminUrl)/_api/SPO.Tenant?`$select=$($parametersToRetrieve -join ',')"
 
 
         return @{
@@ -536,7 +536,7 @@ function Set-TargetResource
         {
             Write-Verbose -Message 'Updating properties via REST PATCH call.'
             Invoke-PnPSPRestMethod -Method PATCH `
-                -Url "$($Global:MSCloudLoginConnectionProfile.PnP.AdminUrl)/_api/SPO.Tenant" `
+                -Url "$((Get-MSCloudLoginConnectionProfile -Workload PnP).AdminUrl)/_api/SPO.Tenant" `
                 -Content $paramsToUpdate
         }
     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelTab/MSFT_TeamsChannelTab.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelTab/MSFT_TeamsChannelTab.psm1
@@ -368,7 +368,7 @@ function Set-TargetResource
         Write-Verbose -Message "Params: $($CurrentParameters | Out-String)"
 
         $additionalProperties = @{
-            'teamsApp@odata.bind' = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/appCatalogs/teamsApps/$TeamsApp"
+            'teamsApp@odata.bind' = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)v1.0/appCatalogs/teamsApps/$TeamsApp"
         }
         $CurrentParameters.Add('AdditionalProperties', $additionalProperties)
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -443,7 +443,7 @@ function Set-TargetResource
 
             Write-Verbose -Message "Retrieving Group Owner {$currentOwner}"
             $ownerUser = Get-MgUser -Search $currentOwner -ConsistencyLevel eventual
-            $ownerOdataID = "$($Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl)v1.0/directoryObjects/$($ownerUser.Id)"
+            $ownerOdataID = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)v1.0/directoryObjects/$($ownerUser.Id)"
 
             Write-Verbose -Message "Adding Owner {$($ownerUser.Id)} to Group {$($group.Id)}"
             try

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -2547,7 +2547,7 @@ function Update-IntuneDeviceConfigurationPolicy
 
     try
     {
-        $Uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + "beta/deviceManagement/configurationPolicies/$DeviceConfigurationPolicyId"
+        $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/configurationPolicies/$DeviceConfigurationPolicyId"
 
         $policy = @{
             'name'              = $Name

--- a/Modules/Microsoft365DSC/Modules/M365DSCTelemetryEngine.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCTelemetryEngine.psm1
@@ -118,7 +118,7 @@ function Add-M365DSCTelemetryEvent
                     }
                     $Script:M365DSCCurrentRoles = @()
 
-                    $uri = $Global:MSCloudLoginConnectionProfile.MicrosoftGraph.ResourceUrl + 'v1.0/me?$select=id'
+                    $uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + 'v1.0/me?$select=id'
                     $currentUser = Invoke-MgGraphRequest -Uri $uri -Method GET
                     $currentUserId = $currentUser.id
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1437,7 +1437,7 @@ function Export-M365DSCConfiguration
     try
     {
         Disconnect-MgGraph -ErrorAction Stop | Out-Null
-        $global:MsCloudLoginConnectionProfile.MicrosoftGraph.Connected = $false
+        Reset-MSCloudLoginConnectionProfileContext
     }
     catch
     {

--- a/Modules/Microsoft365DSC/Modules/WorkloadHelpers/M365DSCAzureDevOPSHelper.psm1
+++ b/Modules/Microsoft365DSC/Modules/WorkloadHelpers/M365DSCAzureDevOPSHelper.psm1
@@ -21,7 +21,7 @@ function Invoke-M365DSCAzureDevOPSWebRequest
     )
 
     $headers = @{
-        Authorization = $global:MsCloudLoginConnectionProfile.AzureDevOPS.AccessToken
+        Authorization = (Get-MSCloudLoginConnectionProfile -Workload AzureDevOPS).AccessToken
         'Content-Type' = $ContentType
     }
 

--- a/Modules/Microsoft365DSC/Modules/WorkloadHelpers/M365DSCDefenderHelper.psm1
+++ b/Modules/Microsoft365DSC/Modules/WorkloadHelpers/M365DSCDefenderHelper.psm1
@@ -18,7 +18,7 @@ function Invoke-M365DSCDefenderREST
 
     $bodyJSON = ConvertTo-Json $Body -Depth 10 -Compress
     $headers = @{
-        Authorization = $Global:MSCloudLoginConnectionProfile.DefenderForEndpoint.AccessToken
+        Authorization = (Get-MSCloudLoginConnectionProfile -Workload DefenderForEndpoint).AccessToken
         "Content-Type" = "application/json"
     }
     $response = Invoke-WebRequest -Method $Method `

--- a/Modules/Microsoft365DSC/Modules/WorkloadHelpers/M365DSCFabricHelper.psm1
+++ b/Modules/Microsoft365DSC/Modules/WorkloadHelpers/M365DSCFabricHelper.psm1
@@ -17,7 +17,7 @@ function Invoke-M365DSCFabricWebRequest
     )
 
     $headers = @{
-        Authorization = $global:MsCloudLoginConnectionProfile.Fabric.AccessToken
+        Authorization = (Get-MSCloudLoginConnectionProfile -Workload Fabric).AccessToken
     }
 
     $response = Invoke-WebRequest -Method $Method -Uri $Uri -Headers $headers -Body $Body

--- a/ResourceGenerator/UnitTest.Template.ps1
+++ b/ResourceGenerator/UnitTest.Template.ps1
@@ -27,6 +27,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
+            Mock -CommandName Reset-MSCloudLoginConnectionProfileContext -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADAdminConsentRequestPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADAdminConsentRequestPolicy.Tests.ps1
@@ -31,6 +31,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return "Credentials"
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADAdministrativeUnit.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADAdministrativeUnit.Tests.ps1
@@ -28,6 +28,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Add-M365DSCTelemetryEvent -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADApplication.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADApplication.Tests.ps1
@@ -26,6 +26,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADAuthenticationMethodPolicyExternal.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADAuthenticationMethodPolicyExternal.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-MgBetaPolicyAuthenticationMethodPolicyAuthenticationMethodConfiguration -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADAuthenticationRequirement.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADAuthenticationRequirement.Tests.ps1
@@ -31,6 +31,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return "Credentials"
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADConditionalAccessPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADConditionalAccessPolicy.Tests.ps1
@@ -26,7 +26,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
 
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
+            }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
             }
 
             Mock -CommandName New-M365DSCConnection -MockWith {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADDeviceRegistrationPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADDeviceRegistrationPolicy.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Update-MgBetaDirectoryAttributeSet -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADEnrichedAuditLogs.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADEnrichedAuditLogs.Tests.ps1
@@ -31,6 +31,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return "Credentials"
             }
@@ -85,7 +88,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Credential            = $Credential;
                 }
             }
-            
+
             It 'Should return false from the Test method' {
                 Test-TargetResource @testParams | Should -Be $false
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADEntitlementManagementAccessPackage.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADEntitlementManagementAccessPackage.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADEntitlementManagementConnectedOrganization.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADEntitlementManagementConnectedOrganization.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Update-MgBetaEntitlementManagementConnectedOrganization -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADFederationConfiguration.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADFederationConfiguration.Tests.ps1
@@ -31,6 +31,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return "Credentials"
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADGroup.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADGroup.Tests.ps1
@@ -28,6 +28,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADIdentityB2XUserFlow.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADIdentityB2XUserFlow.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADIdentityProtectionPolicySettings.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADIdentityProtectionPolicySettings.Tests.ps1
@@ -31,6 +31,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return "Credentials"
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADNamedLocationPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADNamedLocationPolicy.Tests.ps1
@@ -26,6 +26,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADNetworkAccessForwardingPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADNetworkAccessForwardingPolicy.Tests.ps1
@@ -31,6 +31,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return "Credentials"
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADOnPremisesPublishingProfilesSettings.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADOnPremisesPublishingProfilesSettings.Tests.ps1
@@ -31,6 +31,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return "Credentials"
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADOrganizationCertificateBasedAuthConfiguration.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADOrganizationCertificateBasedAuthConfiguration.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADRemoteNetwork.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADRemoteNetwork.Tests.ps1
@@ -31,6 +31,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-MgBetaNetworkAccessConnectivityRemoteNetwork -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADServicePrincipal.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADServicePrincipal.Tests.ps1
@@ -23,8 +23,10 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             $secpasswd = ConvertTo-SecureString (New-Guid | Out-String) -AsPlainText -Force
             $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@contoso.com', $secpasswd)
 
-
             Mock -CommandName Get-PSSession -MockWith {
+            }
+
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
             }
 
             Mock -CommandName Remove-PSSession -MockWith {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADVerifiedIdAuthority.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADVerifiedIdAuthority.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 
@@ -75,7 +78,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 Test-TargetResource @testParams | Should -Be $false
             }
             It 'Should Create the id from the Set method' {
-                Set-TargetResource @testParams 
+                Set-TargetResource @testParams
                 Should -Invoke -CommandName Invoke-M365DSCVerifiedIdWebRequest -Exactly 2
             }
         }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADVerifiedIdAuthorityContract.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADVerifiedIdAuthorityContract.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 
@@ -62,7 +65,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         } -ClientOnly)
                         attestations = (New-CimInstance -ClassName MSFT_AADVerifiedIdAuthorityContractAttestations -Property @{
                             required = $True
-                        } -ClientOnly) 
+                        } -ClientOnly)
 
                     } -ClientOnly)
                     Ensure = 'Present'
@@ -92,7 +95,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                 )
                             }
                         }
-                        default { 
+                        default {
                             return @{
                                 value = @()
                             }
@@ -108,7 +111,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 Test-TargetResource @testParams | Should -Be $false
             }
             It 'Should Create the id from the Set method' {
-                Set-TargetResource @testParams 
+                Set-TargetResource @testParams
                 Should -Invoke -CommandName Invoke-M365DSCVerifiedIdWebRequest -Exactly 4
             }
         }
@@ -195,7 +198,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                 )
                             }
                         }
-                        default { 
+                        default {
                             return @{
                                 value = @(
                                     @{
@@ -416,7 +419,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                 )
                             }
                         }
-                        default { 
+                        default {
                             return @{
                                 value = @(
                                     @{
@@ -628,7 +631,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                 )
                             }
                         }
-                        default { 
+                        default {
                             return @{
                                 value = @(
                                     @{
@@ -799,7 +802,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                 )
                             }
                         }
-                        default { 
+                        default {
                             return @{
                                 value = @(
                                     @{

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureVerifiedIdFaceCheck.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureVerifiedIdFaceCheck.Tests.ps1
@@ -31,6 +31,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return "Credentials"
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOManagementRoleAssignment.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOManagementRoleAssignment.Tests.ps1
@@ -29,6 +29,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Save-M365DSCPartialExport -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
+            Mock -CommandName Reset-MSCloudLoginConnectionProfileContext -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return 'Credentials'
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.FabricAdminTenantSettings.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.FabricAdminTenantSettings.Tests.ps1
@@ -28,6 +28,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return "ServicePrincipalWithThumbprint"
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneASRRulesPolicyWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneASRRulesPolicyWindows10.Tests.ps1
@@ -28,6 +28,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Save-M365DSCPartialExport  -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAccountProtectionPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAccountProtectionPolicy.Tests.ps1
@@ -28,6 +28,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return 'Credentials'
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAppProtectionPolicyiOS.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAppProtectionPolicyiOS.Tests.ps1
@@ -28,6 +28,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return 'Credentials'
             }
@@ -55,7 +58,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     @{
                         id = '3eacc231-d77b-4efb-bb5f-310f68bd6198'
                         DisplayName = 'MyExcludedGroup'
-                    },                    
+                    },
                     @{
                         id = '6ee86c9f-2b3c-471d-ad38-ff4673ed723e'
                         DisplayName = 'MyAssignedGroup'

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAppleMDMPushNotificationCertificate.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAppleMDMPushNotificationCertificate.Tests.ps1
@@ -31,6 +31,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return "Credentials"
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceCleanupRule.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceCleanupRule.Tests.ps1
@@ -28,6 +28,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return 'Credentials'
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationWiredNetworkPolicyWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceConfigurationWiredNetworkPolicyWindows10.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Update-MgBetaDeviceManagementDeviceConfiguration -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceEnrollmentStatusPageWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceEnrollmentStatusPageWindows10.Tests.ps1
@@ -26,6 +26,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {}
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {}
+
             Mock -CommandName Get-PSSession -MockWith {}
 
             Mock -CommandName Remove-PSSession -MockWith {}

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceManagementComplianceSettings.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceManagementComplianceSettings.Tests.ps1
@@ -28,6 +28,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return 'Credentials'
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceManagementEnrollmentAndroidGooglePlay.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceManagementEnrollmentAndroidGooglePlay.Tests.ps1
@@ -18,6 +18,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
 
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {}
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {}
             Mock -CommandName New-M365DSCConnection -MockWith { return "Credentials" }
 
             Mock -CommandName Get-MgBetaDeviceManagementAndroidManagedStoreAccountEnterpriseSetting -MockWith {}

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDiskEncryptionMacOS.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDiskEncryptionMacOS.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsMacOSLobApp.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsMacOSLobApp.Tests.ps1
@@ -31,6 +31,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsWindowsOfficeSuiteApp.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsWindowsOfficeSuiteApp.Tests.ps1
@@ -31,6 +31,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntunePolicySets.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntunePolicySets.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneRoleAssignment.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneRoleAssignment.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneSettingCatalogCustomPolicyWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneSettingCatalogCustomPolicyWindows10.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Get-PSSession -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.O365Group.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.O365Group.Tests.ps1
@@ -27,6 +27,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return 'Credentials'
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.O365OrgSettings.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.O365OrgSettings.Tests.ps1
@@ -28,6 +28,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
+            Mock -CommandName Reset-MSCloudLoginConnectionProfileContext -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return 'Credentials'
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.PlannerTask.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.PlannerTask.Tests.ps1
@@ -28,6 +28,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Save-M365DSCPartialExport -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName Connect-Graph -MockWith {
             }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SPOTenantSettings.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SPOTenantSettings.Tests.ps1
@@ -28,6 +28,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return 'Credentials'
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsChannelTab.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsChannelTab.Tests.ps1
@@ -30,6 +30,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Save-M365DSCPartialExport -MockWith {
             }
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
             Mock -CommandName New-M365DSCConnection -MockWith {
                 return 'Credentials'
             }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsTeam.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsTeam.Tests.ps1
@@ -27,6 +27,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             $Global:PartialExportFileName = 'c:\TestPath'
 
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
 
             Mock -CommandName Save-M365DSCPartialExport -MockWith {
             }

--- a/Tests/Unit/Stubs/Generic.psm1
+++ b/Tests/Unit/Stubs/Generic.psm1
@@ -1273,3 +1273,20 @@ function Disable-EOPProtectionPolicyRule
         $Identity
     )
 }
+
+
+#region MSCloudLoginAssistant
+function Get-MSCloudLoginConnectionProfile{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $Workload
+    )
+}
+
+function Reset-MSCloudLoginConnectionProfileContext
+{
+}
+#endregion


### PR DESCRIPTION
#### Pull Request (PR) description
This PR migrates the `$global:MSCloudLoginConnectionProfile` access to its specific workload cmdlet counterpart that was introduced with version 1.1.29 of MSCloudLoginAssistant. Without this change, every resource that uses any part of the authentication context will fail!

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
