### PR TITLE
Fix TeamsMeetingPolicy's missing Parameter 'RoomAttributeUserOverride'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
     FIXES [#4609](https://github.com/microsoft/Microsoft365DSC/issues/4609)
 * AADGroupElegibilityScheduleSettings
   * New resource AADGroupElegibilityScheduleSettings
+* TeamsMeetingPolicy
+  * Added missing Parameter 'RoomAttributeUserOverride' to Get-TargetResource's output.
+    Fixes [#6183](https://github.com/microsoft/Microsoft365DSC/issues/6183)
 
 # 1.25.611.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingPolicy/MSFT_TeamsMeetingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingPolicy/MSFT_TeamsMeetingPolicy.psm1
@@ -477,6 +477,7 @@ function Get-TargetResource
             ParticipantNameChange                      = $policy.ParticipantNameChange
             PreferredMeetingProviderForIslandsMode     = $policy.PreferredMeetingProviderForIslandsMode
             QnAEngagementMode                          = $policy.QnAEngagementMode
+            RoomAttributeUserOverride                  = $policy.RoomAttributeUserOverride
             RoomPeopleNameUserOverride                 = $policy.RoomPeopleNameUserOverride
             ScreenSharingMode                          = $policy.ScreenSharingMode
             SpeakerAttributionMode                     = $policy.SpeakerAttributionMode

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsMeetingPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsMeetingPolicy.Tests.ps1
@@ -211,6 +211,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     MediaBitRateKb                             = 50000
                     ScreenSharingMode                          = 'EntireScreen'
                     WhoCanRegister                             = 'EveryoneInCompany'
+                    RoomAttributeUserOverride                  = 'OFF'
                     Ensure                                     = 'Present'
                     Credential                                 = $Credential
                 }
@@ -249,6 +250,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         ScreenSharingMode                          = 'EntireScreen'
                         VoiceIsolation                             = 'Disabled'
                         WhoCanRegister                             = 'EveryoneInCompany'
+                        RoomAttributeUserOverride                  = 'OFF'
                     }
                 }
             }


### PR DESCRIPTION
#### Pull Request (PR) description
Added missing Parameter 'RoomAttributeUserOverride' to Get-TargetResource's output

#### This Pull Request (PR) fixes the following issues
- Fixes #6183

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
