### PR TITLE
Update MSCloudLoginAssistant to version 1.1.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@
     updating Intune intent policy type settings.
     FIXES [#6252](https://github.com/microsoft/Microsoft365DSC/issues/6252)
 * DEPENDENCIES
-  * Updated MSCloudLoginAssistant to version 1.1.47.
+  * Updated MSCloudLoginAssistant to version 1.1.48.
 
 # 1.25.611.1
 

--- a/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
+++ b/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
@@ -126,7 +126,7 @@
         },
         @{
             ModuleName      = "MSCloudLoginAssistant"
-            RequiredVersion = "1.1.47"
+            RequiredVersion = "1.1.48"
         },
         @{
             ModuleName      = 'PnP.PowerShell'


### PR DESCRIPTION
#### Pull Request (PR) description
* Bumped the required version of MSCloudLoginAssistant from 1.1.47 to 1.1.48 in the dependencies manifest and updated the changelog to reflect this change.

#### This Pull Request (PR) fixes the following issues
* N/A