### PR TITLE
Update description and new property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+* IntuneDeviceCompliancePolicyAndroidDeviceOwner
+  * Added new property `SecurityBlockJailbrokenDevices`.
 * IntuneWindowsHelloForBusinessGlobalPolicy
   * Initial release.
     FIXES [#4561](https://github.com/microsoft/Microsoft365DSC/issues/4561)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner.psm1
@@ -117,6 +117,10 @@ function Get-TargetResource
         $SecurityRequireIntuneAppIntegrity,
 
         [Parameter()]
+        [System.Boolean]
+        $SecurityBlockJailbrokenDevices,
+
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Assignments,
 
@@ -259,6 +263,7 @@ function Get-TargetResource
             PasswordPreviousPasswordCountToBlock               = $devicePolicy.AdditionalProperties.passwordPreviousPasswordCountToBlock
             StorageRequireEncryption                           = $devicePolicy.AdditionalProperties.storageRequireEncryption
             SecurityRequireIntuneAppIntegrity                  = $devicePolicy.AdditionalProperties.securityRequireIntuneAppIntegrity
+            SecurityBlockJailbrokenDevices                     = $devicePolicy.AdditionalProperties.securityBlockJailbrokenDevices
             RoleScopeTagIds                                    = $devicePolicy.roleScopeTagIds
             Ensure                                             = 'Present'
             Credential                                         = $Credential
@@ -266,7 +271,7 @@ function Get-TargetResource
             TenantId                                           = $TenantId
             ApplicationSecret                                  = $ApplicationSecret
             CertificateThumbprint                              = $CertificateThumbprint
-            Managedidentity                                    = $ManagedIdentity.IsPresent
+            ManagedIdentity                                    = $ManagedIdentity.IsPresent
             AccessTokens                                       = $AccessTokens
         }
 
@@ -410,6 +415,10 @@ function Set-TargetResource
         [Parameter()]
         [System.Boolean]
         $SecurityRequireIntuneAppIntegrity,
+
+        [Parameter()]
+        [System.Boolean]
+        $SecurityBlockJailbrokenDevices,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
@@ -680,6 +689,10 @@ function Test-TargetResource
         $SecurityRequireIntuneAppIntegrity,
 
         [Parameter()]
+        [System.Boolean]
+        $SecurityBlockJailbrokenDevices,
+
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Assignments,
 
@@ -880,7 +893,7 @@ function Export-TargetResource
                 TenantId              = $TenantId
                 ApplicationSecret     = $ApplicationSecret
                 CertificateThumbprint = $CertificateThumbprint
-                Managedidentity       = $ManagedIdentity.IsPresent
+                ManagedIdentity       = $ManagedIdentity.IsPresent
                 AccessTokens          = $AccessTokens
             }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner.schema.mof
@@ -51,6 +51,7 @@ class MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner : OMI_BaseResource
     [Write, Description("PasswordPreviousPasswordCountToBlock of the Android Device Owner device compliance policy.")] Uint32 PasswordPreviousPasswordCountToBlock;
     [Write, Description("StorageRequireEncryption of the Android Device Owner device compliance policy.")] Boolean StorageRequireEncryption;
     [Write, Description("SecurityRequireIntuneAppIntegrity of the Android Device Owner device compliance policy.")] Boolean SecurityRequireIntuneAppIntegrity;
+    [Write, Description("Block rooted Android devices.")] Boolean SecurityBlockJailbrokenDevices;
     [Write, Description("List of Scope Tags for this Entity instance. Inherited from deviceConfiguration")] String RoleScopeTagIds[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Credentials of the Intune Admin"), EmbeddedInstance("MSFT_Credential")] String Credential;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidDeviceOwner/readme.md
@@ -2,8 +2,8 @@
 
 ## Description
 
-This resource configures the settings of Android Work Profile device compliance policies
-in your cloud-based organization.
+This resource configures the settings of Android Work Profile device compliance policies in your cloud-based organization.
+Labeled in Intune as `Fully managed, dedicated, and corporate-owned work profile` policy type under `Android Enterprise`.
 
 ## Parameters
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyAndroidWorkProfile/readme.md
@@ -2,8 +2,8 @@
 
 ## Description
 
-This resource configures the settings of Android Work Profile device compliance policies
-in your cloud-based organization.
+This resource configures the settings of Android Work Profile device compliance policies in your cloud-based organization.
+Labeled in Intune as `Personally-owned work profile` policy type under `Android Enterprise`.
 
 ## Parameters
 


### PR DESCRIPTION
#### Pull Request (PR) description
Updates the description of two Android device compliance policies to better clarify which policy type in Intune is specifically targeted by what resource. Additionally, a new property `SecurityBlockJailbrokenDevices` is added for the `DeviceOwner` resource.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
