### PR TITLE
Add prefix to Remove-EmptyValue command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCUtil
+  * Add M365DSC prefix to `Remove-EmptyValue`.
+    FIXES [#3861](https://github.com/microsoft/Microsoft365DSC/issues/3861)
+
 # 1.25.212.2
 
 * MISC

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
@@ -427,7 +427,7 @@ function Set-TargetResource
         Confirm                    = $false
     }
     # Removes empty properties from Splat to prevent function throwing errors if parameter is null or empty
-    Remove-EmptyValue -Splat $NewOrganizationRelationshipParams
+    Remove-M365DSCEmptyValue -Splat $NewOrganizationRelationshipParams
 
     $SetOrganizationRelationshipParams = @{
         ArchiveAccessEnabled       = $ArchiveAccessEnabled
@@ -454,7 +454,7 @@ function Set-TargetResource
         Confirm                    = $false
     }
     # Removes empty properties from Splat to prevent function throwing errors if parameter is null or empty
-    Remove-EmptyValue -Splat $SetOrganizationRelationshipParams
+    Remove-M365DSCEmptyValue -Splat $SetOrganizationRelationshipParams
 
     # CASE: Organization Relationship doesn't exist but should;
     if ($Ensure -eq 'Present' -and $currentOrgRelationshipConfig.Ensure -eq 'Absent')

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -3516,13 +3516,13 @@ This function removes all empty values from a dictionary object
 .Functionality
 Internal
 #>
-function Remove-EmptyValue
+function Remove-M365DSCEmptyValue
 {
-    [alias('Remove-EmptyValues')]
+    [Alias('Remove-M365DSCEmptyValues')]
     [CmdletBinding()]
     param
     (
-        [alias('Splat', 'IDictionary')][Parameter(Mandatory)][System.Collections.IDictionary] $Hashtable,
+        [Alias('Splat', 'IDictionary')][Parameter(Mandatory)][System.Collections.IDictionary] $Hashtable,
         [string[]] $ExcludeParameter,
         [switch] $Recursive,
         [int] $Rerun
@@ -3542,7 +3542,7 @@ function Remove-EmptyValue
                     }
                     else
                     {
-                        Remove-EmptyValue -Hashtable $Hashtable[$Key] -Recursive:$Recursive
+                        Remove-M365DSCEmptyValue -Hashtable $Hashtable[$Key] -Recursive:$Recursive
                     }
                 }
                 else
@@ -3566,7 +3566,7 @@ function Remove-EmptyValue
     {
         for ($i = 0; $i -lt $Rerun; $i++)
         {
-            Remove-EmptyValue -Hashtable $Hashtable -Recursive:$Recursive
+            Remove-M365DSCEmptyValue -Hashtable $Hashtable -Recursive:$Recursive
         }
     }
 }
@@ -3764,7 +3764,7 @@ function Update-M365DSCExportAuthenticationResults
             $noEscape += 'AccessTokens'
         }
     }
-    
+
     return @{
         Results = $Results
         NoEscape = $noEscape
@@ -5288,7 +5288,7 @@ Export-ModuleMember -Function @(
     'New-M365DSCCmdletDocumentation',
     'New-M365DSCConnection',
     'New-M365DSCMissingResourcesExample',
-    'Remove-EmptyValue',
+    'Remove-M365DSCEmptyValue',
     'Remove-M365DSCAuthenticationParameter',
     'Remove-NullEntriesFromHashtable',
     'Set-EXOSafeAttachmentRule',

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.Utils.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.Utils.Tests.ps1
@@ -21,7 +21,7 @@
             Test6 = 6
         }
 
-        Remove-EmptyValue -Splat $Splat
+        Remove-M365DSCEmptyValue -Splat $Splat
         { Test-FunctionHashtable @Splat } | Should -Not -Throw
     }
     It 'From OrderedDictionary' {
@@ -44,7 +44,7 @@
             Test5 = 0
             Test6 = 6
         }
-        Remove-EmptyValue -Splat $SplatDictionary
+        Remove-M365DSCEmptyValue -Splat $SplatDictionary
         { Test-FunctionOrderedDictionary @SplatDictionary } | Should -Not -Throw
     }
     It 'From OrderedDictionary but with ExcludedProperty' {
@@ -56,7 +56,7 @@
             Test5 = 0
             Test6 = 6
         }
-        Remove-EmptyValue -Splat $SplatDictionary -ExcludeParameter 'Test3'
+        Remove-M365DSCEmptyValue -Splat $SplatDictionary -ExcludeParameter 'Test3'
         $SplatDictionary['Test3'] | Should -Be ''
     }
     It 'From OrderedDictionary Recursive' {
@@ -69,10 +69,10 @@
             Test6 = 6
             Test7 = @{}
         }
-        Remove-EmptyValue -Splat $SplatDictionary
+        Remove-M365DSCEmptyValue -Splat $SplatDictionary
         $SplatDictionary.Keys | Should -Contain 'Test7'
 
-        Remove-EmptyValue -Splat $SplatDictionary -Recursive
+        Remove-M365DSCEmptyValue -Splat $SplatDictionary -Recursive
         $SplatDictionary.Keys | Should -Not -Contain 'Test7'
     }
     It 'From OrderedDictionary Recursive with ILIST check' {
@@ -91,11 +91,11 @@
         }
         $SplatDictionary.Test6.Add($DummyObject)
 
-        Remove-EmptyValue -Splat $SplatDictionary
+        Remove-M365DSCEmptyValue -Splat $SplatDictionary
         $SplatDictionary.Keys | Should -Contain 'Test6'
         $SplatDictionary.Keys | Should -Contain 'Test7'
 
-        Remove-EmptyValue -Splat $SplatDictionary -Recursive
+        Remove-M365DSCEmptyValue -Splat $SplatDictionary -Recursive
         $SplatDictionary.Keys | Should -Not -Contain 'Test7'
     }
     It 'From OrderedDictionary Recursive with ILIST check for Empty Arrays' {
@@ -117,14 +117,14 @@
         }
         $SplatDictionary.Test6.Add($DummyObject)
 
-        Remove-EmptyValue -Splat $SplatDictionary
+        Remove-M365DSCEmptyValue -Splat $SplatDictionary
         $SplatDictionary.Keys | Should -Contain 'Test6'
         $SplatDictionary.Keys | Should -Contain 'Test7'
         $SplatDictionary.Keys | Should -Not -Contain 'Test8'
         $SplatDictionary.Keys | Should -Not -Contain 'Test9'
         $SplatDictionary.Keys | Should -Contain 'Test10'
 
-        Remove-EmptyValue -Splat $SplatDictionary -Recursive
+        Remove-M365DSCEmptyValue -Splat $SplatDictionary -Recursive
         $SplatDictionary.Keys | Should -Not -Contain 'Test7'
     }
     It 'Testing edge cases' {
@@ -151,7 +151,7 @@
             Rotate6     = $null, ''
         }
 
-        Remove-EmptyValue -Hashtable $Splat
+        Remove-M365DSCEmptyValue -Hashtable $Splat
         $Splat.Keys | Should -Contain 'Rotate6'
         $Splat.Keys | Should -Not -Contain 'Rotate5'
         $Splat.Keys | Should -Contain 'Rotate4'
@@ -168,7 +168,7 @@
         $Splat.Margins.Keys | Should -Contain TestBool2
         $Splat.Margins.Keys | Should -Contain TestBoolArray
 
-        Remove-EmptyValue -Hashtable $Splat -Recursive
+        Remove-M365DSCEmptyValue -Hashtable $Splat -Recursive
         $Splat.Margins.Keys | Should -Not -Contain MarginRight2
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
Add M365DSC prefix to `Remove-EmptyValue` command. 

#### This Pull Request (PR) fixes the following issues
- Fixes #3861 

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
