### PR TITLE
Fix AADDeviceRegistrationPolicy to correctly use parsed Group and User objects for Select EntraJoin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+* AADDeviceRegistrationPolicy
+  * FIXES [#5798](https://github.com/microsoft/Microsoft365DSC/issues/5798) - Fix issue setting Selected Users and Groups for Entra Join
 * AADRoleEligibilityScheduleRequest
   * Reduce call count when reconciling object type
     FIXES [#5621](https://github.com/microsoft/Microsoft365DSC/issues/5621)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADDeviceRegistrationPolicy/MSFT_AADDeviceRegistrationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADDeviceRegistrationPolicy/MSFT_AADDeviceRegistrationPolicy.psm1
@@ -406,8 +406,8 @@ function Set-TargetResource
             isAdminConfigurable = $AzureADJoinIsAdminConfigurable
             allowedToJoin       = @{
                 '@odata.type' = $azureADRegistrationAllowedToRegister
-                users         = $AzureADAllowedToJoinUsers
-                groups        = $AzureADAllowedToJoinGroups
+                users         = $azureADRegistrationAllowedUsers
+                groups        = $azureADRegistrationAllowedGroups
             }
             localAdmins         = @{
                 enableGlobalAdmins = $LocalAdminsEnableGlobalAdmins


### PR DESCRIPTION
Fix AADDeviceRegistrationPolicy to correctly use parsed Group and User objects for Select EntraJoin

#### Pull Request (PR) description
Use correct variables that store objectids of Users and Groups for Select Entra Join Device registration

#### This Pull Request (PR) fixes the following issues
-Fixes #5798 

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
