### PR TITLE
Added UseBasicParsing to Invoke-WebRequest calls for AADVerifiedIdAuthority, AADVerifiedIdAuthorityContract, and AzureVerifiedIdFaceCheck

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADVerifiedIdAuthority/MSFT_AADVerifiedIdAuthority.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADVerifiedIdAuthority/MSFT_AADVerifiedIdAuthority.psm1
@@ -575,11 +575,11 @@ function Invoke-M365DSCVerifiedIdWebRequest
     if ($Method -eq 'PATCH' -or $Method -eq 'POST')
     {
         $BodyJson = $body | ConvertTo-Json
-        $response = Invoke-WebRequest -Method $Method -Uri $Uri -Headers $headers -Body $BodyJson
+        $response = Invoke-WebRequest -Method $Method -Uri $Uri -Headers $headers -Body $BodyJson -UseBasicParsing
     }
     else
     {
-        $response = Invoke-WebRequest -Method $Method -Uri $Uri -Headers $headers
+        $response = Invoke-WebRequest -Method $Method -Uri $Uri -Headers $headers -UseBasicParsing
     }
 
     if ($Method -eq 'DELETE')

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADVerifiedIdAuthorityContract/MSFT_AADVerifiedIdAuthorityContract.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADVerifiedIdAuthorityContract/MSFT_AADVerifiedIdAuthorityContract.psm1
@@ -922,11 +922,11 @@ function Invoke-M365DSCVerifiedIdWebRequest
     if ($Method -eq 'PATCH' -or $Method -eq 'POST')
     {
         $BodyJson = $body | ConvertTo-Json -Depth 10
-        $response = Invoke-WebRequest -Method $Method -Uri $Uri -Headers $headers -Body $BodyJson
+        $response = Invoke-WebRequest -Method $Method -Uri $Uri -Headers $headers -Body $BodyJson -UseBasicParsing
     }
     else
     {
-        $response = Invoke-WebRequest -Method $Method -Uri $Uri -Headers $headers
+        $response = Invoke-WebRequest -Method $Method -Uri $Uri -Headers $headers -UseBasicParsing
     }
 
     if ($Method -eq 'DELETE')

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AzureVerifiedIdFaceCheck/MSFT_AzureVerifiedIdFaceCheck.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AzureVerifiedIdFaceCheck/MSFT_AzureVerifiedIdFaceCheck.psm1
@@ -345,7 +345,7 @@ function Export-TargetResource
             Authorization = (Get-MSCloudLoginConnectionProfile -Workload AdminAPI).AccessToken
         }
         $uri = 'https://verifiedid.did.msidentity.com/v1.0/verifiableCredentials/authorities'
-        $response = Invoke-WebRequest -Uri $uri -Method Get -Headers $headers
+        $response = Invoke-WebRequest -Uri $uri -Method Get -Headers $headers -UseBasicParsing
         $authorities = ConvertFrom-Json $response.Content
 
         $resourceGroups = Get-AzResourceGroup -ErrorAction Stop


### PR DESCRIPTION
Added `UseBasicParsing` to `Invoke-WebRequest` calls for **AADVerifiedIdAuthority**, **AADVerifiedIdAuthorityContract**, and **AzureVerifiedIdFaceCheck**

#### Pull Request (PR) description

Added the `-UseBasicParsing` switch parameter to `Invoke-WebRequest` calls for the **AADVerifiedIdAuthority**, **AADVerifiedIdAuthorityContract**, and **AzureVerifiedIdFaceCheck** resources.

#### This Pull Request (PR) fixes the following issues

- Fixes the following error: `The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.`

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
