### PR TITLE
Update input variety for workloads by resource names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+* M365DSCUtil
+  * Update `Get-M365DSCWorkloadsListFromResourceNames` function for more input types.
+    FIXES [#5525](https://github.com/microsoft/Microsoft365DSC/issues/5525)
+
 # 1.24.1211.1
 
 * AADApplication

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -4207,13 +4207,20 @@ function Test-M365DSCObjectHasProperty
 
 <#
 .Description
-This function returns the used workloads for the specified DSC resources
+    This function returns the used workloads for the specified DSC resources
 
 .Parameter ResourceNames
-Specifies the resources for which the workloads should be determined.
+    Specifies the resources for which the workloads should be determined.
+    Either a single string, an array of strings or an object with 'Name' and 'AuthenticationMethod' can be provided.
 
 .Example
-Get-M365DSCWorkloadsListFromResourceNames -ResourceNames AADUSer
+    Get-M365DSCWorkloadsListFromResourceNames -ResourceNames AADUser
+
+.EXAMPLE
+    Get-M365DSCWorkloadsListFromResourceNames -ResourceNames @('AADUser', 'AADGroup')
+
+.EXAMPLE
+    Get-M365DSCWorkloadsListFromResourceNames -ResourceNames @{Name = 'AADUser'; AuthenticationMethod = 'Credentials'}
 
 .Functionality
 Public
@@ -4232,7 +4239,13 @@ function Get-M365DSCWorkloadsListFromResourceNames
     [Array] $workloads = @()
     foreach ($resource in $ResourceNames)
     {
-        switch ($resource.Name.Substring(0, 2).ToUpper())
+        $resourceName = $resource.Name
+        $authMethod = $resource.AuthenticationMethod
+        if ([System.String]::IsNullOrEmpty($resourceName))
+        {
+            $resourceName = $resource
+        }
+        switch ($resourceName.Substring(0, 2).ToUpper())
         {
             'AA'
             {
@@ -4240,7 +4253,7 @@ function Get-M365DSCWorkloadsListFromResourceNames
                 {
                     $workloads += @{
                         Name                 = 'MicrosoftGraph'
-                        AuthenticationMethod = $resource.AuthenticationMethod
+                        AuthenticationMethod = $authMethod
                     }
                 }
             }
@@ -4250,7 +4263,7 @@ function Get-M365DSCWorkloadsListFromResourceNames
                 {
                     $workloads += @{
                         Name                 = 'ExchangeOnline'
-                        AuthenticationMethod = $resource.AuthenticationMethod
+                        AuthenticationMethod = $authMethod
                     }
                 }
             }
@@ -4260,7 +4273,7 @@ function Get-M365DSCWorkloadsListFromResourceNames
                 {
                     $workloads += @{
                         Name                 = 'MicrosoftGraph'
-                        AuthenticationMethod = $resource.AuthenticationMethod
+                        AuthenticationMethod = $authMethod
                     }
                 }
             }
@@ -4270,14 +4283,14 @@ function Get-M365DSCWorkloadsListFromResourceNames
                 {
                     $workloads += @{
                         Name                 = 'MicrosoftGraph'
-                        AuthenticationMethod = $resource.AuthenticationMethod
+                        AuthenticationMethod = $authMethod
                     }
                 }
                 elseif (-not $workloads.Name -or -not $workloads.Name.Contains('ExchangeOnline'))
                 {
                     $workloads += @{
                         Name                 = 'ExchangeOnline'
-                        AuthenticationMethod = $resource.AuthenticationMethod
+                        AuthenticationMethod = $authMethod
                     }
                 }
             }
@@ -4287,7 +4300,7 @@ function Get-M365DSCWorkloadsListFromResourceNames
                 {
                     $workloads += @{
                         Name                 = 'PnP'
-                        AuthenticationMethod = $resource.AuthenticationMethod
+                        AuthenticationMethod = $authMethod
                     }
                 }
             }
@@ -4297,7 +4310,7 @@ function Get-M365DSCWorkloadsListFromResourceNames
                 {
                     $workloads += @{
                         Name                 = 'MicrosoftGraph'
-                        AuthenticationMethod = $resource.AuthenticationMethod
+                        AuthenticationMethod = $authMethod
                     }
                 }
             }
@@ -4307,7 +4320,7 @@ function Get-M365DSCWorkloadsListFromResourceNames
                 {
                     $workloads += @{
                         Name                 = 'PnP'
-                        AuthenticationMethod = $resource.AuthenticationMethod
+                        AuthenticationMethod = $authMethod
                     }
                 }
             }
@@ -4317,7 +4330,7 @@ function Get-M365DSCWorkloadsListFromResourceNames
                 {
                     $workloads += @{
                         Name                 = 'SecurityComplianceCenter'
-                        AuthenticationMethod = $resource.AuthenticationMethod
+                        AuthenticationMethod = $authMethod
                     }
                 }
             }
@@ -4327,7 +4340,7 @@ function Get-M365DSCWorkloadsListFromResourceNames
                 {
                     $workloads += @{
                         Name                 = 'MicrosoftTeams'
-                        AuthenticationMethod = $resource.AuthenticationMethod
+                        AuthenticationMethod = $authMethod
                     }
                 }
             }


### PR DESCRIPTION
#### Pull Request (PR) description
This PR improves the possible input for the `Get-M365DSCWorkloadsListFromResourceNames` function. It is now able to use strings as resource names as well as the previous intended way with an object containing `Name` and `AuthenticationMethod` properties. If strings as resource names are present, the output property `AuthenticationMethod` for the workload will always be empty. 

#### This Pull Request (PR) fixes the following issues
- Fixes #5525

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
