### PR TITLE
Multiple Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,45 @@
 
 # UNRELEASED
 
+* AADApplication
+  * Test-TargetResource logic updated to skip evaluating CIMArrays that are empty
+    when passed as desired values.
+* AADDeviceRegistrationPolicy
+  * Fixed an issue where the AzureADJoinIsAdminConfigurable was not returned by the
+    Get-TargetResource function.
+* AADGroup
+  * Returns an empty array for roles and licenses from the Get-TargetResource
+    function instead of null when no instances are found.
 * AADRoleEligibilityScheduleRequest
   * Reduce call count when reconciling object type
     FIXES [#5621](https://github.com/microsoft/Microsoft365DSC/issues/5621)
+* AADServicePrincipal
+  * Evaluating assigned users based on UPN and not just on DisplayName.
 * ADOSecurityPolicy
   * Fixes an issue where the resource threw an error trying to parse the default
     values.
+* EXODistributionGroup
+  * Changed logic to retrieve existing members by UserPrincipalName.
+* EXORoleGroup
+  * Evaluating assigned users based on UPN and not just on DisplayName if they
+    have an associated mailbox.
+* IntuneDeviceManagementEnrollmentAndroidGooglePlay
+  * Marked the Id property as mandatory in the resource.
+* M365DSCRuleEvaluation
+  * Added support for specifying a Filter property.
 * M365DSCUtil
   * Add M365DSC prefix to `Remove-EmptyValue`.
   * Fixes an issue with `Credential` property being escaped and indentation.
   * Adds the possibility to allow variables in strings and no authentication
     results update during conversion to final export.
     FIXES [#3861](https://github.com/microsoft/Microsoft365DSC/issues/3861)
+* SCInsiderRiskPolicy
+  * Enforces the MDATPTriageStatus to be a string array.
 * SCSensitivityLabel
   * Fixes invalid accepted content type values.
 * TeamsAppPermissionPolicy
-  * Updated correct Typecasting for AppPresetMeeting and PinnedMessagebarApps before adding them to the policy
+  * Updated correct Typecasting for AppPresetMeeting and PinnedMessagebarApps
+    before adding them to the policy
 * TeamsAppSetupPolicy
   * FIXES [[#5752](https://github.com/microsoft/Microsoft365DSC/issues/5752)
 * TeamsM365App
@@ -48,7 +71,6 @@
 * EXOSmtpDaneInbound
   * Updated authentication properties to align with MOF definition.
     FIXES [#5709](https://github.com/microsoft/Microsoft365DSC/issues/5709)
-
 * MISC
   * PowerPlatform resource revamp to use direct REST API calls.
   * Simplify export behavior for all resources and complex objects.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -1425,14 +1425,21 @@ function Test-TargetResource
         $target = $CurrentValues.$key
         if ($null -ne $source -and $source.GetType().Name -like '*CimInstance*')
         {
-            $testResult = Compare-M365DSCComplexObject `
-                -Source ($source) `
-                -Target ($target)
-
-            if (-not $testResult)
+            if (-not ($source.GetType().Name -eq 'CimInstance[]' -and $source.Count -eq 0))
             {
-                Write-Verbose "TestResult returned False for $source"
-                $testTargetResource = $false
+                $testResult = Compare-M365DSCComplexObject `
+                    -Source ($source) `
+                    -Target ($target)
+
+                if (-not $testResult)
+                {
+                    Write-Verbose "TestResult returned False for $source"
+                    $testTargetResource = $false
+                }
+                else
+                {
+                    $ValuesToCheck.Remove($key) | Out-Null
+                }
             }
             else
             {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADDeviceRegistrationPolicy/MSFT_AADDeviceRegistrationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADDeviceRegistrationPolicy/MSFT_AADDeviceRegistrationPolicy.psm1
@@ -215,6 +215,7 @@ function Get-TargetResource
         }
         $results = @{
             IsSingleInstance                        = 'Yes'
+            AzureADJoinIsAdminConfigurable          = [Boolean]$getValue.AzureAdJoin.IsAdminConfigurable
             AzureADAllowedToJoin                    = $AzureADAllowedToJoin
             AzureADAllowedToJoinGroups              = $AzureADAllowedToJoinGroups
             AzureADAllowedToJoinUsers               = $AzureADAllowedToJoinUsers

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -245,7 +245,7 @@ function Get-TargetResource
         }
 
         # AssignedToRole
-        $AssignedToRoleValues = $null
+        $AssignedToRoleValues = @()
         if ($Group.IsAssignableToRole -eq $true)
         {
             $AssignedToRoleValues = @()
@@ -258,7 +258,7 @@ function Get-TargetResource
         }
 
         # Licenses
-        $assignedLicensesValues = $null
+        $assignedLicensesValues = @()
         $uri = (Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl + "v1.0/groups/$($Group.Id)/assignedLicenses"
         $assignedLicensesRequest = Invoke-MgGraphRequest -Method 'GET' `
             -Uri $uri

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
@@ -175,14 +175,12 @@ function Get-TargetResource
                     $appInstance = Get-MgApplication -Filter "DisplayName eq '$AppId'"
                     if ($appInstance)
                     {
-                        $AADServicePrincipal = Get-MgServicePrincipal -Filter "AppID eq '$($appInstance.AppId)'" `
-                            -Expand 'AppRoleAssignedTo'
+                        $AADServicePrincipal = Get-MgServicePrincipal -Filter "AppID eq '$($appInstance.AppId)'"
                     }
                 }
                 else
                 {
-                    $AADServicePrincipal = Get-MgServicePrincipal -Filter "AppID eq '$($AppId)'" `
-                        -Expand 'AppRoleAssignedTo'
+                    $AADServicePrincipal = Get-MgServicePrincipal -Filter "AppID eq '$($AppId)'"
                 }
             }
             if ($null -eq $AADServicePrincipal)
@@ -196,7 +194,8 @@ function Get-TargetResource
         }
 
         $AppRoleAssignedToValues = @()
-        foreach ($principal in $AADServicePrincipal.AppRoleAssignedTo)
+        $assignmentsValue = Get-MgServicePrincipalAppROleAssignedTo -ServicePrincipalId $AADServicePrincipal.Id -ErrorAction SilentlyContinue
+        foreach ($principal in $assignmentsValue)
         {
             $currentAssignment = @{
                 PrincipalType = $null
@@ -206,7 +205,7 @@ function Get-TargetResource
             {
                 $user = Get-MgUser -UserId $principal.PrincipalId
                 $currentAssignment.PrincipalType = 'User'
-                $currentAssignment.Identity = $user.UserPrincipalName.Split('@')[0]
+                $currentAssignment.Identity = $user.UserPrincipalName
                 $AppRoleAssignedToValues += $currentAssignment
             }
             elseif ($principal.PrincipalType -eq 'Group')

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/MSFT_EXODistributionGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/MSFT_EXODistributionGroup.psm1
@@ -241,7 +241,7 @@ function Get-TargetResource
             $nullReturn = $PSBoundParameters
             $nullReturn.Ensure = 'Absent'
 
-            if ($null -ne $PrimarySmtpAddress)
+            if (-not [System.String]::IsNullOrEmpty($PrimarySmtpAddress))
             {
                 $distributionGroup = Get-DistributionGroup -Identity $PrimarySmtpAddress -ErrorAction Stop
             }
@@ -261,7 +261,7 @@ function Get-TargetResource
             $distributionGroup = $Script:exportedInstance
         }
 
-        if ($null -ne $PrimarySmtpAddress)
+        if (-not [System.String]::IsNullOrEmpty($PrimarySmtpAddress))
         {
             $distributionGroupMembers = Get-DistributionGroupMember -Identity $PrimarySmtpAddress `
                 -ErrorAction 'Stop' `
@@ -272,6 +272,13 @@ function Get-TargetResource
             $distributionGroupMembers = Get-DistributionGroupMember -Identity $Identity `
                     -ErrorAction 'Stop' `
                     -ResultSize 'Unlimited'
+        }
+
+        $distributionMembersValue = @()
+        foreach ($member in $distributionGroupMembers)
+        {
+            $user = Get-User -Identity $member -ErrorAction Stop
+            $distributionMembersValue += $user.UserPrincipalName
         }
 
         Write-Verbose -Message "Found existing Distribution Group {$Identity}."
@@ -331,7 +338,7 @@ function Get-TargetResource
             ManagedBy                              = $ManagedByValue
             MemberDepartRestriction                = $distributionGroup.MemberDepartRestriction
             MemberJoinRestriction                  = $distributionGroup.MemberJoinRestriction
-            Members                                = $distributionGroupMembers.Name
+            Members                                = $distributionMembersValue
             ModeratedBy                            = $ModeratedByValue
             ModerationEnabled                      = $distributionGroup.ModerationEnabled
             Name                                   = $distributionGroup.Name

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/MSFT_EXODistributionGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/MSFT_EXODistributionGroup.psm1
@@ -277,8 +277,15 @@ function Get-TargetResource
         $distributionMembersValue = @()
         foreach ($member in $distributionGroupMembers)
         {
-            $user = Get-User -Identity $member -ErrorAction Stop
-            $distributionMembersValue += $user.UserPrincipalName
+            $user = Get-User -Identity $member.DisplayName -ErrorAction SilentlyContinue
+            if ($null -ne $user)
+            {
+                $distributionMembersValue += $user.UserPrincipalName
+            }
+            else
+            {
+                $distributionMembersValue += $member.DisplayName
+            }
         }
 
         Write-Verbose -Message "Found existing Distribution Group {$Identity}."

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleGroup/MSFT_EXORoleGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleGroup/MSFT_EXORoleGroup.psm1
@@ -102,7 +102,7 @@ function Get-TargetResource
         $result = @{
             Name                  = $RoleGroup.Name
             Description           = $RoleGroup.Description
-            Members               = $roleGroupMember.DisplayName
+            Members               = $roleGroupMember.PrimarySmtpAddress
             Roles                 = $RoleGroup.Roles
             Ensure                = 'Present'
             Credential            = $Credential

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleGroup/MSFT_EXORoleGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleGroup/MSFT_EXORoleGroup.psm1
@@ -97,12 +97,24 @@ function Get-TargetResource
         }
 
         # Get RoleGroup Members DN if RoleGroup exists. This is required especially when adding Members like "Exchange Administrator" or "Global Administrator" that have different Names across Tenants
-        $roleGroupMember = Get-RoleGroupMember -Identity $Name | Select-Object DisplayName
+        $roleGroupMembers = Get-RoleGroupMember -Identity $Name | Select-Object DisplayName, RecipientTypeDetails, PrimarySmtpAddress
 
+        $roleGroupMembersValue = @()
+        foreach ($member in $roleGroupMembers)
+        {
+            if ($member.RecipientTypeDetails -eq 'UserMailbox' -and -not [System.String]::IsNullOrEmpty($member.PrimarySmtpAddress))
+            {
+                $roleGroupMembersValue += $member.PrimarySmtpAddress
+            }
+            else
+            {
+                $roleGroupMembersValue += $member.DisplayName
+            }
+        }
         $result = @{
             Name                  = $RoleGroup.Name
             Description           = $RoleGroup.Description
-            Members               = $roleGroupMember.PrimarySmtpAddress
+            Members               = $roleGroupMembersValue
             Roles                 = $RoleGroup.Roles
             Ensure                = 'Present'
             Credential            = $Credential

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay/MSFT_IntuneDeviceManagementEnrollmentAndroidGooglePlay.psm1
@@ -6,7 +6,7 @@ function Get-TargetResource
     (
         #region Intune resource parameters
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $Id,
 
@@ -70,7 +70,7 @@ function Get-TargetResource
         $AccessTokens
     )
 
-    Write-Verbose -Message "Getting configuration of the Intune Device Management Android Google Play Enrollment with Id {$Id} and DisplayName {$DisplayName}"
+    Write-Verbose -Message "Getting configuration of the Intune Device Management Android Google Play Enrollment with Id {$Id}"
 
     try
     {
@@ -152,7 +152,7 @@ function Set-TargetResource
     (
         #region Intune resource parameters
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $Id,
 
@@ -274,7 +274,7 @@ function Test-TargetResource
     (
         #region Intune resource parameters
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $Id,
 
@@ -350,7 +350,7 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    Write-Verbose -Message "Testing configuration of the Intune Device Management Android Google Play Enrollment with Id {$Id} and DisplayName {$DisplayName}"
+    Write-Verbose -Message "Testing configuration of the Intune Device Management Android Google Play Enrollment with Id {$Id}"
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
@@ -21,6 +21,10 @@ function Get-TargetResource
         $AfterRuleCountQuery,
 
         [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -71,6 +75,10 @@ function Set-TargetResource
         [Parameter()]
         [System.String]
         $AfterRuleCountQuery,
+
+        [Parameter()]
+        [System.String]
+        $Filter,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -124,6 +132,10 @@ function Test-TargetResource
         [Parameter()]
         [System.String]
         $AfterRuleCountQuery,
+
+        [Parameter()]
+        [System.String]
+        $Filter,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -182,6 +194,10 @@ function Test-TargetResource
         if ($null -ne $PSBoundParameters.AccessTokens)
         {
             $params.Add('AccessTokens', $PSBoundParameters.AccessTokens)
+        }
+        if ($null -ne $PSBoundParameters.Filter)
+        {
+            $params.Add('Filter', $Filter)
         }
 
         Write-Verbose -Message "Importing module from Path {$($module)}"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.schema.mof
@@ -5,6 +5,7 @@ class MSFT_M365DSCRuleEvaluation : OMI_BaseResource
     [Key, Description("Specify the rules to monitor the resource for.")] String RuleDefinition;
     [Write, Description("Custom display name for the rule. This will show up in the logs on drift detection.")] String RuleName;
     [Write, Description("Query to check how many instances exist, using PowerShell format")] String AfterRuleCountQuery;
+    [Write, Description("Specifies a filter for the current resource type to be evaluated. This reduces the overall set of instances the rule will be evaluated against.")] String Filter;
     [Write, Description("Credentials of the Azure Active Directory Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCInsiderRiskPolicy/MSFT_SCInsiderRiskPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCInsiderRiskPolicy/MSFT_SCInsiderRiskPolicy.psm1
@@ -807,6 +807,12 @@ function Get-TargetResource
                 $RaiseAuditAlertValue = [Boolean]::Parse($tenantSettings.FeatureSettings.RaiseAuditAlert)
             }
 
+            $MDATPTriageStatusValue = @()
+            if (-not [System.String]::IsNullOrEmpty($tenantSettings.IntelligentDetections.MDATPTriageStatus))
+            {
+                $MDATPTriageStatusValue = [Array]($tenantSettings.IntelligentDetections.MDATPTriageStatus.Replace('"', '').Replace('[', '').Replace(']', '').Split(','))
+            }
+
             $tenantSettingsHash = @{
                 Anonymization                                 = $AnonymizationValue
                 DLPUserRiskSync                               = $DLPUserRiskSyncValue
@@ -814,7 +820,7 @@ function Get-TargetResource
                 RaiseAuditAlert                               = $RaiseAuditAlertValue
                 FileVolCutoffLimits                           = $tenantSettings.IntelligentDetections.FileVolCutoffLimits
                 AlertVolume                                   = $tenantSettings.IntelligentDetections.AlertVolume
-                MDATPTriageStatus                             = $tenantSettings.IntelligentDetections.MDATPTriageStatus
+                MDATPTriageStatus                             = $MDATPTriageStatusValue
                 AnomalyDetections                             = ($tenantSettings.Indicators | Where-Object -FilterScript { $_.Name -eq 'AnomalyDetections' }).Enabled
                 CopyToPersonalCloud                           = ($tenantSettings.Indicators | Where-Object -FilterScript { $_.Name -eq 'CopyToPersonalCloud' }).Enabled
                 CopyToUSB                                     = ($tenantSettings.Indicators | Where-Object -FilterScript { $_.Name -eq 'CopyToUSB' }).Enabled
@@ -1843,8 +1849,18 @@ function Set-TargetResource
     }
 
     # Tenant Settings
+    $MDATPTriageStatusValue = "["
+    foreach ($status in $MDATPTriageStatus)
+    {
+        $MDATPTriageStatusValue += "\`"$($status)\`","
+    }
+    if ($MDATPTriageStatusValue.EndsWith(','))
+    {
+        $MDATPTriageStatusValue = $MDATPTriageStatusValue.Substring(0, $MDATPTriageStatusValue.Length -1)
+    }
+    $MDATPTriageStatusValue += "]"
     $featureSettingsValue = "{`"Anonymization`":$($Anonymization.ToString().ToLower()), `"DLPUserRiskSync`":$($DLPUserRiskSync.ToString().ToLower()), `"OptInIRMDataExport`":$($OptInIRMDataExport.ToString().ToLower()), `"RaiseAuditAlert`":$($RaiseAuditAlert.ToString().ToLower()), `"EnableTeam`":$($EnableTeam.ToString().ToLower())}"
-    $intelligentDetectionValue = "{`"FileVolCutoffLimits`":`"$($FileVolCutoffLimits)`", `"AlertVolume`":`"$($AlertVolume)`", `"MDATPTriageStatus`": `"$($MDATPTriageStatus)`"}"
+    $intelligentDetectionValue = "{`"FileVolCutoffLimits`":`"$($FileVolCutoffLimits)`", `"AlertVolume`":`"$($AlertVolume)`", `"MDATPTriageStatus`": `"$($MDATPTriageStatusValue)`"}"
 
 
     $tenantSettingsValue = "{`"Region`":`"WW`", `"FeatureSettings`":$($featureSettingsValue), " + `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCInsiderRiskPolicy/MSFT_SCInsiderRiskPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCInsiderRiskPolicy/MSFT_SCInsiderRiskPolicy.schema.mof
@@ -171,7 +171,7 @@ class MSFT_SCInsiderRiskPolicy : OMI_BaseResource
     [Write, Description("Official documentation to come.")] UInt32 ProfileInScopeTimeSpan;
     [Write, Description("Official documentation to come.")] UInt32 GPUUtilizationLimit;
     [Write, Description("Official documentation to come.")] UInt32 CPUUtilizationLimit;
-    [Write, Description("Official documentation to come.")] String MDATPTriageStatus;
+    [Write, Description("Official documentation to come.")] String MDATPTriageStatus[];
     [Write, Description("Present ensures the instance exists, absent ensures it is removed."), ValueMap{"Absent","Present"}, Values{"Absent","Present"}] string Ensure;
     [Write, Description("Credentials of the workload's Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -853,7 +853,7 @@ function Compare-M365DSCComplexObject
                         }
 
                         $compareResult = $true
-                        $ordinalComparison = [System.String]::Equals($referenceObject, $differenceObject, [System.StringComparison]::Ordinal)
+                        $ordinalComparison = [System.String]::Equals($referenceObject, $differenceObject, [System.StringComparison]::OrdinalIgnoreCase)
                         if (-not $ordinalComparison)
                         {
                             $compareResult = $false

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.PPDLPPolicyConnectorConfigurations.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.PPDLPPolicyConnectorConfigurations.Tests.ps1
@@ -259,7 +259,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             connectorActionConfigurations = @(
                                 @{
                                     connectorId = '/providers/Microsoft.PowerApps/apis/shared_aadinvitationmanager'
-                                    defaultConnectorActionRuleBehavior = 'Allow'
+                                    defaultConnectorActionRuleBehavior = 'Deny' #Drift
                                     actionRules = @(
                                         @{
                                             actionId = "CreateInvitation"


### PR DESCRIPTION
#### Pull Request (PR) description
* AADApplication
  * Test-TargetResource logic updated to skip evaluating CIMArrays that are empty
    when passed as desired values.
* AADDeviceRegistrationPolicy
  * Fixed an issue where the AzureADJoinIsAdminConfigurable was not returned by the
    Get-TargetResource function.
* AADGroup
  * Returns an empty array for roles and licenses from the Get-TargetResource
    function instead of null when no instances are found.
* AADServicePrincipal
  * Evaluating assigned users based on UPN and not just on DisplayName.
* EXODistributionGroup
  * Changed logic to retrieve existing members by UserPrincipalName.
* EXORoleGroup
  * Evaluating assigned users based on UPN and not just on DisplayName if they
    have an associated mailbox.
* IntuneDeviceManagementEnrollmentAndroidGooglePlay
  * Marked the Id property as mandatory in the resource.
* M365DSCRuleEvaluation
  * Added support for specifying a Filter property.
* SCInsiderRiskPolicy
  * Enforces the MDATPTriageStatus to be a string array.

#### This Pull Request (PR) fixes the following issues
* N/A