### PR TITLE
bugfix: Revert change to entitlement management catalog Id assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   * Removed clearing of M365DSC authentication parameters from numerous Intune resources.
   * Updated the new Write-M365DSChost function to only print
     messages when they are not null.
+* AADEntitlementManagementAccessPackage
+  * Fix incorrect assignment where `$results.CatalogId` was assigned `catalog.DisplayName` instead of `catalog.Id`
 
 # 1.25.402.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * AADApplication
   * DEPRECATED: Parameter AvailableToOtherTenants.
   * Added direct support for the SignInAudience parameter.
+* AADEntitlementManagementAccessPackage
+  * Fix incorrect assignment where `$results.CatalogId` was assigned
+    `catalog.DisplayName` instead of `catalog.Id`
 * EXOSafeAttachmentRule
   * Inlined function calls.
 * EXOSafeLinksRule
@@ -23,8 +26,6 @@
   * Removed clearing of M365DSC authentication parameters from numerous Intune resources.
   * Updated the new Write-M365DSChost function to only print
     messages when they are not null.
-* AADEntitlementManagementAccessPackage
-  * Fix incorrect assignment where `$results.CatalogId` was assigned `catalog.DisplayName` instead of `catalog.Id`
 
 # 1.25.402.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackage/MSFT_AADEntitlementManagementAccessPackage.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackage/MSFT_AADEntitlementManagementAccessPackage.psm1
@@ -168,7 +168,7 @@ function Get-TargetResource
 
         $results = @{
             Id                              = $getValue.Id
-            CatalogId                       = $catalog.DisplayName
+            CatalogId                       = $catalog.Id
             Description                     = $getValue.Description
             DisplayName                     = $getValue.DisplayName
             IsHidden                        = $getValue.IsHidden


### PR DESCRIPTION
#### Pull Request (PR) description

This PR reverts a change that updated Catalog ID assignment from ID to DisplayName.

https://github.com/microsoft/Microsoft365DSC/commit/41649b15fcb75485896dd00ffbb003458c0b133a#diff-89344a5e420fd38276b064d760ff189ed4a83fa6c6c07db49b65cdb4fa123fdcR170

This causes issues with the Get-MgBetaEntitlementManagementAccessPackageCatalogAccessPackageResource call where -AccessPackageCatalogId needs the catalog guid NOT displayname.

#### This Pull Request (PR) fixes the following issues
- Fixes #4032 

#### Task list

- [X ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [X ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
