### PR TITLE
Apply ordering during export for Get-Team cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* TeamsChannel
+  * Apply ordering during export.
+    FIXES [#5829](https://github.com/microsoft/Microsoft365DSC/issues/5829)
+* TeamsTeam
+  * Apply ordering during export.
+* TeamsUser
+  * Apply ordering during export.
+
+
 # 1.25.219.3
 
 * AADApplication

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannel/MSFT_TeamsChannel.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsChannel/MSFT_TeamsChannel.psm1
@@ -415,7 +415,7 @@ function Export-TargetResource
 
     try
     {
-        $teams = Get-Team -ErrorAction Stop
+        $teams = Get-Team -ErrorAction Stop | Sort-Object -Property GroupId
         $j = 1
         $dscContent = ''
         Write-Host "`r`n" -NoNewline

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -725,7 +725,7 @@ function Export-TargetResource
             $organization = $Credential.UserName.Split('@')[1]
         }
 
-        $teams = Get-Team
+        $teams = Get-Team | Sort-Object -Property GroupId
         $i = 1
         $dscContent = ''
         Write-Host "`r`n" -NoNewline

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
@@ -349,7 +349,7 @@ function Export-TargetResource
 
     try
     {
-        [array]$instances = Get-Team
+        [array]$instances = Get-Team | Sort-Object -Property GroupId
         if ($instances.Length -eq 0)
         {
             Write-Host $Global:M365DSCEmojiGreenCheckMark


### PR DESCRIPTION
#### Pull Request (PR) description
This PR applies ordering by GroupId of the `Get-Team` cmdlet during export.

#### This Pull Request (PR) fixes the following issues
- Fixes #5829 

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
