### PR TITLE
Remove not existing command from exported cmdlets list

### DIFF
--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -93,7 +93,8 @@
   #FunctionsToExport = @()
 
   # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-  CmdletsToExport   = @('Assert-M365DSCBlueprint',
+  CmdletsToExport   = @(
+    'Assert-M365DSCBlueprint',
     'Compare-M365DSCConfigurations',
     'Confirm-M365DSCDependencies',
     'Export-M365DSCConfiguration',
@@ -107,7 +108,6 @@
     'New-M365DSCStubFiles',
     'Remove-M365DSCNotificationEndPointRegistration',
     'Set-M365DSCAgentCertificateConfiguration',
-    'Start-M365DSCConfiguration',
     'Test-M365DSCAgent',
     'Test-M365DSCDependenciesForNewVersions',
     'Test-M365DSCModuleValidity',


### PR DESCRIPTION
#### Pull Request (PR) description
This PR removes the `Start-M365DSCConfiguration` cmdlet, which doesn't exist, from the exported cmdlets list. 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
