### PR TITLE
Allow combination of sha1 and sha2 algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneDeviceConfigurationSCEPCertificatePolicyWindows10
+  * Allow the combination of `sha1,sha2` as a value for `HashAlgorithm`.
+
 # 1.25.515.1
 
 * AADApplication

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.psm1
@@ -11,7 +11,7 @@ function Get-TargetResource
         $CertificateStore,
 
         [Parameter()]
-        [ValidateSet('sha1', 'sha2')]
+        [ValidateSet('sha1', 'sha2', 'sha1,sha2')]
         [System.String]
         $HashAlgorithm,
 
@@ -344,7 +344,7 @@ function Set-TargetResource
         $CertificateStore,
 
         [Parameter()]
-        [ValidateSet('sha1', 'sha2')]
+        [ValidateSet('sha1', 'sha2', 'sha1,sha2')]
         [System.String]
         $HashAlgorithm,
 
@@ -637,7 +637,7 @@ function Test-TargetResource
         $CertificateStore,
 
         [Parameter()]
-        [ValidateSet('sha1', 'sha2')]
+        [ValidateSet('sha1', 'sha2', 'sha1,sha2')]
         [System.String]
         $HashAlgorithm,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10/MSFT_IntuneDeviceConfigurationSCEPCertificatePolicyWindows10.schema.mof
@@ -25,7 +25,7 @@ class MSFT_MicrosoftGraphExtendedKeyUsage
 class MSFT_IntuneDeviceConfigurationScepCertificatePolicyWindows10 : OMI_BaseResource
 {
     [Write, Description("Target store certificate. Possible values are: user, machine."), ValueMap{"user","machine"}, Values{"user","machine"}] String CertificateStore;
-    [Write, Description("SCEP Hash Algorithm. Possible values are: sha1, sha2."), ValueMap{"sha1","sha2"}, Values{"sha1","sha2"}] String HashAlgorithm;
+    [Write, Description("SCEP Hash Algorithm. Possible values are: sha1, sha2."), ValueMap{"sha1","sha2","sha1,sha2"}, Values{"sha1","sha2","sha1,sha2"}] String HashAlgorithm;
     [Write, Description("SCEP Key Size. Possible values are: size1024, size2048, size4096."), ValueMap{"size1024","size2048","size4096"}, Values{"size1024","size2048","size4096"}] String KeySize;
     [Write, Description("SCEP Key Usage. Possible values are: keyEncipherment, digitalSignature."), ValueMap{"keyEncipherment","digitalSignature"}, Values{"keyEncipherment","digitalSignature"}] String KeyUsage[];
     [Write, Description("SCEP Server Url(s).")] String ScepServerUrls[];


### PR DESCRIPTION
#### Pull Request (PR) description
This PR allows selecting the combination of `sha1,sha2` as a valid value for `HashAlgorithm` in the `IntuneDeviceConfigurationSCEPCertificatePolicyWindows10`

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
