### PR TITLE
Add note for no update possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneDeviceEnrollmentPlatformRestriction
+  * Added note that update is no longer possible.
+    FIXES [#5127](https://github.com/microsoft/Microsoft365DSC/issues/5127)
+
 # 1.25.226.1
 
 * AADConditionalAccessPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentPlatformRestriction/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceEnrollmentPlatformRestriction/readme.md
@@ -5,6 +5,10 @@
 
 This resource configures the Intune device platform enrollment restrictions.
 
+### Restrictions
+
+After deploying the configuration, updating the policies is no longer possible. This is a restriction by the Microsoft Graph API. Any further updates to the policies have to be done using the Intune Portal. 
+
 **Be aware**: To deploy a Android platform restriction policy, two individual configurations must exist:
 
 * The first one contains the key for `AndroidRestriction`


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds a note to the documentation of the `IntuneDeviceEnrollmentPlatformRestriction` resource, stating that updating the configuration is no longer possible after deploying it once. This is a restriction by the Microsoft Graph API. 

@NikCharlebois I guess the Set and Test method need to be updated. What should they do in the case of an Update or drift detection?

#### This Pull Request (PR) fixes the following issues
- Fixes #5127 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
