### PR TITLE
Fix fancy double quote handling in CIM instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCDRGUtil
+  * Fixes an issue with fancy double quotes being replaced that break the string.  
+    FIXES [#5775](https://github.com/microsoft/Microsoft365DSC/issues/5775)  
+    FIXES [#5623](https://github.com/microsoft/Microsoft365DSC/issues/5623)
+
 # 1.25.226.1
 
 * AADConditionalAccessPolicy

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -498,14 +498,6 @@ function Get-M365DSCDRGComplexTypeToString
         $currentProperty = [string]::Empty
     }
 
-    if ($null -ne $currentProperty)
-    {
-        $fancySingleQuotes = "[\u2019\u2018]"
-        $fancyDoubleQuotes = "[\u201C\u201D]"
-        $currentProperty = [regex]::Replace($currentProperty, $fancySingleQuotes, "''")
-        $currentProperty = [regex]::Replace($currentProperty, $fancyDoubleQuotes, '"')
-    }
-
     return $currentProperty
 }
 
@@ -539,8 +531,15 @@ function Get-M365DSCDRGSimpleObjectTypeToString
             {
                 $key = 'odataType'
             }
-            $Value = $Value.Replace('`', '``').Replace('$', '`$').Replace('"', '`"')
-            $returnValue = $Space + $Key + ' = "' + $Value + """`r`n"
+            #0x201E = „
+            #0x201C = “
+            #0x201D = ”
+            $newString = $Value.Replace('`', '``').Replace('$', '`$')
+            $newString = $newString.Replace("$([char]0x201E)", "``$([char]0x201E)")
+            $newString = $newString.Replace("$([char]0x201C)", "``$([char]0x201C)")
+            $newString = $newString.Replace("$([char]0x201D)", "``$([char]0x201D)")
+            $newString = $newString.Replace('"', '`"')
+            $returnValue = $Space + $Key + ' = "' + $newString + """`r`n"
         }
         '*.DateTime'
         {


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue with "fancy double quote" handling in CIM instances. There is another PR open at the ReverseDSC repository: https://github.com/microsoft/ReverseDSC/pull/40.  This will add the same behavior for all other cases, not only CIM instances. 

#### This Pull Request (PR) fixes the following issues
- Fixes #5775 
- Fixes #5623 

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
