### PR TITLE
Fix for #5592 & #5593 - Updated IntuneDeviceCompliancePolicyAndroidDeviceOwner & WorkProfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
     FIXES [#3861](https://github.com/microsoft/Microsoft365DSC/issues/3861)
 * SCSensitivityLabel
   * Fixes invalid accepted content type values.
+* IntuneDeviceCompliancePolicyAndroidDeviceOwner
+  * Adds support for Scheduled Actions and other missing properties
+    FIXES [#5593] (https://github.com/microsoft/Microsoft365DSC/issues/5593)
+* IntuneDeviceCompliancePolicyAndroidWorkProfile
+  * Adds support for Scheduled Actions and other missing properties
+    FIXES [#5593] (https://github.com/microsoft/Microsoft365DSC/issues/5592)
 * TeamsAppPermissionPolicy
   * Updated correct Typecasting for AppPresetMeeting and PinnedMessagebarApps before adding them to the policy
 * TeamsAppSetupPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner.schema.mof
@@ -9,12 +9,32 @@ class MSFT_DeviceManagementConfigurationPolicyAssignments
     [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
 };
 
+[ClassVersion("1.0.0.0")]
+class MSFT_scheduledActionConfigurations
+{
+    [Write, Description("The unique identifier of the action configuration.")] String id;
+    [Write, Description("Number of hours to wait till the action will be enforced. Valid values 0 to 8760.")] Uint32 gracePeriodHours;
+    [Write, Description("The action to take."), ValueMap{"notification", "block", "retire", "remoteLock", "pushNotification"}, Values{"notification", "block", "retire", "remoteLock", "pushNotification"}] String actionType;
+    [Write, Description("The notification Message template to use.")] String notificationTemplateId;
+    [Write, Description("A list of group IDs to specify who to CC this notification message to.")] String notificationMessageCCList[];
+};
+
 [ClassVersion("1.0.0.0"), FriendlyName("IntuneDeviceCompliancePolicyAndroidDeviceOwner")]
 class MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner : OMI_BaseResource
 {
     [Key, Description("Display name of the Android Device Owner device compliance policy.")] String DisplayName;
     [Write, Description("Description of the Android Device Owner device compliance policy.")] String Description;
     [Write, Description("Assignments of the Intune Policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
+    [Write, Description("Minimum Android security patch level.")] String MinAndroidSecurityPatchLevel;
+    [Write, Description("Indicates the minimum number of letter characters required for device password. Valid values 1 to 16.")] Uint32 PasswordMinimumLetterCharacters;
+    [Write, Description("Indicates the minimum number of lower case characters required for device password. Valid values 1 to 16.")] Uint32 PasswordMinimumLowerCaseCharacters;
+    [Write, Description("Indicates the minimum number of non-letter characters required for device password. Valid values 1 to 16.")] Uint32 PasswordMinimumNonLetterCharacters;
+    [Write, Description("Indicates the minimum number of numeric characters required for device password. Valid values 1 to 16.")] Uint32 PasswordMinimumNumericCharacters;
+    [Write, Description("Indicates the minimum number of symbol characters required for device password. Valid values 1 to 16.")] Uint32 PasswordMinimumSymbolCharacters;
+    [Write, Description("Indicates the minimum number of upper case letter characters required for device password. Valid values 1 to 16.")] Uint32 PasswordMinimumUpperCaseCharacters;
+    [Write, Description("Require device to have no pending Android system updates.")] Boolean RequireNoPendingSystemUpdates;
+    [Write, Description("Require a specific Play Integrity evaluation type for compliance. Possible values are: basic, hardwareBacked."), ValueMap{"basic","hardwareBacked"}, Values{"basic","hardwareBacked"}] String SecurityRequiredAndroidSafetyNetEvaluationType;
+    [Write, Description("Specifies the non-compliance actions."), EmbeddedInstance("MSFT_scheduledActionConfigurations")] String ScheduledActionsForRule[];
     [Write, Description("DeviceThreatProtectionEnabled of the Android Device Owner device compliance policy.")] Boolean DeviceThreatProtectionEnabled;
     [Write, Description("DeviceThreatProtectionRequiredSecurityLevel of the Android Device Owner device compliance policy.")] String DeviceThreatProtectionRequiredSecurityLevel;
     [Write, Description("AdvancedThreatProtectionRequiredSecurityLevel of the Android Device Owner device compliance policy.")] String AdvancedThreatProtectionRequiredSecurityLevel;
@@ -40,3 +60,4 @@ class MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner : OMI_BaseResource
     [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
     [Write, Description("Access token used for authentication.")] String AccessTokens[];
 };
+

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile.psm1
@@ -13,6 +13,53 @@ function Get-TargetResource
         $Description,
 
         [Parameter()]
+        [System.String]
+        [ValidateSet('none', 'low', 'medium', 'high')]
+        $RequiredPasswordComplexity,
+
+        [Parameter()]
+        [System.Boolean]
+        $SecurityBlockDeviceAdministratorManagedDevices,
+
+        [Parameter()]
+        [System.String[]]
+        $RestrictedApps,
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('deviceDefault', 'lowSecurityBiometric', 'required', 'atLeastNumeric', 'numericComplex', 'atLeastAlphabetic', 'atLeastAlphanumeric', 'alphanumericWithSymbols')] #Specifies Android Work Profile password type.
+        $WorkProfilePasswordRequiredType,
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('None', 'Low', 'Medium', 'High')]
+        $WorkProfileRequiredPasswordComplexity, 
+
+        [Parameter()]
+        [System.Boolean]
+        $WorkProfileRequirePassword,
+
+        [Parameter()]
+        [System.Int32]
+        $WorkProfilePreviousPasswordBlockCount,
+
+        [Parameter()]
+        [System.Int32]
+        $WorkProfileInactiveBeforeScreenLockInMinutes,
+
+        [Parameter()]
+        [System.Int32]
+        $WorkProfilePasswordMinimumLength,
+
+        [Parameter()]
+        [System.Int32]
+        $WorkProfilePasswordExpirationInDays,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $ScheduledActionsForRule,
+
+        [Parameter()]
         [System.Boolean]
         $PasswordRequired,
 
@@ -180,6 +227,7 @@ function Get-TargetResource
 
             $devicePolicy = Get-MgBetaDeviceManagementDeviceCompliancePolicy `
                 -All `
+                -ExpandProperty 'scheduledActionsForRule($expand=scheduledActionConfigurations)' `
                 -ErrorAction SilentlyContinue | Where-Object `
                 -FilterScript { $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidWorkProfileCompliancePolicy' -and `
                     $_.displayName -eq $($DisplayName) }
@@ -199,9 +247,43 @@ function Get-TargetResource
         }
 
         Write-Verbose -Message "Found Intune Android Work Profile Device Compliance Policy with displayName {$DisplayName}"
+
+        #scheduledActionsForRule needs processing before we can interact with it
+        $psCustomObject = $devicePolicy.ScheduledActionsForRule | convertTo-JSON | ConvertFrom-JSON  
+        $scheduledActionsForRuleHashTable = @{} 
+        $psCustomObject.PsObject.Properties | ForEach-Object {     
+            $scheduledActionsForRuleHashTable[$_.Name] = $_.Value        
+        }         
+        $hashtable = @{}
+        $complexScheduledActionsForRule = @()        
+        $scheduledActionsForRuleHashTable.ScheduledActionConfigurations.PsObject.Properties | ForEach-Object {
+            if($_.Value -match "ActionType")
+            {
+                foreach($item in $_.Value){
+                        $hashtable = @{}
+                        $hashtable.Add('actionType', $item.ActionType)
+                        $hashtable.Add('gracePeriodHours', $item.GracePeriodHours)
+                        $hashtable.Add('notificationMessageCcList', ([Array]$item.NotificationMessageCcList -split " ") )
+                        $hashtable.Add('notificationTemplateId', $item.NotificationTemplateId)
+                        $complexScheduledActionsForRule += $hashtable                    
+                 }               
+            }
+        }
+
         $results = @{
             DisplayName                                        = $devicePolicy.DisplayName
             Description                                        = $devicePolicy.Description
+            RequiredPasswordComplexity                         = $devicePolicy.AdditionalProperties.requiredPasswordComplexity
+            SecurityBlockDeviceAdministratorManagedDevices     = $devicePolicy.AdditionalProperties.securityBlockDeviceAdministratorManagedDevices
+            RestrictedApps                                     = $devicePolicy.AdditionalProperties.restrictedApps
+            WorkProfilePasswordRequiredType                    = $devicePolicy.AdditionalProperties.workProfilePasswordRequiredType
+            WorkProfileRequiredPasswordComplexity              = $devicePolicy.AdditionalProperties.workProfileRequiredPasswordComplexity
+            WorkProfileRequirePassword                         = $devicePolicy.AdditionalProperties.workProfileRequirePassword
+            WorkProfilePreviousPasswordBlockCount              = $devicePolicy.AdditionalProperties.workProfilePreviousPasswordBlockCount
+            WorkProfileInactiveBeforeScreenLockInMinutes       = $devicePolicy.AdditionalProperties.workProfileInactiveBeforeScreenLockInMinutes
+            WorkProfilePasswordMinimumLength                   = $devicePolicy.AdditionalProperties.workProfilePasswordMinimumLength
+            WorkProfilePasswordExpirationInDays                = $devicePolicy.AdditionalProperties.workProfilePasswordExpirationInDays
+            ScheduledActionsForRule                            = $complexScheduledActionsForRule
             PasswordRequired                                   = $devicePolicy.AdditionalProperties.passwordRequired
             PasswordMinimumLength                              = $devicePolicy.AdditionalProperties.passwordMinimumLength
             PasswordRequiredType                               = $devicePolicy.AdditionalProperties.passwordRequiredType
@@ -226,7 +308,6 @@ function Get-TargetResource
             SecurityRequireUpToDateSecurityProviders           = $devicePolicy.AdditionalProperties.securityRequireUpToDateSecurityProviders
             SecurityRequireCompanyPortalAppIntegrity           = $devicePolicy.AdditionalProperties.securityRequireCompanyPortalAppIntegrity
             SecurityRequiredAndroidSafetyNetEvaluationType     = $devicePolicy.AdditionalProperties.securityRequiredAndroidSafetyNetEvaluationType
-
             RoleScopeTagIds                                    = $devicePolicy.AdditionalProperties.roleScopeTagIds
             Ensure                                             = 'Present'
             Credential                                         = $Credential
@@ -275,6 +356,53 @@ function Set-TargetResource
         [Parameter()]
         [System.String]
         $Description,
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('none', 'low', 'medium', 'high')]
+        $RequiredPasswordComplexity,
+
+        [Parameter()]
+        [System.Boolean]
+        $SecurityBlockDeviceAdministratorManagedDevices,
+
+        [Parameter()]
+        [System.String[]]
+        $RestrictedApps,
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('deviceDefault', 'lowSecurityBiometric', 'required', 'atLeastNumeric', 'numericComplex', 'atLeastAlphabetic', 'atLeastAlphanumeric', 'alphanumericWithSymbols')] #Specifies Android Work Profile password type.
+        $WorkProfilePasswordRequiredType,
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('None', 'Low', 'Medium', 'High')]
+        $WorkProfileRequiredPasswordComplexity, 
+
+        [Parameter()]
+        [System.Boolean]
+        $WorkProfileRequirePassword,
+
+        [Parameter()]
+        [System.Int32]
+        $WorkProfilePreviousPasswordBlockCount,
+
+        [Parameter()]
+        [System.Int32]
+        $WorkProfileInactiveBeforeScreenLockInMinutes,
+
+        [Parameter()]
+        [System.Int32]
+        $WorkProfilePasswordMinimumLength,
+
+        [Parameter()]
+        [System.Int32]
+        $WorkProfilePasswordExpirationInDays,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $ScheduledActionsForRule,
 
         [Parameter()]
         [System.Boolean]
@@ -437,23 +565,18 @@ function Set-TargetResource
 
     $currentDeviceAndroidPolicy = Get-TargetResource @PSBoundParameters
 
-    $PSBoundParameters.Remove('Ensure') | Out-Null
-    $PSBoundParameters.Remove('Credential') | Out-Null
-    $PSBoundParameters.Remove('ApplicationId') | Out-Null
-    $PSBoundParameters.Remove('TenantId') | Out-Null
-    $PSBoundParameters.Remove('ApplicationSecret') | Out-Null
-    $PSBoundParameters.Remove('AccessTokens') | Out-Null
+    $PSBoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
 
-    $scheduledActionsForRule = @{
+    #reconstruct scheduled action configurations for use with New/Update-MgBetaDeviceManagementDeviceCompliancePolicy  
+    $hashtable = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $PSBoundParameters.ScheduledActionsForRule
+    $scheduledActionConfigurations = @()
+    $scheduledActionConfigurations += $hashtable
+    $PSBoundParameters.Remove('ScheduledActionsForRule') | Out-Null  
+    $myScheduledActionsForRule = @{
         '@odata.type'                 = '#microsoft.graph.deviceComplianceScheduledActionForRule'
-        ruleName                      = 'PasswordRequired'
-        scheduledActionConfigurations = @(
-            @{
-                '@odata.type' = '#microsoft.graph.deviceComplianceActionItem'
-                actionType    = 'block'
-            }
-        )
-    }
+        ruleName                      = '' #this is always blank and can't be set in GUI
+        scheduledActionConfigurations = $scheduledActionConfigurations
+    } 
 
     if ($Ensure -eq 'Present' -and $currentDeviceAndroidPolicy.Ensure -eq 'Absent')
     {
@@ -466,7 +589,7 @@ function Set-TargetResource
         $policy = New-MgBetaDeviceManagementDeviceCompliancePolicy -DisplayName $DisplayName `
             -Description $Description `
             -AdditionalProperties $AdditionalProperties `
-            -ScheduledActionsForRule $scheduledActionsForRule
+            -ScheduledActionsForRule $myScheduledActionsForRule
 
         #region Assignments
         $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
@@ -494,6 +617,14 @@ function Set-TargetResource
         Update-MgBetaDeviceManagementDeviceCompliancePolicy -AdditionalProperties $AdditionalProperties `
             -Description $Description `
             -DeviceCompliancePolicyId $configDeviceAndroidPolicy.Id
+            #-ScheduledActionsForRule $myScheduledActionsForRule #This does not work even though it is a valid parameter
+       
+        #handle ScheduledActionsForRule separately with Invoke-MgGraph       
+        $Uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "beta/deviceManagement/deviceCompliancePolicies/$($configDeviceAndroidPolicy.Id)/scheduleActionsForRules"        
+        $mgGraphScheduledActionForRules = @{
+            deviceComplianceScheduledActionForRules = @( $myScheduledActionsForRule )
+        }        
+        Invoke-MgGraphRequest -Method POST -Uri $Uri -Body $($mgGraphScheduledActionForRules | ConvertTo-Json -Depth 10) -Verbose
 
         #region Assignments
         $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
@@ -527,6 +658,53 @@ function Test-TargetResource
         [Parameter()]
         [System.String]
         $Description,
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('none', 'low', 'medium', 'high')]
+        $RequiredPasswordComplexity,
+
+        [Parameter()]
+        [System.Boolean]
+        $SecurityBlockDeviceAdministratorManagedDevices,
+
+        [Parameter()]
+        [System.String[]]
+        $RestrictedApps,
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('deviceDefault', 'lowSecurityBiometric', 'required', 'atLeastNumeric', 'numericComplex', 'atLeastAlphabetic', 'atLeastAlphanumeric', 'alphanumericWithSymbols')] #Specifies Android Work Profile password type.
+        $WorkProfilePasswordRequiredType,
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('None', 'Low', 'Medium', 'High')]
+        $WorkProfileRequiredPasswordComplexity, 
+
+        [Parameter()]
+        [System.Boolean]
+        $WorkProfileRequirePassword,
+
+        [Parameter()]
+        [System.Int32]
+        $WorkProfilePreviousPasswordBlockCount,
+
+        [Parameter()]
+        [System.Int32]
+        $WorkProfileInactiveBeforeScreenLockInMinutes,
+
+        [Parameter()]
+        [System.Int32]
+        $WorkProfilePasswordMinimumLength,
+
+        [Parameter()]
+        [System.Int32]
+        $WorkProfilePasswordExpirationInDays,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $ScheduledActionsForRule,
 
         [Parameter()]
         [System.Boolean]
@@ -674,47 +852,64 @@ function Test-TargetResource
     Confirm-M365DSCDependencies
 
     #region Telemetry
-    $ResourceName = $MyInvocation.MyCommand.ModuleName -replace 'MSFT_', ''
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
     $CommandName = $MyInvocation.MyCommand
     $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
         -CommandName $CommandName `
         -Parameters $PSBoundParameters
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
-    Write-Verbose -Message "Testing configuration of Intune Android Work Profile Device Compliance Policy {$DisplayName}"
+
+    Write-Verbose -Message "Testing configuration of {$Id}"
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
-    if (-not (Test-M365DSCAuthenticationParameter -BoundParameters $CurrentValues))
+    $ValuesToCheck = ([Hashtable]$PSBoundParameters).clone()
+    $testResult = $true
+
+    #Compare Cim instances
+    foreach ($key in $PSBoundParameters.Keys)
     {
-        Write-Verbose "An error occured in Get-TargetResource, the policy {$displayName} will not be processed"
-        throw "An error occured in Get-TargetResource, the policy {$displayName} will not be processed. Refer to the event viewer logs for more information."
+        $source = $PSBoundParameters.$key
+        $target = $CurrentValues.$key
+        if ($source.GetType().Name -like '*CimInstance*')
+        {
+            $testResult = Compare-M365DSCComplexObject `
+                -Source ($source) `
+                -Target ($target)
+
+            if (-not $testResult) { break }
+
+            $ValuesToCheck.Remove($key) | Out-Null
+        }
     }
+
+    $ValuesToCheck.Remove('Id') | Out-Null
+    $ValuesToCheck = Remove-M365DSCAuthenticationParameter -BoundParameters $ValuesToCheck
 
     Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
-    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
+    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $ValuesToCheck)"
 
-    $ValuesToCheck = $PSBoundParameters
-    $testResult = $true
-    #region Assignments
-    if ($testResult)
+    #Convert any DateTime to String
+    foreach ($key in $ValuesToCheck.Keys)
     {
-        $source = Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $PSBoundParameters.Assignments
-        $target = $CurrentValues.Assignments
-        $testResult = Compare-M365DSCIntunePolicyAssignment -Source $source -Target $target
-        $ValuesToCheck.Remove('Assignments') | Out-Null
+        if (($null -ne $CurrentValues[$key]) `
+                -and ($CurrentValues[$key].getType().Name -eq 'DateTime'))
+        {
+            $CurrentValues[$key] = $CurrentValues[$key].toString()
+        }
     }
-    #endregion
 
     if ($testResult)
     {
-        $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
+        $testResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
             -Source $($MyInvocation.MyCommand.Source) `
             -DesiredValues $PSBoundParameters `
             -ValuesToCheck $ValuesToCheck.Keys
     }
-    Write-Verbose -Message "Test-TargetResource returned $TestResult"
 
-    return $TestResult
+    Write-Verbose -Message "Test-TargetResource returned $testResult"
+
+    return $testResult
 }
 
 function Export-TargetResource
@@ -779,6 +974,7 @@ function Export-TargetResource
             $Filter = Remove-ComplexFunctionsFromFilterQuery -FilterQuery $Filter
         }
         [array]$configDeviceAndroidPolicies = Get-MgBetaDeviceManagementDeviceCompliancePolicy `
+            -ExpandProperty 'scheduledActionsForRule($expand=scheduledActionConfigurations)' `
             -ErrorAction Stop -All:$true -Filter $Filter | Where-Object `
             -FilterScript { $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.androidWorkProfileCompliancePolicy' }
         $configDeviceAndroidPolicies = Find-GraphDataUsingComplexFunctions -ComplexFunctions $complexFunctions -Policies $configDeviceAndroidPolicies
@@ -835,13 +1031,27 @@ function Export-TargetResource
                 }
             }
 
+            if ($Results.ScheduledActionsForRule)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.ScheduledActionsForRule `
+                    -CIMInstanceName MSFT_scheduledActionConfigurations
+                if ($complexTypeStringResult)
+                {
+                    $Results.ScheduledActionsForRule = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('ScheduledActionsForRule') | Out-Null
+                }
+            }
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
                 -Credential $Credential `
-                -NoEscape @('Assignments')
+                -NoEscape @('Assignments', 'ScheduledActionsForRule')
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile.schema.mof
@@ -9,12 +9,33 @@ class MSFT_DeviceManagementConfigurationPolicyAssignments
     [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
 };
 
+[ClassVersion("1.0.0.0")]
+class MSFT_scheduledActionConfigurations
+{
+    [Write, Description("The unique identifier of the action configuration.")] String id;
+    [Write, Description("Number of hours to wait till the action will be enforced. Valid values 0 to 8760.")] Uint32 gracePeriodHours;
+    [Write, Description("The action to take."), ValueMap{"notification", "block", "retire", "remoteLock", "pushNotification"}, Values{"notification", "block", "retire", "remoteLock", "pushNotification"}] String actionType;
+    [Write, Description("The notification Message template to use.")] String notificationTemplateId;
+    [Write, Description("A list of group IDs to specify who to CC this notification message to.")] String notificationMessageCCList[];
+};
+
 [ClassVersion("1.0.0.0"), FriendlyName("IntuneDeviceCompliancePolicyAndroidWorkProfile")]
 class MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile : OMI_BaseResource
 {
     [Key, Description("Display name of the AndroidWorkProfile device compliance policy.")] String DisplayName;
     [Write, Description("Description of the AndroidWorkProfile device compliance policy.")] String Description;
     [Write, Description("Assignments of the Intune Policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
+    [Write, Description("The password complexity types that can be set on Android. One of: NONE, LOW, MEDIUM, HIGH. This is an API targeted to Android 11+."), ValueMap{"none", "low", "medium", "high"}, Values{"none", "low", "medium", "high"}] String RequiredPasswordComplexity;
+    [Write, Description("Setting securityBlockDeviceAdministratorManagedDevices to true enhances security by preventing devices managed through the legacy device administrator method from accessing corporate resources.")] Boolean SecurityBlockDeviceAdministratorManagedDevices;
+    [Write, Description("Specify applications that users are prohibited from installing or using on their devices.")] String RestrictedApps[];
+    [Write, Description("Specifies Android Work Profile password type."), ValueMap{"deviceDefault", "lowSecurityBiometric", "required", "atLeastNumeric", "numericComplex", "atLeastAlphabetic", "atLeastAlphanumeric", "alphanumericWithSymbols"}, Values{"deviceDefault", "lowSecurityBiometric", "required", "atLeastNumeric", "numericComplex", "atLeastAlphabetic", "atLeastAlphanumeric", "alphanumericWithSymbols"}] String WorkProfilePasswordRequiredType;
+    [Write, Description("Specifies Android Work Profile password complexity."), ValueMap{"None", "Low", "Medium", "High"}, Values{"None", "Low", "Medium", "High"}] String WorkProfileRequiredPasswordComplexity;
+    [Write, Description("Specifies if Android Work Profile password is required.")] Boolean WorkProfileRequirePassword;
+    [Write, Description("Specifies the number of previous passwords that cannot be reused in an Android Work Profile compliance policy.")] Uint32 WorkProfilePreviousPasswordBlockCount;
+    [Write, Description("Defines the duration of inactivity (in minutes) after which the screen is locked.")] Uint32 WorkProfileInactiveBeforeScreenLockInMinutes;
+    [Write, Description("Specifies the minimum number of characters required in a password for an Android Work Profile.")] Uint32 WorkProfilePasswordMinimumLength;
+    [Write, Description("Specifies the number of days before a password expires for an Android Work Profile.")] Uint32 WorkProfilePasswordExpirationInDays;
+    [Write, Description("Specifies the non-compliance actions."), EmbeddedInstance("MSFT_scheduledActionConfigurations")] String ScheduledActionsForRule[];
     [Write, Description("PasswordRequired of the AndroidWorkProfile device compliance policy.")] Boolean PasswordRequired;
     [Write, Description("PasswordMinimumLength of the AndroidWorkProfile device compliance policy.")] Uint32 PasswordMinimumLength;
     [Write, Description("PasswordRequiredType of the AndroidWorkProfile device compliance policy."), ValueMap{"deviceDefault", "alphabetic", "alphanumeric", "alphanumericWithSymbols", "lowSecurityBiometric", "numeric", "numericComplex", "any"}, Values{"deviceDefault", "alphabetic", "alphanumeric", "alphanumericWithSymbols", "lowSecurityBiometric", "numeric", "numericComplex", "any"}] String PasswordRequiredType;

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceCompliancePolicyAndroidDeviceOwner.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceCompliancePolicyAndroidDeviceOwner.Tests.ps1
@@ -60,6 +60,13 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     DisplayName                                        = 'Test Android Device Owner Device Compliance Policy'
                     Description                                        = 'Test Android Device Owner Device Compliance Policy Description'
+                    PasswordMinimumLetterCharacters                    = 1
+                    PasswordMinimumLowerCaseCharacters                 = 1
+                    PasswordMinimumNonLetterCharacters                 = 1
+                    PasswordMinimumNumericCharacters                   = 1
+                    PasswordMinimumSymbolCharacters                    = 1
+                    PasswordMinimumUpperCaseCharacters                 = 1
+                    RequireNoPendingSystemUpdates                      = $true
                     DeviceThreatProtectionEnabled                      = $True
                     DeviceThreatProtectionRequiredSecurityLevel        = 'Unavailable'
                     AdvancedThreatProtectionRequiredSecurityLevel      = 'Unavailable'
@@ -75,8 +82,41 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     PasswordPreviousPasswordCountToBlock               = 10
                     StorageRequireEncryption                           = $True
                     SecurityRequireIntuneAppIntegrity                  = $True
+                    MinAndroidSecurityPatchLevel                       = '2024-01-24'
+                    SecurityRequiredAndroidSafetyNetEvaluationType     = 'hardwareBacked'
                     Ensure                                             = 'Present'
-                    Credential                                         = $Credential
+                    Credential                                         = $Credential   
+                    ScheduledActionsForRule = [CimInstance[]]@(
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'block'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'pushNotification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'remoteLock'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'Notification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                                } -ClientOnly)
+                        )                 
                 }
 
                 Mock -CommandName Get-MgBetaDeviceManagementDeviceCompliancePolicy -MockWith {
@@ -103,6 +143,13 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     DisplayName                                        = 'Test Android Device Owner Device Compliance Policy'
                     Description                                        = 'Test Android Device Owner Device Compliance Policy Description'
+                    PasswordMinimumLetterCharacters                    = 1
+                    PasswordMinimumLowerCaseCharacters                 = 1
+                    PasswordMinimumNonLetterCharacters                 = 1
+                    PasswordMinimumNumericCharacters                   = 1
+                    PasswordMinimumSymbolCharacters                    = 1
+                    PasswordMinimumUpperCaseCharacters                 = 1
+                    RequireNoPendingSystemUpdates                      = $true
                     DeviceThreatProtectionEnabled                      = $True
                     DeviceThreatProtectionRequiredSecurityLevel        = 'Unavailable'
                     AdvancedThreatProtectionRequiredSecurityLevel      = 'Unavailable'
@@ -118,17 +165,88 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     PasswordPreviousPasswordCountToBlock               = 10
                     StorageRequireEncryption                           = $True
                     SecurityRequireIntuneAppIntegrity                  = $True
+                    minAndroidSecurityPatchLevel                       = '2024-01-24'
+                    securityRequiredAndroidSafetyNetEvaluationType     = 'hardwareBacked'
                     Ensure                                             = 'Present'
-                    Credential                                         = $Credential
-                }
+                    Credential                                         = $Credential      
+                    ScheduledActionsForRule = [CimInstance[]]@(
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'block'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'pushNotification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'remoteLock'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'Notification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                                } -ClientOnly)
+                        )                
+            }
 
-                Mock -CommandName Get-MgBetaDeviceManagementDeviceCompliancePolicy -MockWith {
-                    return @{
-                        DisplayName          = 'Test Android Device Owner Device Compliance Policy'
-                        Description          = 'Different Value'
-                        Id                   = '9c4e2ed7-706e-4874-a826-0c2778352d46'
+            Mock -CommandName Get-MgBetaDeviceManagementDeviceCompliancePolicy -MockWith {
+                return @{
+                    DisplayName          = 'Test Android Device Owner Device Compliance Policy'
+                    Description          = 'Different Value'
+                    Id                   = '9c4e2ed7-706e-4874-a826-0c2778352d46'
+                    ScheduledActionsForRule =@(
+                        @{
+                            ruleName = ''
+                            scheduledActionConfigurations = @(
+                                @{
+                                    actionType = 'block'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'pushNotification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'remoteLock'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'Notification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                }
+                            )
+                          }
+                        )
                         AdditionalProperties = @{
                             '@odata.type'                                      = '#microsoft.graph.androidDeviceOwnerCompliancePolicy'
+                            PasswordMinimumLetterCharacters                    = 1
+                            PasswordMinimumLowerCaseCharacters                 = 1
+                            PasswordMinimumNonLetterCharacters                 = 1
+                            PasswordMinimumNumericCharacters                   = 1
+                            PasswordMinimumSymbolCharacters                    = 1
+                            PasswordMinimumUpperCaseCharacters                 = 1
+                            RequireNoPendingSystemUpdates                      = $true
                             DeviceThreatProtectionEnabled                      = $True
                             DeviceThreatProtectionRequiredSecurityLevel        = 'Unavailable'
                             AdvancedThreatProtectionRequiredSecurityLevel      = 'Unavailable'
@@ -145,6 +263,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             StorageRequireEncryption                           = $True
                             SecurityRequireIntuneAppIntegrity                  = $True
                             RoleScopeTagIds                                    = '0'
+                            minAndroidSecurityPatchLevel                       = '2024-01-24'
+                            securityRequiredAndroidSafetyNetEvaluationType     = 'hardwareBacked'
                         }
                     }
                 }
@@ -169,6 +289,13 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     DisplayName                                        = 'Test Android Device Owner Device Compliance Policy'
                     Description                                        = 'Test Android Device Owner Device Compliance Policy Description'
+                    PasswordMinimumLetterCharacters                    = 1
+                    PasswordMinimumLowerCaseCharacters                 = 1
+                    PasswordMinimumNonLetterCharacters                 = 1
+                    PasswordMinimumNumericCharacters                   = 1
+                    PasswordMinimumSymbolCharacters                    = 1
+                    PasswordMinimumUpperCaseCharacters                 = 1
+                    RequireNoPendingSystemUpdates                      = $true
                     DeviceThreatProtectionEnabled                      = $True
                     DeviceThreatProtectionRequiredSecurityLevel        = 'Unavailable'
                     AdvancedThreatProtectionRequiredSecurityLevel      = 'Unavailable'
@@ -185,7 +312,40 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     StorageRequireEncryption                           = $True
                     SecurityRequireIntuneAppIntegrity                  = $True
                     Ensure                                             = 'Present'
+                    minAndroidSecurityPatchLevel                       = '2024-01-24'
+                    securityRequiredAndroidSafetyNetEvaluationType     = 'hardwareBacked'
                     Credential                                         = $Credential
+                    ScheduledActionsForRule = [CimInstance[]]@(
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'block'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'pushNotification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'remoteLock'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'Notification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                                } -ClientOnly)
+                        ) 
                 }
 
                 Mock -CommandName Get-MgBetaDeviceManagementDeviceCompliancePolicy -MockWith {
@@ -193,8 +353,46 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         DisplayName          = 'Test Android Device Owner Device Compliance Policy'
                         Description          = 'Test Android Device Owner Device Compliance Policy Description'
                         Id                   = '9c4e2ed7-706e-4874-a826-0c2778352d46'
+                        ScheduledActionsForRule =@(
+                            @{
+                                ruleName = ''
+                                scheduledActionConfigurations = @(
+                                    @{
+                                        actionType = 'block'
+                                        gracePeriodHours = 0
+                                        notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                        notificationMessageCCList = @()
+                                    },
+                                    @{
+                                        actionType = 'pushNotification'
+                                        gracePeriodHours = 0
+                                        notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                        notificationMessageCCList = @()
+                                    },
+                                    @{
+                                        actionType = 'remoteLock'
+                                        gracePeriodHours = 0
+                                        notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                        notificationMessageCCList = @()
+                                    },
+                                    @{
+                                        actionType = 'Notification'
+                                        gracePeriodHours = 0
+                                        notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                        notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                    }
+                                )
+                              }
+                            )
                         AdditionalProperties = @{
                             '@odata.type'                                      = '#microsoft.graph.androidDeviceOwnerCompliancePolicy'
+                            PasswordMinimumLetterCharacters                    = 1
+                            PasswordMinimumLowerCaseCharacters                 = 1
+                            PasswordMinimumNonLetterCharacters                 = 1
+                            PasswordMinimumNumericCharacters                   = 1
+                            PasswordMinimumSymbolCharacters                    = 1
+                            PasswordMinimumUpperCaseCharacters                 = 1
+                            RequireNoPendingSystemUpdates                      = $true
                             DeviceThreatProtectionEnabled                      = $True
                             DeviceThreatProtectionRequiredSecurityLevel        = 'Unavailable'
                             AdvancedThreatProtectionRequiredSecurityLevel      = 'Unavailable'
@@ -211,6 +409,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             StorageRequireEncryption                           = $True
                             SecurityRequireIntuneAppIntegrity                  = $True
                             RoleScopeTagIds                                    = '0'
+                            minAndroidSecurityPatchLevel                       = '2024-01-24'
+                            securityRequiredAndroidSafetyNetEvaluationType     = 'hardwareBacked'
                         }
                     }
                 }
@@ -234,8 +434,46 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         DisplayName          = 'Test Android Device Owner Device Compliance Policy'
                         Description          = 'Test Android Device Owner Device Compliance Policy Description'
                         Id                   = '9c4e2ed7-706e-4874-a826-0c2778352d46'
+                        ScheduledActionsForRule =@(
+                        @{
+                            ruleName = ''
+                            scheduledActionConfigurations = @(
+                                @{
+                                    actionType = 'block'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'pushNotification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'remoteLock'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'Notification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                }
+                            )
+                          }
+                        )
                         AdditionalProperties = @{
                             '@odata.type'                                      = '#microsoft.graph.androidDeviceOwnerCompliancePolicy'
+                            PasswordMinimumLetterCharacters                    = 1
+                            PasswordMinimumLowerCaseCharacters                 = 1
+                            PasswordMinimumNonLetterCharacters                 = 1
+                            PasswordMinimumNumericCharacters                   = 1
+                            PasswordMinimumSymbolCharacters                    = 1
+                            PasswordMinimumUpperCaseCharacters                 = 1
+                            RequireNoPendingSystemUpdates                      = $true
                             DeviceThreatProtectionEnabled                      = $True
                             DeviceThreatProtectionRequiredSecurityLevel        = 'Unavailable'
                             AdvancedThreatProtectionRequiredSecurityLevel      = 'Unavailable'
@@ -252,6 +490,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             StorageRequireEncryption                           = $True
                             SecurityRequireIntuneAppIntegrity                  = $True
                             RoleScopeTagIds                                    = '0'
+                            minAndroidSecurityPatchLevel                       = '2024-01-24'
+                            securityRequiredAndroidSafetyNetEvaluationType     = 'hardwareBacked'
                         }
                     }
                 }
@@ -284,8 +524,46 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         DisplayName          = 'Test Android Device Owner Device Compliance Policy'
                         Description          = 'Test Android Device Owner Device Compliance Policy Description'
                         Id                   = '9c4e2ed7-706e-4874-a826-0c2778352d46'
+                        ScheduledActionsForRule =@(
+                        @{
+                            ruleName = ''
+                            scheduledActionConfigurations = @(
+                                @{
+                                    actionType = 'block'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'pushNotification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'remoteLock'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'Notification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                }
+                            )
+                          }
+                        )
                         AdditionalProperties = @{
                             '@odata.type'                                      = '#microsoft.graph.androidDeviceOwnerCompliancePolicy'
+                            PasswordMinimumLetterCharacters                    = 1
+                            PasswordMinimumLowerCaseCharacters                 = 1
+                            PasswordMinimumNonLetterCharacters                 = 1
+                            PasswordMinimumNumericCharacters                   = 1
+                            PasswordMinimumSymbolCharacters                    = 1
+                            PasswordMinimumUpperCaseCharacters                 = 1
+                            RequireNoPendingSystemUpdates                      = $true
                             DeviceThreatProtectionEnabled                      = $True
                             DeviceThreatProtectionRequiredSecurityLevel        = 'Unavailable'
                             AdvancedThreatProtectionRequiredSecurityLevel      = 'Unavailable'
@@ -302,6 +580,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             StorageRequireEncryption                           = $True
                             SecurityRequireIntuneAppIntegrity                  = $True
                             RoleScopeTagIds                                    = '0'
+                            minAndroidSecurityPatchLevel                       = '2024-01-24'
+                            securityRequiredAndroidSafetyNetEvaluationType     = 'hardwareBacked'
                         }
                     }
                 }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceCompliancePolicyAndroidWorkProfile.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceCompliancePolicyAndroidWorkProfile.Tests.ps1
@@ -82,8 +82,49 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     SecurityRequireGooglePlayServices                  = $True
                     SecurityRequireUpToDateSecurityProviders           = $True
                     SecurityRequireCompanyPortalAppIntegrity           = $True
+                    MinAndroidSecurityPatchLevel                       = "2024-01-01";
+                    RequiredPasswordComplexity                         = "medium";
+                    SecurityRequiredAndroidSafetyNetEvaluationType     = "hardwareBacked"
+                    WorkProfileInactiveBeforeScreenLockInMinutes       = 480
+                    WorkProfilePasswordExpirationInDays                = 30
+                    WorkProfilePasswordMinimumLength                   = 12
+                    WorkProfilePasswordRequiredType                    = "atLeastNumeric"
+                    WorkProfilePreviousPasswordBlockCount              = 5
+                    WorkProfileRequiredPasswordComplexity              = "high"
+                    WorkProfileRequirePassword                         = $True
                     Ensure                                             = 'Present'
                     Credential                                         = $Credential
+                    ScheduledActionsForRule = [CimInstance[]]@(
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'block'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'pushNotification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'remoteLock'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'Notification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                                } -ClientOnly)
+                        )   
                 }
 
                 Mock -CommandName Get-MgBetaDeviceManagementDeviceCompliancePolicy -MockWith {
@@ -132,21 +173,96 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     SecurityRequireGooglePlayServices                  = $True
                     SecurityRequireUpToDateSecurityProviders           = $True
                     SecurityRequireCompanyPortalAppIntegrity           = $True
+                    MinAndroidSecurityPatchLevel                       = "2024-01-01";
+                    SecurityRequiredAndroidSafetyNetEvaluationType     = "hardwareBacked"
+                    WorkProfileInactiveBeforeScreenLockInMinutes       = 480
+                    WorkProfilePasswordExpirationInDays                = 30
+                    WorkProfilePasswordMinimumLength                   = 12
+                    WorkProfilePasswordRequiredType                    = "atLeastNumeric"
+                    WorkProfilePreviousPasswordBlockCount              = 5
+                    WorkProfileRequiredPasswordComplexity              = "high"
+                    WorkProfileRequirePassword                         = $True
                     Ensure                                             = 'Present'
                     Credential                                         = $Credential
+                    RequiredPasswordComplexity                         = 'low'
+                    SecurityBlockDeviceAdministratorManagedDevices     = $true
+                    RestrictedApps                                     = @('App1', 'App2', 'App3')
+                    ScheduledActionsForRule = [CimInstance[]]@(
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'block'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'pushNotification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'remoteLock'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'Notification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                                } -ClientOnly)
+                        )   
+
                 }
 
                 Mock -CommandName Get-MgBetaDeviceManagementDeviceCompliancePolicy -MockWith {
                     return @{
-                        DisplayName          = 'Test Android Work Profile Device Compliance Policy'
-                        Description          = 'Test Android Work Profile Device Compliance Policy Description'
-                        Id                   = '9c4e2ed7-706e-4874-a826-0c2778352d47'
+                        DisplayName                                    = 'Test Android Work Profile Device Compliance Policy'
+                        Description                                    = 'Test Android Work Profile Device Compliance Policy Description'
+                        Id                                             = '9c4e2ed7-706e-4874-a826-0c2778352d47'
+                        ScheduledActionsForRule =@(
+                        @{
+                            ruleName = ''
+                            scheduledActionConfigurations = @(
+                                @{
+                                    actionType = 'block'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'pushNotification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'remoteLock'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'Notification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                }
+                            )
+                          }
+                        )
                         AdditionalProperties = @{
                             '@odata.type'                                      = '#microsoft.graph.androidWorkProfileCompliancePolicy'
                             PasswordRequired                                   = $True
                             PasswordMinimumLength                              = 6
                             PasswordRequiredType                               = 'DeviceDefault'
-                            RequiredPasswordComplexity                         = 'None'
+                            RequiredPasswordComplexity                         = 'low'
                             PasswordMinutesOfInactivityBeforeLock              = 5
                             PasswordExpirationDays                             = 365
                             PasswordPreviousPasswordBlockCount                 = 10
@@ -167,6 +283,17 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             SecurityRequireUpToDateSecurityProviders           = $True
                             SecurityRequireCompanyPortalAppIntegrity           = $True
                             RoleScopeTagIds                                    = '0'
+                            MinAndroidSecurityPatchLevel                       = "2024-01-01";
+                            SecurityRequiredAndroidSafetyNetEvaluationType     = "hardwareBacked"
+                            WorkProfileInactiveBeforeScreenLockInMinutes       = 480
+                            WorkProfilePasswordExpirationInDays                = 30
+                            WorkProfilePasswordMinimumLength                   = 12
+                            WorkProfilePasswordRequiredType                    = "atLeastNumeric"
+                            WorkProfilePreviousPasswordBlockCount              = 5
+                            WorkProfileRequiredPasswordComplexity              = "high"
+                            WorkProfileRequirePassword                         = $True
+                            SecurityBlockDeviceAdministratorManagedDevices     = $true
+                            RestrictedApps                                     = @('App1', 'App2', 'App3')
                         }
                     }
                 }
@@ -212,22 +339,96 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     SecurityRequireSafetyNetAttestationCertifiedDevice = $True
                     SecurityRequireGooglePlayServices                  = $True
                     SecurityRequireUpToDateSecurityProviders           = $True
-                    SecurityRequireCompanyPortalAppIntegrity           = $True
+                    SecurityRequireCompanyPortalAppIntegrity           = $True                   
+                    MinAndroidSecurityPatchLevel                       = "2024-01-01";
+                    SecurityRequiredAndroidSafetyNetEvaluationType     = "hardwareBacked"
+                    WorkProfileInactiveBeforeScreenLockInMinutes       = 480
+                    WorkProfilePasswordExpirationInDays                = 30
+                    WorkProfilePasswordMinimumLength                   = 12
+                    WorkProfilePasswordRequiredType                    = "atLeastNumeric"
+                    WorkProfilePreviousPasswordBlockCount              = 5
+                    WorkProfileRequiredPasswordComplexity              = "high"
+                    WorkProfileRequirePassword                         = $True
                     Ensure                                             = 'Present'
                     Credential                                         = $Credential
+                    RequiredPasswordComplexity                         = 'low'
+                    SecurityBlockDeviceAdministratorManagedDevices     = $true
+                    RestrictedApps                                     = @('App1', 'App2', 'App3')
+                    ScheduledActionsForRule = [CimInstance[]]@(
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'block'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'pushNotification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'remoteLock'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'Notification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                                } -ClientOnly)
+                        )   
                 }
 
                 Mock -CommandName Get-MgBetaDeviceManagementDeviceCompliancePolicy -MockWith {
                     return @{
-                        DisplayName          = 'Test Android Work Profile Device Compliance Policy'
-                        Description          = 'Test Android Work Profile Device Compliance Policy Description'
-                        Id                   = '9c4e2ed7-706e-4874-a826-0c2778352d46'
+                        DisplayName                                    = 'Test Android Work Profile Device Compliance Policy'
+                        Description                                    = 'Test Android Work Profile Device Compliance Policy Description'
+                        Id                                             = '9c4e2ed7-706e-4874-a826-0c2778352d46'                       
+                        ScheduledActionsForRule =@(
+                        @{
+                            ruleName = ''
+                            scheduledActionConfigurations = @(
+                                @{
+                                    actionType = 'block'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'pushNotification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'remoteLock'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'Notification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                }
+                            )
+                          }
+                        )
                         AdditionalProperties = @{
                             '@odata.type'                                      = '#microsoft.graph.androidWorkProfileCompliancePolicy'
                             PasswordRequired                                   = $True
                             PasswordMinimumLength                              = 6
                             PasswordRequiredType                               = 'DeviceDefault'
-                            RequiredPasswordComplexity                         = 'None'
+                            RequiredPasswordComplexity                         = 'low'
                             PasswordMinutesOfInactivityBeforeLock              = 5
                             PasswordExpirationDays                             = 365
                             PasswordPreviousPasswordBlockCount                 = 10
@@ -248,6 +449,17 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             SecurityRequireUpToDateSecurityProviders           = $True
                             SecurityRequireCompanyPortalAppIntegrity           = $True
                             RoleScopeTagIds                                    = '0'
+                            MinAndroidSecurityPatchLevel                       = "2024-01-01";
+                            SecurityRequiredAndroidSafetyNetEvaluationType     = "hardwareBacked"
+                            WorkProfileInactiveBeforeScreenLockInMinutes       = 480
+                            WorkProfilePasswordExpirationInDays                = 30
+                            WorkProfilePasswordMinimumLength                   = 12
+                            WorkProfilePasswordRequiredType                    = "atLeastNumeric"
+                            WorkProfilePreviousPasswordBlockCount              = 5
+                            WorkProfileRequiredPasswordComplexity              = "high"
+                            WorkProfileRequirePassword                         = $True
+                            SecurityBlockDeviceAdministratorManagedDevices     = $true
+                            RestrictedApps                                     = @('App1', 'App2', 'App3')
                         }
                     }
                 }
@@ -287,19 +499,84 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     SecurityRequireCompanyPortalAppIntegrity           = $True
                     Ensure                                             = 'Absent'
                     Credential                                         = $Credential
+                    RequiredPasswordComplexity                         = 'low'
+                    SecurityBlockDeviceAdministratorManagedDevices     = $true
+                    RestrictedApps                                     = @('App1', 'App2', 'App3')
+                    ScheduledActionsForRule = [CimInstance[]]@(
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'block'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'pushNotification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'remoteLock'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                } -ClientOnly)
+                                                (New-CimInstance `
+                                                -ClassName MSFT_scheduledActionConfigurations `
+                                                -Property @{
+                                                    actionType = 'Notification'
+                                                    gracePeriodHours = 0
+                                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                                } -ClientOnly)
+                        )   
                 }
 
                 Mock -CommandName Get-MgBetaDeviceManagementDeviceCompliancePolicy -MockWith {
                     return @{
-                        DisplayName          = 'Test Android Work Profile Device Compliance Policy'
-                        Description          = 'Test Android Work Profile Device Compliance Policy Description'
-                        Id                   = '9c4e2ed7-706e-4874-a826-0c2778352d46'
+                        DisplayName                                    = 'Test Android Work Profile Device Compliance Policy'
+                        Description                                    = 'Test Android Work Profile Device Compliance Policy Description'
+                        Id                                             = '9c4e2ed7-706e-4874-a826-0c2778352d46'
+                        ScheduledActionsForRule =@(
+                        @{
+                            ruleName = ''
+                            scheduledActionConfigurations = @(
+                                @{
+                                    actionType = 'block'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'pushNotification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'remoteLock'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'Notification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                }
+                            )
+                          }
+                        )
                         AdditionalProperties = @{
                             '@odata.type'                                      = '#microsoft.graph.androidWorkProfileCompliancePolicy'
                             PasswordRequired                                   = $True
                             PasswordMinimumLength                              = 6
                             PasswordRequiredType                               = 'DeviceDefault'
-                            RequiredPasswordComplexity                         = 'None'
+                            RequiredPasswordComplexity                         = 'low'
                             PasswordMinutesOfInactivityBeforeLock              = 5
                             PasswordExpirationDays                             = 365
                             PasswordPreviousPasswordBlockCount                 = 10
@@ -320,6 +597,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             SecurityRequireUpToDateSecurityProviders           = $True
                             SecurityRequireCompanyPortalAppIntegrity           = $True
                             RoleScopeTagIds                                    = '0'
+                            SecurityBlockDeviceAdministratorManagedDevices     = $true
+                            RestrictedApps                                     = @('App1', 'App2', 'App3')
                         }
                     }
                 }
@@ -349,15 +628,46 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
                 Mock -CommandName Get-MgBetaDeviceManagementDeviceCompliancePolicy -MockWith {
                     return @{
-                        DisplayName          = 'Test Android Device Compliance Policy'
-                        Description          = 'Test Android Device Compliance Policy Description'
-                        Id                   = '9c4e2ed7-706e-4874-a826-0c2778352d46'
+                        DisplayName                                    = 'Test Android Device Compliance Policy'
+                        Description                                    = 'Test Android Device Compliance Policy Description'
+                        Id                                             = '9c4e2ed7-706e-4874-a826-0c2778352d46'
+                        ScheduledActionsForRule =@(
+                        @{
+                            ruleName = ''
+                            scheduledActionConfigurations = @(
+                                @{
+                                    actionType = 'block'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'pushNotification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'remoteLock'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @()
+                                },
+                                @{
+                                    actionType = 'Notification'
+                                    gracePeriodHours = 0
+                                    notificationTemplateId = '00000000-0000-0000-0000-000000000000'
+                                    notificationMessageCCList = @('00000000-0000-0000-0000-000000000000','00000000-0000-0000-0000-000000000000')
+                                }
+                            )
+                          }
+                        )
                         AdditionalProperties = @{
                             '@odata.type'                                      = '#microsoft.graph.androidWorkProfileCompliancePolicy'
                             PasswordRequired                                   = $True
                             PasswordMinimumLength                              = 6
                             PasswordRequiredType                               = 'DeviceDefault'
-                            RequiredPasswordComplexity                         = 'None'
+                            RequiredPasswordComplexity                         = 'low'
                             PasswordMinutesOfInactivityBeforeLock              = 5
                             PasswordExpirationDays                             = 365
                             PasswordPreviousPasswordBlockCount                 = 10
@@ -377,6 +687,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             SecurityRequireGooglePlayServices                  = $True
                             SecurityRequireUpToDateSecurityProviders           = $True
                             SecurityRequireCompanyPortalAppIntegrity           = $True
+                            SecurityBlockDeviceAdministratorManagedDevices     = $true
+                            RestrictedApps                                     = @('App1', 'App2', 'App3')
                         }
                     }
                 }


### PR DESCRIPTION
Fix for #5592 & #5593 - Updated IntuneDeviceCompliancePolicyAndroidDeviceOwner & WorkProfile



#### Pull Request (PR) description
* IntuneDeviceCompliancePolicyAndroidDeviceOwner Added missing properties for androidForWorkCompliancePolicy resource type: https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceconfig-androiddeviceownercompliancepolicy?view=graph-rest-beta. Non-compliance/scheduled actions now supported

* IntuneDeviceCompliancePolicyAndroidWorkProfile Added missing properties for androidForWorkCompliancePolicy resource type: https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceconfig-androidforworkcompliancepolicy?view=graph-rest-beta. Non-compliance/scheduled actions now supported
* 
#### This Pull Request (PR) fixes the following issues

    - Fixes #5593 
    - Fixes #5592 


#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
