### PR TITLE
Add note for supported auth methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* O365SearchAndIntelligenceConfigurations
+  * Added note that only Credentials are supported for the resource.
+* TeamsOrgWideAppSettings
+  * Added note that only Credentials are supported for the resource.
+    FIXES [#3394](https://github.com/microsoft/Microsoft365DSC/issues/3394)
+
 # 1.25.226.1
 
 * AADConditionalAccessPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365SearchAndIntelligenceConfigurations/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365SearchAndIntelligenceConfigurations/readme.md
@@ -3,3 +3,5 @@
 ## Description
 
 This resource configures the Search And Intelligence configuration settings.
+
+**This resource currently only supports Credential authentication. Please refer to [Microsoft Graph REST API Beta Reference](https://learn.microsoft.com/en-us/graph/api/organizationsettings-list-contactinsights?view=graph-rest-beta&tabs=http) for further information about the supported authentication methods.**

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOrgWideAppSettings/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOrgWideAppSettings/readme.md
@@ -4,3 +4,5 @@
 ## Description
 
 This resource configures Org-Wide App Settings for Teams.
+
+**This resource currently only supports Credential authentication. Please refer to [Teams PowerShell Application Authentication](https://learn.microsoft.com/en-us/microsoftteams/teams-powershell-application-authentication) for further information.**


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds a note to `TeamsOrgWideAppSettings` and `O365SearchAndIntelligenceConfigurations` that they only support Credentials as their authentication method. There are a couple of issues open on this topic, so we might want to close them all with the note that this is a Graph API "issue". 

Issues alike: #5680, #5759 

#### This Pull Request (PR) fixes the following issues
- Fixes #3394 
- Fixes #4798

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
