### PR TITLE
Fix issue during uninstall of dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+* M365DSCUtil
+  * Fixed an issue where `Uninstall-M365DSCOutdatedDependencies` would throw an error during
+    checking of the Microsoft.Graph.Authentication module.
+    FIXES [#6274](https://github.com/microsoft/Microsoft365DSC/issues/6274)
 * MISC
   * Updated CIM version for `MSFT_DeviceManagementConfigurationPolicyAssignments` class.
 * DEPENDENCIES

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -3517,7 +3517,7 @@ function Uninstall-M365DSCOutdatedDependencies
         Write-Error $_
     }
 
-    $authModule = $manifest.Dependencies | Where-Object { $_.ModuleName -eq 'Microsoft.Graph.Authentication' }
+    $authModule = $Script:M365DSCDependencies | Where-Object { $_.ModuleName -eq 'Microsoft.Graph.Authentication' }
     try
     {
         Write-Information -MessageData 'Checking Microsoft.Graph.Authentication'


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes a missing variable reference in `Uninstall-M365DSCOutdatedDependencies`, leading to an error during checking of the Microsoft.Graph.Authentication module. 

#### This Pull Request (PR) fixes the following issues
- Fixes #6274 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
