### PR TITLE
Add support for RoleScopeTagIds property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   * Fix for removing Group owner.
 * IntuneDeviceCompliancePolicyAndroidDeviceOwner
   * Added new property `SecurityBlockJailbrokenDevices`.
+* IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10
+  * Added support for property `RoleScopeTagIds`.
 * IntuneDefenderGlobalExclusionsPolicyLinux
   * Initial release.
 * IntuneWindowsHelloForBusinessGlobalPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.psm1
@@ -27,6 +27,10 @@ function Get-TargetResource
         $DefinitionValues,
 
         [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Assignments,
         #endregion
@@ -240,6 +244,7 @@ function Get-TargetResource
             #PolicyConfigurationIngestionType = $enumPolicyConfigurationIngestionType
             DefinitionValues      = $complexDefinitionValues
             Id                    = $getValue.Id
+            RoleScopeTagIds       = $getValue.RoleScopeTagIds
             Ensure                = 'Present'
             Credential            = $Credential
             ApplicationId         = $ApplicationId
@@ -311,6 +316,10 @@ function Set-TargetResource
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $DefinitionValues,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
@@ -632,6 +641,10 @@ function Test-TargetResource
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $DefinitionValues,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10/MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10.schema.mof
@@ -63,6 +63,7 @@ class MSFT_IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10 : OMI_
     [Write, Description("Type of definitions configured for this policy. Possible values are: unknown, custom, builtIn, mixed, unknownFutureValue."), ValueMap{"unknown","custom","builtIn","mixed","unknownFutureValue"}, Values{"unknown","custom","builtIn","mixed","unknownFutureValue"}] String PolicyConfigurationIngestionType;
     [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
     [Write, Description("The list of enabled or disabled group policy definition values for the configuration."), EmbeddedInstance("MSFT_IntuneGroupPolicyDefinitionValue")] String DefinitionValues[];
+    [Write, Description("List of Scope Tag IDs for this policy instance.")] String RoleScopeTagIds[];
     [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds support for the `RoleScopeTagIds` property in the `IntuneDeviceConfigurationAdministrativeTemplatePolicyWindows10` resource.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
