### PR TITLE
Fix Office ExcludedApps property export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneMobileAppsWindowsOfficeSuiteApp
+  * Fixed an issue where the `ExcludedApps` property would be in an invalid format.
+
 # 1.25.515.1
 
 * AADApplication

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp.psm1
@@ -215,6 +215,10 @@ function Get-TargetResource
                 $complexExcludedApps.Add($_.Key, $_.Value)
             }
         }
+        if ($complexExcludedApps.Count -eq 0)
+        {
+            $complexExcludedApps = $null
+        }
 
         # $complexLargeIcon = @{}
         # if ($null -ne $instance.LargeIcon.Value)


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes the export of the `ExcludedApps` property in the `IntuneMobileAppsWindowsOfficeSuiteApp` resource. If there are no apps to exclude (might happen if the supplied configuration xml does not contain any), it exported the hashtable properties like Count, IsFixedSize etc. 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
