### PR TITLE
AADApplication Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+* AADApplication
+  * If both the current and desired values have the Ensure property set
+    to absent, ignoring the drift detection and return true from
+    the Test-TargetResource function.
 * AADAuthenticationMethodPolicyQRCodeImage
   * Initial release.
 * AADGroupSettings

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -1420,6 +1420,12 @@ function Test-TargetResource
     $ValuesToCheck = ([Hashtable]$PSBoundParameters).clone()
     $testTargetResource = $true
 
+    if ($CurrentValues.Ensure -eq 'Absent' -and $Ensure -eq 'Absent')
+    {
+        Write-Verbose -Message "Both the desired and current value for Ensure are set to Absent. Therefore ignoring the drift assessment."
+        return $true
+    }
+
     #Compare Cim instances
     foreach ($key in $PSBoundParameters.Keys)
     {


### PR DESCRIPTION
#### Pull Request (PR) description
* AADApplication
  * If both the current and desired values have the Ensure property set to absent, ignoring the drift detection and return true from the Test-TargetResource function.

#### This Pull Request (PR) fixes the following issues
* N/A