### PR TITLE
Release 1.25.416.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log for Microsoft365DSC
 
-# UNRELEASED
+# 1.25.416.1
 
 * EXOResourceConfiguration
   * Added required permissions to settings.json file.
@@ -29,6 +29,8 @@
   * Added export of module functions to several EXO resources.
   * Update export to use common function for multiple resources.
   * Update `requiredrolegroups` property of settings.json file to array.
+  * Updated the Write-M365DSCHost function to make the Message parameter
+    optional to fix null errors.
 
 # 1.25.409.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -4874,7 +4874,7 @@ function Write-M365DSCHost
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param
     (
-        [Parameter(Mandatory = $true, Position = 0)]
+        [Parameter(Position = 0)]
         [System.String]
         $Message,
 
@@ -4891,49 +4891,52 @@ function Write-M365DSCHost
         $CommitWrite
     )
 
-    if ($null -eq $Script:M365DSCHostMessages)
+    if (-not [System.String]::IsNullOrEmpty($Message))
     {
-        $Script:M365DSCHostMessages = @()
-    }
-
-    if ($DeferWrite)
-    {
-        $Script:M365DSCHostMessages += @{
-            Message = $Message
-            ForegroundColor = $ForegroundColor
-        }
-        return
-    }
-
-    if ([Environment]::UserInteractive)
-    {
-        if ($CommitWrite -and $Script:M365DSCHostMessages.Count -gt 0)
+        if ($null -eq $Script:M365DSCHostMessages)
         {
-            for ($i = 0; $i -lt $Script:M365DSCHostMessages.Count - 1; $i++)
-            {
-                Write-Host -Object $Script:M365DSCHostMessages[$i].Message -ForegroundColor $Script:M365DSCHostMessages[$i].ForegroundColor -NoNewline
+            $Script:M365DSCHostMessages = @()
+        }
+
+        if ($DeferWrite)
+        {
+            $Script:M365DSCHostMessages += @{
+                Message = $Message
+                ForegroundColor = $ForegroundColor
             }
-            Write-Host -Object $Script:M365DSCHostMessages[-1].Message -ForegroundColor $Script:M365DSCHostMessages[-1].ForegroundColor -NoNewline
-            $Script:M365DSCHostMessages = @()
+            return
         }
 
-        if (-not [System.String]::IsNullOrEmpty($Message))
+        if ([Environment]::UserInteractive)
         {
-            Write-Host -Object $Message -ForegroundColor $ForegroundColor
+            if ($CommitWrite -and $Script:M365DSCHostMessages.Count -gt 0)
+            {
+                for ($i = 0; $i -lt $Script:M365DSCHostMessages.Count - 1; $i++)
+                {
+                    Write-Host -Object $Script:M365DSCHostMessages[$i].Message -ForegroundColor $Script:M365DSCHostMessages[$i].ForegroundColor -NoNewline
+                }
+                Write-Host -Object $Script:M365DSCHostMessages[-1].Message -ForegroundColor $Script:M365DSCHostMessages[-1].ForegroundColor -NoNewline
+                $Script:M365DSCHostMessages = @()
+            }
+
+            if (-not [System.String]::IsNullOrEmpty($Message))
+            {
+                Write-Host -Object $Message -ForegroundColor $ForegroundColor
+            }
         }
-    }
-    else
-    {
-        $outputMessage = ''
-        if ($CommitWrite)
+        else
         {
-            $outputMessage += $Script:M365DSCHostMessages.Message -join ''
-            $Script:M365DSCHostMessages = @()
-        }
-        $finalMessage = $outputMessage + $Message
-        if (-not [System.String]::IsNullOrEmpty($Message))
-        {
-            Write-Verbose -Message $finalMessage -Verbose
+            $outputMessage = ''
+            if ($CommitWrite)
+            {
+                $outputMessage += $Script:M365DSCHostMessages.Message -join ''
+                $Script:M365DSCHostMessages = @()
+            }
+            $finalMessage = $outputMessage + $Message
+            if (-not [System.String]::IsNullOrEmpty($Message))
+            {
+                Write-Verbose -Message $finalMessage -Verbose
+            }
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
* EXOResourceConfiguration
  * Added required permissions to settings.json file.
* EXOTenantAllowBlockListItems
  * Inlined function call.
* IntuneDeviceControlPolicyWindows10
  * Added support for `DefaultEnforcement` and `DeviceControlEnabled` properties.
* IntuneDeviceManagementAndroidDeviceOwnerEnrollmentProfile
  * Fix export and remove read-only properties.
    FIXES [#5969](https://github.com/microsoft/Microsoft365DSC/issues/5969)
* IntuneSecurityBaselineHoloLens2Advanced
  * Initial release.
 * IntuneWifiConfigurationPolicyMacOS
  * Fixed an issue where fetching the assignments of a policy that only exists by display name fails.
    FIXES [#5971](https://github.com/microsoft/Microsoft365DSC/issues/5971)
* PlannerTask
  * Update export to use common functions.
    FIXES [#6004](https://github.com/microsoft/Microsoft365DSC/issues/6004)
* M365DSCDRGUtil
  * Removed undefined variable from if statement.
* M365DSCPermissions
  * Add `AdministrativeRoles` and `RequiredRoles` property to export.
* MISC
  * Removed `-Verbose` parameter from multiple commands where it's not necessary.
  * Removed unused functions across several resources.
  * Added export of module functions to several EXO resources.
  * Update export to use common function for multiple resources.
  * Update `requiredrolegroups` property of settings.json file to array.
  * Updated the Write-M365DSCHost function to make the Message parameter
    optional to fix null errors.

#### This Pull Request (PR) fixes the following issues
* N/A