### PR TITLE
Fix null reference error in AppRoleAssignedTo comparison

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
@@ -604,43 +604,48 @@ function Set-TargetResource
             $appInstance = Get-MgApplication -Filter "AppId eq '$AppId'"
             Update-MgApplication -ApplicationId $appInstance.Id -IdentifierUris $IdentifierUris
         }
-        if ($AppRoleAssignedTo)
-        {
-            [Array]$currentPrincipals = $currentAADServicePrincipal.AppRoleAssignedTo.Identity
-            [Array]$desiredPrincipals = $AppRoleAssignedTo.Identity
+       if ($AppRoleAssignedTo -and $AppRoleAssignedTo.Count -gt 0) {
+          [Array]$currentPrincipals = $currentAADServicePrincipal.AppRoleAssignedTo.Identity
+          [Array]$desiredPrincipals = $AppRoleAssignedTo.Identity
 
-            [Array]$differences = Compare-Object -ReferenceObject $currentPrincipals -DifferenceObject $desiredPrincipals
-            [Array]$membersToAdd = $differences | Where-Object -FilterScript { $_.SideIndicator -eq '=>' }
-            [Array]$membersToRemove = $differences | Where-Object -FilterScript { $_.SideIndicator -eq '<=' }
+    # Ensure both arrays are initialized before using Compare-Object
+    if ($currentPrincipals -and $desiredPrincipals -and $currentPrincipals.Count -gt 0 -and $desiredPrincipals.Count -gt 0) {
+        [Array]$differences = Compare-Object -ReferenceObject $currentPrincipals -DifferenceObject $desiredPrincipals
+        [Array]$membersToAdd = $differences | Where-Object { $_.SideIndicator -eq '=>' }
+        [Array]$membersToRemove = $differences | Where-Object { $_.SideIndicator -eq '<=' }
+    } else {
+        Write-Verbose "Either currentPrincipals or desiredPrincipals is empty. Skipping comparison."
+        [Array]$membersToAdd = @()
+        [Array]$membersToRemove = @()
+    }
 
-            if ($differences.Count -gt 0)
-            {
-                if ($membersToAdd.Count -gt 0)
-                {
-                    $AppRoleAssignedToValues = @()
-                    foreach ($assignment in $AppRoleAssignedTo)
-                    {
-                        $AppRoleAssignedToValues += @{
-                            PrincipalType = $assignment.PrincipalType
-                            Identity      = $assignment.Identity
-                        }
+    if ($differences.Count -gt 0) {
+        if ($membersToAdd.Count -gt 0) {
+            $AppRoleAssignedToValues = @()
+            foreach ($assignment in $AppRoleAssignedTo) {
+                $AppRoleAssignedToValues += @{
+                    PrincipalType = $assignment.PrincipalType
+                    Identity      = $assignment.Identity
+                }
+            }
+            foreach ($member in $membersToAdd) {
+                $assignment = $AppRoleAssignedToValues | Where-Object { $_.Identity -eq $member.InputObject }
+                
+                if ($assignment) {
+                    if ($assignment.PrincipalType -eq 'User') {
+                        Write-Verbose -Message "Retrieving user {$($assignment.Identity)}"
+                        $user = Get-MgUser -Filter "startswith(UserPrincipalName, '$($assignment.Identity)')"
+                        $PrincipalIdValue = $user.Id
+                    } elseif ($assignment.PrincipalType -eq 'Group') {
+                        Write-Verbose -Message "Retrieving group {$($assignment.Identity)}"
+                        $group = Get-MgGroup -Filter "DisplayName eq '$($assignment.Identity)'"
+                        $PrincipalIdValue = $group.Id
+                    } else {
+                        Write-Verbose "Unknown PrincipalType: $($assignment.PrincipalType). Skipping."
+                        continue
                     }
-                    foreach ($member in $membersToAdd)
-                    {
-                        $assignment = $AppRoleAssignedToValues | Where-Object -FilterScript { $_.Identity -eq $member.InputObject }
-                        if ($assignment.PrincipalType -eq 'User')
-                        {
-                            Write-Verbose -Message "Retrieving user {$($assignment.Identity)}"
-                            $user = Get-MgUser -Filter "startswith(UserPrincipalName, '$($assignment.Identity)')"
-                            $PrincipalIdValue = $user.Id
-                        }
-                        else
-                        {
-                            Write-Verbose -Message "Retrieving group {$($assignment.Identity)}"
-                            $group = Get-MgGroup -Filter "DisplayName eq '$($assignment.Identity)'"
-                            $PrincipalIdValue = $group.Id
-                        }
 
+                    if ($PrincipalIdValue) {
                         $bodyParam = @{
                             principalId = $PrincipalIdValue
                             resourceId  = $currentAADServicePrincipal.ObjectID
@@ -649,47 +654,63 @@ function Set-TargetResource
                         Write-Verbose -Message "Adding member {$($member.InputObject.ToString())}"
                         New-MgServicePrincipalAppRoleAssignedTo -ServicePrincipalId $currentAADServicePrincipal.ObjectID `
                             -BodyParameter $bodyParam | Out-Null
-                    }
-                }
-
-                if ($membersToRemove.Count -gt 0)
-                {
-                    $AppRoleAssignedToValues = @()
-                    foreach ($assignment in $currentAADServicePrincipal.AppRoleAssignedTo)
-                    {
-                        $AppRoleAssignedToValues += @{
-                            PrincipalType = $assignment.PrincipalType
-                            Identity      = $assignment.Identity
-                        }
-                    }
-                    foreach ($member in $membersToRemove)
-                    {
-                        $assignment = $AppRoleAssignedToValues | Where-Object -FilterScript { $_.Identity -eq $member.InputObject }
-                        if ($assignment.PrincipalType -eq 'User')
-                        {
-                            Write-Verbose -Message "Retrieving user {$($assignment.Identity)}"
-                            $user = Get-MgUser -Filter "startswith(UserPrincipalName, '$($assignment.Identity)')"
-                            $PrincipalIdValue = $user.Id
-                        }
-                        else
-                        {
-                            Write-Verbose -Message "Retrieving group {$($assignment.Identity)}"
-                            $group = Get-MgGroup -Filter "DisplayName eq '$($assignment.Identity)'"
-                            $PrincipalIdValue = $group.Id
-                        }
-                        Write-Verbose -Message "PrincipalID Value = '$PrincipalIdValue'"
-                        Write-Verbose -Message "ServicePrincipalId = '$($currentAADServicePrincipal.ObjectID)'"
-                        $allAssignments = Get-MgServicePrincipalAppRoleAssignedTo -ServicePrincipalId $currentAADServicePrincipal.ObjectID
-                        $assignmentToRemove = $allAssignments | Where-Object -FilterScript { $_.PrincipalId -eq $PrincipalIdValue }
-                        Write-Verbose -Message "Removing member {$($member.InputObject.ToString())}"
-                        Remove-MgServicePrincipalAppRoleAssignedTo -ServicePrincipalId $currentAADServicePrincipal.ObjectID `
-                            -AppRoleAssignmentId $assignmentToRemove.Id | Out-Null
+                    } else {
+                        Write-Verbose "Failed to retrieve PrincipalId for {$($assignment.Identity)}. Skipping."
                     }
                 }
             }
         }
 
-        Write-Verbose -Message 'Checking if owners need to be updated...'
+        if ($membersToRemove.Count -gt 0) {
+            $AppRoleAssignedToValues = @()
+            foreach ($assignment in $currentAADServicePrincipal.AppRoleAssignedTo) {
+                $AppRoleAssignedToValues += @{
+                    PrincipalType = $assignment.PrincipalType
+                    Identity      = $assignment.Identity
+                }
+            }
+            foreach ($member in $membersToRemove) {
+                $assignment = $AppRoleAssignedToValues | Where-Object { $_.Identity -eq $member.InputObject }
+
+                if ($assignment) {
+                    if ($assignment.PrincipalType -eq 'User') {
+                        Write-Verbose -Message "Retrieving user {$($assignment.Identity)}"
+                        $user = Get-MgUser -Filter "startswith(UserPrincipalName, '$($assignment.Identity)')"
+                        $PrincipalIdValue = $user.Id
+                    } elseif ($assignment.PrincipalType -eq 'Group') {
+                        Write-Verbose -Message "Retrieving group {$($assignment.Identity)}"
+                        $group = Get-MgGroup -Filter "DisplayName eq '$($assignment.Identity)'"
+                        $PrincipalIdValue = $group.Id
+                    } else {
+                        Write-Verbose "Unknown PrincipalType: $($assignment.PrincipalType). Skipping."
+                        continue
+                    }
+
+                    if ($PrincipalIdValue) {
+                        Write-Verbose -Message "PrincipalID Value = '$PrincipalIdValue'"
+                        Write-Verbose -Message "ServicePrincipalId = '$($currentAADServicePrincipal.ObjectID)'"
+                        
+                        $allAssignments = Get-MgServicePrincipalAppRoleAssignedTo -ServicePrincipalId $currentAADServicePrincipal.ObjectID
+                        $assignmentToRemove = $allAssignments | Where-Object { $_.PrincipalId -eq $PrincipalIdValue }
+
+                        if ($assignmentToRemove) {
+                            Write-Verbose -Message "Removing member {$($member.InputObject.ToString())}"
+                            Remove-MgServicePrincipalAppRoleAssignedTo -ServicePrincipalId $currentAADServicePrincipal.ObjectID `
+                                -AppRoleAssignmentId $assignmentToRemove.Id | Out-Null
+                        } else {
+                            Write-Verbose "No matching assignment found for PrincipalId $PrincipalIdValue. Skipping removal."
+                        }
+                    } else {
+                        Write-Verbose "Failed to retrieve PrincipalId for {$($assignment.Identity)}. Skipping removal."
+                    }
+                }
+            }
+        }
+    }
+}
+
+Write-Verbose -Message 'Checking if owners need to be updated...'
+
 
         if ($null -ne $Owners)
         {


### PR DESCRIPTION

**Title:** Fix Null Reference Error in AppRoleAssignedTo Comparison

**Description:**
- Fixed null reference errors when comparing `AppRoleAssignedTo` values in `MSFT_AADServicePrincipal.psm1`.
- Added proper null checks and logging to prevent errors in cases where `AppRoleAssignedTo` is empty or missing data.
- Ensured that the comparison logic works correctly with both empty and populated `AppRoleAssignedTo` values.
- Enhanced error handling and verbosity for better traceability during execution.

**Fixes:** #5717
