### PR TITLE
Add Entra roles to export of permissions list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * IntuneSecurityBaselineHoloLens2Standard
   * Initial release.
 * M365DSCPermissions
+  * Add `AdministrativeRoles` property to export of `Get-M365DSCCompiledPermissionList`.
   * Removed commented out `Update-M365DSCResourcesSettingsJSON` definition.
 * M365DSCUtil
   * Removed numerous EXO functions.

--- a/Modules/Microsoft365DSC/Modules/M365DSCPermissions.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCPermissions.psm1
@@ -63,26 +63,27 @@ function Get-M365DSCCompiledPermissionList
     }
 
     $results = @{
-        Read               = @(
+        AdministrativeRoles = @()
+        Read                = @(
             @{
-                API        = 'Graph'
-                Permission = @{
+                API         = 'Graph'
+                Permission  = @{
                     Name = 'Organization.Read.All'
                     Type = 'Application'
                 }
             }
         )
-        Update             = @(
+        Update              = @(
             @{
-                API        = 'Graph'
-                Permission = @{
+                API         = 'Graph'
+                Permission  = @{
                     Name = 'Organization.Read.All'
                     Type = 'Application'
                 }
             }
         )
-        RequiredRoles      = @()
-        RequiredRoleGroups = @()
+        RequiredRoles       = @()
+        RequiredRoleGroups  = @()
     }
 
     $total = $ResourceNameList.Count
@@ -110,6 +111,17 @@ function Get-M365DSCCompiledPermissionList
         {
             $fileContent = Get-Content $settingsFilePath -Raw
             $resourceSettings = ConvertFrom-Json -InputObject $fileContent
+
+            # Entra / Administrative roles
+            if ($resourceSettings.roles.Count -gt 0)
+            {
+                $readRoles = $resourceSettings.roles.read
+                $updateRoles = $resourceSettings.roles.update
+                $results.AdministrativeRoles = @{
+                    Read = ,$readRoles
+                    Update = ,$updateRoles
+                }
+            }
 
             if ($null -eq $resourceSettings.permissions)
             {


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds the `AdministrativeRoles` property to the output of `Get-M365DSCCompiledPermissionList`. It now returns the specified Entra roles, grouped by Read and Update type. Part of the work on #5996.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
