### PR TITLE
Simplify export of complex properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     FIXES [#5709](https://github.com/microsoft/Microsoft365DSC/issues/5709)
 * MISC
   * PowerPlatform resource revamp to use direct REST API calls.
+  * Simplify export behavior for all resources and complex objects.
 * DEPENDENCIES
   * Removed dependency on Microsoft.PowerApps.Administration.PowerShell.
   * Updated MSCloudLoginAssistant to version 1.1.37.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAccessReviewDefinition/MSFT_AADAccessReviewDefinition.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAccessReviewDefinition/MSFT_AADAccessReviewDefinition.psm1
@@ -823,8 +823,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.ScopeValue)
             {
                 $complexMapping = @(
@@ -959,19 +957,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ScopeValue)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ScopeValue' -IsCIMArray:$False
-            }
-            if ($Results.SettingsValue)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'SettingsValue' -IsCIMArray:$False
-            }
-            if ($Results.StageSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'StageSettings' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('ScopeValue', 'SettingsValue', 'StageSettings')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAccessReviewPolicy/MSFT_AADAccessReviewPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAccessReviewPolicy/MSFT_AADAccessReviewPolicy.psm1
@@ -318,9 +318,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADActivityBasedTimeoutPolicy/MSFT_AADActivityBasedTimeoutPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADActivityBasedTimeoutPolicy/MSFT_AADActivityBasedTimeoutPolicy.psm1
@@ -534,9 +534,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdminConsentRequestPolicy/MSFT_AADAdminConsentRequestPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdminConsentRequestPolicy/MSFT_AADAdminConsentRequestPolicy.psm1
@@ -485,9 +485,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             if ($null -ne $Results.Reviewers)
             {
                 $complexMapping = @(
@@ -516,11 +513,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Reviewers)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Reviewers' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('Reviewers')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
@@ -1089,7 +1089,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-
             if ($null -ne $Results.ScopedRoleMembers)
             {
                 $complexMapping = @(
@@ -1120,25 +1119,13 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($null -ne $Results.ScopedRoleMembers)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ScopedRoleMembers' -IsCIMArray $true
-            }
-            if ($null -ne $Results.Members)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Members' -IsCIMArray $true
-                $currentDSCBlock = $currentDSCBlock.Replace("`",`"`r`n", '')
-                $currentDSCBlock = $currentDSCBlock.Replace(",`r`n", '').Replace("`");`r`n", ");`r`n")
-            }
+                -Credential $Credential `
+                -NoEscape @('Members', 'ScopedRoleMembers')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -1552,8 +1552,6 @@ function Export-TargetResource
                 $Results = Get-TargetResource @Params
                 if ($Results.Ensure -eq 'Present')
                 {
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
 
                     if ($Results.Permissions.Count -gt 0)
                     {
@@ -1758,49 +1756,8 @@ function Export-TargetResource
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `
                         -Results $Results `
-                        -Credential $Credential
-
-                    if ($Results.Api)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Api' -IsCIMArray:$False
-                    }
-
-                    if ($null -ne $Results.Permissions)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                            -ParameterName 'Permissions' `
-                            -IsCIMArray:$True
-                    }
-
-                    if ($Results.OptionalClaims)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'OptionalClaims' -IsCIMArray:$False
-                    }
-
-                    if ($Results.OnPremisesPublishing)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'OnPremisesPublishing' -IsCIMArray:$False
-                    }
-
-                    if ($Results.AuthenticationBehaviors)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AuthenticationBehaviors' -IsCIMArray:$False
-                    }
-
-                    if ($Results.KeyCredentials)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'KeyCredentials' -IsCIMArray:$True
-                    }
-
-                    if ($Results.PasswordCredentials)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'PasswordCredentials' -IsCIMArray:$True
-                    }
-
-                    if ($Results.AppRoles)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AppRoles' -IsCIMArray:$True
-                    }
+                        -Credential $Credential `
+                        -NoEscape @('Api', 'Permissions', 'OptionalClaims', 'OnPremisesPublishing', 'AuthenticationBehaviors', 'KeyCredentials', 'PasswordCredentials', 'AppRoles')
 
                     $dscContent.Append($currentDSCBlock) | Out-Null
                     Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAttributeSet/MSFT_AADAttributeSet.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAttributeSet/MSFT_AADAttributeSet.psm1
@@ -370,9 +370,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationContextClassReference/MSFT_AADAuthenticationContextClassReference.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationContextClassReference/MSFT_AADAuthenticationContextClassReference.psm1
@@ -394,9 +394,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationFlowPolicy/MSFT_AADAuthenticationFlowPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationFlowPolicy/MSFT_AADAuthenticationFlowPolicy.psm1
@@ -347,11 +347,10 @@ function Export-TargetResource
             ManagedIdentity       = $ManagedIdentity.IsPresent
             AccessTokens          = $AccessTokens
         }
-        $Results = Get-TargetResource @Params
 
+        $Results = Get-TargetResource @Params
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicy/MSFT_AADAuthenticationMethodPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicy/MSFT_AADAuthenticationMethodPolicy.psm1
@@ -646,8 +646,6 @@ function Export-TargetResource
 
                 $Script:exportedInstance = $config
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 if ($null -ne $Results.RegistrationEnforcement)
                 {
                     $complexMapping = @(
@@ -755,20 +753,9 @@ function Export-TargetResource
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `
                     -Results $Results `
-                    -Credential $Credential
-                if ($Results.RegistrationEnforcement)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'RegistrationEnforcement' -IsCIMArray:$False
-                }
-                if ($Results.SystemCredentialPreferences)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'SystemCredentialPreferences' -IsCIMArray:$False
-                }
+                    -Credential $Credential `
+                    -NoEscape @('RegistrationEnforcement', 'ReportSuspiciousActivitySettings', 'SystemCredentialPreferences')
 
-                if ($Results.ReportSuspiciousActivitySettings)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ReportSuspiciousActivitySettings' -IsCIMArray:$False
-                }
                 $dscContent += $currentDSCBlock
                 Save-M365DSCPartialExport -Content $currentDSCBlock `
                     -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyAuthenticator/MSFT_AADAuthenticationMethodPolicyAuthenticator.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyAuthenticator/MSFT_AADAuthenticationMethodPolicyAuthenticator.psm1
@@ -928,8 +928,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.FeatureSettings)
             {
                 $complexMapping = @(
@@ -1016,19 +1014,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.FeatureSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'FeatureSettings' -IsCIMArray:$False
-            }
-            if ($Results.ExcludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExcludeTargets' -IsCIMArray:$True
-            }
-            if ($Results.IncludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IncludeTargets' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('FeatureSettings', 'ExcludeTargets', 'IncludeTargets')
+
             $currentDSCBlock = Remove-M365DSCCimInstanceTrailingCharacterFromExport -DSCBlock $currentDSCBlock
 
             # FIX #3645

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyEmail/MSFT_AADAuthenticationMethodPolicyEmail.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyEmail/MSFT_AADAuthenticationMethodPolicyEmail.psm1
@@ -589,8 +589,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.ExcludeTargets)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -625,15 +623,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ExcludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExcludeTargets' -IsCIMArray:$True
-            }
-            if ($Results.IncludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IncludeTargets' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('ExcludeTargets', 'IncludeTargets')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyExternal/MSFT_AADAuthenticationMethodPolicyExternal.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyExternal/MSFT_AADAuthenticationMethodPolicyExternal.psm1
@@ -573,8 +573,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.ExcludeTargets)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -624,19 +622,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ExcludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExcludeTargets' -IsCIMArray:$True
-            }
-            if ($Results.IncludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IncludeTargets' -IsCIMArray:$True
-            }
-            if ($Results.OpenIdConnectSetting)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'OpenIdConnectSetting' -IsCIMArray:$False
-            }
+                -Credential $Credential `
+                -NoEscape @('ExcludeTargets', 'IncludeTargets', 'OpenIdConnectSetting')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyFido2/MSFT_AADAuthenticationMethodPolicyFido2.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyFido2/MSFT_AADAuthenticationMethodPolicyFido2.psm1
@@ -616,8 +616,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.KeyRestrictions)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -665,19 +663,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.KeyRestrictions)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'KeyRestrictions' -IsCIMArray:$False
-            }
-            if ($Results.ExcludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExcludeTargets' -IsCIMArray:$True
-            }
-            if ($Results.IncludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IncludeTargets' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('KeyRestrictions', 'ExcludeTargets', 'IncludeTargets')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyHardware/MSFT_AADAuthenticationMethodPolicyHardware.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyHardware/MSFT_AADAuthenticationMethodPolicyHardware.psm1
@@ -559,8 +559,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.ExcludeTargets)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -595,15 +593,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ExcludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExcludeTargets' -IsCIMArray:$True
-            }
-            if ($Results.IncludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IncludeTargets' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('ExcludeTargets', 'IncludeTargets')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicySms/MSFT_AADAuthenticationMethodPolicySms.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicySms/MSFT_AADAuthenticationMethodPolicySms.psm1
@@ -563,8 +563,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.ExcludeTargets)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -599,15 +597,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ExcludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExcludeTargets' -IsCIMArray:$True
-            }
-            if ($Results.IncludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IncludeTargets' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('ExcludeTargets', 'IncludeTargets')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicySoftware/MSFT_AADAuthenticationMethodPolicySoftware.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicySoftware/MSFT_AADAuthenticationMethodPolicySoftware.psm1
@@ -562,8 +562,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.ExcludeTargets)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -598,15 +596,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ExcludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExcludeTargets' -IsCIMArray:$True
-            }
-            if ($Results.IncludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IncludeTargets' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('ExcludeTargets', 'IncludeTargets')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyTemporary/MSFT_AADAuthenticationMethodPolicyTemporary.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyTemporary/MSFT_AADAuthenticationMethodPolicyTemporary.psm1
@@ -636,8 +636,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.ExcludeTargets)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -672,15 +670,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ExcludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExcludeTargets' -IsCIMArray:$True
-            }
-            if ($Results.IncludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IncludeTargets' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('ExcludeTargets', 'IncludeTargets')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyVoice/MSFT_AADAuthenticationMethodPolicyVoice.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyVoice/MSFT_AADAuthenticationMethodPolicyVoice.psm1
@@ -575,8 +575,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.ExcludeTargets)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -611,15 +609,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ExcludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExcludeTargets' -IsCIMArray:$True
-            }
-            If ($Results.IncludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IncludeTargets' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('ExcludeTargets', 'IncludeTargets')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyX509/MSFT_AADAuthenticationMethodPolicyX509.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicyX509/MSFT_AADAuthenticationMethodPolicyX509.psm1
@@ -639,8 +639,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.AuthenticationModeConfiguration)
             {
                 $complexMapping = @(
@@ -717,25 +715,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.AuthenticationModeConfiguration)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AuthenticationModeConfiguration' -IsCIMArray:$False
-            }
-            if ($Results.CertificateUserBindings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'CertificateUserBindings' -IsCIMArray:$True
-                $currentDSCBlock = $currentDSCBlock.Replace('CertificateUserBindings         = @("', 'CertificateUserBindings         = @(')
-                $currentDSCBlock = $currentDSCBlock.Replace("            `",`"`r`n", '')
-            }
-            if ($Results.ExcludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExcludeTargets' -IsCIMArray:$True
-            }
-            If ($Results.IncludeTargets)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IncludeTargets' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('AuthenticationModeConfiguration', 'CertificateUserBindings', 'ExcludeTargets', 'IncludeTargets')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationRequirement/MSFT_AADAuthenticationRequirement.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationRequirement/MSFT_AADAuthenticationRequirement.psm1
@@ -352,9 +352,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationStrengthPolicy/MSFT_AADAuthenticationStrengthPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationStrengthPolicy/MSFT_AADAuthenticationStrengthPolicy.psm1
@@ -408,9 +408,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthorizationPolicy/MSFT_AADAuthorizationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthorizationPolicy/MSFT_AADAuthorizationPolicy.psm1
@@ -586,13 +586,10 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
             Write-Host "`r`n" -NoNewline
             Write-Host "    |---[1/1] $($results.DisplayName)" -NoNewline
-            $results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADClaimsMappingPolicy/MSFT_AADClaimsMappingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADClaimsMappingPolicy/MSFT_AADClaimsMappingPolicy.psm1
@@ -554,9 +554,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             if ($null -ne $Results.Definition)
             {
                 $complexMapping = @(
@@ -605,12 +602,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Definition)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Definition' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('Definition')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -2355,14 +2355,11 @@ function Export-TargetResource
                 }
                 $Script:exportedInstance = $Policy
                 $Results = Get-TargetResource @Params
-
                 if ([System.String]::IsNullOrEmpty($Results.DeviceFilterMode))
                 {
                     $Results.Remove('DeviceFilterMode') | Out-Null
                 }
 
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConnectorGroupApplicationProxy/MSFT_AADConnectorGroupApplicationProxy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConnectorGroupApplicationProxy/MSFT_AADConnectorGroupApplicationProxy.psm1
@@ -426,9 +426,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCrossTenantAccessPolicy/MSFT_AADCrossTenantAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCrossTenantAccessPolicy/MSFT_AADCrossTenantAccessPolicy.psm1
@@ -354,9 +354,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
-
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCrossTenantAccessPolicyConfigurationDefault/MSFT_AADCrossTenantAccessPolicyConfigurationDefault.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCrossTenantAccessPolicyConfigurationDefault/MSFT_AADCrossTenantAccessPolicyConfigurationDefault.psm1
@@ -461,8 +461,6 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
 
         if ($null -ne $Results.B2BCollaborationInbound)
         {
@@ -648,28 +646,8 @@ function Export-TargetResource
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `
             -Results $Results `
-            -Credential $Credential
-
-        if ($Results.B2BCollaborationInbound)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'B2BCollaborationInbound' -IsCIMArray:$True
-        }
-        if ($Results.B2BCollaborationOutbound)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'B2BCollaborationOutbound' -IsCIMArray:$True
-        }
-        if ($Results.B2BDirectConnectInbound)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'B2BDirectConnectInbound' -IsCIMArray:$True
-        }
-        if ($Results.B2BDirectConnectOutbound)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'B2BDirectConnectOutbound' -IsCIMArray:$True
-        }
-        if ($Results.InboundTrust)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'InboundTrust' -IsCIMArray:$True
-        }
+            -Credential $Credential `
+            -NoEscape @('B2BCollaborationInbound', 'B2BCollaborationOutbound', 'B2BDirectConnectInbound', 'B2BDirectConnectOutbound', 'InboundTrust')
 
         # Fix OrganizationName variable in CIMInstance
         $currentDSCBlock = $currentDSCBlock.Replace('@$OrganizationName''', "@' + `$OrganizationName")

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCrossTenantAccessPolicyConfigurationPartner/MSFT_AADCrossTenantAccessPolicyConfigurationPartner.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCrossTenantAccessPolicyConfigurationPartner/MSFT_AADCrossTenantAccessPolicyConfigurationPartner.psm1
@@ -505,8 +505,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $entry
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($null -ne $Results.B2BCollaborationInbound)
             {
@@ -716,32 +714,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.B2BCollaborationInbound)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'B2BCollaborationInbound' -IsCIMArray:$True
-            }
-            if ($Results.B2BCollaborationOutbound)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'B2BCollaborationOutbound' -IsCIMArray:$True
-            }
-            if ($Results.B2BDirectConnectInbound)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'B2BDirectConnectInbound' -IsCIMArray:$True
-            }
-            if ($Results.B2BDirectConnectOutbound)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'B2BDirectConnectOutbound' -IsCIMArray:$True
-            }
-            if ($Results.InboundTrust)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'InboundTrust' -IsCIMArray:$True
-            }
-            if ($Results.AutomaticUserConsentSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AutomaticUserConsentSettings' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('B2BCollaborationInbound', 'B2BCollaborationOutbound', 'B2BDirectConnectInbound', 'B2BDirectConnectOutbound', 'InboundTrust', 'AutomaticUserConsentSettings')
 
             # Fix OrganizationName variable in CIMInstance
             $currentDSCBlock = $currentDSCBlock.Replace('@$OrganizationName''', "@' + `$OrganizationName")

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomAuthenticationExtension/MSFT_AADCustomAuthenticationExtension.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomAuthenticationExtension/MSFT_AADCustomAuthenticationExtension.psm1
@@ -626,7 +626,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-
             $endpointConfigurationCimString = Get-M365DSCDRGComplexTypeToString `
                 -ComplexObject $Results.EndpointConfiguration `
                 -CIMInstanceName 'MSFT_AADCustomAuthenticationExtensionEndPointConfiguration'
@@ -638,24 +637,12 @@ function Export-TargetResource
             $Results.EndPointConfiguration = $endpointConfigurationCimString
             $Results.ClaimsForTokenConfiguration = $ClaimsForTokenConfigurationCimString
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.EndPointConfiguration -ne $null)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EndPointConfiguration'
-            }
-
-            if ($Results.ClaimsForTokenConfiguration -ne $null)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ClaimsForTokenConfiguration' -IsCIMArray $true
-            }
+                -Credential $Credential `
+                -NoEscape @('EndPointConfiguration', 'ClaimsForTokenConfiguration')
 
             $dscContent += $currentDSCBlock
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/MSFT_AADCustomSecurityAttributeDefinition.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/MSFT_AADCustomSecurityAttributeDefinition.psm1
@@ -461,8 +461,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADDeviceRegistrationPolicy/MSFT_AADDeviceRegistrationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADDeviceRegistrationPolicy/MSFT_AADDeviceRegistrationPolicy.psm1
@@ -616,8 +616,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
 
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADDomain/MSFT_AADDomain.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADDomain/MSFT_AADDomain.psm1
@@ -490,8 +490,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEnrichedAuditLogs/MSFT_AADEnrichedAuditLogs.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEnrichedAuditLogs/MSFT_AADEnrichedAuditLogs.psm1
@@ -331,8 +331,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
 
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackage/MSFT_AADEntitlementManagementAccessPackage.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackage/MSFT_AADEntitlementManagementAccessPackage.psm1
@@ -952,7 +952,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-
             if ($null -ne $Results.AccessPackageResourceRoleScopes)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject ([Array]$Results.AccessPackageResourceRoleScopes) `
@@ -966,20 +965,12 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-
-            if ($null -ne $Results.AccessPackageResourceRoleScopes)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AccessPackageResourceRoleScopes' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('AccessPackageResourceRoleScopes')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
@@ -988,9 +979,6 @@ function Export-TargetResource
             Write-Host $Global:M365DSCEmojiGreenCheckMark
             $i++
         }
-
-        #Removing extra coma between items in cim instance array created by Convert-DSCStringParamToVariable
-        $dscContent = $dscContent.replace("            ,`r`n", '')
 
         return $dscContent
     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.psm1
@@ -944,8 +944,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($null -ne $Results.AccessReviewSettings)
             {
@@ -1083,29 +1081,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($null -ne $Results.AccessReviewSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AccessReviewSettings'
-                #$currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Reviewers'
-            }
-            if ($null -ne $Results.Questions )
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Questions' -IsCIMArray:$true
-            }
-            if ($null -ne $Results.RequestApprovalSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'RequestApprovalSettings'
-            }
-            if ($null -ne $Results.RequestorSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'RequestorSettings'
-            }
-            if ($null -ne $Results.CustomExtensionHandlers)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'CustomExtensionHandlers' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('AccessReviewSettings', 'Questions', 'RequestApprovalSettings', 'RequestorSettings', 'CustomExtensionHandlers')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageCatalog/MSFT_AADEntitlementManagementAccessPackageCatalog.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageCatalog/MSFT_AADEntitlementManagementAccessPackageCatalog.psm1
@@ -492,8 +492,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageCatalogResource/MSFT_AADEntitlementManagementAccessPackageCatalogResource.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageCatalogResource/MSFT_AADEntitlementManagementAccessPackageCatalogResource.psm1
@@ -756,7 +756,6 @@ function Export-TargetResource
                 }
 
                 $Results = Get-TargetResource @Params
-
                 if ($null -ne $Results.Attributes)
                 {
                     $complexMapping = @(
@@ -801,19 +800,12 @@ function Export-TargetResource
                     }
                 }
 
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
-
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `
                     -Results $Results `
-                    -Credential $Credential
-
-                if ($null -ne $Results.Attributes)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Attributes' -IsCIMArray:$true
-                }
+                    -Credential $Credential `
+                    -NoEscape @('Attributes')
                 $dscContent += $currentDSCBlock
                 Save-M365DSCPartialExport -Content $currentDSCBlock `
                     -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementConnectedOrganization/MSFT_AADEntitlementManagementConnectedOrganization.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementConnectedOrganization/MSFT_AADEntitlementManagementConnectedOrganization.psm1
@@ -799,8 +799,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.IdentitySources)
             {
@@ -819,12 +817,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.IdentitySources)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IdentitySources' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('IdentitySources')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementRoleAssignment/MSFT_AADEntitlementManagementRoleAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementRoleAssignment/MSFT_AADEntitlementManagementRoleAssignment.psm1
@@ -476,9 +476,6 @@ function Export-TargetResource
 
             $Results = Get-TargetResource @Params
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementSettings/MSFT_AADEntitlementManagementSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementSettings/MSFT_AADEntitlementManagementSettings.psm1
@@ -304,8 +304,6 @@ function Export-TargetResource
             $Global:M365DSCExportResourceInstancesCount++
         }
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
 
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADExternalIdentityPolicy/MSFT_AADExternalIdentityPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADExternalIdentityPolicy/MSFT_AADExternalIdentityPolicy.psm1
@@ -344,8 +344,6 @@ function Export-TargetResource
         {
             Write-Host "`r`n" -NoNewline
             Write-Host '    |---[1/1] External Identity Policy' -NoNewline
-            $results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADFeatureRolloutPolicy/MSFT_AADFeatureRolloutPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADFeatureRolloutPolicy/MSFT_AADFeatureRolloutPolicy.psm1
@@ -469,8 +469,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADFederationConfiguration/MSFT_AADFederationConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADFederationConfiguration/MSFT_AADFederationConfiguration.psm1
@@ -466,8 +466,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADFilteringPolicy/MSFT_AADFilteringPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADFilteringPolicy/MSFT_AADFilteringPolicy.psm1
@@ -400,8 +400,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADFilteringPolicyRule/MSFT_AADFilteringPolicyRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADFilteringPolicyRule/MSFT_AADFilteringPolicyRule.psm1
@@ -497,8 +497,7 @@ function Export-TargetResource
                 }
 
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
+
 
                 if ($Results.Destinations)
                 {
@@ -516,12 +515,9 @@ function Export-TargetResource
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `
                     -Results $Results `
-                    -Credential $Credential
+                    -Credential $Credential `
+                    -NoEscape @('Destinations')
 
-                if ($Results.Destinations)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Destinations' -IsCIMArray:$true
-                }
                 $dscContent += $currentDSCBlock
                 Save-M365DSCPartialExport -Content $currentDSCBlock `
                     -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADFilteringProfile/MSFT_AADFilteringProfile.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADFilteringProfile/MSFT_AADFilteringProfile.psm1
@@ -492,8 +492,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Policies)
             {
@@ -512,12 +510,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Policies)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Policies' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Policies')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -1235,8 +1235,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $group
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($null -ne $Results.AssignedLicenses)
             {
@@ -1265,12 +1263,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($null -ne $Results.AssignedLicenses)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'AssignedLicenses'
-            }
+                -Credential $Credential `
+                -NoEscape @('AssignedLicenses')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupEligibilitySchedule/MSFT_AADGroupEligibilitySchedule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupEligibilitySchedule/MSFT_AADGroupEligibilitySchedule.psm1
@@ -834,8 +834,7 @@ function Export-TargetResource
                 }
 
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
+
                 if ($null -ne $Results.ScheduleInfo)
                 {
                     $complexMapping = @(
@@ -884,11 +883,8 @@ function Export-TargetResource
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `
                     -Results $Results `
-                    -Credential $Credential
-                if ($Results.ScheduleInfo)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "ScheduleInfo" -IsCIMArray:$False
-                }
+                    -Credential $Credential `
+                    -NoEscape @('ScheduleInfo')
 
                 $dscContent += $currentDSCBlock
                 Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupLifecyclePolicy/MSFT_AADGroupLifecyclePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupLifecyclePolicy/MSFT_AADGroupLifecyclePolicy.psm1
@@ -466,8 +466,7 @@ function Export-TargetResource
         $Results = Get-TargetResource @Params
         if ($Results.Ensure -eq 'Present')
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsNamingPolicy/MSFT_AADGroupsNamingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsNamingPolicy/MSFT_AADGroupsNamingPolicy.psm1
@@ -381,11 +381,8 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-
         if ($Results.Ensure -eq 'Present')
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsSettings/MSFT_AADGroupsSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsSettings/MSFT_AADGroupsSettings.psm1
@@ -534,8 +534,6 @@ function Export-TargetResource
         }
         $dscContent = ''
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADHomeRealmDiscoveryPolicy/MSFT_AADHomeRealmDiscoveryPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADHomeRealmDiscoveryPolicy/MSFT_AADHomeRealmDiscoveryPolicy.psm1
@@ -489,9 +489,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             if ($null -ne $Results.Definition)
             {
                 $complexMapping = @(
@@ -524,13 +521,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($null -ne $Results.Definition)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'Definition'
-            }
+                -Credential $Credential `
+                -NoEscape @('Definition')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityAPIConnector/MSFT_AADIdentityAPIConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityAPIConnector/MSFT_AADIdentityAPIConnector.psm1
@@ -686,9 +686,6 @@ function Export-TargetResource
             $Results = Get-TargetResource @Params
             $Results.Password = "New-Object System.Management.Automation.PSCredential('Password', (ConvertTo-SecureString ('Please insert a valid Password') -AsPlainText -Force));"
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             if ($null -ne $Results.Certificates)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -708,13 +705,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
+                -Credential $Credential `
+                -NoEscape @('Certificates')
 
-
-            if ($Results.Certificates)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Certificates' -IsCIMArray:$True
-            }
 
             # Replace the main password variable.
             $currentDSCBlock = $currentDSCBlock.Replace('"New-Object System.', 'New-Object System.').Replace(') -AsPlainText -Force));";', ') -AsPlainText -Force));')

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityB2XUserFlow/MSFT_AADIdentityB2XUserFlow.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityB2XUserFlow/MSFT_AADIdentityB2XUserFlow.psm1
@@ -624,8 +624,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.ApiConnectorConfiguration)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -669,15 +667,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ApiConnectorConfiguration)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ApiConnectorConfiguration' -IsCIMArray:$False
-            }
-            if ($Results.UserAttributeAssignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserAttributeAssignments' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('ApiConnectorConfiguration', 'UserAttributeAssignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityGovernanceLifecycleWorkflow/MSFT_AADIdentityGovernanceLifecycleWorkflow.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityGovernanceLifecycleWorkflow/MSFT_AADIdentityGovernanceLifecycleWorkflow.psm1
@@ -521,9 +521,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             if ($null -ne $Results.Tasks)
             {
                 $complexMapping = @(
@@ -591,17 +588,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($null -ne $Results.Tasks)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'Tasks' -IsCIMArray:$true
-            }
-            if ($null -ne $Results.ExecutionConditions)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'ExecutionConditions' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Tasks', 'ExecutionConditions')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityGovernanceLifecycleWorkflowCustomTaskExtension/MSFT_AADIdentityGovernanceLifecycleWorkflowCustomTaskExtension.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityGovernanceLifecycleWorkflowCustomTaskExtension/MSFT_AADIdentityGovernanceLifecycleWorkflowCustomTaskExtension.psm1
@@ -519,9 +519,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             if ($null -ne $Results.EndpointConfiguration)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -571,20 +568,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.EndpointConfiguration)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EndpointConfiguration' -IsCIMArray:$False
-            }
-            if ($Results.ClientConfiguration)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ClientConfiguration' -IsCIMArray:$False
-            }
-            if ($Results.CallbackConfiguration)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'CallbackConfiguration' -IsCIMArray:$False
-            }
+                -Credential $Credential `
+                -NoEscape @('EndpointConfiguration', 'ClientConfiguration', 'CallbackConfiguration')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityGovernanceProgram/MSFT_AADIdentityGovernanceProgram.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityGovernanceProgram/MSFT_AADIdentityGovernanceProgram.psm1
@@ -407,9 +407,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityProtectionPolicySettings/MSFT_AADIdentityProtectionPolicySettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADIdentityProtectionPolicySettings/MSFT_AADIdentityProtectionPolicySettings.psm1
@@ -317,8 +317,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADLifecycleWorkflowSettings/MSFT_AADLifecycleWorkflowSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADLifecycleWorkflowSettings/MSFT_AADLifecycleWorkflowSettings.psm1
@@ -349,8 +349,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNamedLocationPolicy/MSFT_AADNamedLocationPolicy.psm1
@@ -546,11 +546,8 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $AADNamedLocation
             $Results = Get-TargetResource @Params
-
             if ($Results.Ensure -eq 'Present')
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNetworkAccessForwardingPolicy/MSFT_AADNetworkAccessForwardingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNetworkAccessForwardingPolicy/MSFT_AADNetworkAccessForwardingPolicy.psm1
@@ -415,8 +415,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($null -ne $Results.PolicyRules)
             {
@@ -446,13 +444,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($null -ne $Results.PolicyRules)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'PolicyRules' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('PolicyRules')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNetworkAccessForwardingProfile/MSFT_AADNetworkAccessForwardingProfile.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNetworkAccessForwardingProfile/MSFT_AADNetworkAccessForwardingProfile.psm1
@@ -470,8 +470,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($null -ne $Results.Policies)
             {
@@ -501,13 +499,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
+                -Credential $Credential `
+                -NoEscape @('Policies')
 
-            if ($null -ne $Results.Policies)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'Policies' -IsCIMArray:$true
-            }
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNetworkAccessSettingConditionalAccess/MSFT_AADNetworkAccessSettingConditionalAccess.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNetworkAccessSettingConditionalAccess/MSFT_AADNetworkAccessSettingConditionalAccess.psm1
@@ -286,8 +286,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
 
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADNetworkAccessSettingCrossTenantAccess/MSFT_AADNetworkAccessSettingCrossTenantAccess.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADNetworkAccessSettingCrossTenantAccess/MSFT_AADNetworkAccessSettingCrossTenantAccess.psm1
@@ -286,8 +286,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
 
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADOnPremisesPublishingProfilesSettings/MSFT_AADOnPremisesPublishingProfilesSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADOnPremisesPublishingProfilesSettings/MSFT_AADOnPremisesPublishingProfilesSettings.psm1
@@ -298,8 +298,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
 
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADOrganizationCertificateBasedAuthConfiguration/MSFT_AADOrganizationCertificateBasedAuthConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADOrganizationCertificateBasedAuthConfiguration/MSFT_AADOrganizationCertificateBasedAuthConfiguration.psm1
@@ -436,8 +436,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.CertificateAuthorities)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -457,11 +455,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.CertificateAuthorities)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'CertificateAuthorities' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('CertificateAuthorities')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADPasswordRuleSettings/MSFT_AADPasswordRuleSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADPasswordRuleSettings/MSFT_AADPasswordRuleSettings.psm1
@@ -453,8 +453,6 @@ function Export-TargetResource
         }
         $dscContent = ''
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRemoteNetwork/MSFT_AADRemoteNetwork.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRemoteNetwork/MSFT_AADRemoteNetwork.psm1
@@ -508,8 +508,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($null -ne $Results.DeviceLinks)
             {
@@ -554,12 +552,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.DeviceLinks)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DeviceLinks' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('DeviceLinks')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleAssignmentScheduleRequest/MSFT_AADRoleAssignmentScheduleRequest.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleAssignmentScheduleRequest/MSFT_AADRoleAssignmentScheduleRequest.psm1
@@ -802,8 +802,6 @@ function Export-TargetResource
 
             $Results = Get-TargetResource @Params
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.ScheduleInfo)
             {
                 $complexMapping = @(
@@ -874,17 +872,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($null -ne $Results.ScheduleInfo)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'ScheduleInfo'
-            }
-            if ($null -ne $Results.TicketInfo)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'TicketInfo'
-            }
+                -Credential $Credential `
+                -NoEscape @('ScheduleInfo', 'TicketInfo')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleDefinition/MSFT_AADRoleDefinition.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleDefinition/MSFT_AADRoleDefinition.psm1
@@ -472,11 +472,8 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $AADRoleDefinition
             $Results = Get-TargetResource @Params
-
             if ($Results.Ensure -eq 'Present' -and ([array]$results.RolePermissions).Length -gt 0)
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleEligibilityScheduleRequest/MSFT_AADRoleEligibilityScheduleRequest.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleEligibilityScheduleRequest/MSFT_AADRoleEligibilityScheduleRequest.psm1
@@ -765,8 +765,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.ScheduleInfo)
             {
@@ -808,17 +806,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ScheduleInfo)
-            {
-                $isCIMArray = $false
-                if ($Results.ScheduleInfo.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                        -ParameterName 'ScheduleInfo' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('ScheduleInfo')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleManagementPolicyRule/MSFT_AADRoleManagementPolicyRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleManagementPolicyRule/MSFT_AADRoleManagementPolicyRule.psm1
@@ -519,8 +519,6 @@ function Export-TargetResource
 
                 $Results = Get-TargetResource @Params
 
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
 
                 if ($null -ne $Results.expirationRule)
                 {
@@ -667,34 +665,9 @@ function Export-TargetResource
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `
                     -Results $Results `
-                    -Credential $Credential
+                    -Credential $Credential `
+                    -NoEscape @('expirationRule', 'notificationRule', 'enablementRule', 'approvalRule', 'authenticationContextRule')
 
-                if ($Results.expirationRule)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'expirationRule' -IsCIMArray:$false
-                }
-
-
-                if ($Results.notificationRule)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'notificationRule' -IsCIMArray:$false
-                }
-
-
-                if ($Results.enablementRule)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'enablementRule' -IsCIMArray:$false
-                }
-
-                if ($Results.approvalRule)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'approvalRule' -IsCIMArray:$false
-                }
-
-                if ($Results.authenticationContextRule)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'authenticationContextRule' -IsCIMArray:$false
-                }
                 $dscContent.Append($currentDSCBlock) | Out-Null
                 Save-M365DSCPartialExport -Content $currentDSCBlock `
                     -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADRoleSetting/MSFT_AADRoleSetting.psm1
@@ -1494,11 +1494,8 @@ function Export-TargetResource
 
             $Script:exportedInstance = $role
             $Results = Get-TargetResource @Params
-
             if ($Results.Ensure -eq 'Present')
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADSecurityDefaults/MSFT_AADSecurityDefaults.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADSecurityDefaults/MSFT_AADSecurityDefaults.psm1
@@ -350,8 +350,6 @@ function Export-TargetResource
         }
         $dscContent = ''
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
@@ -1031,11 +1031,8 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $AADServicePrincipal
             $Results = Get-TargetResource @Params
-
             if ($Results.Ensure -eq 'Present')
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 if ($Results.AppRoleAssignedTo.Count -gt 0)
                 {
                     $Results.AppRoleAssignedTo = Get-M365DSCAzureADServicePrincipalAssignmentAsString -Assignments $Results.AppRoleAssignedTo
@@ -1080,34 +1077,8 @@ function Export-TargetResource
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `
                     -Results $Results `
-                    -Credential $Credential
-                if ($null -ne $Results.AppRoleAssignedTo)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                        -ParameterName 'AppRoleAssignedTo'
-                }
-                if ($null -ne $Results.DelegatedPermissionClassifications)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                        -ParameterName 'DelegatedPermissionClassifications'
-                }
-                if ($null -ne $Results.KeyCredentials)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                        -ParameterName 'KeyCredentials' -IsCIMArray:$True
-                }
-
-                if ($null -ne $Results.PasswordCredentials)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                        -ParameterName 'PasswordCredentials' -IsCIMArray:$True
-                }
-
-                if ($null -ne $Results.CustomSecurityAttributes)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                        -ParameterName 'CustomSecurityAttributes'
-                }
+                    -Credential $Credential `
+                    -NoEscape @('AppRoleAssignedTo', 'DelegatedPermissionClassifications', 'KeyCredentials', 'PasswordCredentials', 'CustomSecurityAttributes')
 
                 $dscContent += $currentDSCBlock
                 Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADSocialIdentityProvider/MSFT_AADSocialIdentityProvider.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADSocialIdentityProvider/MSFT_AADSocialIdentityProvider.psm1
@@ -408,8 +408,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADTenantDetails/MSFT_AADTenantDetails.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADTenantDetails/MSFT_AADTenantDetails.psm1
@@ -385,11 +385,10 @@ function Export-TargetResource
             IsSingleInstance                     = 'Yes'
             AccessTokens                         = $AccessTokens
         }
-        $Results = Get-TargetResource @Params
 
+        $Results = Get-TargetResource @Params
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADTokenLifetimePolicy/MSFT_AADTokenLifetimePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADTokenLifetimePolicy/MSFT_AADTokenLifetimePolicy.psm1
@@ -421,7 +421,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $AADPolicy
             $Results = Get-TargetResource @Params
-
             # Fix quotes inside the Definition's JSON;
             $NewDefinition = @()
             foreach ($item in $Results.Definition)
@@ -433,8 +432,6 @@ function Export-TargetResource
 
             if ($Results.Ensure -eq 'Present')
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/MSFT_AADUser.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/MSFT_AADUser.psm1
@@ -1093,20 +1093,16 @@ function Export-TargetResource
 
                 $Script:exportedInstance = $user
                 $Results = Get-TargetResource @Params
-                $Results.Password = "New-Object System.Management.Automation.PSCredential('Password', (ConvertTo-SecureString ((New-Guid).ToString()) -AsPlainText -Force));"
+                $Results.Password = "New-Object System.Management.Automation.PSCredential('Password', (ConvertTo-SecureString ((New-Guid).ToString()) -AsPlainText -Force))"
                 if ($null -ne $Results.UserPrincipalName)
                 {
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `
                         -Results $Results `
                         -Credential $Credential
 
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Password'
                     $dscContent.Append($currentDSCBlock) | Out-Null
-
                     Save-M365DSCPartialExport -Content $currentDSCBlock `
                         -FileName $Global:PartialExportFileName
                 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADUserFlowAttribute/MSFT_AADUserFlowAttribute.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADUserFlowAttribute/MSFT_AADUserFlowAttribute.psm1
@@ -407,11 +407,8 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-
             if ($Results.Ensure -eq 'Present')
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADVerifiedIdAuthority/MSFT_AADVerifiedIdAuthority.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADVerifiedIdAuthority/MSFT_AADVerifiedIdAuthority.psm1
@@ -450,8 +450,6 @@ function Export-TargetResource
             $Results = Get-TargetResource @Params
             if ($Results.Ensure -eq 'Present')
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
 
                 if ($null -ne $Results.KeyVaultMetadata)
                 {
@@ -477,17 +475,12 @@ function Export-TargetResource
                     }
                 }
 
-
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `
                     -Results $Results `
-                    -Credential $Credential
-
-                if ($Results.KeyVaultMetadata)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'KeyVaultMetadata' -IsCIMArray:$False
-                }
+                    -Credential $Credential `
+                    -NoEscape @('KeyVaultMetadata')
 
                 $dscContent.Append($currentDSCBlock) | Out-Null
                 Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADVerifiedIdAuthorityContract/MSFT_AADVerifiedIdAuthorityContract.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADVerifiedIdAuthorityContract/MSFT_AADVerifiedIdAuthorityContract.psm1
@@ -495,11 +495,8 @@ function Export-TargetResource
                 }
 
                 $Results = Get-TargetResource @Params
-
                 if ($Results.Ensure -eq 'Present')
                 {
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
 
                     if ($null -ne $Results.displays)
                     {
@@ -620,17 +617,8 @@ function Export-TargetResource
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `
                         -Results $Results `
-                        -Credential $Credential
-
-                    if ($Results.displays)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'displays' -IsCIMArray:$true
-                    }
-
-                    if ($Results.rules)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'rules' -IsCIMArray:$false
-                    }
+                        -Credential $Credential `
+                        -NoEscape @('displays', 'rules')
 
                     $dscContent.Append($currentDSCBlock) | Out-Null
                     Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ADOOrganizationOwner/MSFT_ADOOrganizationOwner.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ADOOrganizationOwner/MSFT_ADOOrganizationOwner.psm1
@@ -311,8 +311,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ADOPermissionGroup/MSFT_ADOPermissionGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ADOPermissionGroup/MSFT_ADOPermissionGroup.psm1
@@ -530,8 +530,6 @@ function Export-TargetResource
                 if (-not $config.principalName.StartsWith('[TEAM FOUNDATION]'))
                 {
                     $Results = Get-TargetResource @Params
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
 
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ADOPermissionGroupSettings/MSFT_ADOPermissionGroupSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ADOPermissionGroupSettings/MSFT_ADOPermissionGroupSettings.psm1
@@ -469,8 +469,6 @@ function Export-TargetResource
                 if (-not $config.principalName.StartsWith('[TEAM FOUNDATION]'))
                 {
                     $Results = Get-TargetResource @Params
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
                     if ($results.AllowPermissions.Length -gt 0)
                     {
                         $Results.AllowPermissions = Get-M365DSCADOPermissionsAsString $Results.AllowPermissions
@@ -485,18 +483,8 @@ function Export-TargetResource
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `
                         -Results $Results `
-                        -Credential $Credential
-
-                    if ($null -ne $Results.AllowPermissions)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                            -ParameterName 'AllowPermissions'
-                    }
-                    if ($null -ne $Results.DenyPermissions)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                            -ParameterName 'DenyPermissions'
-                    }
+                        -Credential $Credential `
+                        -NoEscape @('AllowPermissions', 'DenyPermissions')
 
                     $dscContent += $currentDSCBlock
                     Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ADOSecurityPolicy/MSFT_ADOSecurityPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ADOSecurityPolicy/MSFT_ADOSecurityPolicy.psm1
@@ -501,8 +501,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AzureBillingAccountPolicy/MSFT_AzureBillingAccountPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AzureBillingAccountPolicy/MSFT_AzureBillingAccountPolicy.psm1
@@ -423,8 +423,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.EnterpriseAgreementPolicies)
             {
@@ -442,17 +440,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
+                -Credential $Credential `
+                -NoEscape @('EnterpriseAgreementPolicies')
 
-            if ($Results.EnterpriseAgreementPolicies)
-            {
-                $isCIMArray = $false
-                if ($Results.EnterpriseAgreementPolicies.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EnterpriseAgreementPolicies' -IsCIMArray:$isCIMArray
-            }
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AzureBillingAccountScheduledAction/MSFT_AzureBillingAccountScheduledAction.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AzureBillingAccountScheduledAction/MSFT_AzureBillingAccountScheduledAction.psm1
@@ -497,8 +497,6 @@ function Export-TargetResource
                 }
 
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
 
                 if ($Results.Notification)
                 {
@@ -528,26 +526,8 @@ function Export-TargetResource
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `
                     -Results $Results `
-                    -Credential $Credential
-
-                if ($Results.Notification)
-                {
-                    $isCIMArray = $false
-                    if ($Results.Notification.getType().Fullname -like '*[[\]]')
-                    {
-                        $isCIMArray = $true
-                    }
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Notification' -IsCIMArray:$isCIMArray
-                }
-                if ($Results.Schedule)
-                {
-                    $isCIMArray = $false
-                    if ($Results.Schedule.getType().Fullname -like '*[[\]]')
-                    {
-                        $isCIMArray = $true
-                    }
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Schedule' -IsCIMArray:$isCIMArray
-                }
+                    -Credential $Credential `
+                    -NoEscape @('Notification', 'Schedule')
                 $dscContent += $currentDSCBlock
                 Save-M365DSCPartialExport -Content $currentDSCBlock `
                     -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AzureBillingAccountsAssociatedTenant/MSFT_AzureBillingAccountsAssociatedTenant.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AzureBillingAccountsAssociatedTenant/MSFT_AzureBillingAccountsAssociatedTenant.psm1
@@ -399,8 +399,6 @@ function Export-TargetResource
                 }
 
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
 
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AzureBillingAccountsRoleAssignment/MSFT_AzureBillingAccountsRoleAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AzureBillingAccountsRoleAssignment/MSFT_AzureBillingAccountsRoleAssignment.psm1
@@ -426,8 +426,6 @@ function Export-TargetResource
                 }
 
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
 
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AzureDiagnosticSettings/MSFT_AzureDiagnosticSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AzureDiagnosticSettings/MSFT_AzureDiagnosticSettings.psm1
@@ -478,8 +478,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Categories)
             {
@@ -498,17 +496,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Categories)
-            {
-                $isCIMArray = $false
-                if ($Results.Categories.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Categories' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Categories')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AzureDiagnosticSettingsCustomSecurityAttribute/MSFT_AzureDiagnosticSettingsCustomSecurityAttribute.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AzureDiagnosticSettingsCustomSecurityAttribute/MSFT_AzureDiagnosticSettingsCustomSecurityAttribute.psm1
@@ -479,8 +479,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Categories)
             {
@@ -499,17 +497,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Categories)
-            {
-                $isCIMArray = $false
-                if ($Results.Categories.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Categories' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Categories')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AzureSubscription/MSFT_AzureSubscription.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AzureSubscription/MSFT_AzureSubscription.psm1
@@ -417,8 +417,6 @@ function Export-TargetResource
                     }
 
                     $Results = Get-TargetResource @Params
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
 
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AzureVerifiedIdFaceCheck/MSFT_AzureVerifiedIdFaceCheck.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AzureVerifiedIdFaceCheck/MSFT_AzureVerifiedIdFaceCheck.psm1
@@ -406,8 +406,6 @@ function Export-TargetResource
                 }
 
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
 
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_CommerceSelfServicePurchase/MSFT_CommerceSelfServicePurchase.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_CommerceSelfServicePurchase/MSFT_CommerceSelfServicePurchase.psm1
@@ -348,8 +348,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_DefenderDeviceAuthenticatedScanDefinition/MSFT_DefenderDeviceAuthenticatedScanDefinition.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_DefenderDeviceAuthenticatedScanDefinition/MSFT_DefenderDeviceAuthenticatedScanDefinition.psm1
@@ -565,8 +565,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.ScannerAgent)
             {
@@ -598,27 +596,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.ScanAuthenticationParams)
-            {
-                $isCIMArray = $false
-                if ($Results.ScanAuthenticationParams.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ScanAuthenticationParams' -IsCIMArray:$isCIMArray
-            }
-
-            if ($Results.ScannerAgent)
-            {
-                $isCIMArray = $false
-                if ($Results.ScannerAgent.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ScannerAgent' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('ScannerAgent', 'ScanAuthenticationParams')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_DefenderSubscriptionPlan/MSFT_DefenderSubscriptionPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_DefenderSubscriptionPlan/MSFT_DefenderSubscriptionPlan.psm1
@@ -421,8 +421,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOATPBuiltInProtectionRule/MSFT_EXOATPBuiltInProtectionRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOATPBuiltInProtectionRule/MSFT_EXOATPBuiltInProtectionRule.psm1
@@ -360,8 +360,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAcceptedDomain/MSFT_EXOAcceptedDomain.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAcceptedDomain/MSFT_EXOAcceptedDomain.psm1
@@ -411,8 +411,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/MSFT_EXOActiveSyncDeviceAccessRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/MSFT_EXOActiveSyncDeviceAccessRule.psm1
@@ -432,8 +432,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncMailboxPolicy/MSFT_EXOActiveSyncMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncMailboxPolicy/MSFT_EXOActiveSyncMailboxPolicy.psm1
@@ -1024,8 +1024,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressBookPolicy/MSFT_EXOAddressBookPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressBookPolicy/MSFT_EXOAddressBookPolicy.psm1
@@ -442,8 +442,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressList/MSFT_EXOAddressList.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressList/MSFT_EXOAddressList.psm1
@@ -756,8 +756,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $addressList
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishPolicy/MSFT_EXOAntiPhishPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishPolicy/MSFT_EXOAntiPhishPolicy.psm1
@@ -880,8 +880,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishRule/MSFT_EXOAntiPhishRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishRule/MSFT_EXOAntiPhishRule.psm1
@@ -567,8 +567,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOApplicationAccessPolicy/MSFT_EXOApplicationAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOApplicationAccessPolicy/MSFT_EXOApplicationAccessPolicy.psm1
@@ -500,8 +500,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/MSFT_EXOArcConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/MSFT_EXOArcConfig.psm1
@@ -360,8 +360,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
@@ -428,11 +428,8 @@ function Export-TargetResource
                     AccessTokens          = $AccessTokens
                 }
                 $Results = Get-TargetResource @Params
-
                 if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
                 {
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpProtectionPolicyRule/MSFT_EXOAtpProtectionPolicyRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpProtectionPolicyRule/MSFT_EXOAtpProtectionPolicyRule.psm1
@@ -501,8 +501,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAuthenticationPolicy/MSFT_EXOAuthenticationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAuthenticationPolicy/MSFT_EXOAuthenticationPolicy.psm1
@@ -565,8 +565,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAuthenticationPolicyAssignment/MSFT_EXOAuthenticationPolicyAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAuthenticationPolicyAssignment/MSFT_EXOAuthenticationPolicyAssignment.psm1
@@ -377,8 +377,6 @@ function Export-TargetResource
                     AccessTokens          = $AccessTokens
                 }
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityAddressSpace/MSFT_EXOAvailabilityAddressSpace.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityAddressSpace/MSFT_EXOAvailabilityAddressSpace.psm1
@@ -535,8 +535,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityConfig/MSFT_EXOAvailabilityConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityConfig/MSFT_EXOAvailabilityConfig.psm1
@@ -373,8 +373,6 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxPlan/MSFT_EXOCASMailboxPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxPlan/MSFT_EXOCASMailboxPlan.psm1
@@ -442,11 +442,8 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-
             if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxSettings/MSFT_EXOCASMailboxSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxSettings/MSFT_EXOCASMailboxSettings.psm1
@@ -808,11 +808,8 @@ function Export-TargetResource
                     AccessTokens          = $AccessTokens
                 }
                 $Results = Get-TargetResource @Params
-
                 if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
                 {
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCalendarProcessing/MSFT_EXOCalendarProcessing.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCalendarProcessing/MSFT_EXOCalendarProcessing.psm1
@@ -919,8 +919,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOClientAccessRule/MSFT_EXOClientAccessRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOClientAccessRule/MSFT_EXOClientAccessRule.psm1
@@ -587,8 +587,6 @@ function Export-TargetResource
                     AccessTokens          = $AccessTokens
                 }
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataAtRestEncryptionPolicy/MSFT_EXODataAtRestEncryptionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataAtRestEncryptionPolicy/MSFT_EXODataAtRestEncryptionPolicy.psm1
@@ -364,8 +364,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataAtRestEncryptionPolicyAssignment/MSFT_EXODataAtRestEncryptionPolicyAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataAtRestEncryptionPolicyAssignment/MSFT_EXODataAtRestEncryptionPolicyAssignment.psm1
@@ -285,8 +285,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataClassification/MSFT_EXODataClassification.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataClassification/MSFT_EXODataClassification.psm1
@@ -469,8 +469,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $DataClassification
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataEncryptionPolicy/MSFT_EXODataEncryptionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataEncryptionPolicy/MSFT_EXODataEncryptionPolicy.psm1
@@ -459,8 +459,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/MSFT_EXODistributionGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/MSFT_EXODistributionGroup.psm1
@@ -1060,7 +1060,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $distributionGroup
             $Results = Get-TargetResource @Params
-
             if ($Results.AcceptMessagesOnlyFromSendersOrMembers.Length -eq 0)
             {
                 $Results.Remove('AcceptMessagesOnlyFromSendersOrMembers') | Out-Null
@@ -1076,8 +1075,6 @@ function Export-TargetResource
                 $Results.Remove('AcceptMessagesOnlyFromDLMembers') | Out-Null
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODkimSigningConfig/MSFT_EXODkimSigningConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODkimSigningConfig/MSFT_EXODkimSigningConfig.psm1
@@ -445,8 +445,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODnssecForVerifiedDomain/MSFT_EXODnssecForVerifiedDomain.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODnssecForVerifiedDomain/MSFT_EXODnssecForVerifiedDomain.psm1
@@ -301,8 +301,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEOPProtectionPolicyRule/MSFT_EXOEOPProtectionPolicyRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEOPProtectionPolicyRule/MSFT_EXOEOPProtectionPolicyRule.psm1
@@ -503,8 +503,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailAddressPolicy/MSFT_EXOEmailAddressPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailAddressPolicy/MSFT_EXOEmailAddressPolicy.psm1
@@ -467,8 +467,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailTenantSettings/MSFT_EXOEmailTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailTenantSettings/MSFT_EXOEmailTenantSettings.psm1
@@ -395,8 +395,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOExternalInOutlook/MSFT_EXOExternalInOutlook.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOExternalInOutlook/MSFT_EXOExternalInOutlook.psm1
@@ -367,8 +367,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOFocusedInbox/MSFT_EXOFocusedInbox.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOFocusedInbox/MSFT_EXOFocusedInbox.psm1
@@ -320,8 +320,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGlobalAddressList/MSFT_EXOGlobalAddressList.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGlobalAddressList/MSFT_EXOGlobalAddressList.psm1
@@ -736,8 +736,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $GlobalAddressList
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGroupSettings/MSFT_EXOGroupSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGroupSettings/MSFT_EXOGroupSettings.psm1
@@ -1024,11 +1024,8 @@ function Export-TargetResource
                 }
                 $Script:exportedInstance = $group
                 $Results = Get-TargetResource @Params
-
                 if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
                 {
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedConnectionFilterPolicy/MSFT_EXOHostedConnectionFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedConnectionFilterPolicy/MSFT_EXOHostedConnectionFilterPolicy.psm1
@@ -485,8 +485,6 @@ function Export-TargetResource
             }
             Write-Host "    |---[$i/$($HostedConnectionFilterPolicies.Length)] $($HostedConnectionFilterPolicy.Identity)" -NoNewline
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
@@ -1188,8 +1188,6 @@ function Export-TargetResource
             }
             Write-Host "    |---[$i/$($HostedContentFilterPolicies.Length)] $($HostedContentFilterPolicy.Identity)" -NoNewline
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/MSFT_EXOHostedContentFilterRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/MSFT_EXOHostedContentFilterRule.psm1
@@ -568,8 +568,6 @@ function Export-TargetResource
                 AccessTokens              = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterPolicy/MSFT_EXOHostedOutboundSpamFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterPolicy/MSFT_EXOHostedOutboundSpamFilterPolicy.psm1
@@ -512,8 +512,6 @@ function Export-TargetResource
             }
             Write-Host "    |---[$i/$($HostedOutboundSpamFilterPolicies.Length)] $($HostedOutboundSpamFilterPolicy.Identity)" -NoNewline
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterRule/MSFT_EXOHostedOutboundSpamFilterRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterRule/MSFT_EXOHostedOutboundSpamFilterRule.psm1
@@ -551,8 +551,6 @@ function Export-TargetResource
                 AccessTokens                   = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIRMConfiguration/MSFT_EXOIRMConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIRMConfiguration/MSFT_EXOIRMConfiguration.psm1
@@ -554,8 +554,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOInboundConnector/MSFT_EXOInboundConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOInboundConnector/MSFT_EXOInboundConnector.psm1
@@ -615,8 +615,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIntraOrganizationConnector/MSFT_EXOIntraOrganizationConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIntraOrganizationConnector/MSFT_EXOIntraOrganizationConnector.psm1
@@ -442,8 +442,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOJournalRule/MSFT_EXOJournalRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOJournalRule/MSFT_EXOJournalRule.psm1
@@ -451,8 +451,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailContact/MSFT_EXOMailContact.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailContact/MSFT_EXOMailContact.psm1
@@ -851,8 +851,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailTips/MSFT_EXOMailTips.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailTips/MSFT_EXOMailTips.psm1
@@ -416,8 +416,6 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxAuditBypassAssociation/MSFT_EXOMailboxAuditBypassAssociation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxAuditBypassAssociation/MSFT_EXOMailboxAuditBypassAssociation.psm1
@@ -295,8 +295,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxAutoReplyConfiguration/MSFT_EXOMailboxAutoReplyConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxAutoReplyConfiguration/MSFT_EXOMailboxAutoReplyConfiguration.psm1
@@ -550,8 +550,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxCalendarConfiguration/MSFT_EXOMailboxCalendarConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxCalendarConfiguration/MSFT_EXOMailboxCalendarConfiguration.psm1
@@ -840,8 +840,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxCalendarFolder/MSFT_EXOMailboxCalendarFolder.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxCalendarFolder/MSFT_EXOMailboxCalendarFolder.psm1
@@ -463,8 +463,6 @@ function Export-TargetResource
                 $Results.Remove('SharedCalendarSyncStartDate') | Out-Null
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxFolderPermission/MSFT_EXOMailboxFolderPermission.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxFolderPermission/MSFT_EXOMailboxFolderPermission.psm1
@@ -442,8 +442,6 @@ function Export-TargetResource
             $MailboxFolderPermissions = Get-TargetResource @Params
 
             $Result = $MailboxFolderPermissions
-            $Result = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Result
             if ($Result.UserPermissions.Count -gt 0)
             {
                 $Result.UserPermissions = Get-M365DSCEXOUserPermissionsList $Result.UserPermissions
@@ -452,13 +450,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Result `
-                -Credential $Credential
-
-            if ($null -ne $Result.UserPermissions)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'UserPermissions'
-            }
+                -Credential $Credential `
+                -NoEscape @('UserPermissions')
 
             $dscContent += $currentDSCBlock
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxIRMAccess/MSFT_EXOMailboxIRMAccess.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxIRMAccess/MSFT_EXOMailboxIRMAccess.psm1
@@ -357,8 +357,6 @@ function Export-TargetResource
                 }
 
                 $Result = $dscIRMAccess
-                $Result = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Result
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPermission/MSFT_EXOMailboxPermission.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPermission/MSFT_EXOMailboxPermission.psm1
@@ -461,11 +461,8 @@ function Export-TargetResource
 
                 $Script:exportedInstance = $permission
                 $Results = Get-TargetResource @Params
-
                 if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
                 {
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPlan/MSFT_EXOMailboxPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPlan/MSFT_EXOMailboxPlan.psm1
@@ -491,11 +491,8 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-
             if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxSettings/MSFT_EXOMailboxSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxSettings/MSFT_EXOMailboxSettings.psm1
@@ -468,11 +468,8 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-
             if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterPolicy/MSFT_EXOMalwareFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterPolicy/MSFT_EXOMalwareFilterPolicy.psm1
@@ -620,7 +620,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-
             $keysToRemove = @()
             foreach ($key in $Results.Keys)
             {
@@ -633,8 +632,6 @@ function Export-TargetResource
             {
                 $Results.Remove($key) | Out-Null
             }
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterRule/MSFT_EXOMalwareFilterRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterRule/MSFT_EXOMalwareFilterRule.psm1
@@ -521,8 +521,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRole/MSFT_EXOManagementRole.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRole/MSFT_EXOManagementRole.psm1
@@ -410,8 +410,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $ManagementRole
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/MSFT_EXOManagementRoleAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/MSFT_EXOManagementRoleAssignment.psm1
@@ -598,8 +598,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $assignment
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleEntry/MSFT_EXOManagementRoleEntry.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleEntry/MSFT_EXOManagementRoleEntry.psm1
@@ -381,8 +381,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $roleEntry
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementScope/MSFT_EXOManagementScope.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementScope/MSFT_EXOManagementScope.psm1
@@ -374,8 +374,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMessageClassification/MSFT_EXOMessageClassification.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMessageClassification/MSFT_EXOMessageClassification.psm1
@@ -526,8 +526,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $MessageClassification
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMigration/MSFT_EXOMigration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMigration/MSFT_EXOMigration.psm1
@@ -568,8 +568,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMigrationEndpoint/MSFT_EXOMigrationEndpoint.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMigrationEndpoint/MSFT_EXOMigrationEndpoint.psm1
@@ -588,8 +588,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMobileDeviceMailboxPolicy/MSFT_EXOMobileDeviceMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMobileDeviceMailboxPolicy/MSFT_EXOMobileDeviceMailboxPolicy.psm1
@@ -1165,8 +1165,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOMEConfiguration/MSFT_EXOOMEConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOMEConfiguration/MSFT_EXOOMEConfiguration.psm1
@@ -523,8 +523,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOfflineAddressBook/MSFT_EXOOfflineAddressBook.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOfflineAddressBook/MSFT_EXOOfflineAddressBook.psm1
@@ -455,8 +455,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOnPremisesOrganization/MSFT_EXOOnPremisesOrganization.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOnPremisesOrganization/MSFT_EXOOnPremisesOrganization.psm1
@@ -491,8 +491,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationConfig/MSFT_EXOOrganizationConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationConfig/MSFT_EXOOrganizationConfig.psm1
@@ -1766,11 +1766,8 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
@@ -730,8 +730,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOutboundConnector/MSFT_EXOOutboundConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOutboundConnector/MSFT_EXOOutboundConnector.psm1
@@ -610,8 +610,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
@@ -1531,8 +1531,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPartnerApplication/MSFT_EXOPartnerApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPartnerApplication/MSFT_EXOPartnerApplication.psm1
@@ -469,8 +469,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPerimeterConfiguration/MSFT_EXOPerimeterConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPerimeterConfiguration/MSFT_EXOPerimeterConfiguration.psm1
@@ -370,8 +370,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPhishSimOverrideRule/MSFT_EXOPhishSimOverrideRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPhishSimOverrideRule/MSFT_EXOPhishSimOverrideRule.psm1
@@ -405,8 +405,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPlace/MSFT_EXOPlace.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPlace/MSFT_EXOPlace.psm1
@@ -662,8 +662,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPolicyTipConfig/MSFT_EXOPolicyTipConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPolicyTipConfig/MSFT_EXOPolicyTipConfig.psm1
@@ -407,8 +407,6 @@ function Export-TargetResource
                     AccessTokens          = $AccessTokens
                 }
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOQuarantinePolicy/MSFT_EXOQuarantinePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOQuarantinePolicy/MSFT_EXOQuarantinePolicy.psm1
@@ -663,7 +663,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-
             $keysToRemove = @()
             foreach ($key in $Results.Keys)
             {
@@ -676,8 +675,6 @@ function Export-TargetResource
             {
                 $Results.Remove($key) | Out-Null
             }
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORecipientPermission/MSFT_EXORecipientPermission.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORecipientPermission/MSFT_EXORecipientPermission.psm1
@@ -478,11 +478,8 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-
             if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORemoteDomain/MSFT_EXORemoteDomain.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORemoteDomain/MSFT_EXORemoteDomain.psm1
@@ -702,8 +702,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOReportSubmissionPolicy/MSFT_EXOReportSubmissionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOReportSubmissionPolicy/MSFT_EXOReportSubmissionPolicy.psm1
@@ -693,7 +693,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-
         $keysToRemove = @()
         foreach ($key in $Results.Keys)
         {
@@ -706,8 +705,6 @@ function Export-TargetResource
         {
             $Results.Remove($key) | Out-Null
         }
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOReportSubmissionRule/MSFT_EXOReportSubmissionRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOReportSubmissionRule/MSFT_EXOReportSubmissionRule.psm1
@@ -425,7 +425,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-
         $keysToRemove = @()
         foreach ($key in $Results.Keys)
         {
@@ -438,8 +437,6 @@ function Export-TargetResource
         {
             $Results.Remove($key) | Out-Null
         }
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOResourceConfiguration/MSFT_EXOResourceConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOResourceConfiguration/MSFT_EXOResourceConfiguration.psm1
@@ -372,8 +372,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicy/MSFT_EXORetentionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicy/MSFT_EXORetentionPolicy.psm1
@@ -382,8 +382,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicyTag/MSFT_EXORetentionPolicyTag.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicyTag/MSFT_EXORetentionPolicyTag.psm1
@@ -417,8 +417,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleAssignmentPolicy/MSFT_EXORoleAssignmentPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleAssignmentPolicy/MSFT_EXORoleAssignmentPolicy.psm1
@@ -452,8 +452,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $RoleAssignmentPolicy
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleGroup/MSFT_EXORoleGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleGroup/MSFT_EXORoleGroup.psm1
@@ -458,8 +458,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $RoleGroup
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentPolicy/MSFT_EXOSafeAttachmentPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentPolicy/MSFT_EXOSafeAttachmentPolicy.psm1
@@ -554,8 +554,6 @@ function Export-TargetResource
                     AccessTokens          = $AccessTokens
                 }
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentRule/MSFT_EXOSafeAttachmentRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentRule/MSFT_EXOSafeAttachmentRule.psm1
@@ -546,8 +546,6 @@ function Export-TargetResource
                     AccessTokens          = $AccessTokens
                 }
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.psm1
@@ -577,8 +577,6 @@ function Export-TargetResource
                     AccessTokens          = $AccessTokens
                 }
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksRule/MSFT_EXOSafeLinksRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksRule/MSFT_EXOSafeLinksRule.psm1
@@ -537,8 +537,6 @@ function Export-TargetResource
                     AccessTokens          = $AccessTokens
                 }
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSecOpsOverrideRule/MSFT_EXOSecOpsOverrideRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSecOpsOverrideRule/MSFT_EXOSecOpsOverrideRule.psm1
@@ -347,8 +347,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOServicePrincipal/MSFT_EXOServicePrincipal.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOServicePrincipal/MSFT_EXOServicePrincipal.psm1
@@ -372,8 +372,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharedMailbox/MSFT_EXOSharedMailbox.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharedMailbox/MSFT_EXOSharedMailbox.psm1
@@ -540,8 +540,6 @@ function Export-TargetResource
                 }
                 $Script:exportedInstance = $mailbox
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharingPolicy/MSFT_EXOSharingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharingPolicy/MSFT_EXOSharingPolicy.psm1
@@ -431,8 +431,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSmtpDaneInbound/MSFT_EXOSmtpDaneInbound.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSmtpDaneInbound/MSFT_EXOSmtpDaneInbound.psm1
@@ -358,8 +358,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSweepRule/MSFT_EXOSweepRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSweepRule/MSFT_EXOSweepRule.psm1
@@ -457,8 +457,6 @@ function Export-TargetResource
                 }
 
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
 
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTeamsProtectionPolicy/MSFT_EXOTeamsProtectionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTeamsProtectionPolicy/MSFT_EXOTeamsProtectionPolicy.psm1
@@ -393,8 +393,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTenantAllowBlockListItems/MSFT_EXOTenantAllowBlockListItems.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTenantAllowBlockListItems/MSFT_EXOTenantAllowBlockListItems.psm1
@@ -512,8 +512,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTenantAllowBlockListSpoofItems/MSFT_EXOTenantAllowBlockListSpoofItems.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTenantAllowBlockListSpoofItems/MSFT_EXOTenantAllowBlockListSpoofItems.psm1
@@ -400,8 +400,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportConfig/MSFT_EXOTransportConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportConfig/MSFT_EXOTransportConfig.psm1
@@ -675,11 +675,8 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.psm1
@@ -2714,8 +2714,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $TransportRule
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_FabricAdminTenantSettings/MSFT_FabricAdminTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_FabricAdminTenantSettings/MSFT_FabricAdminTenantSettings.psm1
@@ -2010,8 +2010,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
 
         $newResults = ([Hashtable]$Results).Clone()
         foreach ($key in $Results.Keys)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneASRRulesPolicyWindows10/MSFT_IntuneASRRulesPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneASRRulesPolicyWindows10/MSFT_IntuneASRRulesPolicyWindows10.psm1
@@ -900,25 +900,13 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy/MSFT_IntuneAccountProtectionLocalAdministratorPasswordSolutionPolicy.psm1
@@ -717,9 +717,7 @@ function Export-TargetResource
             }
 
             $Script:exportedInstance = $policy
-            $Results = Get-TargetResource @params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+            $Results = Get-TargetResource @Params
 
             if ($Results.Assignments)
             {
@@ -738,12 +736,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy/MSFT_IntuneAccountProtectionLocalUserGroupMembershipPolicy.psm1
@@ -605,37 +605,12 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-
-            if ($Results.LocalUserGroupCollection)
-            {
-                $isCIMArray = $false
-                if ($Results.LocalUserGroupCollection.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'LocalUserGroupCollection' -IsCIMArray:$isCIMArray
-            }
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
-
-            $currentDSCBlock = $currentDSCBlock.Replace("`r`n            `");", "`r`n            );")
+                -Credential $Credential `
+                -NoEscape @('LocalUserGroupCollection', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicy/MSFT_IntuneAccountProtectionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicy/MSFT_IntuneAccountProtectionPolicy.psm1
@@ -769,25 +769,13 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/MSFT_IntuneAccountProtectionPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAccountProtectionPolicyWindows10/MSFT_IntuneAccountProtectionPolicyWindows10.psm1
@@ -697,8 +697,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.DeviceSettings)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -745,20 +743,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.DeviceSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DeviceSettings' -IsCIMArray:$True
-            }
-            if ($Results.UserSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserSettings' -IsCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('DeviceSettings', 'UserSettings', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAndroidManagedStoreAppConfiguration/MSFT_IntuneAndroidManagedStoreAppConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAndroidManagedStoreAppConfiguration/MSFT_IntuneAndroidManagedStoreAppConfiguration.psm1
@@ -675,8 +675,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -710,27 +708,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
-
-            if ($Results.permissionActions)
-            {
-                $isCIMArray = $false
-                if ($Results.permissionActions.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'permissionActions' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments', 'permissionActions')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusExclusionsPolicyLinux/MSFT_IntuneAntivirusExclusionsPolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusExclusionsPolicyLinux/MSFT_IntuneAntivirusExclusionsPolicyLinux.psm1
@@ -593,8 +593,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.Exclusions)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -627,16 +625,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Exclusions)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Exclusions' -IsCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Exclusions', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusExclusionsPolicyMacOS/MSFT_IntuneAntivirusExclusionsPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusExclusionsPolicyMacOS/MSFT_IntuneAntivirusExclusionsPolicyMacOS.psm1
@@ -594,8 +594,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.Exclusions)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -628,16 +626,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Exclusions)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Exclusions' -IsCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Exclusions', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyLinux/MSFT_IntuneAntivirusPolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyLinux/MSFT_IntuneAntivirusPolicyLinux.psm1
@@ -966,8 +966,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.exclusions)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -1014,20 +1012,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.exclusions)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'exclusions' -IsCIMArray:$True
-            }
-            if ($Results.threatTypeSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'threatTypeSettings' -IsCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('exclusions', 'threatTypeSettings', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyMacOS/MSFT_IntuneAntivirusPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyMacOS/MSFT_IntuneAntivirusPolicyMacOS.psm1
@@ -968,8 +968,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.exclusions)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -1016,20 +1014,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.exclusions)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'exclusions' -IsCIMArray:$True
-            }
-            if ($Results.threatTypeSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'threatTypeSettings' -IsCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('exclusions', 'threatTypeSettings', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
@@ -1691,8 +1691,6 @@ function Export-TargetResource
                 throw "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed. Refer to the event viewer logs for more information."
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -1711,12 +1709,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential -Verbose
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10.psm1
@@ -823,8 +823,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -843,12 +841,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10ConfigMgr/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10ConfigMgr.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10ConfigMgr/MSFT_IntuneAppAndBrowserIsolationPolicyWindows10ConfigMgr.psm1
@@ -811,8 +811,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -831,12 +829,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppCategory/MSFT_IntuneAppCategory.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppCategory/MSFT_IntuneAppCategory.psm1
@@ -392,8 +392,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationDevicePolicy/MSFT_IntuneAppConfigurationDevicePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationDevicePolicy/MSFT_IntuneAppConfigurationDevicePolicy.psm1
@@ -744,8 +744,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.PermissionActions)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -790,19 +788,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.PermissionActions)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'PermissionActions' -IsCIMArray:$True
-            }
-            if ($Results.Settings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Settings' -IsCIMArray:$True
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('PermissionActions', 'Settings', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationPolicy/MSFT_IntuneAppConfigurationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppConfigurationPolicy/MSFT_IntuneAppConfigurationPolicy.psm1
@@ -533,27 +533,13 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($null -ne $Results.CustomSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'CustomSettings'
-            }
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('CustomSettings', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyAndroid/MSFT_IntuneAppProtectionPolicyAndroid.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyAndroid/MSFT_IntuneAppProtectionPolicyAndroid.psm1
@@ -1194,8 +1194,6 @@ function Export-TargetResource
                 Write-Verbose "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed"
                 throw "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed. Refer to the event viewer logs for more information."
             }
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyiOS/MSFT_IntuneAppProtectionPolicyiOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyiOS/MSFT_IntuneAppProtectionPolicyiOS.psm1
@@ -1574,8 +1574,6 @@ function Export-TargetResource
             $Script:exportedInstance = $policy
             $Results = Get-TargetResource @Params
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppleMDMPushNotificationCertificate/MSFT_IntuneAppleMDMPushNotificationCertificate.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppleMDMPushNotificationCertificate/MSFT_IntuneAppleMDMPushNotificationCertificate.psm1
@@ -442,8 +442,6 @@ function Export-TargetResource
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneApplicationControlPolicyWindows10/MSFT_IntuneApplicationControlPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneApplicationControlPolicyWindows10/MSFT_IntuneApplicationControlPolicyWindows10.psm1
@@ -545,18 +545,12 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAttackSurfaceReductionRulesPolicyWindows10ConfigManager/MSFT_IntuneAttackSurfaceReductionRulesPolicyWindows10ConfigManager.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAttackSurfaceReductionRulesPolicyWindows10ConfigManager/MSFT_IntuneAttackSurfaceReductionRulesPolicyWindows10ConfigManager.psm1
@@ -826,9 +826,7 @@ function Export-TargetResource
             }
 
             $Script:exportedInstance = $policy
-            $Results = Get-TargetResource @params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+            $Results = Get-TargetResource @Params
 
             if ($Results.Assignments)
             {
@@ -847,12 +845,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDerivedCredential/MSFT_IntuneDerivedCredential.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDerivedCredential/MSFT_IntuneDerivedCredential.psm1
@@ -486,8 +486,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceAndAppManagementAssignmentFilter/MSFT_IntuneDeviceAndAppManagementAssignmentFilter.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceAndAppManagementAssignmentFilter/MSFT_IntuneDeviceAndAppManagementAssignmentFilter.psm1
@@ -450,12 +450,9 @@ function Export-TargetResource
             }
 
             $Script:exportedInstance = $assignmentFilter
-            $Results = Get-TargetResource @params
-
+            $Results = Get-TargetResource @Params
             if ($Results.Ensure -eq 'Present')
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCategory/MSFT_IntuneDeviceCategory.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCategory/MSFT_IntuneDeviceCategory.psm1
@@ -361,8 +361,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $category
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCleanupRule/MSFT_IntuneDeviceCleanupRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCleanupRule/MSFT_IntuneDeviceCleanupRule.psm1
@@ -389,8 +389,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $cleanupRule
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroid/MSFT_IntuneDeviceCompliancePolicyAndroid.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroid/MSFT_IntuneDeviceCompliancePolicyAndroid.psm1
@@ -873,23 +873,12 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner.psm1
@@ -725,24 +725,13 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile.psm1
@@ -835,23 +835,13 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyMacOS/MSFT_IntuneDeviceCompliancePolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyMacOS/MSFT_IntuneDeviceCompliancePolicyMacOS.psm1
@@ -786,24 +786,13 @@ function Export-TargetResource
                 }
             }
 
-            $results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyWindows10/MSFT_IntuneDeviceCompliancePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyWindows10/MSFT_IntuneDeviceCompliancePolicyWindows10.psm1
@@ -937,8 +937,6 @@ function Export-TargetResource
                 throw "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed. Refer to the event viewer logs for more information."
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.ValidOperatingSystemBuildRanges)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -981,24 +979,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.ValidOperatingSystemBuildRanges)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ValidOperatingSystemBuildRanges'
-            }
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'Assignments' `
-                    -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('ValidOperatingSystemBuildRanges', 'Assignments')
 
             $dscContent += $currentDSCBlock
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyiOs/MSFT_IntuneDeviceCompliancePolicyiOs.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyiOs/MSFT_IntuneDeviceCompliancePolicyiOs.psm1
@@ -780,33 +780,12 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.RestrictedApps)
-            {
-                $isCIMArray = $false
-                if ($Results.RestrictedApps.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'RestrictedApps' -IsCIMArray:$isCIMArray
-            }
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('RestrictedApps', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.psm1
@@ -868,8 +868,6 @@ function Export-TargetResource
                 Write-Verbose "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed"
                 throw "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed. Refer to the event viewer logs for more information."
             }
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.DefinitionValues)
             {
@@ -919,33 +917,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            if ($Results.DefinitionValues)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DefinitionValues' -IsCIMArray:$true
-            }
-            if ($Results.DefinitionValues.Definition)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Definition'
-            }
-            if ($Results.DefinitionValues.PresentationValues)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'PresentationValues'
-            }
-            if ($Results.DefinitionValues.PresentationValues.KeyValuePairValues)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'KeyValuePairValues'
-            }
-
-            #removing trailing commas and semi colons between items of an array of cim instances added by Convert-DSCStringParamToVariable
-            $currentDSCBlock = $currentDSCBlock.replace( "    ,`r`n" , "    `r`n" )
-            $currentDSCBlock = $currentDSCBlock.replace( "`r`n;`r`n" , "`r`n" )
-            $currentDSCBlock = $currentDSCBlock.replace( "`r`n,`r`n" , "`r`n" )
-            $currentDSCBlock = $currentDSCBlock.Replace("}                    Enabled = `$", "}`r`n                    Enabled = `$")
+                -Credential $Credential `
+                -NoEscape @('Assignments', 'DefinitionValues', 'PresentationValues', 'KeyValuePairValues')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10/MSFT_IntuneDeviceConfigurationCustomPolicyWindows10.psm1
@@ -633,8 +633,7 @@ function Export-TargetResource
                 Write-Verbose "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed"
                 throw "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed. Refer to the event viewer logs for more information."
             }
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+
             if ($null -ne $Results.OmaSettings)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -665,16 +664,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
+                -Credential $Credential `
+                -NoEscape @('OmaSettings', 'Assignments')
 
-            if ($Results.OmaSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'OmaSettings' -IsCIMArray:$True
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDefenderForEndpointOnboardingPolicyWindows10/MSFT_IntuneDeviceConfigurationDefenderForEndpointOnboardingPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDefenderForEndpointOnboardingPolicyWindows10/MSFT_IntuneDeviceConfigurationDefenderForEndpointOnboardingPolicyWindows10.psm1
@@ -639,8 +639,7 @@ function Export-TargetResource
                 Write-Verbose "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed"
                 throw "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed. Refer to the event viewer logs for more information."
             }
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -657,11 +656,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDeliveryOptimizationPolicyWindows10/MSFT_IntuneDeviceConfigurationDeliveryOptimizationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDeliveryOptimizationPolicyWindows10/MSFT_IntuneDeviceConfigurationDeliveryOptimizationPolicyWindows10.psm1
@@ -853,8 +853,6 @@ function Export-TargetResource
                 Write-Verbose "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed"
                 throw "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed. Refer to the event viewer logs for more information."
             }
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ( $null -ne $Results.BandwidthMode)
             {
                 $complexMapping = @(
@@ -932,26 +930,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.BandwidthMode)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'BandwidthMode' -IsCIMArray:$False
-            }
-            if ($Results.GroupIdSource)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'GroupIdSource' -IsCIMArray:$False
-            }
-            if ($Results.MaximumCacheSize)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MaximumCacheSize' -IsCIMArray:$False
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            #removing trailing commas and semi colons between items of an array of cim instances added by Convert-DSCStringParamToVariable
-            $currentDSCBlock = $currentDSCBlock.replace( "    ,`r`n" , "    `r`n" )
-            $currentDSCBlock = $currentDSCBlock.replace( "`r`n;`r`n" , "`r`n" )
+                -Credential $Credential `
+                -NoEscape @('BandwidthMode', 'GroupIdSource', 'MaximumCacheSize', 'Assignments')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDomainJoinPolicyWindows10/MSFT_IntuneDeviceConfigurationDomainJoinPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationDomainJoinPolicyWindows10/MSFT_IntuneDeviceConfigurationDomainJoinPolicyWindows10.psm1
@@ -594,8 +594,7 @@ function Export-TargetResource
                 Write-Verbose "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed"
                 throw "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed. Refer to the event viewer logs for more information."
             }
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -612,11 +611,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10/MSFT_IntuneDeviceConfigurationEmailProfilePolicyWindows10.psm1
@@ -756,8 +756,7 @@ function Export-TargetResource
                 Write-Verbose "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed"
                 throw "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed. Refer to the event viewer logs for more information."
             }
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -774,11 +773,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEndpointProtectionPolicyWindows10/MSFT_IntuneDeviceConfigurationEndpointProtectionPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationEndpointProtectionPolicyWindows10/MSFT_IntuneDeviceConfigurationEndpointProtectionPolicyWindows10.psm1
@@ -5003,8 +5003,7 @@ function Export-TargetResource
                 Write-Verbose "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed"
                 throw "An error occured in Get-TargetResource, the policy {$($params.displayName)} will not be processed. Refer to the event viewer logs for more information."
             }
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+
             if ( $null -ne $Results.BitLockerFixedDrivePolicy)
             {
                 $complexMapping = @(
@@ -5973,162 +5972,17 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.BitLockerFixedDrivePolicy)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'BitLockerFixedDrivePolicy' -IsCIMArray:$False
-            }
-            if ($Results.BitLockerRemovableDrivePolicy)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'BitLockerRemovableDrivePolicy' -IsCIMArray:$False
-            }
-            if ($Results.BitLockerSystemDrivePolicy)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'BitLockerSystemDrivePolicy' -IsCIMArray:$False
-            }
-            if ($Results.DefenderDetectedMalwareActions)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DefenderDetectedMalwareActions' -IsCIMArray:$False
-            }
-            if ($Results.FirewallProfileDomain)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'FirewallProfileDomain' -IsCIMArray:$False
-            }
-            if ($Results.FirewallProfilePrivate)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'FirewallProfilePrivate' -IsCIMArray:$False
-            }
-            if ($Results.FirewallProfilePublic)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'FirewallProfilePublic' -IsCIMArray:$False
-            }
-            if ($Results.FirewallRules)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'FirewallRules' -IsCIMArray:$True
-            }
-            if ($Results.UserRightsAccessCredentialManagerAsTrustedCaller)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsAccessCredentialManagerAsTrustedCaller' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsActAsPartOfTheOperatingSystem)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsActAsPartOfTheOperatingSystem' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsAllowAccessFromNetwork)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsAllowAccessFromNetwork' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsBackupData)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsBackupData' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsBlockAccessFromNetwork)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsBlockAccessFromNetwork' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsChangeSystemTime)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsChangeSystemTime' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsCreateGlobalObjects)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsCreateGlobalObjects' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsCreatePageFile)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsCreatePageFile' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsCreatePermanentSharedObjects)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsCreatePermanentSharedObjects' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsCreateSymbolicLinks)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsCreateSymbolicLinks' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsCreateToken)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsCreateToken' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsDebugPrograms)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsDebugPrograms' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsDelegation)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsDelegation' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsDenyLocalLogOn)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsDenyLocalLogOn' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsGenerateSecurityAudits)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsGenerateSecurityAudits' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsImpersonateClient)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsImpersonateClient' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsIncreaseSchedulingPriority)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsIncreaseSchedulingPriority' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsLoadUnloadDrivers)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsLoadUnloadDrivers' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsLocalLogOn)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsLocalLogOn' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsLockMemory)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsLockMemory' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsManageAuditingAndSecurityLogs)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsManageAuditingAndSecurityLogs' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsManageVolumes)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsManageVolumes' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsModifyFirmwareEnvironment)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsModifyFirmwareEnvironment' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsModifyObjectLabels)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsModifyObjectLabels' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsProfileSingleProcess)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsProfileSingleProcess' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsRemoteDesktopServicesLogOn)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsRemoteDesktopServicesLogOn' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsRemoteShutdown)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsRemoteShutdown' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsRestoreData)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsRestoreData' -IsCIMArray:$False
-            }
-            if ($Results.UserRightsTakeOwnership)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserRightsTakeOwnership' -IsCIMArray:$False
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            #removing trailing commas and semi colons between items of an array of cim instances added by Convert-DSCStringParamToVariable
-            $currentDSCBlock = $currentDSCBlock.replace( "    ,`r`n" , "    `r`n" )
-            $currentDSCBlock = $currentDSCBlock.replace( "`r`n;`r`n" , "`r`n" )
+                -Credential $Credential `
+                -NoEscape @('BitLockerFixedDrivePolicy', 'BitLockerRemovableDrivePolicy', 'BitLockerSystemDrivePolicy', 'DefenderDetectedMalwareActions',
+                    'FirewallProfileDomain', 'FirewallProfilePrivate', 'FirewallProfilePublic', 'FirewallRules',
+                    'UserRightsAccessCredentialManagerAsTrustedCaller', 'UserRightsActAsPartOfTheOperatingSystem', 'UserRightsAllowAccessFromNetwork',
+                    'UserRightsBackupData', 'UserRightsBlockAccessFromNetwork', 'UserRightsChangeSystemTime', 'UserRightsCreateGlobalObjects',
+                    'UserRightsCreatePageFile', 'UserRightsCreatePermanentSharedObjects', 'UserRightsCreateSymbolicLinks', 'UserRightsCreateToken',
+                    'UserRightsDebugPrograms', 'UserRightsDelegation', 'UserRightsDenyLocalLogOn', 'UserRightsGenerateSecurityAudits',
+                    'UserRightsImpersonateClient', 'UserRightsIncreaseSchedulingPriority', 'UserRightsLoadUnloadDrivers', 'UserRightsLocalLogOn',
+                    'UserRightsLockMemory', 'UserRightsManageAuditingAndSecurityLogs', 'UserRightsManageVolumes', 'UserRightsModifyFirmwareEnvironment',
+                    'UserRightsModifyObjectLabels', 'UserRightsProfileSingleProcess', 'UserRightsRemoteDesktopServicesLogOn', 'UserRightsRemoteShutdown',
+                    'UserRightsRestoreData', 'UserRightsTakeOwnership', 'Assignments')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationFirmwareInterfacePolicyWindows10/MSFT_IntuneDeviceConfigurationFirmwareInterfacePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationFirmwareInterfacePolicyWindows10/MSFT_IntuneDeviceConfigurationFirmwareInterfacePolicyWindows10.psm1
@@ -991,8 +991,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -1009,11 +1007,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10.psm1
@@ -586,8 +586,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -604,11 +602,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationIdentityProtectionPolicyWindows10/MSFT_IntuneDeviceConfigurationIdentityProtectionPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationIdentityProtectionPolicyWindows10/MSFT_IntuneDeviceConfigurationIdentityProtectionPolicyWindows10.psm1
@@ -739,8 +739,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -757,11 +755,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationImportedPfxCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationImportedPfxCertificatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationImportedPfxCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationImportedPfxCertificatePolicyWindows10.psm1
@@ -652,8 +652,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -670,11 +668,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationKioskPolicyWindows10/MSFT_IntuneDeviceConfigurationKioskPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationKioskPolicyWindows10/MSFT_IntuneDeviceConfigurationKioskPolicyWindows10.psm1
@@ -818,8 +818,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.KioskProfiles)
             {
                 $complexMapping = @(
@@ -898,19 +896,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.KioskProfiles)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'KioskProfiles' -IsCIMArray:$True
-            }
-            if ($Results.WindowsKioskForceUpdateSchedule)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'WindowsKioskForceUpdateSchedule' -IsCIMArray:$False
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('KioskProfiles', 'WindowsKioskForceUpdateSchedule', 'Assignments')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationNetworkBoundaryPolicyWindows10/MSFT_IntuneDeviceConfigurationNetworkBoundaryPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationNetworkBoundaryPolicyWindows10/MSFT_IntuneDeviceConfigurationNetworkBoundaryPolicyWindows10.psm1
@@ -581,8 +581,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.WindowsNetworkIsolationPolicy)
             {
                 $complexMapping = @(
@@ -632,18 +630,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.WindowsNetworkIsolationPolicy)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'WindowsNetworkIsolationPolicy' -IsCIMArray:$False
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            #removing trailing commas and semi colons between items of an array of cim instances added by Convert-DSCStringParamToVariable
-            $currentDSCBlock = $currentDSCBlock.replace("    ,`r`n" , "    `r`n" )
-            $currentDSCBlock = $currentDSCBlock.replace("`r`n;`r`n" , "`r`n" )
+                -Credential $Credential `
+                -NoEscape @('WindowsNetworkIsolationPolicy', 'Assignments')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPkcsCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationPkcsCertificatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPkcsCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationPkcsCertificatePolicyWindows10.psm1
@@ -772,8 +772,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.CustomSubjectAlternativeNames)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -818,19 +816,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.CustomSubjectAlternativeNames)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'CustomSubjectAlternativeNames' -IsCIMArray:$True
-            }
-            if ($Results.ExtendedKeyUsages)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExtendedKeyUsages' -IsCIMArray:$True
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('CustomSubjectAlternativeNames', 'ExtendedKeyUsages', 'Assignments')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.psm1
@@ -620,8 +620,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -638,11 +636,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
@@ -602,8 +602,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -620,11 +618,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceAdministrator.psm1
@@ -1290,8 +1290,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.AppsHideList)
             {
@@ -1371,63 +1369,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.AppsHideList)
-            {
-                $isCIMArray = $false
-                if ($Results.AppsHideList.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AppsHideList' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.AppsInstallAllowList)
-            {
-                $isCIMArray = $false
-                if ($Results.AppsInstallAllowList.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AppsInstallAllowList' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.AppsLaunchBlockList)
-            {
-                $isCIMArray = $false
-                if ($Results.AppsLaunchBlockList.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AppsLaunchBlockList' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.CompliantAppsList)
-            {
-                $isCIMArray = $false
-                if ($Results.CompliantAppsList.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'CompliantAppsList' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.KioskModeApps)
-            {
-                $isCIMArray = $false
-                if ($Results.KioskModeApps.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'KioskModeApps' -IsCIMArray:$isCIMArray
-            }
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('AppsHideList', 'AppsInstallAllowList', 'AppsLaunchBlockList', 'CompliantAppsList', 'KioskModeApps', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceOwner/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceOwner.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceOwner/MSFT_IntuneDeviceConfigurationPolicyAndroidDeviceOwner.psm1
@@ -2522,8 +2522,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.AzureAdSharedDeviceDataClearApps)
             {
@@ -2742,110 +2740,10 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.AzureAdSharedDeviceDataClearApps)
-            {
-                $isCIMArray = $false
-                if ($Results.AzureAdSharedDeviceDataClearApps.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AzureAdSharedDeviceDataClearApps' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.DetailedHelpText)
-            {
-                $isCIMArray = $false
-                if ($Results.DetailedHelpText.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DetailedHelpText' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.DeviceOwnerLockScreenMessage)
-            {
-                $isCIMArray = $false
-                if ($Results.DeviceOwnerLockScreenMessage.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DeviceOwnerLockScreenMessage' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.GlobalProxy)
-            {
-                $isCIMArray = $false
-                if ($Results.GlobalProxy.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'GlobalProxy' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.KioskModeAppPositions)
-            {
-                $isCIMArray = $false
-                if ($Results.KioskModeAppPositions.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'KioskModeAppPositions' -IsCIMArray:$isCIMArray
-            }
-
-            if ($Results.KioskModeApps)
-            {
-                $isCIMArray = $false
-                if ($Results.KioskModeApps.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'KioskModeApps' -IsCIMArray:$isCIMArray
-            }
-
-            if ($Results.KioskModeManagedFolders)
-            {
-                $isCIMArray = $false
-                if ($Results.KioskModeManagedFolders.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'KioskModeManagedFolders' -IsCIMArray:$isCIMArray -Verbose
-            }
-
-            if ($Results.PersonalProfilePersonalApplications)
-            {
-                $isCIMArray = $false
-                if ($Results.PersonalProfilePersonalApplications.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'PersonalProfilePersonalApplications' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.ShortHelpText)
-            {
-                $isCIMArray = $false
-                if ($Results.ShortHelpText.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ShortHelpText' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.SystemUpdateFreezePeriods)
-            {
-                $isCIMArray = $false
-                if ($Results.SystemUpdateFreezePeriods.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'SystemUpdateFreezePeriods' -IsCIMArray:$isCIMArray
-            }
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('AzureAdSharedDeviceDataClearApps', 'DetailedHelpText', 'DeviceOwnerLockScreenMessage', 'GlobalProxy',
+                    'KioskModeAppPositions', 'KioskModeApps', 'KioskModeManagedFolders', 'PersonalProfilePersonalApplications',
+                    'ShortHelpText', 'SystemUpdateFreezePeriods', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject/MSFT_IntuneDeviceConfigurationPolicyAndroidOpenSourceProject.psm1
@@ -752,8 +752,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -772,17 +770,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidWorkProfile/MSFT_IntuneDeviceConfigurationPolicyAndroidWorkProfile.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyAndroidWorkProfile/MSFT_IntuneDeviceConfigurationPolicyAndroidWorkProfile.psm1
@@ -1073,7 +1073,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $policy
             $Results = Get-TargetResource @Params
-
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject ([Array]$Results.Assignments) -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -1088,24 +1087,13 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyMacOS/MSFT_IntuneDeviceConfigurationPolicyMacOS.psm1
@@ -1344,8 +1344,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.CompliantAppsList)
             {
@@ -1389,36 +1387,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.CompliantAppsList)
-            {
-                $isCIMArray = $false
-                if ($Results.CompliantAppsList.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'CompliantAppsList' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.PrivacyAccessControls)
-            {
-                $isCIMArray = $false
-                if ($Results.PrivacyAccessControls.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'PrivacyAccessControls' -IsCIMArray:$isCIMArray
-            }
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('CompliantAppsList', 'PrivacyAccessControls', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationPolicyWindows10.psm1
@@ -4783,8 +4783,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.DefenderDetectedMalwareActions)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -4871,35 +4869,10 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.DefenderDetectedMalwareActions)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DefenderDetectedMalwareActions' -IsCIMArray:$False
-            }
-            if ($Results.EdgeHomeButtonConfiguration)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EdgeHomeButtonConfiguration' -IsCIMArray:$False
-            }
-            if ($Results.EdgeSearchEngine)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EdgeSearchEngine' -IsCIMArray:$False
-            }
-            if ($Results.NetworkProxyServer)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'NetworkProxyServer' -IsCIMArray:$False
-            }
-            if ($Results.Windows10AppsForceUpdateSchedule)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Windows10AppsForceUpdateSchedule' -IsCIMArray:$False
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            #removing trailing commas and semi colons between items of an array of cim instances added by Convert-DSCStringParamToVariable
-            $currentDSCBlock = $currentDSCBlock.Replace("    ,`r`n" , "    `r`n" )
-            $currentDSCBlock = $currentDSCBlock.Replace("`r`n;`r`n" , "`r`n" )
-            $currentDSCBlock = $currentDSCBlock.Replace(",`r`n", '')
+                -Credential $Credential `
+                -NoEscape @('DefenderDetectedMalwareActions', 'EdgeHomeButtonConfiguration', 'EdgeSearchEngine',
+                    'NetworkProxyServer', 'Windows10AppsForceUpdateSchedule', 'Assignments')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyiOS/MSFT_IntuneDeviceConfigurationPolicyiOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPolicyiOS/MSFT_IntuneDeviceConfigurationPolicyiOS.psm1
@@ -3087,8 +3087,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.AppsSingleAppModeList)
             {
@@ -3300,93 +3298,11 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.AppsSingleAppModeList)
-            {
-                $isCIMArray = $false
-                if ($Results.AppsSingleAppModeList.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AppsSingleAppModeList' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.AppsVisibilityList)
-            {
-                $isCIMArray = $false
-                if ($Results.AppsVisibilityList.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AppsVisibilityList' -IsCIMArray:$isCIMArray
-            }
-            if ($Results.CompliantAppsList)
-            {
-                $isCIMArray = $false
-                if ($Results.CompliantAppsList.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'CompliantAppsList' -IsCIMArray:$isCIMArray
-            }
-
-            if ($Results.MediaContentRatingAustralia)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MediaContentRatingAustralia'
-            }
-            if ($Results.MediaContentRatingCanada)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MediaContentRatingCanada'
-            }
-            if ($Results.MediaContentRatingFrance)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MediaContentRatingFrance'
-            }
-
-            if ($Results.MediaContentRatingGermany)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MediaContentRatingGermany'
-            }
-            if ($Results.MediaContentRatingIreland)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MediaContentRatingIreland'
-            }
-            if ($Results.MediaContentRatingJapan)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MediaContentRatingJapan'
-            }
-            if ($Results.MediaContentRatingNewZealand)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MediaContentRatingNewZealand'
-            }
-            if ($Results.MediaContentRatingUnitedKingdom)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MediaContentRatingUnitedKingdom'
-            }
-            if ($Results.MediaContentRatingUnitedStates)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MediaContentRatingUnitedStates'
-            }
-
-            if ($Results.NetworkUsageRules)
-            {
-                $isCIMArray = $false
-                if ($Results.NetworkUsageRules.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'NetworkUsageRules' -IsCIMArray:$isCIMArray
-            }
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('AppsSingleAppModeList', 'AppsVisibilityList', 'CompliantAppsList', 'MediaContentRatingAustralia',
+                    'MediaContentRatingCanada', 'MediaContentRatingFrance', 'MediaContentRatingGermany', 'MediaContentRatingIreland',
+                    'MediaContentRatingJapan', 'MediaContentRatingNewZealand', 'MediaContentRatingUnitedKingdom',
+                    'MediaContentRatingUnitedStates', 'NetworkUsageRules', 'Assignments')
 
             $dscContent += $currentDSCBlock
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.psm1
@@ -921,8 +921,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.CustomSubjectAlternativeNames)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -967,19 +965,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.CustomSubjectAlternativeNames)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'CustomSubjectAlternativeNames' -IsCIMArray:$True
-            }
-            if ($Results.ExtendedKeyUsages)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExtendedKeyUsages' -IsCIMArray:$True
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('CustomSubjectAlternativeNames', 'ExtendedKeyUsages', 'Assignments')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSecureAssessmentPolicyWindows10/MSFT_IntuneDeviceConfigurationSecureAssessmentPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSecureAssessmentPolicyWindows10/MSFT_IntuneDeviceConfigurationSecureAssessmentPolicyWindows10.psm1
@@ -629,8 +629,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -647,11 +645,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSharedMultiDevicePolicyWindows10/MSFT_IntuneDeviceConfigurationSharedMultiDevicePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSharedMultiDevicePolicyWindows10/MSFT_IntuneDeviceConfigurationSharedMultiDevicePolicyWindows10.psm1
@@ -852,8 +852,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.AccountManagerPolicy)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -884,15 +882,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.AccountManagerPolicy)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AccountManagerPolicy' -IsCIMArray:$False
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('AccountManagerPolicy', 'Assignments')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationTrustedCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationTrustedCertificatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationTrustedCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationTrustedCertificatePolicyWindows10.psm1
@@ -564,8 +564,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -582,11 +580,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationVpnPolicyWindows10/MSFT_IntuneDeviceConfigurationVpnPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationVpnPolicyWindows10/MSFT_IntuneDeviceConfigurationVpnPolicyWindows10.psm1
@@ -1092,8 +1092,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.AssociatedApps)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -1251,43 +1249,10 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.AssociatedApps)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AssociatedApps' -IsCIMArray:$True
-            }
-            if ($Results.CryptographySuite)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'CryptographySuite' -IsCIMArray:$False
-            }
-            if ($Results.DnsRules)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DnsRules' -IsCIMArray:$True
-            }
-            if ($Results.ProxyServer)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ProxyServer' -IsCIMArray:$False
-            }
-            if ($Results.Routes)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Routes' -IsCIMArray:$True
-            }
-            if ($Results.SingleSignOnEku)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'SingleSignOnEku' -IsCIMArray:$False
-            }
-            if ($Results.TrafficRules)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'TrafficRules' -IsCIMArray:$True
-            }
-            if ($Results.ServerCollection)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ServerCollection' -IsCIMArray:$True
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('AssociatedApps', 'CryptographySuite', 'DnsRules', 'ProxyServer', 'Routes',
+                    'SingleSignOnEku', 'TrafficRules', 'ServerCollection', 'Assignments')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWindowsTeamPolicyWindows10/MSFT_IntuneDeviceConfigurationWindowsTeamPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWindowsTeamPolicyWindows10/MSFT_IntuneDeviceConfigurationWindowsTeamPolicyWindows10.psm1
@@ -815,8 +815,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -833,11 +831,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10/MSFT_IntuneDeviceConfigurationWiredNetworkPolicyWindows10.psm1
@@ -1127,8 +1127,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -1145,11 +1143,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceControlPolicyWindows10/MSFT_IntuneDeviceControlPolicyWindows10.psm1
@@ -1107,8 +1107,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.PolicyRule)
             {
                 $complexMapping = @(
@@ -1155,16 +1153,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.PolicyRule)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'PolicyRule' -IsCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('PolicyRule', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentLimitRestriction/MSFT_IntuneDeviceEnrollmentLimitRestriction.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentLimitRestriction/MSFT_IntuneDeviceEnrollmentLimitRestriction.psm1
@@ -389,8 +389,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentPlatformRestriction/MSFT_IntuneDeviceEnrollmentPlatformRestriction.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentPlatformRestriction/MSFT_IntuneDeviceEnrollmentPlatformRestriction.psm1
@@ -736,7 +736,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-
             if ($null -ne $Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject ([Array]$Results.Assignments) -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -854,64 +853,14 @@ function Export-TargetResource
                 }
             }
 
-
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($null -ne $Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
-
-            if ($null -ne $Results.IosRestriction)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IosRestriction'
-            }
-
-            if ($null -ne $Results.WindowsRestriction)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'WindowsRestriction'
-            }
-
-            if ($null -ne $Results.WindowsHomeSkuRestriction)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'WindowsHomeSkuRestriction'
-            }
-
-            if ($null -ne $Results.WindowsMobileRestriction)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'WindowsMobileRestriction'
-            }
-
-            if ($null -ne $Results.AndroidRestriction)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AndroidRestriction'
-            }
-
-            if ($null -ne $Results.AndroidForWorkRestriction)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AndroidForWorkRestriction'
-            }
-
-            if ($null -ne $Results.MacRestriction)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MacRestriction'
-            }
-
-            if ($null -ne $Results.MacOSRestriction)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MacOSRestriction'
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments', 'IosRestriction', 'WindowsRestriction', 'WindowsHomeSkuRestriction',
+                    'WindowsMobileRestriction', 'AndroidRestriction', 'AndroidForWorkRestriction',
+                    'MacRestriction','MacOSRestriction')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentStatusPageWindows10/MSFT_IntuneDeviceEnrollmentStatusPageWindows10.psm1
@@ -771,8 +771,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -789,11 +787,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementAndroidDeviceOwnerEnrollmentProfile/MSFT_IntuneDeviceManagementAndroidDeviceOwnerEnrollmentProfile.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementAndroidDeviceOwnerEnrollmentProfile/MSFT_IntuneDeviceManagementAndroidDeviceOwnerEnrollmentProfile.psm1
@@ -669,8 +669,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.QrCodeImage)
             {
@@ -691,13 +689,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.QrCodeImage)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'QrCodeImage' -IsCIMArray:$false
-
-            }
+                -Credential $Credential `
+                -NoEscape @('QrCodeImage')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementComplianceSettings/MSFT_IntuneDeviceManagementComplianceSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementComplianceSettings/MSFT_IntuneDeviceManagementComplianceSettings.psm1
@@ -309,9 +309,7 @@ function Export-TargetResource
             Managedidentity       = $ManagedIdentity.IsPresent
             AccessTokens          = $AccessTokens
         }
-        $Results = Get-TargetResource @params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
+        $Results = Get-TargetResource @Params
 
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay.psm1
@@ -489,9 +489,7 @@ function Export-TargetResource
             }
 
             $Script:exportedInstance = $config
-            $Results = Get-TargetResource @params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+            $Results = Get-TargetResource @Params
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceRemediation/MSFT_IntuneDeviceRemediation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceRemediation/MSFT_IntuneDeviceRemediation.psm1
@@ -830,8 +830,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.DetectionScriptParameters)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -892,22 +890,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.DetectionScriptParameters)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DetectionScriptParameters' -IsCIMArray:$True
-            }
-            if ($Results.RemediationScriptParameters)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'RemediationScriptParameters' -IsCIMArray:$True
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = (Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true).Replace("''", "'")
-                $currentDSCBlock = [Regex]::Replace($currentDSCBlock, "Assignment = '\r\n                ", 'Assignment = ')
-                $currentDSCBlock = $currentDSCBlock.Replace("RunSchedule = '", 'RunSchedule = ').Replace("}'", '}')
-                $currentDSCBlock = [Regex]::Replace($currentDSCBlock, "\r\n            '", '')
-            }
+                -Credential $Credential `
+                -NoEscape @('DetectionScriptParameters', 'RemediationScriptParameters', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/MSFT_IntuneDiskEncryptionMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionMacOS/MSFT_IntuneDiskEncryptionMacOS.psm1
@@ -715,8 +715,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -733,11 +731,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionPDEPolicyWindows10/MSFT_IntuneDiskEncryptionPDEPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionPDEPolicyWindows10/MSFT_IntuneDiskEncryptionPDEPolicyWindows10.psm1
@@ -608,8 +608,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -628,12 +626,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionWindows10/MSFT_IntuneDiskEncryptionWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDiskEncryptionWindows10/MSFT_IntuneDiskEncryptionWindows10.psm1
@@ -1385,8 +1385,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -1405,12 +1403,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
@@ -586,8 +586,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -606,12 +604,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
@@ -586,8 +586,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -606,12 +604,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10/MSFT_IntuneEndpointDetectionAndResponsePolicyWindows10.psm1
@@ -626,9 +626,7 @@ function Export-TargetResource
             }
 
             $Script:exportedInstance = $policy
-            $Results = Get-TargetResource @params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+            $Results = Get-TargetResource @Params
 
             if ($Results.Assignments)
             {
@@ -647,12 +645,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneExploitProtectionPolicyWindows10SettingCatalog/MSFT_IntuneExploitProtectionPolicyWindows10SettingCatalog.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneExploitProtectionPolicyWindows10SettingCatalog/MSFT_IntuneExploitProtectionPolicyWindows10SettingCatalog.psm1
@@ -569,9 +569,7 @@ function Export-TargetResource
             }
 
             $Script:exportedInstance = $policy
-            $Results = Get-TargetResource @params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+            $Results = Get-TargetResource @Params
 
             if ($Results.Assignments)
             {
@@ -590,12 +588,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallPolicyWindows10/MSFT_IntuneFirewallPolicyWindows10.psm1
@@ -1721,8 +1721,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -1741,12 +1739,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallRulesHyperVPolicyWindows10/MSFT_IntuneFirewallRulesHyperVPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallRulesHyperVPolicyWindows10/MSFT_IntuneFirewallRulesHyperVPolicyWindows10.psm1
@@ -578,8 +578,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.FirewallRuleName)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -612,16 +610,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.FirewallRuleName)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'FirewallRuleName' -IsCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('FirewallRuleName', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallRulesPolicyWindows10/MSFT_IntuneFirewallRulesPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallRulesPolicyWindows10/MSFT_IntuneFirewallRulesPolicyWindows10.psm1
@@ -594,8 +594,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.FirewallRuleName)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -628,16 +626,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.FirewallRuleName)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'FirewallRuleName' -IsCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('FirewallRuleName', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallRulesPolicyWindows10ConfigMgr/MSFT_IntuneFirewallRulesPolicyWindows10ConfigMgr.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneFirewallRulesPolicyWindows10ConfigMgr/MSFT_IntuneFirewallRulesPolicyWindows10ConfigMgr.psm1
@@ -580,8 +580,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.FirewallRuleName)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -614,16 +612,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.FirewallRuleName)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'FirewallRuleName' -IsCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('FirewallRuleName', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.psm1
@@ -831,9 +831,7 @@ function Export-TargetResource
             }
 
             $Script:exportedInstance = $config
-            $Results = Get-TargetResource @params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+            $Results = Get-TargetResource @Params
 
             #region complex types
             if ($null -ne $Results.Categories)
@@ -924,34 +922,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            #region complex types
-            if ($null -ne $Results.Categories)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Categories' -IsCIMArray:$true
-            }
-
-            if ($null -ne $Results.ChildApps)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ChildApps' -IsCIMArray:$true
-            }
-
-            if ($null -ne $Results.LargeIcon)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'LargeIcon' -IsCIMArray:$false
-            }
-
-            if ($null -ne $Results.MinimumSupportedOperatingSystem)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'MinimumSupportedOperatingSystem' -IsCIMArray:$false
-            }
-
-            if ($null -ne $Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            #endregion complex types
+                -Credential $Credential `
+                -NoEscape @('Categories', 'ChildApps', 'LargeIcon', 'MinimumSupportedOperatingSystem', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp.psm1
@@ -890,9 +890,7 @@ function Export-TargetResource
             }
 
             $Script:exportedInstance = $config
-            $Results = Get-TargetResource @params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+            $Results = Get-TargetResource @Params
 
             #region complex types
             if ($null -ne $Results.Categories)
@@ -967,29 +965,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            #region complex types
-            if ($null -ne $Results.Categories)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Categories' -IsCIMArray:$true
-            }
-
-            if ($null -ne $Results.ExcludedApps)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExcludedApps' -IsCIMArray:$false
-            }
-
-            # if ($null -ne $Results.LargeIcon)
-            # {
-            #     $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'LargeIcon' -IsCIMArray:$false
-            # }
-
-            if ($null -ne $Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            #endregion complex types
+                -Credential $Credential `
+                -NoEscape @('Categories', 'ExcludedApps', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileThreatDefenseConnector/MSFT_IntuneMobileThreatDefenseConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileThreatDefenseConnector/MSFT_IntuneMobileThreatDefenseConnector.psm1
@@ -607,8 +607,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntunePolicySets/MSFT_IntunePolicySets.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntunePolicySets/MSFT_IntunePolicySets.psm1
@@ -592,8 +592,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -622,15 +620,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            if ($Results.Items)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Items' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments', 'Items')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleAssignment/MSFT_IntuneRoleAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleAssignment/MSFT_IntuneRoleAssignment.psm1
@@ -681,8 +681,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleDefinition/MSFT_IntuneRoleDefinition.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleDefinition/MSFT_IntuneRoleDefinition.psm1
@@ -549,8 +549,6 @@ function Export-TargetResource
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleScopeTag/MSFT_IntuneRoleScopeTag.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleScopeTag/MSFT_IntuneRoleScopeTag.psm1
@@ -512,8 +512,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -532,12 +530,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineDefenderForEndpoint/MSFT_IntuneSecurityBaselineDefenderForEndpoint.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineDefenderForEndpoint/MSFT_IntuneSecurityBaselineDefenderForEndpoint.psm1
@@ -1110,8 +1110,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.DeviceSettings)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -1158,20 +1156,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.DeviceSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DeviceSettings' -IsCIMArray:$False
-            }
-            if ($Results.UserSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserSettings' -IsCIMArray:$False
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('DeviceSettings', 'UserSettings', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoft365AppsForEnterprise/MSFT_IntuneSecurityBaselineMicrosoft365AppsForEnterprise.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoft365AppsForEnterprise/MSFT_IntuneSecurityBaselineMicrosoft365AppsForEnterprise.psm1
@@ -1030,8 +1030,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.DeviceSettings)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -1078,20 +1076,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.DeviceSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DeviceSettings' -IsCIMArray:$False
-            }
-            if ($Results.UserSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserSettings' -IsCIMArray:$False
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('DeviceSettings', 'UserSettings', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/MSFT_IntuneSecurityBaselineMicrosoftEdge.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/MSFT_IntuneSecurityBaselineMicrosoftEdge.psm1
@@ -890,8 +890,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -910,12 +908,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineWindows10/MSFT_IntuneSecurityBaselineWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineWindows10/MSFT_IntuneSecurityBaselineWindows10.psm1
@@ -2532,8 +2532,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.DeviceSettings)
             {
                 $complexMapping = @(
@@ -2594,20 +2592,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.DeviceSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DeviceSettings' -IsCIMArray:$False
-            }
-            if ($Results.UserSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'UserSettings' -IsCIMArray:$False
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('DeviceSettings', 'UserSettings', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10/MSFT_IntuneSettingCatalogASRRulesPolicyWindows10.psm1
@@ -1087,9 +1087,7 @@ function Export-TargetResource
             }
 
             $Script:exportedInstance = $policy
-            $Results = Get-TargetResource @params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+            $Results = Get-TargetResource @Params
 
             if ($Results.Assignments)
             {
@@ -1108,12 +1106,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogCustomPolicyWindows10/MSFT_IntuneSettingCatalogCustomPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogCustomPolicyWindows10/MSFT_IntuneSettingCatalogCustomPolicyWindows10.psm1
@@ -609,8 +609,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($null -ne $Results.Settings)
             {
@@ -701,16 +699,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
+                -Credential $Credential `
+                -NoEscape @('Settings', 'Assignments')
 
-            if ($Results.Settings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Settings' -IsCIMArray:$True
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneTrustedRootCertificateAndroidDeviceOwner/MSFT_IntuneTrustedRootCertificateAndroidDeviceOwner.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneTrustedRootCertificateAndroidDeviceOwner/MSFT_IntuneTrustedRootCertificateAndroidDeviceOwner.psm1
@@ -578,8 +578,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -598,17 +596,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneTrustedRootCertificateAndroidEnterprise/MSFT_IntuneTrustedRootCertificateAndroidEnterprise.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneTrustedRootCertificateAndroidEnterprise/MSFT_IntuneTrustedRootCertificateAndroidEnterprise.psm1
@@ -577,8 +577,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -597,17 +595,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneTrustedRootCertificateAndroidWork/MSFT_IntuneTrustedRootCertificateAndroidWork.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneTrustedRootCertificateAndroidWork/MSFT_IntuneTrustedRootCertificateAndroidWork.psm1
@@ -578,8 +578,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -598,17 +596,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneTrustedRootCertificateIOS/MSFT_IntuneTrustedRootCertificateIOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneTrustedRootCertificateIOS/MSFT_IntuneTrustedRootCertificateIOS.psm1
@@ -579,8 +579,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -599,17 +597,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneVPNConfigurationPolicyAndroidDeviceOwner/MSFT_IntuneVPNConfigurationPolicyAndroidDeviceOwner.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneVPNConfigurationPolicyAndroidDeviceOwner/MSFT_IntuneVPNConfigurationPolicyAndroidDeviceOwner.psm1
@@ -841,8 +841,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -936,42 +934,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.servers)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "servers" -isCIMArray:$True
-            }
-
-            if ($Results.proxyServer)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "proxyServer" -isCIMArray:$True
-            }
-
-            if ($Results.customData)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "customData" -isCIMArray:$True
-            }
-
-            if ($Results.customKeyValueData)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "customKeyValueData" -isCIMArray:$True
-            }
-
-            if ($Results.targetedMobileApps)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "targetedMobileApps" -isCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('servers', 'proxyServer', 'customData', 'customKeyValueData', 'targetedMobileApps', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneVPNConfigurationPolicyAndroidEnterprise/MSFT_IntuneVPNConfigurationPolicyAndroidEnterprise.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneVPNConfigurationPolicyAndroidEnterprise/MSFT_IntuneVPNConfigurationPolicyAndroidEnterprise.psm1
@@ -841,8 +841,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -936,42 +934,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.servers)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "servers" -isCIMArray:$True
-            }
-
-            if ($Results.proxyServer)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "proxyServer" -isCIMArray:$True
-            }
-
-            if ($Results.customData)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "customData" -isCIMArray:$True
-            }
-
-            if ($Results.customKeyValueData)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "customKeyValueData" -isCIMArray:$True
-            }
-
-            if ($Results.targetedMobileApps)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "targetedMobileApps" -isCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('servers', 'proxyServer', 'customData', 'customKeyValueData', 'targetedMobileApps', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneVPNConfigurationPolicyAndroidWork/MSFT_IntuneVPNConfigurationPolicyAndroidWork.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneVPNConfigurationPolicyAndroidWork/MSFT_IntuneVPNConfigurationPolicyAndroidWork.psm1
@@ -841,9 +841,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -936,42 +933,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.servers)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "servers" -isCIMArray:$True
-            }
-
-            if ($Results.proxyServer)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "proxyServer" -isCIMArray:$True
-            }
-
-            if ($Results.customData)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "customData" -isCIMArray:$True
-            }
-
-            if ($Results.customKeyValueData)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "customKeyValueData" -isCIMArray:$True
-            }
-
-            if ($Results.targetedMobileApps)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "targetedMobileApps" -isCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('servers', 'proxyServer', 'customData', 'customKeyValueData', 'targetedMobileApps', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneVPNConfigurationPolicyIOS/MSFT_IntuneVPNConfigurationPolicyIOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneVPNConfigurationPolicyIOS/MSFT_IntuneVPNConfigurationPolicyIOS.psm1
@@ -1053,8 +1053,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -1163,47 +1161,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.server)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "server" -isCIMArray:$True
-            }
-
-            if ($Results.onDemandRules)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "onDemandRules" -isCIMArray:$True
-            }
-
-            if ($Results.proxyServer)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "proxyServer" -isCIMArray:$True
-            }
-
-            if ($Results.customData)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "customData" -isCIMArray:$True
-            }
-
-            if ($Results.customKeyValueData)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "customKeyValueData" -isCIMArray:$True
-            }
-
-            if ($Results.targetedMobileApps)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "targetedMobileApps" -isCIMArray:$True
-            }
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('server', 'onDemandRules', 'proxyServer', 'customData', 'customKeyValueData', 'targetedMobileApps', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministrator/MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministrator.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministrator/MSFT_IntuneWifiConfigurationPolicyAndroidDeviceAdministrator.psm1
@@ -646,8 +646,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
 
             if ($Results.Assignments)
@@ -667,18 +665,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseDeviceOwner/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseDeviceOwner.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseDeviceOwner/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseDeviceOwner.psm1
@@ -735,8 +735,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -755,17 +753,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile/MSFT_IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile.psm1
@@ -643,8 +643,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -663,17 +661,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidForWork/MSFT_IntuneWifiConfigurationPolicyAndroidForWork.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidForWork/MSFT_IntuneWifiConfigurationPolicyAndroidForWork.psm1
@@ -642,8 +642,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -662,17 +660,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidOpenSourceProject/MSFT_IntuneWifiConfigurationPolicyAndroidOpenSourceProject.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyAndroidOpenSourceProject/MSFT_IntuneWifiConfigurationPolicyAndroidOpenSourceProject.psm1
@@ -668,8 +668,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -688,17 +686,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyIOS/MSFT_IntuneWifiConfigurationPolicyIOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyIOS/MSFT_IntuneWifiConfigurationPolicyIOS.psm1
@@ -723,8 +723,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -743,17 +741,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyMacOS/MSFT_IntuneWifiConfigurationPolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyMacOS/MSFT_IntuneWifiConfigurationPolicyMacOS.psm1
@@ -709,8 +709,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -729,17 +727,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyWindows10/MSFT_IntuneWifiConfigurationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiConfigurationPolicyWindows10/MSFT_IntuneWifiConfigurationPolicyWindows10.psm1
@@ -752,8 +752,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($Results.Assignments)
             {
@@ -772,17 +770,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($Results.Assignments)
-            {
-                $isCIMArray = $false
-                if ($Results.Assignments.getType().Fullname -like '*[[\]]')
-                {
-                    $isCIMArray = $true
-                }
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$isCIMArray
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADHybridJoined.psm1
@@ -709,8 +709,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.EnrollmentStatusScreenSettings)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -755,22 +753,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.EnrollmentStatusScreenSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EnrollmentStatusScreenSettings' -IsCIMArray:$False
-            }
-            if ($Results.OutOfBoxExperienceSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'OutOfBoxExperienceSettings' -IsCIMArray:$False
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            #removing trailing commas and semi colons between items of an array of cim instances added by Convert-DSCStringParamToVariable
-            $currentDSCBlock = $currentDSCBlock.replace("    ,`r`n" , "    `r`n" )
-            $currentDSCBlock = $currentDSCBlock.replace("`r`n;`r`n" , "`r`n" )
+                -Credential $Credential `
+                -NoEscape @('EnrollmentStatusScreenSettings', 'OutOfBoxExperienceSettings', 'Assignments')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined.psm1
@@ -705,8 +705,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.EnrollmentStatusScreenSettings)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -751,22 +749,9 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.EnrollmentStatusScreenSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EnrollmentStatusScreenSettings' -IsCIMArray:$False
-            }
-            if ($Results.OutOfBoxExperienceSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'OutOfBoxExperienceSettings' -IsCIMArray:$False
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            #removing trailing commas and semi colons between items of an array of cim instances added by Convert-DSCStringParamToVariable
-            $currentDSCBlock = $currentDSCBlock.replace("    ,`r`n" , "    `r`n" )
-            $currentDSCBlock = $currentDSCBlock.replace("`r`n;`r`n" , "`r`n" )
+                -Credential $Credential `
+                -NoEscape @('EnrollmentStatusScreenSettings', 'OutOfBoxExperienceSettings', 'Assignments')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsInformationProtectionPolicyWindows10MdmEnrolled/MSFT_IntuneWindowsInformationProtectionPolicyWindows10MdmEnrolled.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsInformationProtectionPolicyWindows10MdmEnrolled/MSFT_IntuneWindowsInformationProtectionPolicyWindows10MdmEnrolled.psm1
@@ -989,8 +989,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ( $null -ne $Results.DataRecoveryCertificate)
             {
@@ -1190,58 +1188,12 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.DataRecoveryCertificate)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'DataRecoveryCertificate' -IsCIMArray:$False
-            }
-            if ($Results.EnterpriseInternalProxyServers)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EnterpriseInternalProxyServers' -IsCIMArray:$True
-            }
-            if ($Results.EnterpriseIPRanges)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EnterpriseIPRanges' -IsCIMArray:$True
-            }
-            if ($Results.EnterpriseNetworkDomainNames)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EnterpriseNetworkDomainNames' -IsCIMArray:$True
-            }
-            if ($Results.EnterpriseProtectedDomainNames)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EnterpriseProtectedDomainNames' -IsCIMArray:$True
-            }
-            if ($Results.EnterpriseProxiedDomains)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EnterpriseProxiedDomains' -IsCIMArray:$True
-            }
-            if ($Results.EnterpriseProxyServers)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EnterpriseProxyServers' -IsCIMArray:$True
-            }
-            if ($Results.ExemptApps)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExemptApps' -IsCIMArray:$True
-            }
-            if ($Results.NeutralDomainResources)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'NeutralDomainResources' -IsCIMArray:$True
-            }
-            if ($Results.ProtectedApps)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ProtectedApps' -IsCIMArray:$True
-            }
-            if ($Results.SmbAutoEncryptedFileExtensions)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'SmbAutoEncryptedFileExtensions' -IsCIMArray:$True
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            #removing trailing commas and semi colons between items of an array of cim instances added by Convert-DSCStringParamToVariable
-            $currentDSCBlock = $currentDSCBlock.replace( "    ,`r`n" , "    `r`n" )
-            $currentDSCBlock = $currentDSCBlock.replace( "`r`n;`r`n" , "`r`n" )
+                -Credential $Credential `
+                -NoEscape @('DataRecoveryCertificate', 'EnterpriseInternalProxyServers', 'EnterpriseIPRanges',
+                    'EnterpriseNetworkDomainNames', 'EnterpriseProtectedDomainNames', 'EnterpriseProxiedDomains',
+                    'EnterpriseProxyServers', 'ExemptApps', 'NeutralDomainResources', 'ProtectedApps',
+                    'SmbAutoEncryptedFileExtensions', 'Assignments')
+
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessDriverUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessDriverUpdateProfileWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessDriverUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessDriverUpdateProfileWindows10.psm1
@@ -562,8 +562,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($Results.Assignments)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
@@ -580,11 +578,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessFeatureUpdateProfileWindows10.psm1
@@ -802,8 +802,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ( $null -ne $Results.RolloutSettings)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -834,18 +832,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.RolloutSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'RolloutSettings' -IsCIMArray:$False
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            #removing trailing commas and semi colons between items of an array of cim instances added by Convert-DSCStringParamToVariable
-            $currentDSCBlock = $currentDSCBlock.replace( "    ,`r`n" , "    `r`n" )
-            $currentDSCBlock = $currentDSCBlock.replace( "`r`n;`r`n" , "`r`n" )
+                -Credential $Credential `
+                -NoEscape @('RolloutSettings', 'Assignments')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessQualityUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessQualityUpdateProfileWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessQualityUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessQualityUpdateProfileWindows10.psm1
@@ -556,8 +556,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.ExpeditedUpdateSettings)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -590,16 +588,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ExpeditedUpdateSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExpeditedUpdateSettings' -IsCIMArray:$False
-            }
-
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('ExpeditedUpdateSettings', 'Assignments')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10/MSFT_IntuneWindowsUpdateForBusinessRingUpdateProfileWindows10.psm1
@@ -1138,8 +1138,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($null -ne $Results.InstallationSchedule)
             {
@@ -1172,18 +1170,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.InstallationSchedule)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'InstallationSchedule' -IsCIMArray:$False
-            }
-            if ($Results.Assignments)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Assignments' -IsCIMArray:$true
-            }
-            #removing trailing commas and semi colons between items of an array of cim instances added by Convert-DSCStringParamToVariable
-            $currentDSCBlock = $currentDSCBlock.replace( "    ,`r`n" , "    `r`n" )
-            $currentDSCBlock = $currentDSCBlock.replace( "`r`n;`r`n" , "`r`n" )
+                -Credential $Credential `
+                -NoEscape @('InstallationSchedule', 'Assignments')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365AdminAuditLogConfig/MSFT_O365AdminAuditLogConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365AdminAuditLogConfig/MSFT_O365AdminAuditLogConfig.psm1
@@ -387,11 +387,8 @@ function Export-TargetResource
             AccessTokens                    = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365ExternalConnection/MSFT_O365ExternalConnection.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365ExternalConnection/MSFT_O365ExternalConnection.psm1
@@ -416,8 +416,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365Group/MSFT_O365Group.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365Group/MSFT_O365Group.psm1
@@ -622,8 +622,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $group
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgCustomizationSetting/MSFT_O365OrgCustomizationSetting.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgCustomizationSetting/MSFT_O365OrgCustomizationSetting.psm1
@@ -312,12 +312,9 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-
         $dscContent = ''
         if ($Results.Ensure -eq 'Present')
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
@@ -1099,10 +1099,7 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-
         $dscContent = ''
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365SearchAndIntelligenceConfigurations/MSFT_O365SearchAndIntelligenceConfigurations.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365SearchAndIntelligenceConfigurations/MSFT_O365SearchAndIntelligenceConfigurations.psm1
@@ -439,12 +439,9 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-
         $dscContent = ''
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
@@ -668,15 +668,12 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-
         if ([System.String]::IsNullOrEmpty($Results.GrooveBlockOption))
         {
             $Results.Remove('GrooveBlockOption') | Out-Null
         }
 
         $dscContent = ''
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPAdminDLPPolicy/MSFT_PPAdminDLPPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPAdminDLPPolicy/MSFT_PPAdminDLPPolicy.psm1
@@ -465,8 +465,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPDLPPolicyConnectorConfigurations/MSFT_PPDLPPolicyConnectorConfigurations.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPDLPPolicyConnectorConfigurations/MSFT_PPDLPPolicyConnectorConfigurations.psm1
@@ -444,8 +444,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($null -ne $Results.ConnectorActionConfigurations)
             {
@@ -473,11 +471,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ConnectorActionConfigurations)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ConnectorActionConfigurations' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('ConnectorActionConfigurations')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppPolicyUrlPatterns/MSFT_PPPowerAppPolicyUrlPatterns.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppPolicyUrlPatterns/MSFT_PPPowerAppPolicyUrlPatterns.psm1
@@ -430,8 +430,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($null -ne $Results.RuleSet)
             {
@@ -451,11 +449,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.RuleSet)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'RuleSet' -IsCIMArray:$true
-            }
+                -Credential $Credential `
+                -NoEscape @('RuleSet')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPPowerAppsEnvironment/MSFT_PPPowerAppsEnvironment.psm1
@@ -425,8 +425,6 @@ function Export-TargetResource
                     ApplicationSecret     = $ApplicationSecret
                 }
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPTenantIsolationSettings/MSFT_PPTenantIsolationSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPTenantIsolationSettings/MSFT_PPTenantIsolationSettings.psm1
@@ -702,20 +702,13 @@ function Export-TargetResource
                     $Results.Remove('Rules') | Out-Null
                 }
             }
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
+                -Credential $Credential `
+                -NoEscape @('Rules')
 
-            if ($null -ne $Results.Rules)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'Rules' `
-                    -IsCIMArray:$True
-            }
             $dscContent += $currentDSCBlock
 
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PPTenantSettings/MSFT_PPTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PPTenantSettings/MSFT_PPTenantSettings.psm1
@@ -943,11 +943,8 @@ function Export-TargetResource
             ApplicationSecret     = $ApplicationSecret
         }
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerBucket/MSFT_PlannerBucket.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerBucket/MSFT_PlannerBucket.psm1
@@ -368,8 +368,6 @@ function Export-TargetResource
                             ManagedIdentity       = $ManagedIdentity.IsPresent
                         }
                         $results = Get-TargetResource @params
-                        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                            -Results $Results
                         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                             -ConnectionMode $ConnectionMode `
                             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerPlan/MSFT_PlannerPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerPlan/MSFT_PlannerPlan.psm1
@@ -404,8 +404,6 @@ function Export-TargetResource
 
                     Write-Host "        [$j/$($plans.Length)] $($plan.Title)"
                     $results = Get-TargetResource @params
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerTask/MSFT_PlannerTask.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_PlannerTask/MSFT_PlannerTask.psm1
@@ -757,8 +757,7 @@ function Export-TargetResource
                         {
                             $result.Remove('AssignedUsers') | Out-Null
                         }
-                        $result = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                            -Results $Result
+
                         if ($result.Attachments.Length -gt 0)
                         {
                             $result.Attachments = Convert-M365DSCPlannerTaskAssignmentToCIMArray -Attachments $result.Attachments
@@ -788,18 +787,8 @@ function Export-TargetResource
                             -ConnectionMode $ConnectionMode `
                             -ModulePath $PSScriptRoot `
                             -Results $result `
-                            -Credential $Credential
-
-                        if ($result.Attachments.Length -gt 0)
-                        {
-                            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                                -ParameterName 'Attachments'
-                        }
-                        if ($result.Checklist.Length -gt 0)
-                        {
-                            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                                -ParameterName 'Checklist'
-                        }
+                            -Credential $Credential `
+                            -NoEscape @('Attachments', 'Checklist')
 
                         $dscContent += $currentDSCBlock
                         Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCAuditConfigurationPolicy/MSFT_SCAuditConfigurationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCAuditConfigurationPolicy/MSFT_SCAuditConfigurationPolicy.psm1
@@ -365,8 +365,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $policy
             $Results = Get-TargetResource @PSBoundParameters -Workload $policy.Workload
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCAutoSensitivityLabelPolicy/MSFT_SCAutoSensitivityLabelPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCAutoSensitivityLabelPolicy/MSFT_SCAutoSensitivityLabelPolicy.psm1
@@ -854,8 +854,6 @@ function Export-TargetResource
             $Script:exportedInstance = $policy
             $Results = Get-TargetResource @PSBoundParameters -Name $policy.Name
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCAutoSensitivityLabelRule/MSFT_SCAutoSensitivityLabelRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCAutoSensitivityLabelRule/MSFT_SCAutoSensitivityLabelRule.psm1
@@ -1194,26 +1194,13 @@ function Export-TargetResource
                 $Results.HeaderMatchesPatterns = ConvertTo-HeadersMatchesPatternString -Patterns $Results.HeaderMatchesPatterns
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
+                -Credential $Credential `
+                -NoEscape @('ContentContainsSensitiveInformation', 'ExceptIfContentContainsSensitiveInformation', 'HeaderMatchesPatterns')
 
-            if ($null -ne $Results.ContentContainsSensitiveInformation )
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ContentContainsSensitiveInformation' -IsCIMArray $IsSitCIMArray
-            }
-            if ($null -ne $Results.ExceptIfContentContainsSensitiveInformation )
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExceptIfContentContainsSensitiveInformation' -IsCIMArray $IsCIMArray
-            }
-            if ($null -ne $Results.HeaderMatchesPatterns)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'HeaderMatchesPatterns' -IsCIMArray $false
-            }
             $dscContent += $currentDSCBlock
 
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCCaseHoldPolicy/MSFT_SCCaseHoldPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCCaseHoldPolicy/MSFT_SCCaseHoldPolicy.psm1
@@ -518,8 +518,6 @@ function Export-TargetResource
                     -Name $policy.Name `
                     -Case $case.Name
 
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCCaseHoldRule/MSFT_SCCaseHoldRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCCaseHoldRule/MSFT_SCCaseHoldRule.psm1
@@ -411,8 +411,6 @@ function Export-TargetResource
                 $Results = Get-TargetResource @PSBoundParameters `
                     -Name $Rule.Name `
                     -Policy $policy.Name
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceCase/MSFT_SCComplianceCase.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceCase/MSFT_SCComplianceCase.psm1
@@ -405,8 +405,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $Case
             $Results = Get-TargetResource @PSBoundParameters -Name $Case.Name
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $dscContent += Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
@@ -423,8 +421,6 @@ function Export-TargetResource
         {
             Write-Host "    GDPR: [$i/$($Cases.Count)] $($Case.Name)" -NoNewline
             $Results = Get-TargetResource @PSBoundParameters -Name $Case.Name
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceSearch/MSFT_SCComplianceSearch.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceSearch/MSFT_SCComplianceSearch.psm1
@@ -550,8 +550,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $search
             $Results = Get-TargetResource @PSBoundParameters -Name $search.Name
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $dscContent += Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
@@ -585,8 +583,7 @@ function Export-TargetResource
                 }
                 Write-Host "        |---[$i/$($searches.Name.Count)] $($search.Name)" -NoNewline
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
+
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceSearchAction/MSFT_SCComplianceSearchAction.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceSearchAction/MSFT_SCComplianceSearchAction.psm1
@@ -580,8 +580,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $action
             $Results = Get-TargetResource @PSBoundParameters @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
@@ -625,8 +623,7 @@ function Export-TargetResource
                     $Params.Action = 'Retention'
                 }
                 $Results = Get-TargetResource @PSBoundParameters @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
+
                 $dscContent += Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceTag/MSFT_SCComplianceTag.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceTag/MSFT_SCComplianceTag.psm1
@@ -565,17 +565,12 @@ function Export-TargetResource
             $Script:exportedInstance = $tag
             $Results = Get-TargetResource @PSBoundParameters -Name $tag.Name
             $Results.FilePlanProperty = Get-SCFilePlanPropertyAsString $Results.FilePlanProperty
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($null -ne $Results.FilePlanProperty)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'FilePlanProperty'
-            }
+                -Credential $Credential `
+                -NoEscape @('FilePlanProperty')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCDLPCompliancePolicy/MSFT_SCDLPCompliancePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCDLPCompliancePolicy/MSFT_SCDLPCompliancePolicy.psm1
@@ -974,8 +974,6 @@ function Export-TargetResource
             Write-Host "    |---[$i/$($policies.Count)] $($policy.Name)" -NoNewline
             $Script:exportedInstance = $policy
             $Results = Get-TargetResource @PSBoundParameters -Name $policy.Name
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
@@ -1518,22 +1518,13 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
+                -Credential $Credential `
+                -NoEscape @('ContentContainsSensitiveInformation', 'ExceptIfContentContainsSensitiveInformation')
 
-            if ($null -ne $Results.ContentContainsSensitiveInformation )
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ContentContainsSensitiveInformation' -IsCIMArray $IsSitCIMArray
-            }
-            if ($null -ne $Results.ExceptIfContentContainsSensitiveInformation )
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ExceptIfContentContainsSensitiveInformation' -IsCIMArray $IsCIMArray
-            }
             $dscContent += $currentDSCBlock
 
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCDeviceConditionalAccessPolicy/MSFT_SCDeviceConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCDeviceConditionalAccessPolicy/MSFT_SCDeviceConditionalAccessPolicy.psm1
@@ -391,8 +391,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $policy
             $Results = Get-TargetResource @PSBoundParameters -Name $policy.Name
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCDeviceConditionalAccessRule/MSFT_SCDeviceConditionalAccessRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCDeviceConditionalAccessRule/MSFT_SCDeviceConditionalAccessRule.psm1
@@ -1042,8 +1042,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCDeviceConfigurationPolicy/MSFT_SCDeviceConfigurationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCDeviceConfigurationPolicy/MSFT_SCDeviceConfigurationPolicy.psm1
@@ -393,8 +393,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $policy
             $Results = Get-TargetResource @PSBoundParameters -Name $policy.Name
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCDeviceConfigurationRule/MSFT_SCDeviceConfigurationRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCDeviceConfigurationRule/MSFT_SCDeviceConfigurationRule.psm1
@@ -1027,8 +1027,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCFilePlanPropertyAuthority/MSFT_SCFilePlanPropertyAuthority.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCFilePlanPropertyAuthority/MSFT_SCFilePlanPropertyAuthority.psm1
@@ -362,8 +362,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $Property
             $Results = Get-TargetResource @PSBoundParameters -Name $Property.DisplayName
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCFilePlanPropertyCategory/MSFT_SCFilePlanPropertyCategory.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCFilePlanPropertyCategory/MSFT_SCFilePlanPropertyCategory.psm1
@@ -364,8 +364,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $Property
             $Results = Get-TargetResource @PSBoundParameters -Name $Property.DisplayName
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCFilePlanPropertyCitation/MSFT_SCFilePlanPropertyCitation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCFilePlanPropertyCitation/MSFT_SCFilePlanPropertyCitation.psm1
@@ -389,8 +389,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $Property
             $Results = Get-TargetResource @PSBoundParameters -Name $Property.Name
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCFilePlanPropertyDepartment/MSFT_SCFilePlanPropertyDepartment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCFilePlanPropertyDepartment/MSFT_SCFilePlanPropertyDepartment.psm1
@@ -363,8 +363,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $Property
             $Results = Get-TargetResource @PSBoundParameters -Name $Property.DisplayName
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCFilePlanPropertyReferenceId/MSFT_SCFilePlanPropertyReferenceId.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCFilePlanPropertyReferenceId/MSFT_SCFilePlanPropertyReferenceId.psm1
@@ -363,8 +363,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $Property
             $Results = Get-TargetResource @PSBoundParameters -Name $Property.DisplayName
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCFilePlanPropertySubCategory/MSFT_SCFilePlanPropertySubCategory.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCFilePlanPropertySubCategory/MSFT_SCFilePlanPropertySubCategory.psm1
@@ -392,8 +392,6 @@ function Export-TargetResource
             $Results = Get-TargetResource @PSBoundParameters `
                 -Name $Property.DisplayName `
                 -Category $parent.DisplayName
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCInsiderRiskEntityList/MSFT_SCInsiderRiskEntityList.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCInsiderRiskEntityList/MSFT_SCInsiderRiskEntityList.psm1
@@ -1113,7 +1113,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-
             if ($null -ne $Results.Domains -and $Results.Domains.Length -gt 0 -and `
                 ($Results.ListType -eq 'CustomDomainLists' -or $Results.ListType -eq 'DomainLists'))
             {
@@ -1126,26 +1125,13 @@ function Export-TargetResource
                 $Results.Sites = ConvertTo-M365DSCSCInsiderRiskSiteToString -Sites $Results.Sites
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($null -ne $Results.Domains -and `
-                ($Results.ListType -eq 'CustomDomainLists' -or $Results.ListType -eq 'DomainLists'))
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Domains' -IsCIMArray $true
-            }
-
-            if ($null -ne $Results.Sites -and `
-                ($Results.ListType -eq 'CustomSiteLists' -or $Results.ListType -eq 'SiteLists'))
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'Sites' -IsCIMArray $true
-            }
+                -Credential $Credential `
+                -NoEscape @('Domains', 'Sites')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCInsiderRiskPolicy/MSFT_SCInsiderRiskPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCInsiderRiskPolicy/MSFT_SCInsiderRiskPolicy.psm1
@@ -2740,8 +2740,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCLabelPolicy/MSFT_SCLabelPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCLabelPolicy/MSFT_SCLabelPolicy.psm1
@@ -878,19 +878,12 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($null -ne $Results.AdvancedSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                                        -ParameterName 'AdvancedSettings' `
-                                        -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('AdvancedSettings')
 
             Write-Host $Global:M365DSCEmojiGreenCheckMark
             $dscContent += $currentDSCBlock

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCPolicyConfig/MSFT_SCPolicyConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCPolicyConfig/MSFT_SCPolicyConfig.psm1
@@ -1302,7 +1302,6 @@ function Export-TargetResource
             $Global:M365DSCExportResourceInstancesCount++
         }
         $Results = Get-TargetResource @Params
-
         if ($null -ne $Results.BusinessJustificationList)
         {
             $Results.BusinessJustificationList = ConvertTo-BusinessJustificationListString -ObjectHash $Results.BusinessJustificationList
@@ -1363,98 +1362,15 @@ function Export-TargetResource
             $Results.QuarantineParameters = ConvertTo-QuarantineParametersString -ObjectHash $Results.QuarantineParameters
         }
 
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
 
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `
             -Results $Results `
-            -Credential $Credential
-
-        if ($null -ne $Results.QuarantineParameters)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'QuarantineParameters' `
-                -IsCIMArray:$true
-        }
-
-        if ($null -ne $Results.BusinessJustificationList)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'BusinessJustificationList' `
-                -IsCIMArray:$true
-        }
-
-        if ($null -ne $Results.DLPAppGroups)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'DLPAppGroups' `
-                -IsCIMArray:$true
-        }
-
-        if ($null -ne $Results.DLPNetworkShareGroups)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'DLPNetworkShareGroups' `
-                -IsCIMArray:$true
-        }
-
-        if ($null -ne $Results.DLPPrinterGroups)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'DLPPrinterGroups' `
-                -IsCIMArray:$true
-        }
-
-        if ($null -ne $Results.DLPRemovableMediaGroups)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'DLPRemovableMediaGroups' `
-                -IsCIMArray:$true
-        }
-
-        if ($null -ne $Results.SiteGroups)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'SiteGroups' `
-                -IsCIMArray:$true
-        }
-
-        if ($null -ne $Results.UnallowedApp)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'UnallowedApp' `
-                -IsCIMArray:$true
-        }
-
-        if ($null -ne $Results.UnallowedCloudSyncApp)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'UnallowedCloudSyncApp' `
-                -IsCIMArray:$true
-        }
-
-        if ($null -ne $Results.UnallowedBluetoothApp)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'UnallowedBluetoothApp' `
-                -IsCIMArray:$true
-        }
-
-        if ($null -ne $Results.UnallowedBrowser)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'UnallowedBrowser' `
-                -IsCIMArray:$true
-        }
-
-        if ($null -ne $Results.EvidenceStoreSettings)
-        {
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'EvidenceStoreSettings' `
-                -IsCIMArray:$false
-        }
+            -Credential $Credential `
+            -NoEscape @('QuarantineParameters', 'BusinessJustificationList', 'DLPAppGroups', 'DLPNetworkShareGroups',
+                'DLPPrinterGroups', 'DLPRemovableMediaGroups', 'SiteGroups', 'UnallowedApp', 'UnallowedCloudSyncApp',
+                'UnallowedBluetoothApp', 'UnallowedBrowser', 'EvidenceStoreSettings')
 
         $dscContent += $currentDSCBlock
         Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCProtectionAlert/MSFT_SCProtectionAlert.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCProtectionAlert/MSFT_SCProtectionAlert.psm1
@@ -672,8 +672,6 @@ function Export-TargetResource
             Write-Host "    |---[$i/$($totalAlerts)] $($alert.Name)" -NoNewline
             $Script:exportedInstance = $alert
             $Results = Get-TargetResource @PSBoundParameters -Name $Alert.Name
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRecordReviewNotificationTemplateConfig/MSFT_SCRecordReviewNotificationTemplateConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRecordReviewNotificationTemplateConfig/MSFT_SCRecordReviewNotificationTemplateConfig.psm1
@@ -348,8 +348,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionCompliancePolicy/MSFT_SCRetentionCompliancePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionCompliancePolicy/MSFT_SCRetentionCompliancePolicy.psm1
@@ -1092,8 +1092,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $policy
             $Results = Get-TargetResource @PSBoundParameters -Name $policy.Name
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionComplianceRule/MSFT_SCRetentionComplianceRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionComplianceRule/MSFT_SCRetentionComplianceRule.psm1
@@ -603,8 +603,6 @@ function Export-TargetResource
                 {
                     $Results.Remove('ExpirationDateOption') | Out-Null
                 }
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionEventType/MSFT_SCRetentionEventType.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRetentionEventType/MSFT_SCRetentionEventType.psm1
@@ -380,8 +380,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $eventType
             $Results = Get-TargetResource @PSBoundParameters -Name $eventType.Name
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRoleGroup/MSFT_SCRoleGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRoleGroup/MSFT_SCRoleGroup.psm1
@@ -431,8 +431,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $RoleGroup
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCRoleGroupMember/MSFT_SCRoleGroupMember.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCRoleGroupMember/MSFT_SCRoleGroupMember.psm1
@@ -416,8 +416,6 @@ function Export-TargetResource
             }
             $Script:exportedInstance = $RoleGroup
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCSecurityFilter/MSFT_SCSecurityFilter.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCSecurityFilter/MSFT_SCSecurityFilter.psm1
@@ -552,8 +552,6 @@ function Export-TargetResource
             $Results = Get-M365DSCSCMapSecurityFilter -Filter $filter -Credential $Credential -ApplicationId $ApplicationId `
                 -TenantId $TenantId -CertificateThumbprint $CertificateThumbprint -CertificatePath $CertificatePath -CertificatePassword $CertificatePassword
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
@@ -1688,32 +1688,12 @@ function Export-TargetResource
                 }
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            if ($null -ne $Results.AdvancedSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'AdvancedSettings' `
-                    -IsCIMArray:$True
-            }
-            if ($null -ne $Results.LocaleSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'LocaleSettings' `
-                    -IsCIMArray:$True
-            }
-            if ($null -ne $Results.AutoLabelingSettings)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'AutoLabelingSettings' `
-                    -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('AdvancedSettings', 'LocaleSettings', 'AutoLabelingSettings')
 
             Write-Host $Global:M365DSCEmojiGreenCheckMark
             $dscContent += $currentDSCBlock

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCSupervisoryReviewPolicy/MSFT_SCSupervisoryReviewPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCSupervisoryReviewPolicy/MSFT_SCSupervisoryReviewPolicy.psm1
@@ -420,8 +420,6 @@ function Export-TargetResource
             $Results = Get-TargetResource @PSBoundParameters `
                 -Name $policy.Name `
                 -Reviewers 'Microsoft365DSC'
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCSupervisoryReviewRule/MSFT_SCSupervisoryReviewRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCSupervisoryReviewRule/MSFT_SCSupervisoryReviewRule.psm1
@@ -395,8 +395,6 @@ function Export-TargetResource
             $Results = Get-TargetResource @PSBoundParameters `
                 -Name $rule.Name `
                 -Policy $rule.Policy
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCUnifiedAuditLogRetentionPolicy/MSFT_SCUnifiedAuditLogRetentionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCUnifiedAuditLogRetentionPolicy/MSFT_SCUnifiedAuditLogRetentionPolicy.psm1
@@ -444,8 +444,6 @@ function Export-TargetResource
 
             $Results = Get-TargetResource @Params
             $Results.Remove('Identity') | Out-Null
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOAccessControlSettings/MSFT_SPOAccessControlSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOAccessControlSettings/MSFT_SPOAccessControlSettings.psm1
@@ -539,8 +539,6 @@ function Export-TargetResource
 
         $dscContent = ''
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOApp/MSFT_SPOApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOApp/MSFT_SPOApp.psm1
@@ -440,8 +440,6 @@ function Export-TargetResource
                     }
 
                     $Results = Get-TargetResource @Params
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOBrowserIdleSignout/MSFT_SPOBrowserIdleSignout.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOBrowserIdleSignout/MSFT_SPOBrowserIdleSignout.psm1
@@ -386,11 +386,8 @@ function Export-TargetResource
 
         $dscContent = ''
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOHomeSite/MSFT_SPOHomeSite.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOHomeSite/MSFT_SPOHomeSite.psm1
@@ -385,8 +385,6 @@ function Export-TargetResource
         }
         $dscContent = ''
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOHubSite/MSFT_SPOHubSite.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOHubSite/MSFT_SPOHubSite.psm1
@@ -687,8 +687,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $hub
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOOrgAssetsLibrary/MSFT_SPOOrgAssetsLibrary.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOOrgAssetsLibrary/MSFT_SPOOrgAssetsLibrary.psm1
@@ -503,8 +503,6 @@ function Export-TargetResource
                     AccessTokens          = $AccessTokens
                 }
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOPropertyBag/MSFT_SPOPropertyBag.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOPropertyBag/MSFT_SPOPropertyBag.psm1
@@ -460,8 +460,6 @@ function Export-TargetResource
                     }
 
                     $Results = Get-TargetResource @Params
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName 'SPOPropertyBag' `
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPORetentionLabelsSettings/MSFT_SPORetentionLabelsSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPORetentionLabelsSettings/MSFT_SPORetentionLabelsSettings.psm1
@@ -345,8 +345,6 @@ function Export-TargetResource
         }
 
         $Results = Get-TargetResource @Params
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
 
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSearchManagedProperty/MSFT_SPOSearchManagedProperty.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSearchManagedProperty/MSFT_SPOSearchManagedProperty.psm1
@@ -964,11 +964,8 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-
             if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 2)
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSearchResultSource/MSFT_SPOSearchResultSource.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSearchResultSource/MSFT_SPOSearchResultSource.psm1
@@ -652,11 +652,8 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-
             if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 2)
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSharingSettings/MSFT_SPOSharingSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSharingSettings/MSFT_SPOSharingSettings.psm1
@@ -865,8 +865,6 @@ function Export-TargetResource
         {
             $Results.Remove('RequireAnonymousLinksExpireInDays') | Out-Null
         }
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.psm1
@@ -983,7 +983,6 @@ function Export-TargetResource
             {
                 $Script:exportedInstance = $site
                 $Results = Get-TargetResource @Params
-
                 if ([System.String]::IsNullOrEmpty($Results.SharingDomainRestrictionMode))
                 {
                     $Results.Remove('SharingDomainRestrictionMode') | Out-Null
@@ -1009,8 +1008,6 @@ function Export-TargetResource
                     $Results.Remove('HubUrl') | Out-Null
                 }
 
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
 
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteAuditSettings/MSFT_SPOSiteAuditSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteAuditSettings/MSFT_SPOSiteAuditSettings.psm1
@@ -374,16 +374,13 @@ function Export-TargetResource
                     AccessTokens          = $AccessTokens
                 }
 
-                $Results = Get-TargetResource @params
-
+                $Results = Get-TargetResource @Params
                 if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
                 {
                     if ([System.String]::IsNullOrEmpty($Results.AuditFlags))
                     {
                         $Results.AuditFlags = 'None'
                     }
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteDesign/MSFT_SPOSiteDesign.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteDesign/MSFT_SPOSiteDesign.psm1
@@ -519,8 +519,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteDesignRights/MSFT_SPOSiteDesignRights.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteDesignRights/MSFT_SPOSiteDesignRights.psm1
@@ -456,8 +456,6 @@ function Export-TargetResource
             $Results = Get-TargetResource @Params
             if ($Results.Ensure -eq 'Present')
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `
@@ -485,8 +483,7 @@ function Export-TargetResource
             $Results = Get-TargetResource @Params
             if ($Results.Ensure -eq 'Present')
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
+
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteGroup/MSFT_SPOSiteGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteGroup/MSFT_SPOSiteGroup.psm1
@@ -574,8 +574,6 @@ function Export-TargetResource
                     $Results = Get-TargetResource @Params
                     if ($Results.Ensure -eq 'Present')
                     {
-                        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                            -Results $Results
                         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                             -ConnectionMode $ConnectionMode `
                             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteScript/MSFT_SPOSiteScript.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteScript/MSFT_SPOSiteScript.psm1
@@ -513,8 +513,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOStorageEntity/MSFT_SPOStorageEntity.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOStorageEntity/MSFT_SPOStorageEntity.psm1
@@ -495,8 +495,6 @@ function Export-TargetResource
             }
             Write-Host "    |---[$i/$($storageEntities.Length)] $($storageEntity.Key)" -NoNewline
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantCdnEnabled/MSFT_SPOTenantCdnEnabled.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantCdnEnabled/MSFT_SPOTenantCdnEnabled.psm1
@@ -376,11 +376,8 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-
             if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
             {
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantCdnPolicy/MSFT_SPOTenantCdnPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantCdnPolicy/MSFT_SPOTenantCdnPolicy.psm1
@@ -385,11 +385,8 @@ function Export-TargetResource
 
         Write-Host "`r`n    |---[1/2] Public" -NoNewline
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $dscContent += Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
@@ -421,12 +418,10 @@ function Export-TargetResource
             Credential            = $Credential
         }
         Write-Host '    |---[2/2] Private' -NoNewline
-        $Results = Get-TargetResource @params
-
+        $Results = Get-TargetResource @Params
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTenantSettings/MSFT_SPOTenantSettings.psm1
@@ -858,8 +858,6 @@ function Export-TargetResource
         {
             $Results.Remove('MinCompatibilityLevel') | Out-Null
         }
-        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
             -ConnectionMode $ConnectionMode `
             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTheme/MSFT_SPOTheme.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOTheme/MSFT_SPOTheme.psm1
@@ -430,8 +430,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             if ($null -ne $Results.Palette)
             {
                 $complexMapping = @(
@@ -459,12 +457,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($null -ne $Results.Palette)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                    -ParameterName 'Palette'
-            }
+                -Credential $Credential `
+                -NoEscape @('Palette')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOUserProfileProperty/MSFT_SPOUserProfileProperty.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOUserProfileProperty/MSFT_SPOUserProfileProperty.psm1
@@ -343,7 +343,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-
             if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
             {
                 if ($Results.Properties)
@@ -377,19 +376,12 @@ function Export-TargetResource
                         }
                     }
 
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `
                         -Results $Results `
-                        -Credential $Credential
-                    if ($null -ne $Results.Properties)
-                    {
-                        $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                            -ParameterName 'Properties' `
-                            -IsCIMArray:$True
-                    }
+                        -Credential $Credential `
+                        -NoEscape @('Properties')
                     $dscContent += $currentDSCBlock
                     Save-M365DSCPartialExport -Content $currentDSCBlock `
                         -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SentinelAlertRule/MSFT_SentinelAlertRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SentinelAlertRule/MSFT_SentinelAlertRule.psm1
@@ -1035,8 +1035,6 @@ function Export-TargetResource
                 }
 
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
 
                 if ( $null -ne $Results.EventGroupingSettings)
                 {
@@ -1182,28 +1180,8 @@ function Export-TargetResource
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `
                     -Results $Results `
-                    -Credential $Credential
-
-                if ($Results.EventGroupingSettings)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EventGroupingSettings' -IsCIMArray:$False
-                }
-                if ($Results.CustomDetails)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'CustomDetails' -IsCIMArray:$False
-                }
-                if ($Results.EntityMappings)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EntityMappings' -IsCIMArray:$True
-                }
-                if ($Results.AlertDetailsOverride)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'AlertDetailsOverride' -IsCIMArray:$True
-                }
-                if ($Results.IncidentConfiguration)
-                {
-                    $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'IncidentConfiguration' -IsCIMArray:$True
-                }
+                    -Credential $Credential `
+                    -NoEscape @('EventGroupingSettings', 'CustomDetails', 'EntityMappings', 'AlertDetailsOverride', 'IncidentConfiguration')
 
                 $dscContent += $currentDSCBlock
                 Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SentinelSetting/MSFT_SentinelSetting.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SentinelSetting/MSFT_SentinelSetting.psm1
@@ -447,8 +447,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SentinelThreatIntelligenceIndicator/MSFT_SentinelThreatIntelligenceIndicator.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SentinelThreatIntelligenceIndicator/MSFT_SentinelThreatIntelligenceIndicator.psm1
@@ -625,8 +625,6 @@ function Export-TargetResource
                 }
 
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
 
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SentinelWatchlist/MSFT_SentinelWatchlist.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SentinelWatchlist/MSFT_SentinelWatchlist.psm1
@@ -564,8 +564,6 @@ function Export-TargetResource
                 }
 
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
 
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAppPermissionPolicy/MSFT_TeamsAppPermissionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAppPermissionPolicy/MSFT_TeamsAppPermissionPolicy.psm1
@@ -478,8 +478,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAppSetupPolicy/MSFT_TeamsAppSetupPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAppSetupPolicy/MSFT_TeamsAppSetupPolicy.psm1
@@ -474,8 +474,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAudioConferencingPolicy/MSFT_TeamsAudioConferencingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsAudioConferencingPolicy/MSFT_TeamsAudioConferencingPolicy.psm1
@@ -402,8 +402,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsCallHoldPolicy/MSFT_TeamsCallHoldPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsCallHoldPolicy/MSFT_TeamsCallHoldPolicy.psm1
@@ -397,8 +397,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsCallParkPolicy/MSFT_TeamsCallParkPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsCallParkPolicy/MSFT_TeamsCallParkPolicy.psm1
@@ -436,8 +436,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsCallQueue/MSFT_TeamsCallQueue.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsCallQueue/MSFT_TeamsCallQueue.psm1
@@ -967,8 +967,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsCallingPolicy/MSFT_TeamsCallingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsCallingPolicy/MSFT_TeamsCallingPolicy.psm1
@@ -601,8 +601,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannel/MSFT_TeamsChannel.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannel/MSFT_TeamsChannel.psm1
@@ -446,8 +446,6 @@ function Export-TargetResource
                         AccessTokens          = $AccessTokens
                     }
                     $Results = Get-TargetResource @Params
-                    $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                        -Results $Results
                     $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                         -ConnectionMode $ConnectionMode `
                         -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelTab/MSFT_TeamsChannelTab.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelTab/MSFT_TeamsChannelTab.psm1
@@ -611,12 +611,9 @@ function Export-TargetResource
                         ManagedIdentity       = $ManagedIdentity.IsPresent
                         AccessTokens          = $AccessTokens
                     }
-                    $Results = Get-TargetResource @params
-
+                    $Results = Get-TargetResource @Params
                     if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 3)
                     {
-                        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                            -Results $Results
                         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                             -ConnectionMode $ConnectionMode `
                             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelsPolicy/MSFT_TeamsChannelsPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannelsPolicy/MSFT_TeamsChannelsPolicy.psm1
@@ -408,8 +408,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsClientConfiguration/MSFT_TeamsClientConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsClientConfiguration/MSFT_TeamsClientConfiguration.psm1
@@ -477,7 +477,6 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
             if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -485,8 +484,6 @@ function Export-TargetResource
                 $Global:M365DSCExportResourceInstancesCount++
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsComplianceRecordingPolicy/MSFT_TeamsComplianceRecordingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsComplianceRecordingPolicy/MSFT_TeamsComplianceRecordingPolicy.psm1
@@ -582,8 +582,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             if ($null -ne $Results.ComplianceRecordingApplications)
             {
@@ -613,14 +611,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.ComplianceRecordingApplications)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'ComplianceRecordingApplications' -IsCIMArray:$True
-                $currentDSCBlock = $currentDSCBlock.Replace('ComplianceRecordingApplications         = @("', 'ComplianceRecordingApplications         = @(')
-                $currentDSCBlock = $currentDSCBlock.Replace("            `",`"`r`n", '')
-
-            }
+                -Credential $Credential `
+                -NoEscape @('ComplianceRecordingApplications')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsCortanaPolicy/MSFT_TeamsCortanaPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsCortanaPolicy/MSFT_TeamsCortanaPolicy.psm1
@@ -400,8 +400,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsDialInConferencingTenantSettings/MSFT_TeamsDialInConferencingTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsDialInConferencingTenantSettings/MSFT_TeamsDialInConferencingTenantSettings.psm1
@@ -402,7 +402,6 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
             if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -410,8 +409,6 @@ function Export-TargetResource
                 $Global:M365DSCExportResourceInstancesCount++
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallRoutingPolicy/MSFT_TeamsEmergencyCallRoutingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallRoutingPolicy/MSFT_TeamsEmergencyCallRoutingPolicy.psm1
@@ -412,8 +412,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $result = Get-TargetResource @params
-            $result = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Result
 
             if ($null -ne $result.EmergencyNumbers)
             {
@@ -442,12 +440,8 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Result `
-                -Credential $Credential
-
-            if ($Result.EmergencyNumbers)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'EmergencyNumbers' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('EmergencyNumbers')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallingPolicy/MSFT_TeamsEmergencyCallingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallingPolicy/MSFT_TeamsEmergencyCallingPolicy.psm1
@@ -433,8 +433,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEnhancedEncryptionPolicy/MSFT_TeamsEnhancedEncryptionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEnhancedEncryptionPolicy/MSFT_TeamsEnhancedEncryptionPolicy.psm1
@@ -410,8 +410,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEventsPolicy/MSFT_TeamsEventsPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEventsPolicy/MSFT_TeamsEventsPolicy.psm1
@@ -490,8 +490,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsFederationConfiguration/MSFT_TeamsFederationConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsFederationConfiguration/MSFT_TeamsFederationConfiguration.psm1
@@ -435,7 +435,6 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
             if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -443,8 +442,6 @@ function Export-TargetResource
                 $Global:M365DSCExportResourceInstancesCount++
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsFeedbackPolicy/MSFT_TeamsFeedbackPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsFeedbackPolicy/MSFT_TeamsFeedbackPolicy.psm1
@@ -452,8 +452,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsFilesPolicy/MSFT_TeamsFilesPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsFilesPolicy/MSFT_TeamsFilesPolicy.psm1
@@ -403,8 +403,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsGroupPolicyAssignment/MSFT_TeamsGroupPolicyAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsGroupPolicyAssignment/MSFT_TeamsGroupPolicyAssignment.psm1
@@ -444,8 +444,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             #$results = Get-TargetResource @getParams
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsGuestCallingConfiguration/MSFT_TeamsGuestCallingConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsGuestCallingConfiguration/MSFT_TeamsGuestCallingConfiguration.psm1
@@ -287,7 +287,6 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
             if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -295,8 +294,6 @@ function Export-TargetResource
                 $Global:M365DSCExportResourceInstancesCount++
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsGuestMeetingConfiguration/MSFT_TeamsGuestMeetingConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsGuestMeetingConfiguration/MSFT_TeamsGuestMeetingConfiguration.psm1
@@ -340,7 +340,6 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
             if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -348,8 +347,6 @@ function Export-TargetResource
                 $Global:M365DSCExportResourceInstancesCount++
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsGuestMessagingConfiguration/MSFT_TeamsGuestMessagingConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsGuestMessagingConfiguration/MSFT_TeamsGuestMessagingConfiguration.psm1
@@ -405,7 +405,6 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
             if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -413,8 +412,6 @@ function Export-TargetResource
                 $Global:M365DSCExportResourceInstancesCount++
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsIPPhonePolicy/MSFT_TeamsIPPhonePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsIPPhonePolicy/MSFT_TeamsIPPhonePolicy.psm1
@@ -474,8 +474,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsM365App/MSFT_TeamsM365App.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsM365App/MSFT_TeamsM365App.psm1
@@ -471,8 +471,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingBroadcastConfiguration/MSFT_TeamsMeetingBroadcastConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingBroadcastConfiguration/MSFT_TeamsMeetingBroadcastConfiguration.psm1
@@ -354,8 +354,7 @@ function Export-TargetResource
         }
         Add-ConfigurationDataEntry -Node 'NonNodeData' -Key 'SdnApiToken' -Value '**********'`
             -Description 'API Token for the Teams SDN Provider for Meeting Broadcast'
-        $Results = Get-TargetResource @params
-
+        $Results = Get-TargetResource @Params
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
             if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -363,20 +362,14 @@ function Export-TargetResource
                 $Global:M365DSCExportResourceInstancesCount++
             }
 
-            $results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $results.SdnApiToken = '$ConfigurationData.Settings.SdnApiToken'
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-
-            $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock `
-                -ParameterName 'SdnApiToken'
+                -Credential $Credential `
+                -NoEscape @('SdnApiToken')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingBroadcastPolicy/MSFT_TeamsMeetingBroadcastPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingBroadcastPolicy/MSFT_TeamsMeetingBroadcastPolicy.psm1
@@ -382,8 +382,6 @@ function Export-TargetResource
             }
             Write-Host "    |---[$i/$($policies.Length)] $($policy.Identity)" -NoNewline
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingConfiguration/MSFT_TeamsMeetingConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingConfiguration/MSFT_TeamsMeetingConfiguration.psm1
@@ -447,7 +447,6 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
             if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -455,8 +454,6 @@ function Export-TargetResource
                 $Global:M365DSCExportResourceInstancesCount++
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingPolicy/MSFT_TeamsMeetingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingPolicy/MSFT_TeamsMeetingPolicy.psm1
@@ -1427,8 +1427,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMessagingPolicy/MSFT_TeamsMessagingPolicy.psm1
@@ -667,8 +667,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMobilityPolicy/MSFT_TeamsMobilityPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMobilityPolicy/MSFT_TeamsMobilityPolicy.psm1
@@ -432,8 +432,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsNetworkRoamingPolicy/MSFT_TeamsNetworkRoamingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsNetworkRoamingPolicy/MSFT_TeamsNetworkRoamingPolicy.psm1
@@ -410,8 +410,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOnlineVoiceUser/MSFT_TeamsOnlineVoiceUser.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOnlineVoiceUser/MSFT_TeamsOnlineVoiceUser.psm1
@@ -344,8 +344,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOnlineVoicemailPolicy/MSFT_TeamsOnlineVoicemailPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOnlineVoicemailPolicy/MSFT_TeamsOnlineVoicemailPolicy.psm1
@@ -425,8 +425,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOnlineVoicemailUserSettings/MSFT_TeamsOnlineVoicemailUserSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOnlineVoicemailUserSettings/MSFT_TeamsOnlineVoicemailUserSettings.psm1
@@ -443,7 +443,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-
             if ($Results.Ensure -eq 'Present')
             {
                 if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -451,8 +450,6 @@ function Export-TargetResource
                     $Global:M365DSCExportResourceInstancesCount++
                 }
 
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOrgWideAppSettings/MSFT_TeamsOrgWideAppSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOrgWideAppSettings/MSFT_TeamsOrgWideAppSettings.psm1
@@ -227,7 +227,6 @@ function Export-TargetResource
             AccessTokens     = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-
         if ($Results.Ensure -eq 'Present')
         {
             if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -235,8 +234,6 @@ function Export-TargetResource
                 $Global:M365DSCExportResourceInstancesCount++
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsPstnUsage/MSFT_TeamsPstnUsage.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsPstnUsage/MSFT_TeamsPstnUsage.psm1
@@ -327,8 +327,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsShiftsPolicy/MSFT_TeamsShiftsPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsShiftsPolicy/MSFT_TeamsShiftsPolicy.psm1
@@ -479,8 +479,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -751,8 +751,6 @@ function Export-TargetResource
                     AccessTokens          = $AccessTokens
                 }
                 $Results = Get-TargetResource @Params
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTemplatesPolicy/MSFT_TeamsTemplatesPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTemplatesPolicy/MSFT_TeamsTemplatesPolicy.psm1
@@ -367,8 +367,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantDialPlan/MSFT_TeamsTenantDialPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantDialPlan/MSFT_TeamsTenantDialPlan.psm1
@@ -523,9 +523,7 @@ function Export-TargetResource
                 ManagedIdentity       = $ManagedIdentity.IsPresent
                 AccessTokens          = $AccessTokens
             }
-            $results = Get-TargetResource @params
-            $results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
+            $Results = Get-TargetResource @Params
 
             if ($null -ne $Results.NormalizationRules)
             {
@@ -555,14 +553,10 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
-            if ($Results.NormalizationRules)
-            {
-                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'NormalizationRules' -IsCIMArray:$True
-            }
+                -Credential $Credential `
+                -NoEscape @('NormalizationRules')
 
             $dscContent += $currentDSCBlock
-
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName
             $i++

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkRegion/MSFT_TeamsTenantNetworkRegion.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkRegion/MSFT_TeamsTenantNetworkRegion.psm1
@@ -397,8 +397,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkSite/MSFT_TeamsTenantNetworkSite.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkSite/MSFT_TeamsTenantNetworkSite.psm1
@@ -475,8 +475,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkSubnet/MSFT_TeamsTenantNetworkSubnet.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantNetworkSubnet/MSFT_TeamsTenantNetworkSubnet.psm1
@@ -411,8 +411,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantTrustedIPAddress/MSFT_TeamsTenantTrustedIPAddress.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantTrustedIPAddress/MSFT_TeamsTenantTrustedIPAddress.psm1
@@ -399,8 +399,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTranslationRule/MSFT_TeamsTranslationRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTranslationRule/MSFT_TeamsTranslationRule.psm1
@@ -410,8 +410,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUnassignedNumberTreatment/MSFT_TeamsUnassignedNumberTreatment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUnassignedNumberTreatment/MSFT_TeamsUnassignedNumberTreatment.psm1
@@ -439,8 +439,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpdateManagementPolicy/MSFT_TeamsUpdateManagementPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpdateManagementPolicy/MSFT_TeamsUpdateManagementPolicy.psm1
@@ -444,12 +444,10 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $result = Get-TargetResource @params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $result
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
-                -Results $Results `
+                -Results $result `
                 -Credential $Credential
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpgradeConfiguration/MSFT_TeamsUpgradeConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpgradeConfiguration/MSFT_TeamsUpgradeConfiguration.psm1
@@ -301,7 +301,6 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
         $Results = Get-TargetResource @Params
-
         if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
         {
             if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -309,8 +308,6 @@ function Export-TargetResource
                 $Global:M365DSCExportResourceInstancesCount++
             }
 
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpgradePolicy/MSFT_TeamsUpgradePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUpgradePolicy/MSFT_TeamsUpgradePolicy.psm1
@@ -324,8 +324,7 @@ function Export-TargetResource
                 ManagedIdentity       = $ManagedIdentity.IsPresent
                 AccessTokens          = $AccessTokens
             }
-            $Results = Get-TargetResource @params
-
+            $Results = Get-TargetResource @Params
             if ($Results -is [System.Collections.Hashtable] -and $Results.Count -gt 1)
             {
                 if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -333,8 +332,6 @@ function Export-TargetResource
                     $Global:M365DSCExportResourceInstancesCount++
                 }
 
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
@@ -394,8 +394,6 @@ function Export-TargetResource
                             AccessTokens          = $AccessTokens
                         }
                         $results = Get-TargetResource @getParams
-                        $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                            -Results $Results
                         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                             -ConnectionMode $ConnectionMode `
                             -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUserCallingSettings/MSFT_TeamsUserCallingSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUserCallingSettings/MSFT_TeamsUserCallingSettings.psm1
@@ -466,7 +466,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-
             if ($Results.Ensure -eq 'Present')
             {
                 if ($null -ne $Global:M365DSCExportResourceInstancesCount)
@@ -474,8 +473,6 @@ function Export-TargetResource
                     $Global:M365DSCExportResourceInstancesCount++
                 }
 
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUserPolicyAssignment/MSFT_TeamsUserPolicyAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUserPolicyAssignment/MSFT_TeamsUserPolicyAssignment.psm1
@@ -906,8 +906,6 @@ function Export-TargetResource
                     $Global:M365DSCExportResourceInstancesCount++
                 }
 
-                $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                    -Results $Results
                 $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                     -ConnectionMode $ConnectionMode `
                     -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVdiPolicy/MSFT_TeamsVdiPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVdiPolicy/MSFT_TeamsVdiPolicy.psm1
@@ -397,8 +397,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoute/MSFT_TeamsVoiceRoute.psm1
@@ -432,8 +432,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoutingPolicy/MSFT_TeamsVoiceRoutingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsVoiceRoutingPolicy/MSFT_TeamsVoiceRoutingPolicy.psm1
@@ -363,8 +363,6 @@ function Export-TargetResource
                 AccessTokens          = $AccessTokens
             }
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsWorkloadPolicy/MSFT_TeamsWorkloadPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsWorkloadPolicy/MSFT_TeamsWorkloadPolicy.psm1
@@ -462,8 +462,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
+++ b/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
@@ -134,7 +134,7 @@
         },
         @{
             ModuleName      = 'ReverseDSC'
-            RequiredVersion = '2.0.0.22'
+            RequiredVersion = '2.0.0.25'
         }
     )
 }

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -250,6 +250,7 @@ function Get-M365DSCDRGComplexTypeToHashtable
 function Get-M365DSCDRGComplexTypeToString
 {
     [CmdletBinding()]
+    [OutputType([System.String])]
     param(
         [Parameter()]
         $ComplexObject,
@@ -304,6 +305,12 @@ function Get-M365DSCDRGComplexTypeToString
             }
 
             $currentProperty += Get-M365DSCDRGComplexTypeToString -IsArray @splat
+        }
+
+        # Add an indented new line after the last item in the array
+        if ($currentProperty.Count -gt 0)
+        {
+            $currentProperty[-1] += "`r`n" + $indent
         }
 
         #PowerShell returns all non-captured stream output, not just the argument of the return statement.
@@ -425,7 +432,7 @@ function Get-M365DSCDRGComplexTypeToString
                     {
                         $nestedPropertyString = "`$null`r`n"
                     }
-                    $currentProperty += $nestedPropertyString
+                    $currentProperty += $nestedPropertyString + "`r`n"
                 }
                 if ($IsArray)
                 {
@@ -472,30 +479,36 @@ function Get-M365DSCDRGComplexTypeToString
             }
         }
     }
+
     $indent = ''
     $indent = '    ' * ($IndentLevel -1)
+
     if ($key -in $ComplexTypeMapping.Name)
     {
         $currentProperty += "`r`n"
     }
 
     $currentProperty += "$indent}"
+    <#
     if ($IsArray -or $IndentLevel -gt 4)
     {
         $currentProperty += "`r`n"
     }
+    #>
 
     #Indenting last parenthesis when the cim instance is an array
+    <#
     if ($IndentLevel -eq 5)
     {
         $indent = '    ' * ($IndentLevel -2)
         $currentProperty += $indent
     }
+    #>
 
     $emptyCIM = $currentProperty.Replace(' ', '').Replace("`r`n", '')
     if ($emptyCIM -eq "MSFT_$CIMInstanceName{}")
     {
-        $currentProperty = $null
+        $currentProperty = [string]::Empty
     }
 
     if ($null -ne $currentProperty)
@@ -505,6 +518,7 @@ function Get-M365DSCDRGComplexTypeToString
         $currentProperty = [regex]::Replace($currentProperty, $fancySingleQuotes, "''")
         $currentProperty = [regex]::Replace($currentProperty, $fancyDoubleQuotes, '"')
     }
+
     return $currentProperty
 }
 
@@ -538,11 +552,12 @@ function Get-M365DSCDRGSimpleObjectTypeToString
             {
                 $key = 'odataType'
             }
-            $returnValue = $Space + $Key + " = '" + $Value + "'`r`n"
+            $Value = $Value.Replace('`', '``').Replace('$', '`$').Replace('"', '`"')
+            $returnValue = $Space + $Key + ' = "' + $Value + """`r`n"
         }
         '*.DateTime'
         {
-            $returnValue = $Space + $Key + " = '" + $Value + "'`r`n"
+            $returnValue = $Space + $Key + ' = "' + $Value + """`r`n"
         }
         '*[[\]]'
         {
@@ -561,11 +576,12 @@ function Get-M365DSCDRGSimpleObjectTypeToString
                 {
                     '*.String'
                     {
-                        $returnValue += "$whitespace'$item'$newline"
+                        $item = $item.Replace('`', '``').Replace('$', '`$').Replace('"', '`"')
+                        $returnValue += "$whitespace""$item""$newline"
                     }
                     '*.DateTime'
                     {
-                        $returnValue += "$whitespace'$item'$newline"
+                        $returnValue += "$whitespace""$item""$newline"
                     }
                     Default
                     {
@@ -573,7 +589,8 @@ function Get-M365DSCDRGSimpleObjectTypeToString
                     }
                 }
             }
-            if ($Value.count -gt 1)
+
+            if ($Value.Count -gt 1)
             {
                 $returnValue += "$Space)`r`n"
             }
@@ -588,6 +605,7 @@ function Get-M365DSCDRGSimpleObjectTypeToString
             $returnValue = $Space + $Key + ' = ' + $Value + "`r`n"
         }
     }
+
     return $returnValue
 }
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -3595,6 +3595,7 @@ function Update-M365DSCExportAuthenticationResults
         $Results
     )
 
+    $noEscape = @()
     if ($Results.ContainsKey('ManagedIdentity') -and -not $Results.ManagedIdentity)
     {
         $Results.Remove('ManagedIdentity')
@@ -3664,6 +3665,7 @@ function Update-M365DSCExportAuthenticationResults
         if (-not [System.String]::IsNullOrEmpty($Results.ApplicationId))
         {
             $Results.ApplicationId = "`$ConfigurationData.NonNodeData.ApplicationId"
+            $noEscape += 'ApplicationId'
         }
         else
         {
@@ -3679,6 +3681,7 @@ function Update-M365DSCExportAuthenticationResults
         if (-not [System.String]::IsNullOrEmpty($Results.CertificateThumbprint))
         {
             $Results.CertificateThumbprint = "`$ConfigurationData.NonNodeData.CertificateThumbprint"
+            $noEscape += 'CertificateThumbprint'
         }
         else
         {
@@ -3694,6 +3697,7 @@ function Update-M365DSCExportAuthenticationResults
         if (-not [System.String]::IsNullOrEmpty($Results.CertificatePath))
         {
             $Results.CertificatePath = "`$ConfigurationData.NonNodeData.CertificatePath"
+            $noEscape += 'CertificatePath'
         }
         else
         {
@@ -3709,6 +3713,7 @@ function Update-M365DSCExportAuthenticationResults
         if (-not [System.String]::IsNullOrEmpty($Results.TenantId))
         {
             $Results.TenantId = "`$ConfigurationData.NonNodeData.TenantId"
+            $noEscape += 'TenantId'
         }
         else
         {
@@ -3724,6 +3729,7 @@ function Update-M365DSCExportAuthenticationResults
         if (-not [System.String]::IsNullOrEmpty($Results.ApplicationSecret))
         {
             $Results.ApplicationSecret = "New-Object System.Management.Automation.PSCredential ('ApplicationSecret', (ConvertTo-SecureString `$ConfigurationData.NonNodeData.ApplicationSecret -AsPlainText -Force))"
+            $noEscape += 'ApplicationSecret'
         }
         else
         {
@@ -3755,9 +3761,14 @@ function Update-M365DSCExportAuthenticationResults
         if ($null -ne $Results.AccessTokens)
         {
             $results.AccessTokens = "`$ConfigurationData.NonNodeData.AccessTokens"
+            $noEscape += 'AccessTokens'
         }
     }
-    return $Results
+    
+    return @{
+        Results = $Results
+        NoEscape = $noEscape
+    }
 }
 
 <#
@@ -3792,8 +3803,18 @@ function Get-M365DSCExportContentForResource
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
-        $Credential
+        $Credential,
+
+        [Parameter()]
+        [System.String[]]
+        $NoEscape
     )
+
+    $withoutAuthentication = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
+        -Results $Results
+    $Results = $withoutAuthentication.Results
+    $NoEscape += $withoutAuthentication.NoEscape
+    $NoEscape = $NoEscape | Select-Object -Unique
 
     $OrganizationName = ''
     if ($ConnectionMode -like 'ServicePrincipal*' -or `
@@ -3928,7 +3949,7 @@ function Get-M365DSCExportContentForResource
     $content = [System.Text.StringBuilder]::New()
     [void]$content.Append("        $ResourceName `"$instanceName`"`r`n")
     [void]$content.Append("        {`r`n")
-    $partialContent = Get-DSCBlock -Params $Results -ModulePath $ModulePath
+    $partialContent = Get-DSCBlock -Params $Results -ModulePath $ModulePath -NoEscape $NoEscape
     # Test for both Credentials and CredentialsWithApplicationId
     if ($ConnectionMode -match 'Credentials')
     {

--- a/ResourceGenerator/Module.Template.psm1
+++ b/ResourceGenerator/Module.Template.psm1
@@ -399,8 +399,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
 <#ConvertComplexToString#><#AssignmentsConvertComplexToString#>
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `

--- a/ResourceGenerator/Module.Workloads.Template.psm1
+++ b/ResourceGenerator/Module.Workloads.Template.psm1
@@ -253,9 +253,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceEnrollmentPlatformRestriction.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceEnrollmentPlatformRestriction.Tests.ps1
@@ -25,14 +25,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             $secpasswd = ConvertTo-SecureString ((New-Guid).ToString()) -AsPlainText -Force
             $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
 
-            #Mock -CommandName Update-M365DSCExportAuthenticationResults -MockWith {
-            #   return @{}
-            #}
-
-            #Mock -CommandName Get-M365DSCExportContentForResource -MockWith {
-
-            #}
-
             Mock -CommandName Confirm-M365DSCDependencies -MockWith {
             }
 

--- a/dev-package/Modules/Microsoft365DSC/DSCResources/MSFT_ResourceName/MSFT_ResourceName.psm1
+++ b/dev-package/Modules/Microsoft365DSC/DSCResources/MSFT_ResourceName/MSFT_ResourceName.psm1
@@ -338,9 +338,6 @@ function Export-TargetResource
             }
 
             $Results = Get-TargetResource @Params
-            $Results = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-                -Results $Results
-
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `


### PR DESCRIPTION
#### Pull Request (PR) description
This PR updates the entire export logic of all resources: 

* Removes all calls to `Update-M365DSCExportAuthenticationResults` in the resources and adds it to `Get-M365DSCExportContentForResource`
* Updates all logic that includes CIM instance conversion to be done inside of Microsoft365DSC and not by ReverseDSC
* Removes all calls to `Convert-DSCStringParamToVariable` except for `FabricAdminTenantSettings` --> @NikCharlebois Can you check if it still works and / or guide me to a resolution if it doesn't?

#### This Pull Request (PR) fixes the following issues
- None

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
