### PR TITLE
Add required role for O365OrgSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * IntuneDeviceManagementEnrollmentAndroidGooglePlay
   * Changed the resource to be read-only due to the associated APIs not being
     owned by Microsoft.
+* O365OrgSettings
+  * Add required `Insights Administrator` role for Get and Update.
 * SCDLPCompliancePolicy
   * Fixes strange issue with the Get-TargetResource throwing an error
     complaining about a null object.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/settings.json
@@ -1,6 +1,14 @@
 ﻿{
     "resourceName": "O365OrgSettings",
     "description": "",
+    "roles": {
+        "read": [
+            "Insights Administrator"
+        ],
+        "update": [
+            "Insights Administrator"
+        ]
+    },
     "permissions": {
         "ProjectWorkManagement": {
             "application":{


### PR DESCRIPTION
#### Pull Request (PR) description
Adds the required role `Insights Administrator` to the settings.json of the `O365OrgSettings` resource according to #4340.

#### This Pull Request (PR) fixes the following issues
- Fixes #4340

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
