### PR TITLE
M365DSCUtil: Test-M365DSCParameterState: Replace the line endings before making the comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
+
+* M365DSCUtil
+  * In `Test-M365DSCParameterState` try to replace the line endings before
+    making the comparison otherwise it may fail as it did for a few resources
+    FIXES [#5648](https://github.com/microsoft/Microsoft365DSC/issues/5648)
 * IntuneAppProtectionPolicyiOS
-  * Fixes [#5589] https://github.com/microsoft/Microsoft365DSC/issues/5589
+  * FIXES [#5589](https://github.com/microsoft/Microsoft365DSC/issues/5589)
 
 * AADConditionalAccessPolicy
   * Fixed DisableResilienceDefaults result

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -839,16 +839,36 @@ function Test-M365DSCParameterState
                         {
                             'String'
                             {
-                                if ([string]::IsNullOrEmpty($CurrentValues.$fieldName) `
-                                        -and [string]::IsNullOrEmpty($DesiredValues.$fieldName))
+                                if (-not [string]::IsNullOrEmpty($CurrentValues.$fieldName))
+                                {
+                                    try
+                                    {
+                                        $CurrentValues.$fieldName = $CurrentValues.$fieldName.Replace("`r`n", "`n")
+                                    }
+                                    catch
+                                    {
+                                    }
+                                }
+                                if (-not [string]::IsNullOrEmpty($DesiredValues.$fieldName))
+                                {
+                                    try
+                                    {
+                                        $DesiredValues.$fieldName = $DesiredValues.$fieldName.Replace("`r`n", "`n")
+                                    }
+                                    catch
+                                    {
+                                    }
+                                }
+
+                                if ([string]::IsNullOrEmpty($CurrentValues.$fieldName) -and
+                                    [string]::IsNullOrEmpty($DesiredValues.$fieldName))
                                 {
                                 }
                                 # Align line breaks
-                                elseif (-not [string]::IsNullOrEmpty($CurrentValues.$fieldName) `
-                                        -and -not [string]::IsNullOrEmpty($DesiredValues.$fieldName) `
-                                        -and [string]::Equals($CurrentValues.$fieldName.Replace("`r`n", "`n"), `
-                                        $DesiredValues.$fieldName.Replace("`r`n", "`n"), `
-                                        [System.StringComparison]::Ordinal))
+                                elseif (-not [string]::IsNullOrEmpty($CurrentValues.$fieldName) -and
+                                    -not [string]::IsNullOrEmpty($DesiredValues.$fieldName) -and
+                                    [string]::Equals($CurrentValues.$fieldName, $DesiredValues.$fieldName,
+                                    [System.StringComparison]::Ordinal))
                                 {
                                 }
                                 else


### PR DESCRIPTION
#### Pull Request (PR) description

M365DSCUtil: In `Test-M365DSCParameterState` try to replace the line endings before making the comparison otherwise it may fail as it did for a few resources as I explained on #5648.

#### This Pull Request (PR) fixes the following issues

- Fixes #5648

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
