### PR TITLE
Changed Error Handling Logic in Get-TargetResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* EXODistributionGroup
+  * Changed Get-TargetResource not to throw an error when the instance doesn't exist.
+* EXORetentionPolicy
+  * Changed Get-TargetResource not to throw an error when the instance doesn't exist.
+
 # 1.25.423.1
 
 * AADEntitlementManagementConnectedOrganization

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/MSFT_EXODistributionGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/MSFT_EXODistributionGroup.psm1
@@ -243,11 +243,11 @@ function Get-TargetResource
 
             if (-not [System.String]::IsNullOrEmpty($PrimarySmtpAddress))
             {
-                $distributionGroup = Get-DistributionGroup -Identity $PrimarySmtpAddress -ErrorAction Stop
+                $distributionGroup = Get-DistributionGroup -Identity $PrimarySmtpAddress -ErrorAction SilentlyContinue
             }
             else
             {
-                $distributionGroup = Get-DistributionGroup -Identity $Identity -ErrorAction Stop
+                $distributionGroup = Get-DistributionGroup -Identity $Identity -ErrorAction SilentlyContinue
             }
 
             if ($null -eq $distributionGroup)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicy/MSFT_EXORetentionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicy/MSFT_EXORetentionPolicy.psm1
@@ -83,7 +83,7 @@ function Get-TargetResource
         }
         else
         {
-            $instance = Get-RetentionPolicy -Identity $Identity -ErrorAction Stop
+            $instance = Get-RetentionPolicy -Identity $Identity -ErrorAction SilentlyContinue
         }
         if ($null -eq $instance)
         {


### PR DESCRIPTION
#### Pull Request (PR) description
* EXODistributionGroup
  * Changed Get-TargetResource not to throw an error when the instance doesn't exist.
* EXORetentionPolicy
  * Changed Get-TargetResource not to throw an error when the instance doesn't exist.

#### This Pull Request (PR) fixes the following issues
* N/A