### PR TITLE
Add missing permission for AADAccessReviewPolicy Application Read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+* AADAccessReviewPolicy
+  * FIXES [#5796](https://github.com/microsoft/Microsoft365DSC/issues/5796) Missing AccessReview permission for Application Read access
 * AADRoleEligibilityScheduleRequest
   * Reduce call count when reconciling object type
     FIXES [#5621](https://github.com/microsoft/Microsoft365DSC/issues/5621)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAccessReviewPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAccessReviewPolicy/settings.json
@@ -15,6 +15,9 @@
                 "read": [
                     {
                         "name": "Policy.Read.All"
+                    },
+                    {
+                        "name": "AccessReview.Read.All"
                     }
                 ],
                 "update": [


### PR DESCRIPTION
Add missing permission for AADAccessReviewPolicy Application Read
#### Pull Request (PR) description
"AccessReview.Read.All" permission is required for Access Review Read

#### This Pull Request (PR) fixes the following issues
- Fixes #5796 

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
