### PR TITLE
Fix duplicate policy creation bug & dynamic group compliance 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,38 @@
 * AADAuthenticationRequirement
   * Filtered guests from the export, to prevent errors during export
     FIXES [#5625](https://github.com/microsoft/Microsoft365DSC/issues/5625)
+* AADGroup
+  * Only get Members & GroupAsMembers when a static group is defined.
 * AADGroupEligibilitySchedule
   * New resource for Privileged Identity Management (PIM) for Groups
+* IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneAccountProtectionPolicyWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneAntivirusPolicyLinux
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneAntivirusPolicyMacOS
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneAntivirusPolicyWindows10SettingCatalog
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneAppAndBrowserIsolationPolicyWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneDeviceControlPolicyWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneDiskEncryptionMacOS
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneDiskEncryptionWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneEndpointDetectionAndResponsePolicyLinux
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneEndpointDetectionAndResponsePolicyMacOS
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneEndpointDetectionAndResponsePolicyWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneFirewallPolicyWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
+* IntuneSettingCatalogASRRulesPolicyWindows10
+  * Fixed creation of policy while it was found by name, now it updates existing policies correctly.
 * AADNamingLocationPolicy
   * Improved logging and fixed issue that caused creation of duplicate
     locations with same name.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -216,6 +216,7 @@ function Get-TargetResource
             }
 
             $MembersValues = $null
+            $result = @{}
             if ($Group.MembershipRuleProcessingState -ne 'On')
             {
                 # Members
@@ -237,6 +238,8 @@ function Get-TargetResource
                         $GroupAsMembersValues += $member.AdditionalProperties.displayName
                     }
                 }
+                $result.Add('Members', $MembersValues)
+                $result.Add('GroupAsMembers', $GroupAsMembersValues)
             }
 
             # MemberOf
@@ -276,12 +279,10 @@ function Get-TargetResource
 
             }
 
-            $result = @{
+            $policySettings = @{
                 DisplayName                   = $Group.DisplayName
                 Id                            = $Group.Id
                 Owners                        = $OwnersValues
-                Members                       = $MembersValues
-                GroupAsMembers                = $GroupAsMembersValues
                 MemberOf                      = $MemberOfValues
                 Description                   = $Group.Description
                 GroupTypes                    = [System.String[]]$Group.GroupTypes
@@ -303,6 +304,7 @@ function Get-TargetResource
                 Managedidentity               = $ManagedIdentity.IsPresent
                 AccessTokens                  = $AccessTokens
             }
+            $result += $policySettings
 
             return $result
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/MSFT_IntuneAccountProtectionPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/MSFT_IntuneAccountProtectionPolicyWindows10.psm1
@@ -90,7 +90,10 @@ function Get-TargetResource
 
         $getValue = $null
         #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+        if (-not [System.String]::IsNullOrEmpty($Id))
+        {
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+        }
 
         if ($null -eq $getValue)
         {
@@ -102,6 +105,11 @@ function Get-TargetResource
                     -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
+
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Account Protection Policy for Windows10 named $DisplayName exist in tenant"
+                }
             }
         }
         #endregion
@@ -268,6 +276,13 @@ function Get-TargetResource
             -TenantId $TenantId `
             -Credential $Credential
 
+        # Necessary to rethrow caught exception regarding duplicate policies
+        if ($_.Exception.Message -like "Duplicate*")
+        {
+            throw $_
+        }
+
+        $nullResult = Clear-M365DSCAuthenticationParameter -BoundParameters $nullResult
         return $nullResult
     }
 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyMacOS/MSFT_IntuneAntivirusPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyMacOS/MSFT_IntuneAntivirusPolicyMacOS.psm1
@@ -200,7 +200,10 @@ function Get-TargetResource
 
         $getValue = $null
         #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+        if (-not [System.String]::IsNullOrEmpty($Id))
+        {
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+        }
 
         if ($null -eq $getValue)
         {
@@ -209,9 +212,14 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($DisplayName))
             {
                 $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
-                    -Filter "Name eq '$DisplayName'" `
                     -All `
+                    -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
+
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Antivirus Policy for macOS named $DisplayName exist in tenant"
+                }
             }
         }
         #endregion
@@ -322,6 +330,13 @@ function Get-TargetResource
             -TenantId $TenantId `
             -Credential $Credential
 
+        # Necessary to rethrow caught exception regarding duplicate policies
+        if ($_.Exception.Message -like "Duplicate*")
+        {
+            throw $_
+        }
+
+        $nullResult = Clear-M365DSCAuthenticationParameter -BoundParameters $nullResult
         return $nullResult
     }
 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
@@ -467,7 +467,7 @@ function Get-TargetResource
 
                 if ($policy.Length -gt 1)
                 {
-                    throw "Duplicate Account Protection LAPS Policy named $DisplayName exist in tenant"
+                    throw "Duplicate Intune Antivirus Policy for Windows10 Setting Catalog named $DisplayName exist in tenant"
                 }
             }
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
@@ -444,8 +444,12 @@ function Get-TargetResource
 
         $templateReferences = 'd948ff9b-99cb-4ee0-8012-1fbc09685377_1', 'e3f74c5a-a6de-411d-aef6-eb15628f3a0a_1', '45fea5e9-280d-4da1-9792-fb5736da0ca9_1', '804339ad-1553-4478-a742-138fb5807418_1'
 
-        #Retrieve policy general settings
-        $policy = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Identity -ErrorAction SilentlyContinue
+        # Retrieve policy general settings
+        $policy = $null
+        if (-not [System.String]::IsNullOrEmpty($Identity))
+        {
+            $policy = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Identity -ErrorAction SilentlyContinue
+        }
 
         if ($null -eq $policy)
         {
@@ -459,6 +463,11 @@ function Get-TargetResource
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript {
                     $_.TemplateReference.TemplateId -in $templateReferences
+                    }
+
+                if ($policy.Length -gt 1)
+                {
+                    throw "Duplicate Account Protection LAPS Policy named $DisplayName exist in tenant"
                 }
             }
         }
@@ -536,6 +545,12 @@ function Get-TargetResource
             -Source $($MyInvocation.MyCommand.Source) `
             -TenantId $TenantId `
             -Credential $Credential
+
+        # Necessary to rethrow caught exception regarding duplicate policies
+        if ($_.Exception.Message -like "Duplicate*")
+        {
+            throw $_
+        }
 
         $nullResult = Clear-M365DSCAuthenticationParameter -BoundParameters $nullResult
         return $nullResult

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
@@ -256,7 +256,10 @@ function Get-TargetResource
 
         $getValue = $null
         #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+        if (-not [System.String]::IsNullOrEmpty($Id))
+        {
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+        }
 
         if ($null -eq $getValue)
         {
@@ -268,6 +271,11 @@ function Get-TargetResource
                     -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
+
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Antivirus Policy for macOS named $DisplayName exist in tenant"
+                }
             }
         }
         #endregion
@@ -349,6 +357,13 @@ function Get-TargetResource
             -TenantId $TenantId `
             -Credential $Credential
 
+        # Necessary to rethrow caught exception regarding duplicate policies
+        if ($_.Exception.Message -like "Duplicate*")
+        {
+            throw $_
+        }
+
+        $nullResult = Clear-M365DSCAuthenticationParameter -BoundParameters $nullResult
         return $nullResult
     }
 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
@@ -274,7 +274,7 @@ function Get-TargetResource
 
                 if ($getValue.Length -gt 1)
                 {
-                    throw "Duplicate Intune Antivirus Policy for macOS named $DisplayName exist in tenant"
+                    throw "Duplicate Intune Device Control Policy for Windows10 named $DisplayName exist in tenant"
                 }
             }
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/MSFT_IntuneDiskEncryptionMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/MSFT_IntuneDiskEncryptionMacOS.psm1
@@ -117,7 +117,10 @@ function Get-TargetResource
 
         $getValue = $null
         #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementIntent -DeviceManagementIntentId $Id -ErrorAction SilentlyContinue
+        if (-not [System.String]::IsNullOrEmpty($Id))
+        {
+            $getValue = Get-MgBetaDeviceManagementIntent -DeviceManagementIntentId $Id -ErrorAction SilentlyContinue
+        }
 
         if ($null -eq $getValue)
         {
@@ -131,6 +134,11 @@ function Get-TargetResource
                     -ErrorAction SilentlyContinue | Where-Object `
                     -FilterScript { `
                         $_.TemplateId -eq 'a239407c-698d-4ef8-b314-e3ae409204b8' `
+                }
+
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Disk Encryption for macOS named $DisplayName exist in tenant"
                 }
             }
         }
@@ -192,6 +200,13 @@ function Get-TargetResource
             -TenantId $TenantId `
             -Credential $Credential
 
+        # Necessary to rethrow caught exception regarding duplicate policies
+        if ($_.Exception.Message -like "Duplicate*")
+        {
+            throw $_
+        }
+
+        $nullResult = Clear-M365DSCAuthenticationParameter -BoundParameters $nullResult
         return $nullResult
     }
 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
@@ -91,7 +91,10 @@ function Get-TargetResource
 
         $getValue = $null
         #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+        if (-not [System.String]::IsNullOrEmpty($Id))
+        {
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+        }
 
         if ($null -eq $getValue)
         {
@@ -103,6 +106,11 @@ function Get-TargetResource
                     -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
+
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Endpoint Detection And Response Policy Linux named $DisplayName exist in tenant"
+                }
             }
         }
         #endregion
@@ -158,6 +166,13 @@ function Get-TargetResource
             -TenantId $TenantId `
             -Credential $Credential
 
+        # Necessary to rethrow caught exception regarding duplicate policies
+        if ($_.Exception.Message -like "Duplicate*")
+        {
+            throw $_
+        }
+
+        $nullResult = Clear-M365DSCAuthenticationParameter -BoundParameters $nullResult
         return $nullResult
     }
 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
@@ -109,7 +109,7 @@ function Get-TargetResource
 
                 if ($getValue.Length -gt 1)
                 {
-                    throw "Duplicate Intune Antivirus Policy for macOS named $DisplayName exist in tenant"
+                    throw "Duplicate Intune Endpoint Detection And Response Policy MacOS named $DisplayName exist in tenant"
                 }
             }
         }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
@@ -91,7 +91,10 @@ function Get-TargetResource
 
         $getValue = $null
         #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+        if (-not [System.String]::IsNullOrEmpty($Id))
+        {
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+        }
 
         if ($null -eq $getValue)
         {
@@ -103,6 +106,11 @@ function Get-TargetResource
                     -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
+
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Antivirus Policy for macOS named $DisplayName exist in tenant"
+                }
             }
         }
         #endregion
@@ -158,6 +166,13 @@ function Get-TargetResource
             -TenantId $TenantId `
             -Credential $Credential
 
+        # Necessary to rethrow caught exception regarding duplicate policies
+        if ($_.Exception.Message -like "Duplicate*")
+        {
+            throw $_
+        }
+
+        $nullResult = Clear-M365DSCAuthenticationParameter -BoundParameters $nullResult
         return $nullResult
     }
 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
@@ -72,31 +72,35 @@ function Get-TargetResource
         $AccessTokens
     )
 
-    Write-Verbose -Message "Checking for the Intune Endpoint Protection Policy {$DisplayName}"
+    try
+    {
+        Write-Verbose -Message "Checking for the Intune Endpoint Protection Policy {$DisplayName}"
 
-    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+        $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
         -InboundParameters $PSBoundParameters `
         -ErrorAction Stop
 
-    #Ensure the proper dependencies are installed in the current environment.
-    Confirm-M365DSCDependencies
+        #Ensure the proper dependencies are installed in the current environment.
+        Confirm-M365DSCDependencies
 
-    #region Telemetry
-    $ResourceName = $MyInvocation.MyCommand.ModuleName -replace 'MSFT_', ''
-    $CommandName = $MyInvocation.MyCommand
-    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
-        -CommandName $CommandName `
-        -Parameters $PSBoundParameters
-    Add-M365DSCTelemetryEvent -Data $data
-    #endregion
+        #region Telemetry
+        $ResourceName = $MyInvocation.MyCommand.ModuleName -replace 'MSFT_', ''
+        $CommandName = $MyInvocation.MyCommand
+        $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+            -CommandName $CommandName `
+            -Parameters $PSBoundParameters
+        Add-M365DSCTelemetryEvent -Data $data
+        #endregion
 
-    $nullResult = $PSBoundParameters
-    $nullResult.Ensure = 'Absent'
+        $nullResult = $PSBoundParameters
+        $nullResult.Ensure = 'Absent'
 
-    try
-    {
-        #Retrieve policy general settings
-        $policy = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Identity -ErrorAction SilentlyContinue
+        # Retrieve policy general settings
+        $policy = $null
+        if (-not [System.String]::IsNullOrEmpty($Identity))
+        {
+            $policy = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Identity -ErrorAction SilentlyContinue
+        }
 
         if ($null -eq $policy)
         {
@@ -108,6 +112,11 @@ function Get-TargetResource
                     -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
+
+                if ($policy.Length -gt 1)
+                {
+                    throw "Duplicate Intune Endpoint Detection And Response Policy for Windows10 named $DisplayName exist in tenant"
+                }
             }
         }
 
@@ -172,6 +181,13 @@ function Get-TargetResource
             -TenantId $TenantId `
             -Credential $Credential
 
+        # Necessary to rethrow caught exception regarding duplicate policies
+        if ($_.Exception.Message -like "Duplicate*")
+        {
+            throw $_
+        }
+
+        $nullResult = Clear-M365DSCAuthenticationParameter -BoundParameters $nullResult
         return $nullResult
     }
 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
@@ -467,7 +467,10 @@ function Get-TargetResource
 
         $getValue = $null
         #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+        if (-not [System.String]::IsNullOrEmpty($Id))
+        {
+            $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+        }
 
         if ($null -eq $getValue)
         {
@@ -479,6 +482,11 @@ function Get-TargetResource
                     -All `
                     -Filter "Name eq '$DisplayName'" `
                     -ErrorAction SilentlyContinue
+
+                if ($getValue.Length -gt 1)
+                {
+                    throw "Duplicate Intune Firewall Policy for Windows10 named $DisplayName exist in tenant"
+                }
             }
         }
         #endregion
@@ -541,6 +549,13 @@ function Get-TargetResource
             -TenantId $TenantId `
             -Credential $Credential
 
+        # Necessary to rethrow caught exception regarding duplicate policies
+        if ($_.Exception.Message -like "Duplicate*")
+        {
+            throw $_
+        }
+
+        $nullResult = Clear-M365DSCAuthenticationParameter -BoundParameters $nullResult
         return $nullResult
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
- Fix duplicate policy creation bug, when existing policy was found in tenant, still a new policy was created.
- Fix dynamic group compliance, when dynamic group was found, returned incompliant due to empty parameters Members & GroupAsMembers. Edited so that those params are only added to the comparison when it is a static group.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
