### PR TITLE
EXOTenantAllowBlockListItems: Fix Test-TargetResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
+
+* AADGroupsNamingPolicy, EXOHostedContentFilterPolicy,
+  SCAutoSensitivityLabelPolicy, SCLabelPolicy, SCSecurityFilter
+  * Use correct parameter `DesiredValues` given to `Test-M365DSCParameterState`,
+    contrary to `EXOTenantAllowBlockListItems` these resources are not affected
+    but we still should use the correct parameter
+* EXOTenantAllowBlockListItems
+  * Fixed `Test-TargetResource` by using the correct parameter `DesiredValues`
+    given to `Test-M365DSCParameterState`
 * IntuneAppProtectionPolicyiOS
   * Fixes [#5589] https://github.com/microsoft/Microsoft365DSC/issues/5589
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsNamingPolicy/MSFT_AADGroupsNamingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsNamingPolicy/MSFT_AADGroupsNamingPolicy.psm1
@@ -304,7 +304,7 @@ function Test-TargetResource
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `
-        -DesiredValues $ValuesToCheck `
+        -DesiredValues $PSBoundParameters `
         -ValuesToCheck $ValuesToCheck.Keys
 
     Write-Verbose -Message "Test-TargetResource returned $TestResult"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
@@ -1091,7 +1091,7 @@ function Test-TargetResource
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `
-        -DesiredValues $ValuesToCheck `
+        -DesiredValues $PSBoundParameters `
         -ValuesToCheck $ValuesToCheck.Keys
 
     Write-Verbose -Message "Test-TargetResource returned $TestResult"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTenantAllowBlockListItems/MSFT_EXOTenantAllowBlockListItems.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTenantAllowBlockListItems/MSFT_EXOTenantAllowBlockListItems.psm1
@@ -409,7 +409,7 @@ function Test-TargetResource
 
     $testResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `
-        -DesiredValues $ValuesToCheck `
+        -DesiredValues $PSBoundParameters `
         -ValuesToCheck $ValuesToCheck.Keys
 
     Write-Verbose -Message "Test-TargetResource returned $testResult"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCAutoSensitivityLabelPolicy/MSFT_SCAutoSensitivityLabelPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCAutoSensitivityLabelPolicy/MSFT_SCAutoSensitivityLabelPolicy.psm1
@@ -773,7 +773,7 @@ function Test-TargetResource
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `
-        -DesiredValues $ValuesToCheck `
+        -DesiredValues $PSBoundParameters `
         -ValuesToCheck $ValuesToCheck.Keys
 
     Write-Verbose -Message "Test-TargetResource returned $TestResult"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCLabelPolicy/MSFT_SCLabelPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCLabelPolicy/MSFT_SCLabelPolicy.psm1
@@ -771,7 +771,7 @@ function Test-TargetResource
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `
-        -DesiredValues $ValuesToCheck `
+        -DesiredValues $PSBoundParameters `
         -ValuesToCheck $ValuesToCheck.Keys
 
     Write-Verbose -Message "Test-TargetResource returned $TestResult"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCSecurityFilter/MSFT_SCSecurityFilter.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCSecurityFilter/MSFT_SCSecurityFilter.psm1
@@ -466,7 +466,7 @@ function Test-TargetResource
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `
-        -DesiredValues $ValuesToCheck `
+        -DesiredValues $PSBoundParameters `
         -ValuesToCheck $ValuesToCheck.Keys
 
     Write-Verbose -Message "Test-TargetResource returned $TestResult"


### PR DESCRIPTION
#### Pull Request (PR) description

Looks like my last fix didn't fix *Test-TargetResource* entirely, if the resource is absent and the blueprint also expects it to be absent the test will currently fail because the *Ensure* property is being removed from *ValuesToCheck* and that same property is the one being used for *DesiredValues* given to *Test-M365DSCParameterState*.

This fixes the issue by instead passing *PSBoundParameters* as *DesiredValues* given to *Test-M365DSCParameterState* just like it's done in all other resources, except a few ones which I also change in this PR even though those are not affected since they don't call *Remove-M365DSCAuthenticationParameter* which removes *Ensure* from *ValuesToCheck*.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
