### PR TITLE
Add empty or invalid configuration message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@
 * M365DSCReport
   * Fix missing delimiter when called without the parameter.
     FIXES [#5634](https://github.com/microsoft/Microsoft365DSC/issues/5634)
+  * Add configuration validation to inform about comparisons against empty or invalid configurations.
+    FIXES [#5658](https://github.com/microsoft/Microsoft365DSC/issues/5658)
 * M365DSCTelemetryEngine
   * Report LCM details only if running as administrator.
 * M365DSCUtil

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -2073,8 +2073,12 @@ function Initialize-M365DSCReporting
         $parsedContent = ConvertTo-DSCObject -Content $fileContent
     }
 
-    return $parsedContent
+    if ($null -eq $parsedContent)
+    {
+        Write-Warning -Message "No configuration found in $ConfigurationPath. Either the configuration was empty or the file was not a valid DSC configuration."
+    }
 
+    return $parsedContent
 }
 
 Export-ModuleMember -Function @(


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds a message about an empty parsed content from `ConvertTo-DSCObject` in `Initialize-M365DSCReporting`. This is done to improve error visibility when a comparison against an empty or invalid configuration is done, where `ConvertTo-DSCObject` returns a $null object. 

There is also a PR open at the DSCParser repository which outputs the errors during parse: https://github.com/microsoft/DSCParser/pull/59

#### This Pull Request (PR) fixes the following issues
- Fixes #5658 

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
