### PR TITLE
Fix for removing or resetting builtInControls, customAuthenticationFa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* AADConditionalAccessPolicy
+  * Fix for removing or resetting builtInControls, customAuthenticationFactors, authenticationStrength or termsOfUse
+    FIXES [#6218](https://github.com/microsoft/Microsoft365DSC/issues/6218)
 * AADApplication
   * Fix to properly handle PreAuthorizedApplications in the Set-TargetResource method
     FIXES [#6182](https://github.com/microsoft/Microsoft365DSC/issues/6182)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -1765,15 +1765,15 @@ function Set-TargetResource
                 operator = $GrantControlOperator
             }
 
-            if ($BuiltInControls)
+            if ($currentParameters.ContainsKey('builtInControls'))
             {
                 $GrantControls.Add('builtInControls', $BuiltInControls)
             }
-            if ($customAuthenticationFactors)
+            if ($currentParameters.ContainsKey('customAuthenticationFactors'))
             {
                 $GrantControls.Add('customAuthenticationFactors', $CustomAuthenticationFactors)
             }
-            if ($AuthenticationStrength)
+            if ($currentParameters.ContainsKey('authenticationStrength'))
             {
                 $strengthPolicy = Get-MgBetaPolicyAuthenticationStrengthPolicy | Where-Object -FilterScript { $_.DisplayName -eq $AuthenticationStrength } -ErrorAction SilentlyContinue
                 if ($null -ne $strengthPolicy)
@@ -1786,7 +1786,7 @@ function Set-TargetResource
                 }
             }
 
-           if ($TermsOfUse)
+           if ($currentParameters.ContainsKey('termsOfUse'))
            {
                Write-Verbose -Message "Getting Terms of Use {$TermsOfUse}"
                $TermsOfUseObj = Get-MgBetaAgreement | Where-Object -FilterScript { $_.DisplayName -eq $TermsOfUse }


### PR DESCRIPTION
Fix for removing or resetting builtInControls, customAuthenticationFactors, authenticationStrength or termsOfUse





#### Pull Request (PR) description
When an empty array or an empty string was passed on for one of these properties, the value was dropped for these properties and hence it was not reset.

Instead of checking for 

[bool]$builtInControls

the checks were changed to the presence of the key itself

$currentParameters.ContainsKey('builtInControls')

This way, when an empty array or empty string was set in the config, the property will be taken into account and reset.

#### This Pull Request (PR) fixes the following issues
    - FIXES [#6218](https://github.com/microsoft/Microsoft365DSC/issues/6218)

#### Task list

- [ X ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ X ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
