### PR TITLE
IMPORTANT - Revert Microsoft.Graph module version to 2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* DEPENDENCIES
+  * Revert Microsoft.Graph modules version back to 2.25.0
+
 # 1.25.219.1
 
 * AADAccessReviewPolicy

--- a/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
+++ b/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
@@ -26,91 +26,91 @@
         },
         @{
             ModuleName      = 'Microsoft.Graph.Applications'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Applications'
-            Requiredversion = '2.26.0'
+            Requiredversion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Authentication'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.DeviceManagement'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Devices.CorporateManagement'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.DeviceManagement.Administration'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.DeviceManagement.Enrollment'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.NetworkAccess'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Identity.DirectoryManagement'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Identity.Governance'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Identity.SignIns'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Reports'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Search'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Teams'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.DeviceManagement.Administration'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.DirectoryObjects'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Groups'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Groups'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Planner'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Sites'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Users'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Users.Actions'
-            RequiredVersion = '2.26.0'
+            RequiredVersion = '2.25.0'
         },
         @{
             ModuleName      = 'MicrosoftTeams'


### PR DESCRIPTION
#### Pull Request (PR) description
This PR reverts the version upgrade of the Microsoft.Graph modules back to 2.25.0. Many commands in the Microsoft.Graph.Beta.Devices.CorporateManagement were removed from 2.25.0 to 2.26.0, resulting in the Intune workflow to break on multiple resources. 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
