### PR TITLE
EXORetentionPolicyTag - Change Type for AgeLimitForRetention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * AADApplication
   * Fixed an issue where the `AdminConsentGranted` property had an incorrect value.
     FIXES [#5027](https://github.com/microsoft/Microsoft365DSC/issues/5027)
+* EXORetentionPolicyTag
+  * BREAKING - Changed the AgeLimitForRetention property type to UInt32.
 * EXOTransportRule
   * Fixed an issue where not specified properties would lead to an exception.
 * IntuneASRRulesPolicyWindows10

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicyTag/MSFT_EXORetentionPolicyTag.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicyTag/MSFT_EXORetentionPolicyTag.psm1
@@ -106,7 +106,6 @@ function Get-TargetResource
             MustDisplayCommentEnabled = $instance.MustDisplayCommentEnabled
             RetentionAction           = $instance.RetentionAction
             RetentionEnabled          = $instance.RetentionEnabled
-            AgeLimitForRetention      = $instance.AgeLimitForRetention
             Type                      = $instance.Type
             Ensure                    = 'Present'
             Credential                = $Credential

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicyTag/MSFT_EXORetentionPolicyTag.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicyTag/MSFT_EXORetentionPolicyTag.psm1
@@ -13,7 +13,7 @@ function Get-TargetResource
         $Comment,
 
         [Parameter()]
-        [System.String]
+        [System.UInt32]
         $AgeLimitForRetention,
 
         [Parameter()]
@@ -106,6 +106,7 @@ function Get-TargetResource
             MustDisplayCommentEnabled = $instance.MustDisplayCommentEnabled
             RetentionAction           = $instance.RetentionAction
             RetentionEnabled          = $instance.RetentionEnabled
+            AgeLimitForRetention      = $instance.AgeLimitForRetention
             Type                      = $instance.Type
             Ensure                    = 'Present'
             Credential                = $Credential
@@ -117,7 +118,7 @@ function Get-TargetResource
         }
         if (-not [System.String]::IsNullOrEmpty($instance.AgeLimitForRetention))
         {
-            $results.Add('AgeLimitForRetention', $instance.AgeLimitForRetention.Split('.')[0])
+            $results.Add('AgeLimitForRetention', [UInt32]::Parse($instance.AgeLimitForRetention.Split('.')[0]))
         }
         return [System.Collections.Hashtable] $results
     }
@@ -148,7 +149,7 @@ function Set-TargetResource
         $Comment,
 
         [Parameter()]
-        [System.String]
+        [System.UInt32]
         $AgeLimitForRetention,
 
         [Parameter()]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicyTag/MSFT_EXORetentionPolicyTag.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicyTag/MSFT_EXORetentionPolicyTag.schema.mof
@@ -3,7 +3,7 @@ class MSFT_EXORetentionPolicyTag : OMI_BaseResource
 {
     [Key, Description("The Identity parameter specifies the name of the tag.")] String Identity;
     [Write, Description("The Description parameter specifies a comment for the tag.")] String Comment;
-    [Write, Description("The AgeLimitForRetention parameter specifies the age at which retention is enforced on an item. The age limit corresponds to the number of days from the date the item was delivered, or the date an item was created if it wasn't delivered. If this parameter isn't present and the RetentionEnabled parameter is set to $true, an error is returned.")] String AgeLimitForRetention;
+    [Write, Description("The AgeLimitForRetention parameter specifies the age at which retention is enforced on an item. The age limit corresponds to the number of days from the date the item was delivered, or the date an item was created if it wasn't delivered. If this parameter isn't present and the RetentionEnabled parameter is set to $true, an error is returned.")] UInt32 AgeLimitForRetention;
     [Write, Description("The MessageClass parameter specifies the message type to which the tag applies. If not specified, the default value is set to *.")] String MessageClass;
     [Write, Description("The MustDisplayCommentEnabled parameter specifies whether the comment can be hidden. The default value is $true.")] Boolean MustDisplayCommentEnabled;
     [Write, Description("The RetentionAction parameter specifies the action for the retention policy.")] String RetentionAction;


### PR DESCRIPTION
#### Pull Request (PR) description
* EXORetentionPolicyTag
  * BREAKING - Changed the AgeLimitForRetention property type to UInt32.

#### This Pull Request (PR) fixes the following issues
* N/A
