### PR TITLE
TeamsFederationConfiguration - Deprecated the AllowPublicUsers property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+* TeamsFederationConfiguration
+  * DEPRECATED the AllowPublicUsers property.
 * DEPENDENCIES
   * Updates DSCParser to version 2.0.0.17.
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsFederationConfiguration/MSFT_TeamsFederationConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsFederationConfiguration/MSFT_TeamsFederationConfiguration.psm1
@@ -21,6 +21,7 @@ function Get-TargetResource
         [System.Boolean]
         $AllowFederatedUsers,
 
+        # DEPRECATED
         [Parameter()]
         [System.Boolean]
         $AllowPublicUsers,
@@ -127,7 +128,8 @@ function Get-TargetResource
             AllowedDomains                              = $AllowedDomainsValues
             BlockedDomains                              = $BlockedDomainsValues
             AllowFederatedUsers                         = $config.AllowFederatedUsers
-            AllowPublicUsers                            = $config.AllowPublicUsers
+            #DEPRECATED
+            #AllowPublicUsers                            = $config.AllowPublicUsers
             AllowTeamsConsumer                          = $config.AllowTeamsConsumer
             AllowTeamsConsumerInbound                   = $config.AllowTeamsConsumerInbound
             ExternalAccessWithTrialTenants              = $config.ExternalAccessWithTrialTenants
@@ -265,6 +267,12 @@ function Set-TargetResource
         $SetParams.Add('AllowedDomains', $AllowAllKnownDomains)
     }
 
+    if ($SetParams.ContainsKey('AllowPublicUsers'))
+    {
+        Write-Verbose -Message "[DEPRECATED] The AllowPublicUsers property is deprecated and will be removed."
+        $SetParams.Remove('AllowPublicUsers') | Out-Null
+    }
+
     Write-Verbose -Message "SetParams: $(Convert-M365DscHashtableToString -Hashtable $SetParams)"
     Set-CsTenantFederationConfiguration @SetParams
 }
@@ -365,6 +373,10 @@ function Test-TargetResource
     Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $PSBoundParameters)"
 
     $ValuesToCheck = $PSBoundParameters
+    if ($ValuesToCheck.ContainsKey('AllowPublicUsers'))
+    {
+        $ValuesToCheck.Remove('AllowPublicUsers') | Out-Null
+    }
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsFederationConfiguration/MSFT_TeamsFederationConfiguration.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsFederationConfiguration/MSFT_TeamsFederationConfiguration.schema.mof
@@ -5,7 +5,7 @@ class MSFT_TeamsFederationConfiguration : OMI_BaseResource
     [Write, Description("When set to True users will be potentially allowed to communicate with users from other domains.")] Boolean AllowFederatedUsers;
     [Write, Description("List of federated domains to allow.")] String AllowedDomains[];
     [Write, Description("List of federated domains to block.")] String BlockedDomains[];
-    [Write, Description("When set to True users will be potentially allowed to communicate with users who have accounts on public IM and presence providers.")] Boolean AllowPublicUsers;
+    [Write, Description("DEPRECATED")] Boolean AllowPublicUsers;
     [Write, Description("Allows federation with people using Teams with an account that's not managed by an organization.")] Boolean AllowTeamsConsumer;
     [Write, Description("Allows people using Teams with an account that's not managed by an organization, to discover and start communication with users in your organization.")] Boolean AllowTeamsConsumerInbound;
     [Write, Description("When set to Blocked, all external access with users from Teams subscriptions that contain only trial licenses will be blocked. This means users from these trial-only tenants will not be able to reach to your users via chats, Teams calls, and meetings (using the users authenticated identity) and your users will not be able to reach users in these trial-only tenants. If this setting is set to Blocked, users from the trial-only tenant will also be removed from existing chats."), ValueMap{"Allowed","Blocked"}, Values{"Allowed","Blocked"}] String ExternalAccessWithTrialTenants;


### PR DESCRIPTION
#### Pull Request (PR) description
* TeamsFederationConfiguration
  * DEPRECATED the AllowPublicUsers property.

#### This Pull Request (PR) fixes the following issues
* N/A