### PR TITLE
Update documentation for MOF compilation with empty arrays

### DIFF
--- a/docs/docs/user-guide/get-started/deploying-configurations.md
+++ b/docs/docs/user-guide/get-started/deploying-configurations.md
@@ -31,6 +31,8 @@ For more information and more advanced topics, please make sure you review the f
 
 The first step in trying to deploy a DSC configuration is to compile the configuration file into a MOF file. Doing so simply involves executing the .ps1 file that contains your configuration. The process of compiling your configuration will also perform some level of validation on the configuration, such as ensuring that every component defined in the file has all of their mandatory parameters defined, and that there are no typos in components or property names. If the compilation process is successful, you should see a message indicating that the MOF file was created. By default, this file is created in the same path your configuration file is located, and will create a new subfolder based on the name of the configuration object defined within your file.
 
+**Attention: If your configuration contains empty arrays, then it must be compiled in Windows PowerShell (5.1). Otherwise, the affected properties might be omitted in the result file.**
+
 <figure markdown>
   ![Running a configuration compilation](../../Images/CompileConfiguration.png)
   <figcaption>Running a configuration compilation</figcaption>


### PR DESCRIPTION
#### Pull Request (PR) description
This PR slightly updates the documentation with a note about empty arrays and compiling a configuration with PowerShell 7 and PSDesiredStateConfiguration 2.0.7. If the configuration contains empty arrays, they will be omitted in the compiled MOF file. 

This was first detected in #5546, and traced back to a possible flaw in the compilation logic of PSDesiredStateConfiguration 2.0.7. The relevant snippet in the `PSDesiredStateConfiguration.psm1` file (line 674) is the following: 
```powershell
if ($targetTypeName -notmatch 'Array' -or $p.Value.Count)
{
    $p.Name + ' = ' + (stringify -value $p.Value -asArray $asArray -targetType  $targetType ) + ";`n"
}
```
$targetType is `StringArray`, and `$p.Value.Count` has a value of 0. The if statement evaluates to false, since the target type contains 'Array' (negating the first condition) and 0 is treated as false (negating the second). That's the reason why an empty array is omitted with PS7, and different from PS5. It's doubtful if the maintainers of the module will update it since it's pretty much stale and will eventually be replaced by DSCv3. 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
