### PR TITLE
BREAKING CHANGE: Update parameter value possibilities in password rule setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@
 
 ## BREAKING CHANGES
 
+* AADPasswordRuleSettings
+  * [BREAKING CHANGE] Replace `Enforced` with `Enforce` as a possibility of
+    `BannedPasswordCheckOnPremisesMode` to align with updated Graph value.
 * EXOArcConfig
   * [BREAKING CHANGE] Removed the `Identity` parameter since it does not
     have any functionality and is not exported by default.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADPasswordRuleSettings/MSFT_AADPasswordRuleSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADPasswordRuleSettings/MSFT_AADPasswordRuleSettings.psm1
@@ -30,7 +30,7 @@ function Get-TargetResource
         $EnableBannedPasswordCheckOnPremises,
 
         [Parameter()]
-        [validateset('Enforced', 'Audit')]
+        [ValidateSet('Enforce', 'Audit')]
         [System.String]
         $BannedPasswordCheckOnPremisesMode,
 
@@ -169,7 +169,7 @@ function Set-TargetResource
         $EnableBannedPasswordCheckOnPremises,
 
         [Parameter()]
-        [validateset('Enforced', 'Audit')]
+        [ValidateSet('Enforce', 'Audit')]
         [System.String]
         $BannedPasswordCheckOnPremisesMode,
 
@@ -236,7 +236,6 @@ function Set-TargetResource
 
     if (($Ensure -eq 'Present' -and $currentPolicy.Ensure -eq 'Present') -or $needToUpdate)
     {
-        $index = 0
         foreach ($property in $Policy.Values)
         {
             if ($property.Name -eq 'LockoutThreshold')
@@ -269,7 +268,6 @@ function Set-TargetResource
                 $entry = $Policy.Values | Where-Object -FilterScript { $_.Name -eq $property.Name }
                 $entry.Value = $BannedPasswordCheckOnPremisesMode
             }
-            $index++
         }
 
         Write-Verbose -Message "Updating Policy's Values with $($Policy.Values | Out-String)"
@@ -314,7 +312,7 @@ function Test-TargetResource
         $EnableBannedPasswordCheckOnPremises,
 
         [Parameter()]
-        [validateset('Enforced', 'Audit')]
+        [ValidateSet('Enforce', 'Audit')]
         [System.String]
         $BannedPasswordCheckOnPremisesMode,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADPasswordRuleSettings/MSFT_AADPasswordRuleSettings.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADPasswordRuleSettings/MSFT_AADPasswordRuleSettings.schema.mof
@@ -6,7 +6,7 @@ class MSFT_AADPasswordRuleSettings : OMI_BaseResource
     [Write, Description("The duration in seconds of the initial lockout period.")] UInt32 LockoutDurationInSeconds;
     [Write, Description("Boolean indicating if the banned password check for tenant specific banned password list is turned on or not.")] Boolean EnableBannedPasswordCheck;
     [Write, Description("A list of banned words in passwords.")] String BannedPasswordList[];
-    [Write, Description("How should we enforce password policy check in on-premises system."), ValueMap{"Enforced","Audit"}, Values{"Enforced","Audit"}] String BannedPasswordCheckOnPremisesMode;
+    [Write, Description("How should we enforce password policy check in on-premises system."), ValueMap{"Enforce","Audit"}, Values{"Enforce","Audit"}] String BannedPasswordCheckOnPremisesMode;
     [Write, Description("Boolean indicating if the banned password check is turned on or not for on-premises system.")] Boolean EnableBannedPasswordCheckOnPremises;
     [Write, Description("Specify if the Azure AD Password Rule Settings should exist or not."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Credentials for the Microsoft Graph delegated permissions."), EmbeddedInstance("MSFT_Credential")] string Credential;


### PR DESCRIPTION
#### Pull Request (PR) description
For `AADPasswordRuleSettings`, the possibilities for the `BannedPasswordCheckOnPremisesMode` property changed. Previously, `Enforced` was a valid value. Now, Microsoft Graph only returns `Enforce`. This PR updates the value so that it corresponds to the value of what Graph uses. 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
