### PR TITLE
Add check to New-M365DSCReportFromConfiguration to test for WinRm enablement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@
 * DefenderDeviceAuthenticatedScanDefinition
   * Fixed the Data Type export.
 * MISC
-  * DEFENDER
-    * Added support for the UseBasicParsing paramter for REST calls.
+  * Added check to `New-M365DSCReportFromConfiguration` to make sure Windows
+    Remoting is enabled, which is required to convert the DSC config.
+  * Defender
+    * Added support for the UseBasicParsing parameter for REST calls.
+
+# 1.24.1218.1
 
 * AADApplication
   * Added support for Oauth2PermissionScopes.

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -722,22 +722,29 @@ function New-M365DSCReportFromConfiguration
     }
     process # required with DynamicParam
     {
-    
+        # Test if Windows Remoting is enabled, which is needed to run this function.
+        $result = Test-WSMan -ErrorAction SilentlyContinue
+        if ($null -eq $result)
+        {
+            Write-Error -Message 'Windows Remoting is NOT configured yet. Please configure Windows Remoting (by running `Enable-PSRemoting -SkipNetworkProfileCheck`) before running this function.'
+            return
+        }
+
         # Validate that the latest version of the module is installed.
         Test-M365DSCModuleValidity
-    
+
         #Ensure the proper dependencies are installed in the current environment.
         Confirm-M365DSCDependencies
-    
+
         #region Telemetry
         $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
         $data.Add('Event', 'Report')
         $data.Add('Type', $Type)
         Add-M365DSCTelemetryEvent -Data $data -Type 'NewReport'
         #endregion
-    
+
         [Array] $parsedContent = Initialize-M365DSCReporting -ConfigurationPath $ConfigurationPath
-    
+
         if ($null -ne $parsedContent)
         {
             switch ($Type)


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds a check to New-M365DSCReportFromConfiguration to test for WinRm enablement, which is required for this function

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
