### PR TITLE
Remove ensure property from export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
     FIXES [#3861](https://github.com/microsoft/Microsoft365DSC/issues/3861)
 * TeamsAppPermissionPolicy
   * Updated correct Typecasting for AppPresetMeeting and PinnedMessagebarApps before adding them to the policy
-    FIXES [[#5752](https://github.com/microsoft/Microsoft365DSC/issues/5752)
+    FIXES [#5752](https://github.com/microsoft/Microsoft365DSC/issues/5752)
+* TeamsM365App
+  * Remove `Ensure` property from being exported.
+    FIXES [#5781](https://github.com/microsoft/Microsoft365DSC/issues/5781)
 
 # 1.25.212.2
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsM365App/MSFT_TeamsM365App.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsM365App/MSFT_TeamsM365App.psm1
@@ -69,7 +69,6 @@ function Get-TargetResource
     #endregion
 
     $nullResult = $PSBoundParameters
-    $nullResult.Ensure = 'Absent'
     try
     {
         if ($null -ne $Script:exportedInstances -and $Script:ExportMode)
@@ -112,7 +111,6 @@ function Get-TargetResource
             AssignmentType        = $instance.AvailableTo.AssignmentType
             Users                 = $usersValue
             Groups                = $groupsValue
-            Ensure                = 'Present'
             Credential            = $Credential
             ApplicationId         = $ApplicationId
             TenantId              = $TenantId
@@ -199,7 +197,6 @@ function Set-TargetResource
 
     $currentInstance = Get-TargetResource @PSBoundParameters
 
-    $PSBoundParameters.Remove('Ensure') | Out-Null
     $PSBoundParameters.Remove('Credential') | Out-Null
     $PSBoundParameters.Remove('ApplicationId') | Out-Null
     $PSBoundParameters.Remove('ApplicationSecret') | Out-Null


### PR DESCRIPTION
#### Pull Request (PR) description
This PR removes the `Ensure` property from the export of `TeamsM365App`. The schema does not contain a definition for Ensure, so the export also shouldn't contain it. 

#### This Pull Request (PR) fixes the following issues
- Fixes #5781 

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
