### PR TITLE
BREAKING CHANGE - Add AppId as secondary key parameter to AADApplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * AADApplication
   * Fix to properly handle PreAuthorizedApplications in the Set-TargetResource method
     FIXES [#6182](https://github.com/microsoft/Microsoft365DSC/issues/6182)
+  * [BREAKING CHANGE] Added the `AppId` as a secondary key parameter.
+    FIXES [#6078](https://github.com/microsoft/Microsoft365DSC/issues/6078)
 * AADGroup
   * Fix for removing Group owner.
 * IntuneDeviceCompliancePolicyAndroidDeviceOwner

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -169,10 +169,7 @@ function Get-TargetResource
 
             try
             {
-                if (-not [System.String]::IsNullOrEmpty($AppId))
-                {
-                    $AADApp = Get-MgBetaApplication -Filter "AppId eq '$AppId'"
-                }
+                [array]$AADApp = Get-MgBetaApplication -Filter "AppId eq '$AppId'"
             }
             catch
             {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -12,7 +12,7 @@ function Get-TargetResource
         [System.String]
         $ObjectId,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $AppId,
 
@@ -572,7 +572,7 @@ function Set-TargetResource
         [System.String]
         $ObjectId,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $AppId,
 
@@ -837,7 +837,7 @@ function Set-TargetResource
     if ($currentParameters.Api.PreAuthorizedApplications)
     {
         $PreAuthorizedApplicationsValue = @()
-        
+
         foreach ($preAuthApp in $currentParameters.Api.PreAuthorizedApplications)
         {
             $PreAuthorizedApplicationsValue += @{
@@ -1348,7 +1348,7 @@ function Test-TargetResource
         [System.String]
         $ObjectId,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $AppId,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.schema.mof
@@ -158,7 +158,7 @@ class MSFT_AADApplication : OMI_BaseResource
 {
     [Key, Description("DisplayName of the app")] string DisplayName;
     [Write, Description("ObjectID of the app.")] String ObjectId;
-    [Write, Description("AppId for the app.")] String AppId;
+    [Key, Description("AppId for the app.")] String AppId;
     [Write, Description("DEPRECATED: Indicates whether this application is available in other tenants.")] Boolean AvailableToOtherTenants;
     [Write, Description("A free text field to provide a description of the application object to end users. The maximum allowed size is 1024 characters.")] String Description;
     [Write, Description("A bitmask that configures the groups claim issued in a user or OAuth 2.0 access token that the application expects.")] String GroupMembershipClaims;

--- a/Modules/Microsoft365DSC/Examples/Resources/AADApplication/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/AADApplication/1-Create.ps1
@@ -23,6 +23,7 @@ Configuration Example
     {
         AADApplication 'AADApp1'
         {
+            AppId                     = "12345678-1234-5678-1234-567812345678"
             DisplayName               = "AppDisplayName"
             AvailableToOtherTenants   = $false
             Description               = "Application Description"

--- a/Modules/Microsoft365DSC/Examples/Resources/AADApplication/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/AADApplication/2-Update.ps1
@@ -24,6 +24,7 @@ Configuration Example
     {
         AADApplication 'AADApp1'
         {
+            AppId                     = "12345678-1234-5678-1234-567812345678"
             DisplayName               = "AppDisplayName"
             AuthenticationBehaviors = MSFT_MicrosoftGraphauthenticationBehaviors # To make sure these parameters are not configured
                 {

--- a/Modules/Microsoft365DSC/Examples/Resources/AADApplication/3-Remove.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/AADApplication/3-Remove.ps1
@@ -24,6 +24,7 @@ Configuration Example
     {
         AADApplication 'AADApp1'
         {
+            AppId                     = "12345678-1234-5678-1234-567812345678"
             DisplayName               = "AppDisplayName"
             Ensure                    = "Absent"
             ApplicationId         = $ApplicationId

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADApplication.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADApplication.Tests.ps1
@@ -83,6 +83,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The application should exist but it does not' -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AppId                     = '12345-12345-12345-12345-12345'
                     DisplayName               = 'App1'
                     AvailableToOtherTenants   = $false
                     Description               = 'App description'
@@ -104,7 +105,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return values from the get method' {
                 (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
-                Should -Invoke -CommandName 'Get-MgBetaApplication' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaApplication' -Exactly 2
             }
             It 'Should return false from the test method' {
                 Test-TargetResource @testParams | Should -Be $false
@@ -118,6 +119,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The application exists but it should not' -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AppId                     = '12345-12345-12345-12345-12345'
                     ObjectId                  = '5dcb2237-c61b-4258-9c85-eae2aaeba9d6'
                     DisplayName               = 'App1'
                     AvailableToOtherTenants   = $false
@@ -137,6 +139,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     $AADApp = New-Object PSCustomObject
                     $AADApp | Add-Member -MemberType NoteProperty -Name DisplayName -Value 'App1'
                     $AADApp | Add-Member -MemberType NoteProperty -Name Id -Value '5dcb2237-c61b-4258-9c85-eae2aaeba9d6'
+                    $AADApp | Add-Member -MemberType NoteProperty -Name AppId -Value '12345-12345-12345-12345-12345'
                     $AADApp | Add-Member -MemberType NoteProperty -Name AvailableToOtherTenants -Value $false
                     $AADApp | Add-Member -MemberType NoteProperty -Name Description -Value 'App description'
                     $AADApp | Add-Member -MemberType NoteProperty -Name GroupMembershipClaims -Value 0
@@ -170,6 +173,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'The app exists and values are already in the desired state' -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AppId                     = '12345-12345-12345-12345-12345'
                     DisplayName               = 'App1'
                     AvailableToOtherTenants   = $false
                     Description               = 'App description'
@@ -264,6 +268,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     $AADApp = New-Object PSCustomObject
                     $AADApp | Add-Member -MemberType NoteProperty -Name DisplayName -Value 'App1'
                     $AADApp | Add-Member -MemberType NoteProperty -Name Id -Value '5dcb2237-c61b-4258-9c85-eae2aaeba9d6'
+                    $AADApp | Add-Member -MemberType NoteProperty -Name AppId -Value '12345-12345-12345-12345-12345'
                     $AADApp | Add-Member -MemberType NoteProperty -Name Description -Value 'App description'
                     $AADApp | Add-Member -MemberType NoteProperty -Name GroupMembershipClaims -Value 0
                     $AADApp | Add-Member -MemberType NoteProperty -Name SignInAudience -Value 'AzureADMyOrg'
@@ -365,6 +370,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'Values are not in the desired state' -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AppId                     = '12345-12345-12345-12345-12345'
                     DisplayName               = 'App1'
                     AvailableToOtherTenants   = $false
                     Description               = 'App description'
@@ -383,6 +389,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     $AADApp = New-Object PSCustomObject
                     $AADApp | Add-Member -MemberType NoteProperty -Name DisplayName -Value 'App1'
                     $AADApp | Add-Member -MemberType NoteProperty -Name Id -Value '5dcb2237-c61b-4258-9c85-eae2aaeba9d6'
+                    $AADApp | Add-Member -MemberType NoteProperty -Name AppId -Value '12345-12345-12345-12345-12345'
                     $AADApp | Add-Member -MemberType NoteProperty -Name AvailableToOtherTenants -Value $false
                     $AADApp | Add-Member -MemberType NoteProperty -Name Description -Value 'App description'
                     $AADApp | Add-Member -MemberType NoteProperty -Name GroupMembershipClaims -Value 0
@@ -415,6 +422,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'Assigning Authentication Behaviors to a new Application' -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AppId                     = '12345-12345-12345-12345-12345'
                     DisplayName               = 'App1'
                     AvailableToOtherTenants   = $false
                     Description               = 'App description'
@@ -463,6 +471,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name 'Assigning Permissions to a new Application' -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AppId                     = '12345-12345-12345-12345-12345'
                     DisplayName               = 'App1'
                     AvailableToOtherTenants   = $false
                     Description               = 'App description'
@@ -502,7 +511,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return values from the get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgBetaApplication' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaApplication' -Exactly 2
             }
 
             It 'Should return false from the test method' {
@@ -527,6 +536,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     $AADApp = New-Object PSCustomObject
                     $AADApp | Add-Member -MemberType NoteProperty -Name DisplayName -Value 'App1'
                     $AADApp | Add-Member -MemberType NoteProperty -Name Id -Value '5dcb2237-c61b-4258-9c85-eae2aaeba9d6'
+                    $AADApp | Add-Member -MemberType NoteProperty -Name AppId -Value '12345-12345-12345-12345-12345'
                     $AADApp | Add-Member -MemberType NoteProperty -Name AvailableToOtherTenants -Value $false
                     $AADApp | Add-Member -MemberType NoteProperty -Name Description -Value 'App description'
                     $AADApp | Add-Member -MemberType NoteProperty -Name GroupMembershipClaims -Value 0


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds a seconday key parameter to the `AADApplication` resource to be able to manage app registrations that don't have a unique display name, which may occur if they are autogenerated by the Azure portal (or Copilot Studio etc.). 

#### This Pull Request (PR) fixes the following issues
- Fixes #6078 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
