### PR TITLE
Fix IsAssignableToRole logic in Get-TargetResource function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@
 * AADUser
   * Added the property `OtherMails` to the managed properties.
     FIXES [#4763](https://github.com/microsoft/Microsoft365DSC/issues/4763)
+* AADGroup
+  * Fixed `isAssignableToRole` to support for null values returned by graph.
+    FIXES [#5959](https://github.com/microsoft/Microsoft365DSC/issues/5959)
 * EXOArcConfig
-  * [BREAKING CHANGE] Removed the `Identity` parameter since it does not 
+  * [BREAKING CHANGE] Removed the `Identity` parameter since it does not
     have any functionality and is not exported by default.
 * EXOMailboxSettings
   * Add AuditEnabled

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -280,7 +280,7 @@ function Get-TargetResource
                 MembershipRuleProcessingState = $Group.MembershipRuleProcessingState
                 SecurityEnabled               = $Group.SecurityEnabled
                 MailEnabled                   = $Group.MailEnabled
-                IsAssignableToRole            = $Group.IsAssignableToRole
+                IsAssignableToRole            = $false -or $Group.IsAssignableToRole
                 AssignedToRole                = $AssignedToRoleValues
                 MailNickname                  = $Group.MailNickname
                 Visibility                    = $Group.Visibility


### PR DESCRIPTION
#### Pull Request (PR) description
When Graph returns $null on IsAssignableToRole property of AADGroup, it should be considered $false.

#### This Pull Request (PR) fixes the following issues

Fixes #5959 

#### Task list

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
