### PR TITLE
Fix export of Fabric Admin Tenant Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 * EXODistributionGroup
   * Always use the retrieved Identity when updating the distribution group
     to ensure correct group is updated when retrieved with PrimarySmtpAddress.
+* FabricAdminTenantSettings
+  * Fixed an issue where exported titles could contain unescaped string literals.
+    FIXES [#6199](https://github.com/microsoft/Microsoft365DSC/issues/6199)
 * IntuneDeviceAndAppManagementAssignmentFilter
   * Added property `AssignmentFilterManagementType` to supported properties.
 * IntuneDeviceCompliancePolicyAndroidDeviceOwner

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_FabricAdminTenantSettings/MSFT_FabricAdminTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_FabricAdminTenantSettings/MSFT_FabricAdminTenantSettings.psm1
@@ -1914,7 +1914,7 @@ function Test-TargetResource
     {
         $source = $PSBoundParameters.$key
         $target = $CurrentValues.$key
-        if ($source.getType().Name -like '*CimInstance*')
+        if ($source.GetType().Name -like '*CimInstance*')
         {
             $source = Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $source
 
@@ -2094,7 +2094,7 @@ function Get-M365DSCFabricTenantSettingObject
     $values = @{
         settingName = $Setting.settingName
         enabled     = [Boolean]$Setting.enabled
-        title       = ($Setting.title -creplace '\P{IsBasicLatin}')
+        title       = ($Setting.title -creplace '\P{IsBasicLatin}').Replace("`"", "```"")
     }
     if (-not [System.String]::IsNullOrEmpty($Setting.canSpecifySecurityGroups))
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_FabricAdminTenantSettings/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_FabricAdminTenantSettings/readme.md
@@ -4,3 +4,5 @@
 ## Description
 
 This resource configures the tenant settings for Microsoft Fabric.
+
+**Please note:** For a successful export, you need to use service principals. A guide can be found here: [Authenticate to Fabric](https://nik-charlebois.com/blog/posts/2024/authenticating-to-fabric/index.html)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_FabricAdminTenantSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_FabricAdminTenantSettings/settings.json
@@ -2,8 +2,12 @@
     "resourceName": "FabricAdminTenantSettings",
     "description": "This resource configures the tenant settings for Microsoft Fabric.",
     "roles": {
-        "read": [],
-        "update": []
+        "read": [
+            "Global Reader"
+        ],
+        "update": [
+            "Fabric Administrator"
+        ]
     },
     "permissions": {
         "graph": {


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes the `FabricAdminTenantSettings` export. Titles could contain string literals which wouldn't be escaped and therefore break the M365TenantConfig.ps1 file. 

#### This Pull Request (PR) fixes the following issues
- Fixes #6199 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
