### PR TITLE
Fix drift event log and missing initialized variable

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -931,7 +931,11 @@ function Compare-M365DSCComplexObjectV2
 
         [Parameter()]
         [System.String[]]
-        $PrimaryKeys
+        $PrimaryKeys,
+
+        [Parameter()]
+        [switch]
+        $NoDriftReport
     )
 
     $returnValue = $true
@@ -956,11 +960,20 @@ function Compare-M365DSCComplexObjectV2
         }
 
         Write-Verbose -Message "Configuration drift - Complex object: {$sourceValue$targetValue}"
-        $Global:AllDrifts.DriftInfo += @{
+        $drift = @{
             PropertyName = $PropertyName
             CurrentValue = $targetValue
             DesiredValue = $sourceValue
         }
+        if (-not $NoDriftReport)
+        {
+            $Global:AllDrifts.DriftInfo += $drift
+        }
+        else
+        {
+            $Global:PotentialDrifts += $drift
+        }
+
 
         return $false
     }
@@ -1006,6 +1019,7 @@ function Compare-M365DSCComplexObjectV2
             return $returnValue
         }
 
+        $compareResult = $null
         for ($counter = 0; $counter -lt $Source.Count; $counter++)
         {
             $item = $Source[$counter]
@@ -1017,7 +1031,8 @@ function Compare-M365DSCComplexObjectV2
                     $compareResult = Compare-M365DSCComplexObjectV2 `
                         -Source $item `
                         -Target $targetItem `
-                        -PropertyName ("$PropertyName[$counter]")
+                        -PropertyName ("$PropertyName[$counter]") `
+                        -NoDriftReport
 
                     if ($compareResult)
                     {
@@ -1030,10 +1045,18 @@ function Compare-M365DSCComplexObjectV2
             if (-not $foundMatch)
             {
                 Write-Verbose -Message 'Configuration drift - The complex array items are not identical'
-                $Global:AllDrifts.DriftInfo += @{
-                    PropertyName = ("$PropertyName[$counter]")
-                    CurrentValue = $Target
-                    DesiredValue = $Source
+                if ($null -eq $compareResult) # The loop contained no elements, no potential drifts
+                {
+                    $Global:AllDrifts.DriftInfo += @{
+                        PropertyName = ("$PropertyName[$counter]")
+                        CurrentValue = $Target
+                        DesiredValue = $Source
+                    }
+                }
+                else
+                {
+                    $Global:AllDrifts.DriftInfo += $Global:PotentialDrifts[-1]
+                    $Global:PotentialDrifts = @()
                 }
 
                 return $false
@@ -1041,6 +1064,7 @@ function Compare-M365DSCComplexObjectV2
         }
 
         # Do the opposite check
+        $compareResult = $null
         for ($counter = 0; $counter -lt $Target.Count; $counter++)
         {
             $item = $Target[$counter]
@@ -1052,7 +1076,8 @@ function Compare-M365DSCComplexObjectV2
                     $compareResult = Compare-M365DSCComplexObjectV2 `
                         -Source $item `
                         -Target $targetItem `
-                        -PropertyName ("$PropertyName[$counter]")
+                        -PropertyName ("$PropertyName[$counter]") `
+                        -NoDriftReport
 
                     if ($compareResult)
                     {
@@ -1064,10 +1089,21 @@ function Compare-M365DSCComplexObjectV2
             if (-not $foundMatch -and $Target.GetType().Name -ne 'Hashtable' -and $Target.GetType().Name -ne 'Object[]')
             {
                 Write-Verbose -Message 'Configuration drift - The complex array items are not identical'
-                $Global:AllDrifts.DriftInfo += @{
-                    PropertyName = ("$PropertyName[$counter]")
-                    CurrentValue = $Target
-                    DesiredValue = $Source
+                if (-not $NoDriftReport)
+                {
+                    if ($null -eq $compareResult) # The loop contained no elements, no potential drifts
+                    {
+                        $Global:AllDrifts.DriftInfo += @{
+                            PropertyName = ("$PropertyName[$counter]")
+                            CurrentValue = $Target
+                            DesiredValue = $Source
+                        }
+                    }
+                    else
+                    {
+                        $Global:AllDrifts.DriftInfo += $Global:PotentialDrifts[-1]
+                        $Global:PotentialDrifts = @()
+                    }
                 }
 
                 return $false
@@ -1149,10 +1185,18 @@ function Compare-M365DSCComplexObjectV2
                 Write-Verbose -Message "Configuration drift - key: $key"
                 Write-Verbose -Message "Source {$sourceValue}"
                 Write-Verbose -Message "Target {$targetValue}"
-                $Global:AllDrifts.DriftInfo += @{
-                    PropertyName = ($PropertyName + "." + $key)
+                $drift = @{
+                    PropertyName = $PropertyName + "." + $key
                     CurrentValue = $targetValue
-                    DesiredValue = $SourceValue
+                    DesiredValue = $sourceValue
+                }
+                if (-not $NoDriftReport)
+                {
+                    $Global:AllDrifts.DriftInfo += $drift
+                }
+                else
+                {
+                    $Global:PotentialDrifts += $drift
                 }
 
                 $returnValue = $false
@@ -1180,7 +1224,8 @@ function Compare-M365DSCComplexObjectV2
                         $compareResult = Compare-M365DSCComplexObjectV2 `
                             -Source $Source.$key `
                             -Target $Target.$key `
-                            -PropertyName ($PropertyName + "." + $key)
+                            -PropertyName ($PropertyName + "." + $key) `
+                            -NoDriftReport:$NoDriftReport
                     }
 
                     if (-not $compareResult -and $targetValue.GetType().Name -ne "Hashtable" -and $targetValue.GetType().Name -ne 'Object[]')
@@ -1188,10 +1233,18 @@ function Compare-M365DSCComplexObjectV2
                         Write-Verbose -Message "Configuration drift - complex object key: $key"
                         Write-Verbose -Message "Source {$sourceValue}"
                         Write-Verbose -Message "Target {$targetValue}"
-                        $Global:AllDrifts.DriftInfo += @{
+                        $drift = @{
                             PropertyName = ($PropertyName + "." + $key)
                             CurrentValue = $targetValue
-                            DesiredValue = $SourceValue
+                            DesiredValue = $sourceValue
+                        }
+                        if (-not $NoDriftReport)
+                        {
+                            $Global:AllDrifts.DriftInfo += $drift
+                        }
+                        else
+                        {
+                            $Global:PotentialDrifts += $drift
                         }
 
                         $returnValue = $false
@@ -1255,10 +1308,18 @@ function Compare-M365DSCComplexObjectV2
                         Write-Verbose -Message "Configuration drift - simple object key: $key"
                         Write-Verbose -Message "Source {$sourceValue}"
                         Write-Verbose -Message "Target {$targetValue}"
-                        $Global:AllDrifts.DriftInfo += @{
+                        $drift = @{
                             PropertyName = ($PropertyName + "." + $key)
                             CurrentValue = $targetValue
-                            DesiredValue = $SourceValue
+                            DesiredValue = $sourceValue
+                        }
+                        if (-not $NoDriftReport)
+                        {
+                            $Global:AllDrifts.DriftInfo += $drift
+                        }
+                        else
+                        {
+                            $Global:PotentialDrifts += $drift
                         }
 
                         return $false

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -447,8 +447,22 @@ function Test-M365DSCParameterState
 
         [Parameter(Position = 7)]
         [switch]
-        $NoEventMessage
+        $NoEventMessage,
+
+        [Parameter(Position = 8)]
+        [switch]
+        $NoDriftReset
     )
+
+    if ($null -eq $Global:AllDrifts -or -not $NoDriftReset)
+    {
+        $Global:AllDrifts = @{
+            DriftInfo     = @()
+            CurrentValues = @{}
+            DesiredValues = @{}
+        }
+        $Global:PotentialDrifts = @()
+    }
 
     #region Telemetry
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
@@ -1043,12 +1057,6 @@ function Test-M365DSCParameterState
     return $returnValue
 }
 
-$Global:AllDrifts = @{
-    DriftInfo     = @()
-    CurrentValues = @{}
-    DesiredValues = @{}
-}
-
 <#
 .Description
     Centralized method to evaluate the result of the various Test-TargetResource functions
@@ -1085,6 +1093,7 @@ function Test-M365DSCTargetResource
         CurrentValues = @{}
         DesiredValues = @{}
     }
+    $Global:PotentialDrifts = @()
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
@@ -1193,7 +1202,8 @@ function Test-M365DSCTargetResource
             -Source $($MyInvocation.MyCommand.Source) `
             -DesiredValues $DesiredValues `
             -ValuesToCheck $ValuesToCheck.Keys `
-            -NoEventMessage
+            -NoEventMessage `
+            -NoDriftReset
 
     Write-Verbose -Message "Test-M365DSCTargetResource returned $testResult"
 


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where the drift event log would contain too many entries and another issue where the `$Global:AllDrifts` variable wouldn't be initialized

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
