### PR TITLE
Add secondary key parameter to AADGroupEligibilitySchedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@
   * FIXES [#6198] Adds support for ServicePrincipalRiskLevels
 * AADGroup
   * Fix for removing Group owner.
-* AADGroupElegibilityScheduleSettings
-  * New resource AADGroupElegibilityScheduleSettings
+* AADGroupEligibilitySchedule
+  * Added secondary key parameter `PrincipalDisplayName`.
+* AADGroupEligibilityScheduleSettings
+  * New resource AADGroupEligibilityScheduleSettings
 * AADRoleAssignmentScheduleRequest
   * FIXES [#5710](https://github.com/microsoft/Microsoft365DSC/issues/5710)
 * AADServicePrincipal

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupEligibilitySchedule/MSFT_AADGroupEligibilitySchedule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupEligibilitySchedule/MSFT_AADGroupEligibilitySchedule.psm1
@@ -6,7 +6,7 @@ function Get-TargetResource
     (
         #region resource generator code
         [Parameter()]
-        [ValidateSet('owner','member','unknownFutureValue')]
+        [ValidateSet('owner', 'member', 'unknownFutureValue')]
         [System.String]
         $AccessId,
 
@@ -19,7 +19,7 @@ function Get-TargetResource
         $GroupDisplayName,
 
         [Parameter()]
-        [ValidateSet('direct','group','unknownFutureValue')]
+        [ValidateSet('direct', 'group', 'unknownFutureValue')]
         [System.String]
         $MemberType,
 
@@ -102,15 +102,17 @@ function Get-TargetResource
         $nullResult.Ensure = 'Absent'
 
         $getValue = $null
-        if($GroupId.Length -eq 0){
+        if ($GroupId.Length -eq 0)
+        {
             $Filter = "DisplayName eq '" + $GroupDisplayName + "'"
             $GroupId = (Get-MgGroup -Filter $Filter).Id
         }
-        if ($Id -notmatch '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}_member_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
+        if ($Id -notmatch '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}_member_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
+        {
             $getId = Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilitySchedule `
                 -Filter "Groupid eq '$GroupId'" `
                 -ErrorAction SilentlyContinue
-                $Id = $getId.Id
+            $Id = $getId.Id
         }
 
         $uri = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)v1.0/identityGovernance/privilegedAccess/group/eligibilitySchedules/" + $Id
@@ -137,11 +139,11 @@ function Get-TargetResource
         {
             $complexExpiration.Add('Type', $getValue.scheduleInfo.expiration.type.ToString())
         }
-        if ($complexExpiration.values.Where({$null -ne $_}).Count -eq 0)
+        if ($complexExpiration.values.Where({ $null -ne $_ }).Count -eq 0)
         {
             $complexExpiration = $null
         }
-        $complexScheduleInfo.Add('Expiration',$complexExpiration)
+        $complexScheduleInfo.Add('Expiration', $complexExpiration)
         $complexRecurrence = @{}
         $complexPattern = @{}
         $complexPattern.Add('DayOfMonth', $getValue.scheduleInfo.recurrence.pattern.dayOfMonth)
@@ -163,11 +165,11 @@ function Get-TargetResource
         {
             $complexPattern.Add('Type', $getValue.scheduleInfo.recurrence.pattern.type.ToString())
         }
-        if ($complexPattern.values.Where({$null -ne $_}).Count -eq 0)
+        if ($complexPattern.values.Where({ $null -ne $_ }).Count -eq 0)
         {
             $complexPattern = $null
         }
-        $complexRecurrence.Add('Pattern',$complexPattern)
+        $complexRecurrence.Add('Pattern', $complexPattern)
         $complexRange = @{}
         if ($null -ne $getValue.scheduleInfo.recurrence.range.endDate)
         {
@@ -183,21 +185,21 @@ function Get-TargetResource
         {
             $complexRange.Add('Type', $getValue.scheduleInfo.recurrence.range.type.ToString())
         }
-        if ($complexRange.values.Where({$null -ne $_}).Count -eq 0)
+        if ($complexRange.values.Where({ $null -ne $_ }).Count -eq 0)
         {
             $complexRange = $null
         }
-        $complexRecurrence.Add('Range',$complexRange)
-        if ($complexRecurrence.values.Where({$null -ne $_}).Count -eq 0)
+        $complexRecurrence.Add('Range', $complexRange)
+        if ($complexRecurrence.values.Where({ $null -ne $_ }).Count -eq 0)
         {
             $complexRecurrence = $null
         }
-        $complexScheduleInfo.Add('Recurrence',$complexRecurrence)
+        $complexScheduleInfo.Add('Recurrence', $complexRecurrence)
         if ($null -ne $getValue.ScheduleInfo.startDateTime)
         {
             $complexScheduleInfo.Add('StartDateTime', ([DateTimeOffset]$getValue.ScheduleInfo.startDateTime).ToString('o'))
         }
-        if ($complexScheduleInfo.values.Where({$null -ne $_}).Count -eq 0)
+        if ($complexScheduleInfo.values.Where({ $null -ne $_ }).Count -eq 0)
         {
             $complexScheduleInfo = $null
         }
@@ -219,7 +221,7 @@ function Get-TargetResource
 
         if ([string]::IsNullOrEmpty($getValue.PrincipalType))
         {
-            $getValue.PrincipalType = "unknown"
+            $getValue.PrincipalType = 'unknown'
         }
 
        	switch ($getValue.PrincipalType)
@@ -283,7 +285,7 @@ function Set-TargetResource
     (
         #region resource generator code
         [Parameter()]
-        [ValidateSet('owner','member','unknownFutureValue')]
+        [ValidateSet('owner', 'member', 'unknownFutureValue')]
         [System.String]
         $AccessId,
 
@@ -296,7 +298,7 @@ function Set-TargetResource
         $GroupDisplayName,
 
         [Parameter()]
-        [ValidateSet('direct','group','unknownFutureValue')]
+        [ValidateSet('direct', 'group', 'unknownFutureValue')]
         [System.String]
         $MemberType,
 
@@ -389,64 +391,64 @@ function Set-TargetResource
         $GroupFilter = "DisplayName eq '" + $GroupDisplayName + "'"
         $GroupId = (Get-MgGroup -Filter $GroupFilter).Id
 
-        if($ScheduleInfo.Expiration.Type -eq 'noExpiration'){
+        if ($ScheduleInfo.Expiration.Type -eq 'noExpiration')
+        {
             $p = Get-MgBetaPolicyRoleManagementPolicyAssignment -Filter $("scopeId eq '{0}' and scopeType eq 'Group' and RoleDefinitionId eq 'member'" -f $GroupId)
             $unifiedRoleManagementPolicyId = $p.PolicyId
-            $unifiedRoleManagementPolicyRuleId = "Expiration_Admin_Eligibility"
+            $unifiedRoleManagementPolicyRuleId = 'Expiration_Admin_Eligibility'
             $isExpirationRequired = (Get-MgBetaPolicyRoleManagementPolicyRule -UnifiedRoleManagementPolicyId $unifiedRoleManagementPolicyId -UnifiedRoleManagementPolicyRuleId $unifiedRoleManagementPolicyRuleId).AdditionalProperties.isExpirationRequired
-            if($isExpirationRequired){
+            if ($isExpirationRequired)
+            {
                 $params = @{
-                    "@odata.type" = "#microsoft.graph.unifiedRoleManagementPolicyExpirationRule"
-                    id = "Expiration_Admin_Eligibility"
+                    '@odata.type'        = '#microsoft.graph.unifiedRoleManagementPolicyExpirationRule'
+                    id                   = 'Expiration_Admin_Eligibility'
                     isExpirationRequired = $false
-                    target = @{
-                        caller = "Admin"
-                        operations = @(
-                            "All"
-                        )
-                        level = "Eligibility"
-                        inheritableSettings = @(
-                        )
-                        enforcedSettings = @(
-                        )
+                    target               = @{
+                        caller              = 'Admin'
+                        operations          = @('All')
+                        level               = 'Eligibility'
+                        inheritableSettings = @()
+                        enforcedSettings    = @()
                     }
                 }
+
                 Update-MgBetaPolicyRoleManagementPolicyRule -UnifiedRoleManagementPolicyId $unifiedRoleManagementPolicyId -UnifiedRoleManagementPolicyRuleId $unifiedRoleManagementPolicyRuleId -BodyParameter $params
             }
         }
-        elseif($ScheduleInfo.Expiration.Type -match "^after"){
+        elseif ($ScheduleInfo.Expiration.Type -match '^after')
+        {
             $p = Get-MgBetaPolicyRoleManagementPolicyAssignment -Filter $("scopeId eq '{0}' and scopeType eq 'Group' and RoleDefinitionId eq 'member'" -f $GroupId)
             $unifiedRoleManagementPolicyId = $p.PolicyId
-            $unifiedRoleManagementPolicyRuleId = "Expiration_Admin_Eligibility"
+            $unifiedRoleManagementPolicyRuleId = 'Expiration_Admin_Eligibility'
             $isExpirationRequired = (Get-MgBetaPolicyRoleManagementPolicyRule -UnifiedRoleManagementPolicyId $unifiedRoleManagementPolicyId -UnifiedRoleManagementPolicyRuleId $unifiedRoleManagementPolicyRuleId).AdditionalProperties.isExpirationRequired
-            if(-not $isExpirationRequired){
+            if (-not $isExpirationRequired)
+            {
                 $params = @{
-                    "@odata.type" = "#microsoft.graph.unifiedRoleManagementPolicyExpirationRule"
-                    id = "Expiration_Admin_Eligibility"
+                    '@odata.type'        = '#microsoft.graph.unifiedRoleManagementPolicyExpirationRule'
+                    id                   = 'Expiration_Admin_Eligibility'
                     isExpirationRequired = $true
-                    maximumDuration = 'P365D'
-                    target = @{
-                        caller = "Admin"
-                        operations = @(
-                            "All"
-                        )
-                        level = "Eligibility"
-                        inheritableSettings = @(
-                        )
-                        enforcedSettings = @(
-                        )
+                    maximumDuration      = 'P365D'
+                    target               = @{
+                        caller              = 'Admin'
+                        operations          = @('All')
+                        level               = 'Eligibility'
+                        inheritableSettings = @()
+                        enforcedSettings    = @()
                     }
                 }
+
                 Update-MgBetaPolicyRoleManagementPolicyRule -UnifiedRoleManagementPolicyId $unifiedRoleManagementPolicyId -UnifiedRoleManagementPolicyRuleId $unifiedRoleManagementPolicyRuleId -BodyParameter $params
             }
         }
 
         $createParameters.Add('GroupId', $GroupId)
         $Filter = "DisplayName eq '" + $PrincipalDisplayname + "'"
-        if($PrincipalType -eq 'group'){
+        if ($PrincipalType -eq 'group')
+        {
             $PrincipalId = (Get-MgGroup -Filter $Filter).Id
         }
-        else{
+        else
+        {
             $PrincipalId = (Get-MgUser -Filter $Filter).Id
         }
         $createParameters.Add('PrincipalId', $PrincipalId)
@@ -469,10 +471,12 @@ function Set-TargetResource
 
         $scheduledStart = $currentInstance.ScheduleInfo.StartDateTime
         $scheduledEnd = $currentInstance.ScheduleInfo.Expiration.EndDateTime
-        if($scheduledStart -ne $ScheduleInfo.StartDateTime -or $scheduledEnd -ne $ScheduleInfo.Expiration.EndDateTime){
+        if ($scheduledStart -ne $ScheduleInfo.StartDateTime -or $scheduledEnd -ne $ScheduleInfo.Expiration.EndDateTime)
+        {
             $Action = 'adminExtend'
         }
-        else{
+        else
+        {
             $Action = 'adminUpdate'
         }
         $updateParameters = ([Hashtable]$BoundParameters).Clone()
@@ -486,65 +490,64 @@ function Set-TargetResource
 
         $GroupFilter = "DisplayName eq '" + $GroupDisplayName + "'"
         $GroupId = (Get-MgGroup -Filter $GroupFilter).Id
-        if($ScheduleInfo.Expiration.Type -eq 'noExpiration'){
+        if ($ScheduleInfo.Expiration.Type -eq 'noExpiration')
+        {
             $p = Get-MgBetaPolicyRoleManagementPolicyAssignment -Filter $("scopeId eq '{0}' and scopeType eq 'Group' and RoleDefinitionId eq 'member'" -f $GroupId)
             $unifiedRoleManagementPolicyId = $p.PolicyId
-            $unifiedRoleManagementPolicyRuleId = "Expiration_Admin_Eligibility"
+            $unifiedRoleManagementPolicyRuleId = 'Expiration_Admin_Eligibility'
             $isExpirationRequired = (Get-MgBetaPolicyRoleManagementPolicyRule -UnifiedRoleManagementPolicyId $unifiedRoleManagementPolicyId -UnifiedRoleManagementPolicyRuleId $unifiedRoleManagementPolicyRuleId).AdditionalProperties.isExpirationRequired
-            if($isExpirationRequired){
+            if ($isExpirationRequired)
+            {
                 $params = @{
-                    "@odata.type" = "#microsoft.graph.unifiedRoleManagementPolicyExpirationRule"
-                    id = "Expiration_Admin_Eligibility"
+                    '@odata.type'        = '#microsoft.graph.unifiedRoleManagementPolicyExpirationRule'
+                    id                   = 'Expiration_Admin_Eligibility'
                     isExpirationRequired = $false
-                    target = @{
-                        caller = "Admin"
-                        operations = @(
-                            "All"
-                        )
-                        level = "Eligibility"
-                        inheritableSettings = @(
-                        )
-                        enforcedSettings = @(
-                        )
+                    target               = @{
+                        caller              = 'Admin'
+                        operations          = @('All')
+                        level               = 'Eligibility'
+                        inheritableSettings = @()
+                        enforcedSettings    = @()
                     }
                 }
                 Write-Verbose -Message "Updating the expiration policy for the group {$GroupDisplayName}"
                 Update-MgBetaPolicyRoleManagementPolicyRule -UnifiedRoleManagementPolicyId $unifiedRoleManagementPolicyId -UnifiedRoleManagementPolicyRuleId $unifiedRoleManagementPolicyRuleId -BodyParameter $params
             }
         }
-        elseif($ScheduleInfo.Expiration.Type -match "^after"){
+        elseif ($ScheduleInfo.Expiration.Type -match "^after")
+        {
             $p = Get-MgBetaPolicyRoleManagementPolicyAssignment -Filter $("scopeId eq '{0}' and scopeType eq 'Group' and RoleDefinitionId eq 'member'" -f $GroupId)
             $unifiedRoleManagementPolicyId = $p.PolicyId
-            $unifiedRoleManagementPolicyRuleId = "Expiration_Admin_Eligibility"
+            $unifiedRoleManagementPolicyRuleId = 'Expiration_Admin_Eligibility'
             $isExpirationRequired = (Get-MgBetaPolicyRoleManagementPolicyRule -UnifiedRoleManagementPolicyId $unifiedRoleManagementPolicyId -UnifiedRoleManagementPolicyRuleId $unifiedRoleManagementPolicyRuleId).AdditionalProperties.isExpirationRequired
-            if(-not $isExpirationRequired){
+            if (-not $isExpirationRequired)
+            {
                 $params = @{
-                    "@odata.type" = "#microsoft.graph.unifiedRoleManagementPolicyExpirationRule"
-                    id = "Expiration_Admin_Eligibility"
+                    '@odata.type'        = '#microsoft.graph.unifiedRoleManagementPolicyExpirationRule'
+                    id                   = 'Expiration_Admin_Eligibility'
                     isExpirationRequired = $true
-                    maximumDuration = 'P365D'
-                    target = @{
-                        caller = "Admin"
-                        operations = @(
-                            "All"
-                        )
-                        level = "Eligibility"
-                        inheritableSettings = @(
-                        )
-                        enforcedSettings = @(
-                        )
+                    maximumDuration      = 'P365D'
+                    target               = @{
+                        caller              = 'Admin'
+                        operations          = @('All')
+                        level               = 'Eligibility'
+                        inheritableSettings = @()
+                        enforcedSettings    = @()
                     }
                 }
+
                 Write-Verbose -Message "Updating the expiration policy for the group {$GroupDisplayName}"
                 Update-MgBetaPolicyRoleManagementPolicyRule -UnifiedRoleManagementPolicyId $unifiedRoleManagementPolicyId -UnifiedRoleManagementPolicyRuleId $unifiedRoleManagementPolicyRuleId -BodyParameter $params
             }
         }
         $updateParameters.Add('GroupId', $GroupId)
         $Filter = "DisplayName eq '" + $PrincipalDisplayname + "'"
-        if($PrincipalType -eq 'group'){
+        if ($PrincipalType -eq 'group')
+        {
             $PrincipalId = (Get-MgGroup -Filter $Filter).Id
         }
-        else{
+        else
+        {
             $PrincipalId = (Get-MgUser -Filter $Filter).Id
         }
         $updateParameters.Add('PrincipalId', $PrincipalId)
@@ -579,10 +582,12 @@ function Set-TargetResource
         $GroupId = (Get-MgGroup -Filter $GroupFilter).Id
         $updateParameters.Add('GroupId', $GroupId)
         $Filter = "DisplayName eq '" + $PrincipalDisplayname + "'"
-        if($PrincipalType -eq 'group'){
+        if ($PrincipalType -eq 'group')
+        {
             $PrincipalId = (Get-MgGroup -Filter $Filter).Id
         }
-        else{
+        else
+        {
             $PrincipalId = (Get-MgUser -Filter $Filter).Id
         }
         $updateParameters.Add('PrincipalId', $PrincipalId)
@@ -610,7 +615,7 @@ function Test-TargetResource
     (
         #region resource generator code
         [Parameter()]
-        [ValidateSet('owner','member','unknownFutureValue')]
+        [ValidateSet('owner', 'member', 'unknownFutureValue')]
         [System.String]
         $AccessId,
 
@@ -623,7 +628,7 @@ function Test-TargetResource
         $GroupDisplayName,
 
         [Parameter()]
-        [ValidateSet('direct','group','unknownFutureValue')]
+        [ValidateSet('direct', 'group', 'unknownFutureValue')]
         [System.String]
         $MemberType,
 
@@ -693,7 +698,7 @@ function Test-TargetResource
     #endregion
 
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-                                         -ResourceName $ResourceName
+        -ResourceName $ResourceName
     return $result
 }
 
@@ -754,7 +759,7 @@ function Export-TargetResource
     try
     {
 
-        $groups = Get-MgGroup -Filter "MailEnabled eq false and NOT(groupTypes/any(x:x eq 'DynamicMembership'))" -Property "displayname,Id" -CountVariable CountVar -All -ConsistencyLevel eventual -ErrorAction Stop
+        $groups = Get-MgGroup -Filter "MailEnabled eq false and NOT(groupTypes/any(x:x eq 'DynamicMembership'))" -Property 'displayname,Id' -CountVariable CountVar -All -ConsistencyLevel eventual -ErrorAction Stop
         $j = 1
         if ($groups.Length -eq 0)
         {
@@ -769,7 +774,7 @@ function Export-TargetResource
 
         foreach ($group in $groups)
         {
-            Write-M365DSCHost -Message  "    |---[$j/$($groups.Count)] $($group.DisplayName)" -DeferWrite
+            Write-M365DSCHost -Message "    |---[$j/$($groups.Count)] $($group.DisplayName)" -DeferWrite
             #region resource generator code
             $getValue = Get-MgBetaIdentityGovernancePrivilegedAccessGroupEligibilitySchedule `
                 -Filter "groupId eq '$($group.Id)'" `
@@ -813,29 +818,29 @@ function Export-TargetResource
                 {
                     $complexMapping = @(
                         @{
-                            Name = 'ScheduleInfo'
+                            Name            = 'ScheduleInfo'
                             CimInstanceName = 'MicrosoftGraphRequestSchedule'
-                            IsRequired = $True
+                            IsRequired      = $True
                         }
                         @{
-                            Name = 'Expiration'
+                            Name            = 'Expiration'
                             CimInstanceName = 'MicrosoftGraphExpirationPattern'
-                            IsRequired = $False
+                            IsRequired      = $False
                         }
                         @{
-                            Name = 'Recurrence'
+                            Name            = 'Recurrence'
                             CimInstanceName = 'MicrosoftGraphPatternedRecurrence1'
-                            IsRequired = $False
+                            IsRequired      = $False
                         }
                         @{
-                            Name = 'Pattern'
+                            Name            = 'Pattern'
                             CimInstanceName = 'MicrosoftGraphRecurrencePattern1'
-                            IsRequired = $False
+                            IsRequired      = $False
                         }
                         @{
-                            Name = 'Range'
+                            Name            = 'Range'
                             CimInstanceName = 'MicrosoftGraphRecurrenceRange1'
-                            IsRequired = $False
+                            IsRequired      = $False
                         }
                     )
                     $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupEligibilitySchedule/MSFT_AADGroupEligibilitySchedule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupEligibilitySchedule/MSFT_AADGroupEligibilitySchedule.psm1
@@ -31,7 +31,7 @@ function Get-TargetResource
         [System.String]
         $PrincipalType,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $PrincipalDisplayName,
 
@@ -114,7 +114,7 @@ function Get-TargetResource
         }
 
         $uri = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)v1.0/identityGovernance/privilegedAccess/group/eligibilitySchedules/" + $Id
-        $getvalue = Invoke-GraphRequest -Uri $uri -Method Get -ErrorAction SilentlyContinue
+        $getvalue = Invoke-MgGraphRequest -Uri $uri -Method Get -ErrorAction SilentlyContinue
 
         #endregion
         if ($null -eq $getValue)
@@ -224,20 +224,23 @@ function Get-TargetResource
 
        	switch ($getValue.PrincipalType)
        	{
-       	    'group' {
-		$PrincipalDisplayName = (Get-MgGroup -GroupId $getvalue.PrincipalId).DisplayName
+       	    'group'
+            {
+		        $PrincipalDisplayName = (Get-MgGroup -GroupId $getvalue.PrincipalId).DisplayName
             }
-       	    'user' {
-		$PrincipalDisplayName = (Get-MgUser -UserId $getvalue.PrincipalId).DisplayName
+       	    'user'
+            {
+		        $PrincipalDisplayName = (Get-MgUser -UserId $getvalue.PrincipalId).DisplayName
        	    }
-       	    'unknown' {
+       	    'unknown'
+            {
 		        $objectInfo = Get-MgBetaDirectoryObjectById -Ids $getvalue.PrincipalId -ErrorAction SilentlyContinue
             	$getValue.PrincipalType = $objectInfo.AdditionalProperties['@odata.type'].Split('.')[2]
 		        $PrincipalDisplayName = $objectInfo.AdditionalProperties['displayName']
        	    }
        	}
 
-	$GroupDisplayName = (Get-MgGroup -GroupId $getvalue.GroupId).DisplayName
+	    $GroupDisplayName = (Get-MgGroup -GroupId $getvalue.GroupId).DisplayName
 
         $results = @{
             #region resource generator code
@@ -305,7 +308,7 @@ function Set-TargetResource
         [System.String]
         $PrincipalType,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $PrincipalDisplayName,
 
@@ -632,7 +635,7 @@ function Test-TargetResource
         [System.String]
         $PrincipalType,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $PrincipalDisplayName,
 
@@ -793,6 +796,7 @@ function Export-TargetResource
                 $params = @{
                     Id                    = $config.Id
                     GroupDisplayName      = $group.DisplayName
+                    PrincipalDisplayName  = "Export"
                     Ensure                = 'Present'
                     Credential            = $Credential
                     ApplicationId         = $ApplicationId
@@ -881,4 +885,3 @@ function Export-TargetResource
 }
 
 Export-ModuleMember -Function *-TargetResource
-

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupEligibilitySchedule/MSFT_AADGroupEligibilitySchedule.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupEligibilitySchedule/MSFT_AADGroupEligibilitySchedule.schema.mof
@@ -48,7 +48,7 @@ class MSFT_AADGroupEligibilitySchedule : OMI_BaseResource
     [Write, Description("Indicates whether the assignment is derived from a group assignment. It can further imply whether the caller can manage the schedule. Required. The possible values are: direct, group, unknownFutureValue. Supports $filter (eq)."), ValueMap{"direct","group","unknownFutureValue"}, Values{"direct","group","unknownFutureValue"}] String MemberType;
     [Write, Description("The identifier of the principal whose membership or ownership eligibility is granted through PIM for groups. Required. Supports $filter (eq).")] String PrincipalId;
     [Write, Description("Principal type user or group"), ValueMap{"user","group"}, Values{"user","group"}] String PrincipalType;
-    [Write, Description("Displayname of the Principal")] String PrincipalDisplayName;
+    [Key, Description("Displayname of the Principal")] String PrincipalDisplayName;
     [Write, Description("Represents the period of the access assignment or eligibility. The scheduleInfo can represent a single occurrence or multiple recurring instances. Required."), EmbeddedInstance("MSFT_MicrosoftGraphrequestSchedule")] String ScheduleInfo;
     [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds the property `PrincipalDisplayName` as a secondary key parameter to the `AADGroupEligibilitySchedule` resource. The change is required because the moment you have multiple assigned groups to a PIM enabled group as eligible, the compilation will fail because only the `GroupDisplayName` of the PIM enabled group is considered as a key parameter. The `PrincipalDisplayName` is the one additionally required parameter to distinguish the different eligibile schedules. Without that parameter, deploying a schedule is impossible.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
