### PR TITLE
Fix SPOApp file download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,7 @@
   * Removed the parameter `MaxProcesses` from the public `Export-M365DSCConfiguration` function.
     FIXES [#5982](https://github.com/microsoft/Microsoft365DSC/issues/5982)
   * Add a $null check in `Get-AllSPOPackages` 
-    FIXES [#5810](https://github.com/microsoft/Microsoft365DSC/issues/5810)
-    FIXES [#4557](https://github.com/microsoft/Microsoft365DSC/issues/4557)
+    FIXES [#5810](https://github.com/microsoft/Microsoft365DSC/issues/5810) [#4557](https://github.com/microsoft/Microsoft365DSC/issues/4557)
 
 # 1.25.430.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 * M365DSCUtil
   * Removed the parameter `MaxProcesses` from the public `Export-M365DSCConfiguration` function.
     FIXES [#5982](https://github.com/microsoft/Microsoft365DSC/issues/5982)
+  * Add a $null check in `Get-AllSPOPackages` 
+    FIXES [#5810](https://github.com/microsoft/Microsoft365DSC/issues/5810)
+    FIXES [#4557](https://github.com/microsoft/Microsoft365DSC/issues/4557)
 
 # 1.25.430.1
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2563,7 +2563,10 @@ function Get-AllSPOPackages
 
                 foreach ($file in $allFiles)
                 {
-                    $filesToDownload += @{Name = $file.Name; Site = $tenantAppCatalogUrl; Title = $file.Title }
+                    if($null -ne $file) 
+                    {
+                        $filesToDownload += @{Name = $file.Name; Site = $tenantAppCatalogUrl; Title = $file.Title }
+                    }
                 }
             }
             catch


### PR DESCRIPTION
Fix SPOApp file download with a $null check for empty Elements.

#### Pull Request (PR) description
Fix SPOApp file download with a $null check for empty Elements in $allFiles.

#### This Pull Request (PR) fixes the following issues
    - Fixes #5810
    - Fixes #4557 
