### PR TITLE
Release 1.25.226.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   * Apply ordering during export.
 * TeamsUser
   * Apply ordering during export.
+* DEPENDENCIES
+  * Updated MSCloudLoginAssistant to version 1.1.39.
 
 # 1.25.219.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * IntuneDeviceCompliancePolicyWindows10
   * Fixes the handling of the `DeviceCompliancePolicyScript` property.
     FIXES [#5510](https://github.com/microsoft/Microsoft365DSC/issues/5510)
+* O365OrgSettings
+  * Added support for the AllowPlannerCopilot setting.
 * PPTenantSettings
   * Corrected issue in the resource schema. The description was a multi-line
     string, which is not allowed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Change log for Microsoft365DSC
 
-# UNRELEASED
+# 1.25.226.1
 
 * AADConditionalAccessPolicy
-  * Fixed an issue where `TermsOfUse` was not passed as an array, causing failures in GCC-High environments.  
+  * Fixed an issue where `TermsOfUse` was not passed as an array, causing failures in GCC-High environments.
     FIXES [#5742](https://github.com/microsoft/Microsoft365DSC/issues/5742)
+  * Added verbose to the Get-TargetResource function to print out the retrieved
+    policies from calling the cmdlet.
 * AADPasswordRuleSettings
   * Updated schema to only accept values 'Enforced' and 'Audit' for parameter BannedPasswordCheckOnPremisesMode
 * IntuneDeviceCompliancePolicyWindows10
-  * Fixes the handling of the `DeviceCompliancePolicyScript` property. 
+  * Fixes the handling of the `DeviceCompliancePolicyScript` property.
     FIXES [#5510](https://github.com/microsoft/Microsoft365DSC/issues/5510)
 * PPTenantSettings
   * Corrected issue in the resource schema. The description was a multi-line

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -287,11 +287,16 @@ function Get-TargetResource
             try
             {
                 $Policy = Get-MgBetaIdentityConditionalAccessPolicy -ConditionalAccessPolicyId $Id -ErrorAction Stop
+                $jsonPolicy = ConvertTo-Json $Policy -ErrorAction SilentlyContinue
+                Write-Verbose -Message "Retrieved policy:`r`n$($jsonPolicy)"
             }
             catch
             {
                 Write-Verbose -Message "Couldn't find existing policy by ID {$Id}"
                 $Policy = Get-MgBetaIdentityConditionalAccessPolicy -Filter "DisplayName eq '$DisplayName'"
+                $jsonPolicy = ConvertTo-Json $Policy -ErrorAction SilentlyContinue
+                Write-Verbose -Message "Retrieved policy:`r`n$($jsonPolicy)"
+
                 if ($Policy.Length -gt 1)
                 {
                     throw "Duplicate CA Policies named $DisplayName exist in tenant"
@@ -303,6 +308,9 @@ function Get-TargetResource
             Write-Verbose -Message 'Id was NOT specified'
             ## Can retreive multiple CA Policies since displayname is not unique
             $Policy = Get-MgBetaIdentityConditionalAccessPolicy -Filter "DisplayName eq '$DisplayName'"
+            $jsonPolicy = ConvertTo-Json $Policy -ErrorAction SilentlyContinue
+            Write-Verbose -Message "Retrieved policy:`r`n$($jsonPolicy)"
+
             if ($Policy.Length -gt 1)
             {
                 throw "Duplicate CA Policies named $DisplayName exist in tenant"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.schema.mof
@@ -22,6 +22,7 @@ class MSFT_O365OrgSettings : OMI_BaseResource
     [Write, Description("Specifies whether or not to allow users to have access to use the Viva Insights Outlook add-in and inline suggestions.")] Boolean VivaInsightsOutlookAddInAndInlineSuggestions;
     [Write, Description("Specifies whether or not to allow users to have access to use the Viva Insights schedule send suggestions feature.")] Boolean VivaInsightsScheduleSendSuggestions;
     [Write, Description("Allow Planner users to publish their plans and assigned tasks to Outlook or other calendars through iCalendar feeds.")] Boolean PlannerAllowCalendarSharing;
+    [Write, Description("Enables Copilot for Planner.")] Boolean AllowPlannerCopilot;
     [Write, Description("To Do - Allow external users to join.")] Boolean ToDoIsExternalJoinEnabled;
     [Write, Description("To Do - Allow sharing with external users.")] Boolean ToDoIsExternalShareEnabled;
     [Write, Description("To Do - Allow your users to receive push notifications.")] Boolean ToDoIsPushNotificationEnabled;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
@@ -2,6 +2,20 @@
     "resourceName": "O365OrgSettings",
     "description": "",
     "permissions": {
+        "ProjectWorkManagement": {
+            "application":{
+                "read": [
+                    {
+                        "name": "OrgSettings-Planner.Read.All"
+                    }
+                ],
+                "update": [
+                    {
+                        "name": "OrgSettings-Planner.ReadWrite.All"
+                    }
+                ]
+            }
+        },
         "graph": {
             "delegated": {
                 "read": [

--- a/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
+++ b/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
@@ -118,7 +118,7 @@
         },
         @{
             ModuleName      = "MSCloudLoginAssistant"
-            RequiredVersion = "1.1.38"
+            RequiredVersion = "1.1.39"
         },
         @{
             ModuleName      = 'PnP.PowerShell'


### PR DESCRIPTION
#### Pull Request (PR) description
* AADConditionalAccessPolicy
  * Fixed an issue where `TermsOfUse` was not passed as an array, causing failures in GCC-High environments.
    FIXES [#5742](https://github.com/microsoft/Microsoft365DSC/issues/5742)
  * Added verbose to the Get-TargetResource function to print out the retrieved
    policies from calling the cmdlet.
* AADPasswordRuleSettings
  * Updated schema to only accept values 'Enforced' and 'Audit' for parameter BannedPasswordCheckOnPremisesMode
* IntuneDeviceCompliancePolicyWindows10
  * Fixes the handling of the `DeviceCompliancePolicyScript` property.
    FIXES [#5510](https://github.com/microsoft/Microsoft365DSC/issues/5510)
* O365OrgSettings
  * Added support for the AllowPlannerCopilot setting.
* PPTenantSettings
  * Corrected issue in the resource schema. The description was a multi-line
    string, which is not allowed.
* SPOSiteScript
  * Fix error in Get-TargetResource when a site-script is identified by title only
    FIXES [#5821](https://github.com/microsoft/Microsoft365DSC/issues/5821)
* SPOTenantSettings
  * Add EnableAzureADB2BIntegration and OneDriveSharingCapability properties
* TeamsChannel
  * Apply ordering during export.
    FIXES [#5829](https://github.com/microsoft/Microsoft365DSC/issues/5829)
* TeamsTeam
  * Apply ordering during export.
* TeamsUser
  * Apply ordering during export.
* DEPENDENCIES
  * Updated MSCloudLoginAssistant to version 1.1.39.


#### This Pull Request (PR) fixes the following issues
* N/A

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
