### PR TITLE
Update Intune Edge Security Baseline to latest template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
     defined this property as a string, where the code expected and integer.
     NOTE: This should not cause any issues, since the export already exported
     this value as an integer.
+* IntuneSecurityBaselineMicrosoftEdge
+  * Updated to latest template and deprecated `EdgeEnhanceImagesEnabled` as well as `WebSQLAccess`.
 * SCDLPComplianceRule
   * Fixed apostrophes in the export method.
 * SCSensitivityLabel

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/MSFT_IntuneSecurityBaselineMicrosoftEdge.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/MSFT_IntuneSecurityBaselineMicrosoftEdge.psm1
@@ -126,6 +126,21 @@ function Get-TargetResource
         $TyposquattingCheckerEnabled,
 
         [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $edge_DynamicCodeSettings,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $DynamicCodeSettings_DynamicCodeSettings,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ApplicationBoundEncryptionEnabled,
+
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Assignments,
         #endregion
@@ -170,6 +185,7 @@ function Get-TargetResource
     {
         if (-not $Script:exportedInstance -or $Script:exportedInstance.DisplayName -ne $DisplayName)
         {
+
             $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
                 -InboundParameters $PSBoundParameters
 
@@ -189,6 +205,7 @@ function Get-TargetResource
             $nullResult.Ensure = 'Absent'
 
             $getValue = $null
+
             #region resource generator code
             if (-not [System.String]::IsNullOrEmpty($Id))
             {
@@ -397,6 +414,21 @@ function Set-TargetResource
         $TyposquattingCheckerEnabled,
 
         [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $edge_DynamicCodeSettings,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $DynamicCodeSettings_DynamicCodeSettings,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ApplicationBoundEncryptionEnabled,
+
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Assignments,
         #endregion
@@ -434,6 +466,20 @@ function Set-TargetResource
         $AccessTokens
     )
 
+    Write-Verbose -Message "Setting configuration of the Intune Security Baseline Microsoft Edge with Id {$Id} and Name {$Name}"
+
+    if ($PSBoundParameters.ContainsKey('WebSQLAccess'))
+    {
+        Write-Warning -Message "The WebSQLAccess parameter is deprecated and will be removed in a future version. It will not be used in the current operation."
+        $PSBoundParameters.Remove('WebSQLAccess') | Out-Null
+    }
+
+    if ($PSBoundParameters.ContainsKey('EdgeEnhanceImagesEnabled'))
+    {
+        Write-Warning -Message "The EdgeEnhanceImagesEnabled parameter is deprecated and will be removed in a future version. It will not be used in the current operation."
+        $PSBoundParameters.Remove('EdgeEnhanceImagesEnabled') | Out-Null
+    }
+
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
 
@@ -450,14 +496,14 @@ function Set-TargetResource
 
     $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
 
-    $templateReferenceId = 'c66347b7-8325-4954-a235-3bf2233dfbfd_2'
+    $templateReferenceId = 'c66347b7-8325-4954-a235-3bf2233dfbfd_3'
     $platforms = 'windows10'
     $technologies = 'mdm'
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {
         Write-Verbose -Message "Creating an Intune Security Baseline Microsoft Edge with Name {$DisplayName}"
-        $BoundParameters.Remove('Assignments') | Out-Null
+        $BoundParameters.Remove("Assignments") | Out-Null
 
         $settings = Get-IntuneSettingCatalogPolicySetting `
             -DSCParams ([System.Collections.Hashtable]$BoundParameters) `
@@ -488,7 +534,7 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
     {
         Write-Verbose -Message "Updating the Intune Security Baseline Microsoft Edge with Id {$($currentInstance.Id)}"
-        $BoundParameters.Remove('Assignments') | Out-Null
+        $BoundParameters.Remove("Assignments") | Out-Null
 
         $settings = Get-IntuneSettingCatalogPolicySetting `
             -DSCParams ([System.Collections.Hashtable]$BoundParameters) `
@@ -648,6 +694,21 @@ function Test-TargetResource
         $TyposquattingCheckerEnabled,
 
         [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $edge_DynamicCodeSettings,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $DynamicCodeSettings_DynamicCodeSettings,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ApplicationBoundEncryptionEnabled,
+
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Assignments,
         #endregion
@@ -685,6 +746,18 @@ function Test-TargetResource
         [System.String[]]
         $AccessTokens
     )
+
+    if ($PSBoundParameters.ContainsKey('WebSQLAccess'))
+    {
+        Write-Warning -Message "The WebSQLAccess parameter is deprecated and will be removed in a future version. It will not be used in the current operation."
+        $PSBoundParameters.Remove('WebSQLAccess') | Out-Null
+    }
+
+    if ($PSBoundParameters.ContainsKey('EdgeEnhanceImagesEnabled'))
+    {
+        Write-Warning -Message "The EdgeEnhanceImagesEnabled parameter is deprecated and will be removed in a future version. It will not be used in the current operation."
+        $PSBoundParameters.Remove('EdgeEnhanceImagesEnabled') | Out-Null
+    }
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
@@ -819,8 +892,8 @@ function Export-TargetResource
             -All `
             -ErrorAction Stop | Where-Object `
             -FilterScript {
-            $_.TemplateReference.TemplateId -eq $policyTemplateID
-        }
+                $_.TemplateReference.TemplateId -eq $policyTemplateID
+            }
         #endregion
 
         $i = 1
@@ -880,7 +953,6 @@ function Export-TargetResource
                 -Results $Results `
                 -Credential $Credential `
                 -NoEscape @('Assignments')
-
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/MSFT_IntuneSecurityBaselineMicrosoftEdge.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSecurityBaselineMicrosoftEdge/MSFT_IntuneSecurityBaselineMicrosoftEdge.schema.mof
@@ -20,6 +20,9 @@ class MSFT_IntuneSecurityBaselineMicrosoftEdge : OMI_BaseResource
     [Write, Description("Allow unconfigured sites to be reloaded in Internet Explorer mode (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String InternetExplorerIntegrationReloadInIEModeAllowed;
     [Write, Description("Allow users to proceed from the HTTPS warning page (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String SSLErrorOverrideAllowed;
     [Write, Description("Automatically open downloaded MHT or MHTML files from the web in Internet Explorer mode (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String InternetExplorerIntegrationZoneIdentifierMhtFileAllowed;
+    [Write, Description("Dynamic Code Settings (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String edge_DynamicCodeSettings;
+    [Write, Description("Dynamic Code Settings (Device) - Depends on edge_DynamicCodeSettings (0: Default dynamic code settings, 1: Prevent the browser process from creating dynamic code)"), ValueMap{"0", "1"}, Values{"0", "1"}] String DynamicCodeSettings_DynamicCodeSettings;
+    [Write, Description("Enable Application Bound Encryption (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String ApplicationBoundEncryptionEnabled;
     [Write, Description("Enable browser legacy extension point blocking (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String BrowserLegacyExtensionPointsBlockingEnabled;
     [Write, Description("Enable site isolation for every site (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String SitePerProcess;
     [Write, Description("Enhance images enabled (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] String EdgeEnhanceImagesEnabled;


### PR DESCRIPTION
#### Pull Request (PR) description
Updates the Intune Edge Security Baseline to the latest V128 template. Multiple parameters were deprecated. 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
