### PR TITLE
Revert Export and Get filter changes to Intune ASR resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneASRRulesPolicyWindows10
+  * Removed newly added template ID, it belongs to `IntuneApplicationControlPolicyWindows10`.
+
 # 1.25.515.1
 
 * AADApplication

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneASRRulesPolicyWindows10/MSFT_IntuneASRRulesPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneASRRulesPolicyWindows10/MSFT_IntuneASRRulesPolicyWindows10.psm1
@@ -188,9 +188,7 @@ function Get-TargetResource
             #Retrieve policy general settings
             if (-not [string]::IsNullOrEmpty($Identity))
             {
-                $policy = Get-MgBetaDeviceManagementIntent -DeviceManagementIntentId $Identity `
-                                                           -Filter "TemplateId eq '0e237410-1367-4844-bd7f-15fb0f08943b' or TemplateId eq '63be6324-e3c9-4c97-948a-e7f4b96f0f20'" `
-                                                           -ErrorAction SilentlyContinue
+                $policy = Get-MgBetaDeviceManagementIntent -DeviceManagementIntentId $Identity -ErrorAction SilentlyContinue
             }
 
             if ($null -eq $policy)
@@ -198,7 +196,7 @@ function Get-TargetResource
                 Write-Verbose -Message "No Endpoint Protection Attack Surface Protection rules Policy with identity {$Identity} was found"
                 if (-not [String]::IsNullOrEmpty($DisplayName))
                 {
-                    $filter = "displayName eq '$($DisplayName)' and (TemplateId eq '0e237410-1367-4844-bd7f-15fb0f08943b' or TemplateId eq '63be6324-e3c9-4c97-948a-e7f4b96f0f20')"
+                    $filter = "displayName eq '$($DisplayName)' and (TemplateId eq '0e237410-1367-4844-bd7f-15fb0f08943b')"
                     $policy = Get-MgBetaDeviceManagementIntent -All `
                                                                -Filter $filter -ErrorAction SilentlyContinue
                 }
@@ -842,9 +840,9 @@ function Export-TargetResource
 
     try
     {
-        $policyTemplateIDs = @('0e237410-1367-4844-bd7f-15fb0f08943b','63be6324-e3c9-4c97-948a-e7f4b96f0f20')
+        $policyTemplateID = '0e237410-1367-4844-bd7f-15fb0f08943b'
         [array]$policies = Get-MgBetaDeviceManagementIntent -Filter $Filter -All:$true `
-            -ErrorAction Stop | Where-Object -FilterScript {$policyTemplateIDs.Contains($_.TemplateId) }
+            -ErrorAction Stop | Where-Object -FilterScript { $_.TemplateId -eq $policyTemplateID }
 
         if ($policies.Length -eq 0)
         {


### PR DESCRIPTION
#### Pull Request (PR) description
This PR reverts the newly added filter for the `IntuneASRRulesPolicyWindows10` resource. The added template id belongs to the `IntuneApplicationControlPolicyWindows10` and is managed separately. 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
