### PR TITLE
Require Excel to be installed for .xlsx export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * SCDLPCompliancePolicy
   * Fixes strange issue with the Get-TargetResource throwin an error
     complaining about a null object.
+* M35DSCReport
+  * Require Excel to be installed for .xlsx export.
 * DEPENDENCIES
   * Updated ReverseDSC to version 2.0.0.28.
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -463,7 +463,14 @@ function New-M365DSCConfigurationToExcel
         $OutputPath
     )
 
-    $excel = New-Object -ComObject excel.application
+    try
+    {
+        $excel = New-Object -ComObject excel.application
+    }
+    catch [System.Runtime.InteropServices.COMException]
+    {
+        throw 'Excel is not installed on this machine. Please install Excel to use this feature.'
+    }
     $excel.visible = $True
     $workbook = $excel.Workbooks.Add()
     $report = $workbook.Worksheets.Item(1)


### PR DESCRIPTION
#### Pull Request (PR) description
Require Excel to be installed during .xlsx report generation. If the excel object cannot be created, then throw an exception. 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
