### PR TITLE
Fix export of missing details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneAccountProtectionLocalUserGroupMembershipPolicy
+  * Fixes an issue where not all details were exported.
+* IntuneAccountProtectionPolicy
+  * Fixes an issue where not all details were exported.
+
 # 1.25.122.1
 
 * AADConditionalAccessPolicy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
   * Fixes an issue where not all details were exported.
 * IntuneAccountProtectionPolicy
   * Fixes an issue where not all details were exported.
+* IntuneAppConfigurationPolicy
+  * Fixes an issue with fetching a policy that does not exist.
+    FIXES [#5666](https://github.com/microsoft/Microsoft365DSC/issues/5666)
+* IntuneApplicationControlPolicyWindows10
+  * Fixes an issue with fetching a policy that does not exist.
+* IntuneAppProtectionPolicyAndroid
+  * Fixes an issue with fetching a policy that does not exist.
+* IntuneDeviceEnrollmentPlatformRestriction
+  * Fixes an issue with fetching a policy that does not exist.
+* M365DSCReverse
+  * Only fetch tenant name if not in correct format.
 
 # 1.25.122.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy.psm1
@@ -108,13 +108,13 @@ function Get-TargetResource
                         return $nullResult
                     }
 
-                    $policy = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $policy.id -ExpandProperty settings -ErrorAction SilentlyContinue
+                    $policy = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $policy.Id -ExpandProperty settings -ErrorAction SilentlyContinue
                 }
             }
         }
         else
         {
-            $policy = $Script:exportedInstance
+            $policy = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Script:exportedInstance.Id -ExpandProperty settings
         }
 
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicy/MSFT_IntuneAccountProtectionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicy/MSFT_IntuneAccountProtectionPolicy.psm1
@@ -174,13 +174,13 @@ function Get-TargetResource
                     throw "A policy with a duplicated displayName {'$DisplayName'} was found - Ensure displayName is unique"
                 }
 
-                $policy = Get-MgBetaDeviceManagementIntent -DeviceManagementIntentId $policy.id -ExpandProperty settings, assignments -ErrorAction SilentlyContinue
+                $policy = Get-MgBetaDeviceManagementIntent -DeviceManagementIntentId $policy.Id -ExpandProperty settings, assignments -ErrorAction SilentlyContinue
 
             }
         }
         else
         {
-            $policy = $Script:exportedInstance
+            $policy = Get-MgBetaDeviceManagementIntent -DeviceManagementIntentId $Script:exportedInstance.Id -ExpandProperty settings, assignments
         }
 
         $Identity = $policy.Id

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationPolicy/MSFT_IntuneAppConfigurationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationPolicy/MSFT_IntuneAppConfigurationPolicy.psm1
@@ -86,7 +86,7 @@ function Get-TargetResource
             if (-not [string]::IsNullOrEmpty($Id))
             {
                 $configPolicy = Get-MgBetaDeviceAppManagementTargetedManagedAppConfiguration -TargetedManagedAppConfigurationId $Id `
-                    -ErrorAction Stop
+                    -ErrorAction SilentlyContinue
             }
 
             if ($null -eq $configPolicy)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyAndroid/MSFT_IntuneAppProtectionPolicyAndroid.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyAndroid/MSFT_IntuneAppProtectionPolicyAndroid.psm1
@@ -245,7 +245,7 @@ function Get-TargetResource
             {
                 Write-Verbose -Message "Searching for Policy using Id {$Id}"
                 $policyInfo = Get-MgBetaDeviceAppManagementAndroidManagedAppProtection -Filter "Id eq '$Id'" -ExpandProperty Apps, assignments `
-                    -ErrorAction Stop
+                    -ErrorAction SilentlyContinue
             }
 
             if ($null -eq $policyInfo)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneApplicationControlPolicyWindows10/MSFT_IntuneApplicationControlPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneApplicationControlPolicyWindows10/MSFT_IntuneApplicationControlPolicyWindows10.psm1
@@ -91,7 +91,7 @@ function Get-TargetResource
             #Retrieve policy general settings
             if (-not [System.String]::IsNullOrEmpty($Id))
             {
-                $policy = Get-MgBetaDeviceManagementIntent -DeviceManagementIntentId $Id -ErrorAction Stop
+                $policy = Get-MgBetaDeviceManagementIntent -DeviceManagementIntentId $Id -ErrorAction SilentlyContinue
             }
 
             if ($null -eq $policy)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentPlatformRestriction/MSFT_IntuneDeviceEnrollmentPlatformRestriction.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentPlatformRestriction/MSFT_IntuneDeviceEnrollmentPlatformRestriction.psm1
@@ -136,7 +136,7 @@ function Get-TargetResource
             $config = $null
             if (-not [string]::IsNullOrEmpty($Identity))
             {
-                $config = Get-MgBetaDeviceManagementDeviceEnrollmentConfiguration -DeviceEnrollmentConfigurationId $Identity -ErrorAction Stop
+                $config = Get-MgBetaDeviceManagementDeviceEnrollmentConfiguration -DeviceEnrollmentConfigurationId $Identity -ErrorAction SilentlyContinue
             }
 
             if ($null -eq $config)

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -280,11 +280,18 @@ function Start-M365DSCConfigurationExtract
                 [PSCredential]$AppSecretAsPSCredential = New-Object System.Management.Automation.PSCredential ('ApplicationSecret', $secStringPassword)
             }
 
-            $organization = Get-M365DSCTenantDomain -ApplicationId $ApplicationId `
-                -TenantId $TenantId `
-                -CertificateThumbprint $CertificateThumbprint `
-                -ApplicationSecret $AppSecretAsPSCredential `
-                -CertificatePath $CertificatePath
+            if ($TenantId -like "*.onmicrosoft.com")
+            {
+                $organization = $TenantId
+            }
+            else
+            {
+                $organization = Get-M365DSCTenantDomain -ApplicationId $ApplicationId `
+                    -TenantId $TenantId `
+                    -CertificateThumbprint $CertificateThumbprint `
+                    -ApplicationSecret $AppSecretAsPSCredential `
+                    -CertificatePath $CertificatePath
+            }
         }
         elseif ($AuthMethods -Contains 'Credentials' -or `
                 $AuthMethods -Contains 'CredentialsWithApplicationId')


### PR DESCRIPTION
#### Pull Request (PR) description
When improving the performance, we cached resources and reused them in the `Get-TargetResource` function. For the two resources `IntuneAccountProtectionLocalUserGroupMembershipPolicy` and `IntuneAccountProtectionPolicy`, some details are only available when expanding specific properties or calling the resource directly with its id. 

Additionally, it fixes issues with a couple of resources that had `-ErrorAction Stop` set when fetching the Intune policy in `Get-TargetResource`. They were now updated to ignore any error message just like the other resources. 

#### This Pull Request (PR) fixes the following issues
- Fixes #5666 

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
