### PR TITLE
EXOTransportRule: Fix property type in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
+
+* EXOTransportRule
+  * Fix type of `SenderInRecipientList` in schema
 * IntuneAppProtectionPolicyiOS
   * Fixes [#5589] https://github.com/microsoft/Microsoft365DSC/issues/5589
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.schema.mof
@@ -153,7 +153,7 @@ class MSFT_EXOTransportRule : OMI_BaseResource
     [Write, Description("The SenderADAttributeMatchesPatterns parameter specifies a condition that looks for text patterns in Active Directory attributes of message senders by using regular expressions.")] String SenderADAttributeMatchesPatterns[];
     [Write, Description("The SenderAddressLocation parameter specifies where to look for sender addresses in conditions and exceptions that examine sender email addresses."), ValueMap{"Header","Envelope","HeaderOrEnvelope"}, Values{"Header","Envelope","HeaderOrEnvelope"}] String SenderAddressLocation;
     [Write, Description("The SenderDomainIs parameter specifies a condition that looks for senders with email address in the specified domains.")] String SenderDomainIs[];
-    [Write, Description("This parameter is reserved for internal Microsoft use.")] String SenderInRecipientList;
+    [Write, Description("This parameter is reserved for internal Microsoft use.")] String SenderInRecipientList[];
     [Write, Description("The SenderIpRanges parameter specifies a condition that looks for senders whose IP addresses matches the specified value, or fall within the specified ranges.")] String SenderIpRanges[];
     [Write, Description("The SenderManagementRelationship parameter specifies a condition that looks for the relationship between the sender and recipients in messages."), ValueMap{"Manager","DirectReport"}, Values{"Manager","DirectReport"}] String SenderManagementRelationship;
     [Write, Description("The SentTo parameter specifies a condition that looks for recipients in messages.")] String SentTo[];


### PR DESCRIPTION
#### Pull Request (PR) description

Property *SenderInRecipientList* has an incorrect type assigned in the schema file, it should be a string array and not a simple string, this PR fixes this by changing to the correct type.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
