### PR TITLE
Add managed built in store app for Android and iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneMobileAppsBuiltInStoreApp
+  * Initial release.
+
 # 1.25.716.1
 
 * AADAdministrativeUnit

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.psm1
@@ -1,4 +1,6 @@
 Confirm-M365DSCModuleDependency -ModuleName 'MSFT_IntuneMobileAppsBuiltInStoreApp'
+$Script:androidExclusive = @('V4_0', 'V4_0_3', 'V4_1', 'V4_2', 'V4_3', 'V4_4', 'V5_0', 'V5_1', 'V6_0', 'V7_0', 'V7_1', 'V8_1')
+$Script:iOSExclusive = @('V16_0', 'V17_0', 'V18_0')
 
 function Get-TargetResource
 {
@@ -19,6 +21,18 @@ function Get-TargetResource
         [ValidateSet('Android', 'IOS')]
         [System.String]
         $TargetPlatform,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $ApplicableDeviceType,
+
+        [Parameter()]
+        [System.String]
+        $AppStoreUrl,
+
+        [Parameter()]
+        [System.String]
+        $BundleId,
 
         [Parameter()]
         [System.String]
@@ -59,6 +73,14 @@ function Get-TargetResource
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Categories,
+
+        [Parameter()]
+        [System.String]
+        $PackageId,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $MinimumSupportedOperatingSystem,
 
         [Parameter()]
         [System.String[]]
@@ -180,31 +202,72 @@ function Get-TargetResource
             $complexLargeIcon.Add('Type', $getValue.LargeIcon.Type)
             $complexLargeIcon.Add('Value', [System.Convert]::ToBase64String($getValue.LargeIcon.Value))
         }
+        $complexApplicableDeviceType = @{}
+        $complexApplicableDeviceType.Add('IPad', $getValue.AdditionalProperties.applicableDeviceType.iPad)
+        $complexApplicableDeviceType.Add('IPhoneAndIPod', $getValue.AdditionalProperties.applicableDeviceType.iPhoneAndIPod)
+        if ($complexApplicableDeviceType.Values.Where({ $null -ne $_ }).Count -eq 0)
+        {
+            $complexApplicableDeviceType = $null
+        }
+
+        $complexMinimumSupportedOperatingSystem = [ordered]@{}
+        $complexMinimumSupportedOperatingSystem.Add('V4_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v4_0)
+        $complexMinimumSupportedOperatingSystem.Add('V4_0_3', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v4_0_3)
+        $complexMinimumSupportedOperatingSystem.Add('V4_1', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v4_1)
+        $complexMinimumSupportedOperatingSystem.Add('V4_2', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v4_2)
+        $complexMinimumSupportedOperatingSystem.Add('V4_3', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v4_3)
+        $complexMinimumSupportedOperatingSystem.Add('V4_4', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v4_4)
+        $complexMinimumSupportedOperatingSystem.Add('V5_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v5_0)
+        $complexMinimumSupportedOperatingSystem.Add('V5_1', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v5_1)
+        $complexMinimumSupportedOperatingSystem.Add('V6_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v6_0)
+        $complexMinimumSupportedOperatingSystem.Add('V7_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v7_0)
+        $complexMinimumSupportedOperatingSystem.Add('V7_1', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v7_1)
+        $complexMinimumSupportedOperatingSystem.Add('V8_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v8_0)
+        $complexMinimumSupportedOperatingSystem.Add('V8_1', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v8_1)
+        $complexMinimumSupportedOperatingSystem.Add('V9_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v9_0)
+        $complexMinimumSupportedOperatingSystem.Add('V10_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_0)
+        $complexMinimumSupportedOperatingSystem.Add('V11_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v11_0)
+        $complexMinimumSupportedOperatingSystem.Add('V12_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v12_0)
+        $complexMinimumSupportedOperatingSystem.Add('V13_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v13_0)
+        $complexMinimumSupportedOperatingSystem.Add('V14_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v14_0)
+        $complexMinimumSupportedOperatingSystem.Add('V15_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v15_0)
+        $complexMinimumSupportedOperatingSystem.Add('V16_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v16_0)
+        $complexMinimumSupportedOperatingSystem.Add('V17_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v17_0)
+        $complexMinimumSupportedOperatingSystem.Add('V18_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v18_0)
+        if ($complexMinimumSupportedOperatingSystem.Values.Where({ $null -ne $_ }).Count -eq 0)
+        {
+            $complexMinimumSupportedOperatingSystem = $null
+        }
         #endregion
 
         $results = @{
             #region resource generator code
-            Categories            = $complexCategories
-            Description           = $getValue.Description
-            Developer             = $getValue.Developer
-            DisplayName           = $getValue.DisplayName
-            InformationUrl        = $getValue.InformationUrl
-            IsFeatured            = $getValue.IsFeatured
-            LargeIcon             = $complexLargeIcon
-            Notes                 = $getValue.Notes
-            Owner                 = $getValue.Owner
-            PrivacyInformationUrl = $getValue.PrivacyInformationUrl
-            Publisher             = $getValue.Publisher
-            RoleScopeTagIds       = $getValue.RoleScopeTagIds
-            TargetPlatform        = $getValue.AdditionalProperties.'@odata.type'.Replace('#microsoft.graph.managed', '').Replace('StoreApp', '')
-            Id                    = $getValue.Id
-            Ensure                = 'Present'
-            Credential            = $Credential
-            ApplicationId         = $ApplicationId
-            TenantId              = $TenantId
-            ApplicationSecret     = $ApplicationSecret
-            CertificateThumbprint = $CertificateThumbprint
-            ManagedIdentity       = $ManagedIdentity.IsPresent
+            ApplicableDeviceType            = $complexApplicableDeviceType;
+            AppStoreUrl                     = $getValue.AdditionalProperties.appStoreUrl;
+            BundleId                        = $getValue.AdditionalProperties.bundleId
+            Categories                      = $complexCategories
+            Description                     = $getValue.Description
+            Developer                       = $getValue.Developer
+            DisplayName                     = $getValue.DisplayName
+            InformationUrl                  = $getValue.InformationUrl
+            IsFeatured                      = $getValue.IsFeatured
+            LargeIcon                       = $complexLargeIcon
+            MinimumSupportedOperatingSystem = $complexMinimumSupportedOperatingSystem
+            Notes                           = $getValue.Notes
+            Owner                           = $getValue.Owner
+            PackageId                       = $getValue.AdditionalProperties.packageId
+            PrivacyInformationUrl           = $getValue.PrivacyInformationUrl
+            Publisher                       = $getValue.Publisher
+            RoleScopeTagIds                 = $getValue.RoleScopeTagIds
+            TargetPlatform                  = $getValue.AdditionalProperties.'@odata.type'.Replace('#microsoft.graph.managed', '').Replace('StoreApp', '')
+            Id                              = $getValue.Id
+            Ensure                          = 'Present'
+            Credential                      = $Credential
+            ApplicationId                   = $ApplicationId
+            TenantId                        = $TenantId
+            ApplicationSecret               = $ApplicationSecret
+            CertificateThumbprint           = $CertificateThumbprint
+            ManagedIdentity                 = $ManagedIdentity.IsPresent
             #endregion
         }
         $assignmentsValues = Get-MgBetaDeviceAppManagementMobileAppAssignment -MobileAppId $Id
@@ -249,6 +312,18 @@ function Set-TargetResource
         $TargetPlatform,
 
         [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $ApplicableDeviceType,
+
+        [Parameter()]
+        [System.String]
+        $AppStoreUrl,
+
+        [Parameter()]
+        [System.String]
+        $BundleId,
+
+        [Parameter()]
         [System.String]
         $Description,
 
@@ -287,6 +362,14 @@ function Set-TargetResource
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Categories,
+
+        [Parameter()]
+        [System.String]
+        $PackageId,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $MinimumSupportedOperatingSystem,
 
         [Parameter()]
         [System.String[]]
@@ -333,6 +416,31 @@ function Set-TargetResource
 
     Write-Verbose -Message "Setting configuration of the Intune Mobile Apps Built In Store App with Id {$Id} and DisplayName {$DisplayName}"
 
+    if ($PSBoundParameters.ContainsKey('ApplicableDeviceType') -and $PSBoundParameters.TargetPlatform -ne 'iOS')
+    {
+        throw "ApplicableDeviceType is only applicable for iOS Store Apps."
+    }
+
+    if ($PSBoundParameters.ContainsKey('BundleId') -and $PSBoundParameters.TargetPlatform -ne 'iOS')
+    {
+        throw "BundleId is only applicable for iOS Store Apps."
+    }
+
+    if ($PSBoundParameters.ContainsKey('MinimumSupportedOperatingSystem'))
+    {
+        foreach ($keyValuePair in $PSBoundParameters.MinimumSupportedOperatingSystem.CimInstanceProperties.GetEnumerator())
+        {
+            if ($keyValuePair.Key -in $Script:androidExclusive -and $TargetPlatform -ne 'Android')
+            {
+                throw "MinimumSupportedOperatingSystem.$($keyValuePair.Key) is only applicable for Android Store Apps."
+            }
+            if ($keyValuePair.Key -in $Script:iOSExclusive -and $TargetPlatform -ne 'IOS')
+            {
+                throw "MinimumSupportedOperatingSystem.$($keyValuePair.Key) is only applicable for iOS Store Apps."
+            }
+        }
+    }
+
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
 
@@ -348,6 +456,7 @@ function Set-TargetResource
     $currentInstance = Get-TargetResource @PSBoundParameters
 
     $boundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+    $boundParameters.Remove('Categories') | Out-Null
     $boundParameters.Remove('TargetPlatform') | Out-Null
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
@@ -388,6 +497,7 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
     {
         Write-Verbose -Message "Updating the Intune Mobile Apps Built In Store App with Id {$($currentInstance.Id)}"
+        $boundParameters.Remove('AppStoreUrl') | Out-Null
         $boundParameters.Remove("Assignments") | Out-Null
 
         $updateParameters = ([Hashtable]$boundParameters).Clone()
@@ -449,6 +559,18 @@ function Test-TargetResource
         $TargetPlatform,
 
         [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $ApplicableDeviceType,
+
+        [Parameter()]
+        [System.String]
+        $AppStoreUrl,
+
+        [Parameter()]
+        [System.String]
+        $BundleId,
+
+        [Parameter()]
         [System.String]
         $Description,
 
@@ -487,6 +609,14 @@ function Test-TargetResource
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Categories,
+
+        [Parameter()]
+        [System.String]
+        $PackageId,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $MinimumSupportedOperatingSystem,
 
         [Parameter()]
         [System.String[]]
@@ -531,6 +661,31 @@ function Test-TargetResource
         $AccessTokens
     )
 
+    if ($PSBoundParameters.ContainsKey('ApplicableDeviceType') -and $PSBoundParameters.TargetPlatform -ne 'iOS')
+    {
+        throw "ApplicableDeviceType is only applicable for iOS Store Apps."
+    }
+
+    if ($PSBoundParameters.ContainsKey('BundleId') -and $PSBoundParameters.TargetPlatform -ne 'iOS')
+    {
+        throw "BundleId is only applicable for iOS Store Apps."
+    }
+
+    if ($PSBoundParameters.ContainsKey('MinimumSupportedOperatingSystem'))
+    {
+        foreach ($keyValuePair in $PSBoundParameters.MinimumSupportedOperatingSystem.CimInstanceProperties.GetEnumerator())
+        {
+            if ($keyValuePair.Key -in $Script:androidExclusive -and $TargetPlatform -ne 'Android')
+            {
+                throw "MinimumSupportedOperatingSystem.$($keyValuePair.Key) is only applicable for Android Store Apps."
+            }
+            if ($keyValuePair.Key -in $Script:iOSExclusive -and $TargetPlatform -ne 'IOS')
+            {
+                throw "MinimumSupportedOperatingSystem.$($keyValuePair.Key) is only applicable for iOS Store Apps."
+            }
+        }
+    }
+
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
 
@@ -570,6 +725,7 @@ function Test-TargetResource
     }
 
     $ValuesToCheck.Remove('Id') | Out-Null
+    $ValuesToCheck.Remove('AppStoreUrl') | Out-Null
     $ValuesToCheck.Remove('TargetPlatform') | Out-Null
     $ValuesToCheck = Remove-M365DSCAuthenticationParameter -BoundParameters $ValuesToCheck
 
@@ -699,6 +855,20 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
+            if ($null -ne $Results.ApplicableDeviceType)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.ApplicableDeviceType `
+                    -CIMInstanceName 'MicrosoftGraphiosDeviceType'
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.ApplicableDeviceType = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('ApplicableDeviceType') | Out-Null
+                }
+            }
             if ($null -ne $Results.Categories)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -712,6 +882,20 @@ function Export-TargetResource
                 else
                 {
                     $Results.Remove('Categories') | Out-Null
+                }
+            }
+            if ($null -ne $Results.MinimumSupportedOperatingSystem)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.MinimumSupportedOperatingSystem `
+                    -CIMInstanceName 'MicrosoftGraphMinimumOperatingSystem'
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.MinimumSupportedOperatingSystem = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('MinimumSupportedOperatingSystem') | Out-Null
                 }
             }
 
@@ -748,7 +932,7 @@ function Export-TargetResource
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
                 -Credential $Credential `
-                -NoEscape @('Assignments', 'Categories', 'LargeIcon')
+                -NoEscape @('Assignments', 'ApplicableDeviceType', 'Categories', 'LargeIcon', 'MinimumSupportedOperatingSystem')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.psm1
@@ -1,3 +1,5 @@
+Confirm-M365DSCModuleDependency -ModuleName 'MSFT_IntuneMobileAppsBuiltInStoreApp'
+
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -647,7 +649,7 @@ function Export-TargetResource
         $baseFilter = "isof('microsoft.graph.managedIOSStoreApp') or isof('microsoft.graph.managedAndroidStoreApp')"
         if (-not [System.String]::IsNullOrEmpty($Filter))
         {
-            $Filter += " and ($baseFilter)"
+            $Filter = "($Filter) and ($baseFilter)"
         }
         else
         {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.psm1
@@ -732,7 +732,7 @@ function Export-TargetResource
 
             if ($Results.Assignments)
             {
-                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementMobileAppAssignment
                 if ($complexTypeStringResult)
                 {
                     $Results.Assignments = $complexTypeStringResult

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.psm1
@@ -1,0 +1,772 @@
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Android', 'IOS')]
+        [System.String]
+        $TargetPlatform,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [System.String]
+        $Developer,
+
+        [Parameter()]
+        [System.String]
+        $InformationUrl,
+
+        [Parameter()]
+        [System.Boolean]
+        $IsFeatured,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $LargeIcon,
+
+        [Parameter()]
+        [System.String]
+        $Notes,
+
+        [Parameter()]
+        [System.String]
+        $Owner,
+
+        [Parameter()]
+        [System.String]
+        $PrivacyInformationUrl,
+
+        [Parameter()]
+        [System.String]
+        $Publisher,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Categories,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    Write-Verbose -Message "Getting configuration for the Intune Mobile Apps Built In Store App with Id {$Id} and DisplayName {$DisplayName}"
+
+    try
+    {
+        if (-not $Script:exportedInstance -or $Script:exportedInstance.DisplayName -ne $DisplayName)
+        {
+
+            $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+                -InboundParameters $PSBoundParameters
+
+            #Ensure the proper dependencies are installed in the current environment.
+            Confirm-M365DSCDependencies
+
+            #region Telemetry
+            $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+            $CommandName = $MyInvocation.MyCommand
+            $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+                -CommandName $CommandName `
+                -Parameters $PSBoundParameters
+            Add-M365DSCTelemetryEvent -Data $data
+            #endregion
+
+            $nullResult = $PSBoundParameters
+            $nullResult.Ensure = 'Absent'
+
+            $getValue = $null
+
+            #region resource generator code
+            if (-not [System.String]::IsNullOrEmpty($Id))
+            {
+                $getValue = Get-MgBetaDeviceAppManagementMobileApp -MobileAppId $Id -ExpandProperty 'categories' -ErrorAction SilentlyContinue
+            }
+
+            if ($null -eq $getValue)
+            {
+                Write-Verbose -Message "Could not find an Intune Mobile Apps Built In Store App with Id {$Id}"
+
+                if (-not [System.String]::IsNullOrEmpty($DisplayName))
+                {
+                    $getValue = Get-MgBetaDeviceAppManagementMobileApp `
+                        -Filter "DisplayName eq '$($DisplayName -replace "'", "''")' and (isof('microsoft.graph.managedAndroidStoreApp') or isof('microsoft.graph.managedIOSStoreApp'))" `
+                        -ErrorAction SilentlyContinue
+                }
+            }
+            #endregion
+            if ($null -eq $getValue)
+            {
+                Write-Verbose -Message "Could not find an Intune Mobile Apps Built In Store App with DisplayName {$DisplayName}."
+                return $nullResult
+            }
+
+            $getValue = Get-MgBetaDeviceAppManagementMobileApp -MobileAppId $getValue.Id -ExpandProperty 'categories'
+        }
+        else
+        {
+            $getValue = Get-MgBetaDeviceAppManagementMobileApp -MobileAppId $Script:exportedInstance.Id `
+                -ExpandProperty 'categories'
+        }
+        $Id = $getValue.Id
+        Write-Verbose -Message "An Intune Mobile Apps Built In Store App with Id {$Id} and DisplayName {$DisplayName} was found"
+
+        #region resource generator code
+        $complexCategories = @()
+        foreach ($category in $getValue.Categories)
+        {
+            $myCategory = @{}
+            $myCategory.Add('Id', $category.id)
+            $myCategory.Add('DisplayName', $category.displayName)
+            $complexCategories += $myCategory
+        }
+        $complexLargeIcon = $null
+        if ($null -ne $getValue.LargeIcon.Value)
+        {
+            $complexLargeIcon = @{}
+            $complexLargeIcon.Add('Type', $getValue.LargeIcon.Type)
+            $complexLargeIcon.Add('Value', [System.Convert]::ToBase64String($getValue.LargeIcon.Value))
+        }
+        #endregion
+
+        $results = @{
+            #region resource generator code
+            Categories            = $complexCategories
+            Description           = $getValue.Description
+            Developer             = $getValue.Developer
+            DisplayName           = $getValue.DisplayName
+            InformationUrl        = $getValue.InformationUrl
+            IsFeatured            = $getValue.IsFeatured
+            LargeIcon             = $complexLargeIcon
+            Notes                 = $getValue.Notes
+            Owner                 = $getValue.Owner
+            PrivacyInformationUrl = $getValue.PrivacyInformationUrl
+            Publisher             = $getValue.Publisher
+            RoleScopeTagIds       = $getValue.RoleScopeTagIds
+            TargetPlatform        = $getValue.AdditionalProperties.'@odata.type'.Replace('#microsoft.graph.managed', '').Replace('StoreApp', '')
+            Id                    = $getValue.Id
+            Ensure                = 'Present'
+            Credential            = $Credential
+            ApplicationId         = $ApplicationId
+            TenantId              = $TenantId
+            ApplicationSecret     = $ApplicationSecret
+            CertificateThumbprint = $CertificateThumbprint
+            ManagedIdentity       = $ManagedIdentity.IsPresent
+            #endregion
+        }
+        $assignmentsValues = Get-MgBetaDeviceAppManagementMobileAppAssignment -MobileAppId $Id
+        $assignmentResult = @()
+        if ($assignmentsValues.Count -gt 0)
+        {
+            $assignmentResult += ConvertFrom-IntuneMobileAppAssignment -Assignments $assignmentsValues -IncludeDeviceFilter $true
+        }
+        $results.Add('Assignments', $assignmentResult)
+
+        return [System.Collections.Hashtable] $results
+    }
+    catch
+    {
+        New-M365DSCLogEntry -Message 'Error retrieving data:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return $nullResult
+    }
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Android', 'IOS')]
+        [System.String]
+        $TargetPlatform,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [System.String]
+        $Developer,
+
+        [Parameter()]
+        [System.String]
+        $InformationUrl,
+
+        [Parameter()]
+        [System.Boolean]
+        $IsFeatured,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $LargeIcon,
+
+        [Parameter()]
+        [System.String]
+        $Notes,
+
+        [Parameter()]
+        [System.String]
+        $Owner,
+
+        [Parameter()]
+        [System.String]
+        $PrivacyInformationUrl,
+
+        [Parameter()]
+        [System.String]
+        $Publisher,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Categories,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    Write-Verbose -Message "Setting configuration of the Intune Mobile Apps Built In Store App with Id {$Id} and DisplayName {$DisplayName}"
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    $currentInstance = Get-TargetResource @PSBoundParameters
+
+    $boundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+    $boundParameters.Remove('TargetPlatform') | Out-Null
+
+    if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
+    {
+        Write-Verbose -Message "Creating an Intune Mobile Apps Built In Store App with DisplayName {$DisplayName}"
+        $boundParameters.Remove("Assignments") | Out-Null
+
+        $createParameters = ([Hashtable]$boundParameters).Clone()
+        $createParameters = Rename-M365DSCCimInstanceParameter -Properties $createParameters
+        $createParameters.Remove('Id') | Out-Null
+
+        $keys = (([Hashtable]$createParameters).Clone()).Keys
+        foreach ($key in $keys)
+        {
+            if ($null -ne $createParameters.$key -and $createParameters.$key.GetType().Name -like '*CimInstance*')
+            {
+                $createParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $createParameters.$key
+            }
+        }
+        #region resource generator code
+        $createParameters.Add("@odata.type", "#microsoft.graph.managed$($TargetPlatform)StoreApp")
+        $policy = Invoke-MgGraphRequest -Method POST -Uri "/beta/deviceAppManagement/mobileApps" -Body $($createParameters | ConvertTo-Json -Depth 10)
+
+        if ($PSBoundParameters.ContainsKey('Categories'))
+        {
+            Update-DeviceAppManagementAppCategory -App $policy -Categories $Categories
+        }
+
+        if ($policy.Id)
+        {
+            $assignmentsHash = ConvertTo-IntuneMobileAppAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
+             Update-DeviceAppManagementPolicyAssignment `
+                -AppManagementPolicyId $policy.Id `
+                -Assignments $assignmentsHash
+        }
+        #endregion
+    }
+    elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Updating the Intune Mobile Apps Built In Store App with Id {$($currentInstance.Id)}"
+        $boundParameters.Remove("Assignments") | Out-Null
+
+        $updateParameters = ([Hashtable]$boundParameters).Clone()
+        $updateParameters = Rename-M365DSCCimInstanceParameter -Properties $updateParameters
+
+        $updateParameters.Remove('Id') | Out-Null
+
+        $keys = (([Hashtable]$updateParameters).Clone()).Keys
+        foreach ($key in $keys)
+        {
+            if ($null -ne $pdateParameters.$key -and $updateParameters.$key.GetType().Name -like '*CimInstance*')
+            {
+                $updateParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $updateParameters.MobileAppId
+            }
+        }
+
+        #region resource generator code
+        $updateParameters.Add("@odata.type", "#microsoft.graph.managed$($TargetPlatform)StoreApp")
+        Invoke-MgGraphRequest -Method PATCH -Uri "/beta/deviceAppManagement/mobileApps/$($currentInstance.Id)" -Body $($updateParameters | ConvertTo-Json -Depth 10)
+
+        if ($PSBoundParameters.ContainsKey('Categories'))
+        {
+            Update-DeviceAppManagementAppCategory -App $currentInstance -Categories $Categories -Compare
+        }
+
+        $assignmentsHash = ConvertTo-IntuneMobileAppAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
+        Update-DeviceAppManagementPolicyAssignment `
+            -AppManagementPolicyId $currentInstance.Id `
+            -Assignments $assignmentsHash
+        #endregion
+    }
+    elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Removing the Intune Mobile Apps Built In Store App with Id {$($currentInstance.Id)}"
+        #region resource generator code
+        Remove-MgBetaDeviceAppManagementMobileApp -MobileAppId $currentInstance.Id
+        #endregion
+    }
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Android', 'IOS')]
+        [System.String]
+        $TargetPlatform,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [System.String]
+        $Developer,
+
+        [Parameter()]
+        [System.String]
+        $InformationUrl,
+
+        [Parameter()]
+        [System.Boolean]
+        $IsFeatured,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $LargeIcon,
+
+        [Parameter()]
+        [System.String]
+        $Notes,
+
+        [Parameter()]
+        [System.String]
+        $Owner,
+
+        [Parameter()]
+        [System.String]
+        $PrivacyInformationUrl,
+
+        [Parameter()]
+        [System.String]
+        $Publisher,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Categories,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    Write-Verbose -Message "Testing configuration of the Intune Mobile Apps Built In Store App with Id {$Id} and DisplayName {$DisplayName}"
+
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+    $ValuesToCheck = ([hashtable]$PSBoundParameters).Clone()
+    $testResult = $true
+
+    #Compare Cim instances
+    foreach ($key in $PSBoundParameters.Keys)
+    {
+        $source = $PSBoundParameters.$key
+        $target = $CurrentValues.$key
+        if ($null -ne $source -and $source.GetType().Name -like '*CimInstance*')
+        {
+            $testResult = Compare-M365DSCComplexObject `
+                -Source ($source) `
+                -Target ($target)
+
+            if (-not $testResult)
+            {
+                break
+            }
+
+            $ValuesToCheck.Remove($key) | Out-Null
+        }
+    }
+
+    $ValuesToCheck.Remove('Id') | Out-Null
+    $ValuesToCheck.Remove('TargetPlatform') | Out-Null
+    $ValuesToCheck = Remove-M365DSCAuthenticationParameter -BoundParameters $ValuesToCheck
+
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
+    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $ValuesToCheck)"
+
+    if ($testResult)
+    {
+        $testResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -DesiredValues $PSBoundParameters `
+            -ValuesToCheck $ValuesToCheck.Keys
+    }
+
+    Write-Verbose -Message "Test-TargetResource returned $testResult"
+
+    return $testResult
+}
+
+function Export-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+        -InboundParameters $PSBoundParameters
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    try
+    {
+        #region resource generator code
+        $baseFilter = "isof('microsoft.graph.managedIOSStoreApp') or isof('microsoft.graph.managedAndroidStoreApp')"
+        if (-not [System.String]::IsNullOrEmpty($Filter))
+        {
+            $Filter += " and ($baseFilter)"
+        }
+        else
+        {
+            $Filter = $baseFilter
+        }
+        [array]$getValue = Get-MgBetaDeviceAppManagementMobileApp `
+            -Filter $Filter `
+            -All `
+            -ErrorAction Stop
+        #endregion
+
+        $i = 1
+        $dscContent = ''
+        if ($getValue.Length -eq 0)
+        {
+            Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
+        }
+        else
+        {
+            Write-M365DSCHost -Message "`r`n" -DeferWrite
+        }
+        foreach ($config in $getValue)
+        {
+            $displayedKey = $config.Id
+            if (-not [String]::IsNullOrEmpty($config.displayName))
+            {
+                $displayedKey = $config.displayName
+            }
+            elseif (-not [string]::IsNullOrEmpty($config.name))
+            {
+                $displayedKey = $config.name
+            }
+            Write-M365DSCHost -Message "    |---[$i/$($getValue.Count)] $displayedKey" -DeferWrite
+            $params = @{
+                Id                    = $config.Id
+                DisplayName           = $config.DisplayName
+                TargetPlatform        = $config.AdditionalProperties.'@odata.type'.Replace('#microsoft.graph.managed', '').Replace('StoreApp', '')
+                Ensure                = 'Present'
+                Credential            = $Credential
+                ApplicationId         = $ApplicationId
+                TenantId              = $TenantId
+                ApplicationSecret     = $ApplicationSecret
+                CertificateThumbprint = $CertificateThumbprint
+                ManagedIdentity       = $ManagedIdentity.IsPresent
+                AccessTokens          = $AccessTokens
+            }
+
+            $Script:exportedInstance = $config
+            $Results = Get-TargetResource @Params
+            if ($null -ne $Results.Categories)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.Categories `
+                    -CIMInstanceName 'DeviceManagementMobileAppCategory'
+
+                if (-not [System.String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.Categories = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('Categories') | Out-Null
+                }
+            }
+
+            if ($null -ne $Results.LargeIcon)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.LargeIcon `
+                    -CIMInstanceName 'DeviceManagementMimeContent'
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.LargeIcon = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('LargeIcon') | Out-Null
+                }
+            }
+
+            if ($Results.Assignments)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
+                if ($complexTypeStringResult)
+                {
+                    $Results.Assignments = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('Assignments') | Out-Null
+                }
+            }
+
+            $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
+                -ConnectionMode $ConnectionMode `
+                -ModulePath $PSScriptRoot `
+                -Results $Results `
+                -Credential $Credential `
+                -NoEscape @('Assignments', 'Categories', 'LargeIcon')
+            $dscContent += $currentDSCBlock
+            Save-M365DSCPartialExport -Content $currentDSCBlock `
+                -FileName $Global:PartialExportFileName
+            $i++
+            Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
+        }
+        return $dscContent
+    }
+    catch
+    {
+        Write-M365DSCHost -Message $Global:M365DSCEmojiRedX -CommitWrite
+
+        New-M365DSCLogEntry -Message 'Error during Export:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return ''
+    }
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.schema.mof
@@ -1,13 +1,13 @@
 [ClassVersion("1.0.0.1")]
-class MSFT_DeviceManagementConfigurationPolicyAssignments
+class MSFT_DeviceManagementMobileAppAssignment
 {
-    [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}] String dataType;
-    [Write, Description("The type of filter of the target assignment i.e. Exclude or Include. Possible values are:none, include, exclude."), ValueMap{"none","include","exclude"}, Values{"none","include","exclude"}] String deviceAndAppManagementAssignmentFilterType;
+    [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}] String dataType;
     [Write, Description("The Id of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterId;
     [Write, Description("The display name of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterDisplayName;
+    [Write, Description("The type of filter of the target assignment i.e. Exclude or Include. Possible values are: none, include, exclude."), ValueMap{"none", "include", "exclude"}, Values{"none", "include", "exclude"}] String deviceAndAppManagementAssignmentFilterType;
     [Write, Description("The group Id that is the target of the assignment.")] String groupId;
     [Write, Description("The group Display Name that is the target of the assignment.")] String groupDisplayName;
-    [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
+    [Write, Description("Possible values for the install intent chosen by the admin."), ValueMap{"available", "required", "uninstall", "availableWithoutEnrollment"}, Values{"available", "required", "uninstall", "availableWithoutEnrollment"}] String intent;
 };
 
 [ClassVersion("1.0.0")]
@@ -41,7 +41,7 @@ class MSFT_IntuneMobileAppsBuiltInStoreApp : OMI_BaseResource
     [Write, Description("List of scope tag ids for this mobile app.")] String RoleScopeTagIds[];
     [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
     [Key, Description("The target platform of the mobile app."), ValueMap{"Android","IOS"}, Values{"Android","IOS"}] String TargetPlatform;
-    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementMobileAppAssignment")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.schema.mof
@@ -11,6 +11,41 @@ class MSFT_DeviceManagementMobileAppAssignment
 };
 
 [ClassVersion("1.0.0")]
+class MSFT_MicrosoftGraphIosDeviceType
+{
+    [Write, Description("Whether the app should run on iPads.")] Boolean IPad;
+    [Write, Description("Whether the app should run on iPhones and iPods.")] Boolean IPhoneAndIPod;
+};
+
+[ClassVersion("1.0.0")]
+class MSFT_MicrosoftGraphMinimumOperatingSystem
+{
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 4.0 or later is required to install the app. If 'False', Version 8.0 is not the minimum version. Applicable only for the 'Android' TargetPlatform.")] Boolean V4_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 4.0.3 or later is required to install the app. If 'False', Version 8.0 is not the minimum version. Applicable only for the 'Android' TargetPlatform.")] Boolean V4_0_3;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 4.1 or later is required to install the app. If 'False', Version 8.0 is not the minimum version. Applicable only for the 'Android' TargetPlatform.")] Boolean V4_1;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 4.2 or later is required to install the app. If 'False', Version 8.0 is not the minimum version. Applicable only for the 'Android' TargetPlatform.")] Boolean V4_2;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 4.3 or later is required to install the app. If 'False', Version 8.0 is not the minimum version. Applicable only for the 'Android' TargetPlatform.")] Boolean V4_3;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 4.4 or later is required to install the app. If 'False', Version 8.0 is not the minimum version. Applicable only for the 'Android' TargetPlatform.")] Boolean V4_4;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 5.0 or later is required to install the app. If 'False', Version 8.0 is not the minimum version. Applicable only for the 'Android' TargetPlatform.")] Boolean V5_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 5.1 or later is required to install the app. If 'False', Version 8.0 is not the minimum version. Applicable only for the 'Android' TargetPlatform.")] Boolean V5_1;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 6.0 or later is required to install the app. If 'False', Version 8.0 is not the minimum version. Applicable only for the 'Android' TargetPlatform.")] Boolean V6_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 7.0 or later is required to install the app. If 'False', Version 8.0 is not the minimum version. Applicable only for the 'Android' TargetPlatform.")] Boolean V7_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 7.1 or later is required to install the app. If 'False', Version 8.0 is not the minimum version. Applicable only for the 'Android' TargetPlatform.")] Boolean V7_1;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 8.0 or later is required to install the app. If 'False', Version 8.0 is not the minimum version.")] Boolean V8_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 8.1 or later is required to install the app. If 'False', Version 8.0 is not the minimum version. Applicable only for the 'Android' TargetPlatform.")] Boolean V8_1;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 9.0 or later is required to install the app. If 'False', Version 9.0 is not the minimum version.")] Boolean V9_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 10.0 or later is required to install the app. If 'False', Version 10.0 is not the minimum version.")] Boolean V10_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 11.0 or later is required to install the app. If 'False', Version 11.0 is not the minimum version.")] Boolean V11_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 12.0 or later is required to install the app. If 'False', Version 12.0 is not the minimum version.")] Boolean V12_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 13.0 or later is required to install the app. If 'False', Version 13.0 is not the minimum version.")] Boolean V13_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 14.0 or later is required to install the app. If 'False', Version 14.0 is not the minimum version.")] Boolean V14_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 15.0 or later is required to install the app. If 'False', Version 15.0 is not the minimum version.")] Boolean V15_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 16.0 or later is required to install the app. If 'False', Version 16.0 is not the minimum version. Applicable only for the 'iOS' TargetPlatform.")] Boolean V16_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 17.0 or later is required to install the app. If 'False', Version 17.0 is not the minimum version. Applicable only for the 'iOS' TargetPlatform.")] Boolean V17_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 18.0 or later is required to install the app. If 'False', Version 18.0 is not the minimum version. Applicable only for the 'iOS' TargetPlatform.")] Boolean V18_0;
+};
+
+[ClassVersion("1.0.0")]
 class MSFT_DeviceManagementMimeContent
 {
     [Write, Description("Indicates the type of content mime.")] String Type;
@@ -27,20 +62,25 @@ class MSFT_DeviceManagementMobileAppCategory
 [ClassVersion("1.0.0.0"), FriendlyName("IntuneMobileAppsBuiltInStoreApp")]
 class MSFT_IntuneMobileAppsBuiltInStoreApp : OMI_BaseResource
 {
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
+    [Key, Description("The admin provided or imported title of the app.")] String DisplayName;
+    [Write, Description("The architecture for which this app can run on. Only applicable for the 'iOS' TargetPlatform."), EmbeddedInstance("MSFT_MicrosoftGraphiosDeviceType")] String ApplicableDeviceType;
+    [Write, Description("The App Store URL. Cannot be changed after creation.")] String AppStoreUrl;
+    [Write, Description("The Identity Name. Only applicable for the 'iOS' TargetPlatform.")] String BundleId;
+    [Write, Description("The value for the minimum applicable operating system."), EmbeddedInstance("MSFT_MicrosoftGraphMinimumOperatingSystem")] String MinimumSupportedOperatingSystem;
     [Write, Description("The description of the app.")] String Description;
     [Write, Description("The developer of the app.")] String Developer;
-    [Key, Description("The admin provided or imported title of the app.")] String DisplayName;
     [Write, Description("The more information Url.")] String InformationUrl;
     [Write, Description("The value indicating whether the app is marked as featured by the admin.")] Boolean IsFeatured;
     [Write, Description("The large icon, to be displayed in the app details and used for upload of the icon."), EmbeddedInstance("MSFT_DeviceManagementMimeContent")] String LargeIcon;
     [Write, Description("Notes for the app.")] String Notes;
     [Write, Description("The owner of the app.")] String Owner;
+    [Write, Description("The app's package ID. Only applicable for the 'Android' TargetPlatform")] String PackageId;
     [Write, Description("The privacy statement Url.")] String PrivacyInformationUrl;
     [Write, Description("The publisher of the app.")] String Publisher;
     [Write, Description("The list of categories for this app."), EmbeddedInstance("MSFT_DeviceManagementMobileAppCategory")] String Categories[];
     [Write, Description("List of scope tag ids for this mobile app.")] String RoleScopeTagIds[];
-    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
-    [Key, Description("The target platform of the mobile app."), ValueMap{"Android","IOS"}, Values{"Android","IOS"}] String TargetPlatform;
+    [Required, Description("The target platform of the mobile app."), ValueMap{"Android","IOS"}, Values{"Android","IOS"}] String TargetPlatform;
     [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementMobileAppAssignment")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.schema.mof
@@ -1,0 +1,53 @@
+[ClassVersion("1.0.0.1")]
+class MSFT_DeviceManagementConfigurationPolicyAssignments
+{
+    [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}] String dataType;
+    [Write, Description("The type of filter of the target assignment i.e. Exclude or Include. Possible values are:none, include, exclude."), ValueMap{"none","include","exclude"}, Values{"none","include","exclude"}] String deviceAndAppManagementAssignmentFilterType;
+    [Write, Description("The Id of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterId;
+    [Write, Description("The display name of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterDisplayName;
+    [Write, Description("The group Id that is the target of the assignment.")] String groupId;
+    [Write, Description("The group Display Name that is the target of the assignment.")] String groupDisplayName;
+    [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
+};
+
+[ClassVersion("1.0.0")]
+class MSFT_DeviceManagementMimeContent
+{
+    [Write, Description("Indicates the type of content mime.")] String Type;
+    [Write, Description("The Base64 encoded string content.")] String Value;
+};
+
+[ClassVersion("1.0.0")]
+class MSFT_DeviceManagementMobileAppCategory
+{
+    [Key, Description("The name of the app category.")] String DisplayName;
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
+};
+
+[ClassVersion("1.0.0.0"), FriendlyName("IntuneMobileAppsBuiltInStoreApp")]
+class MSFT_IntuneMobileAppsBuiltInStoreApp : OMI_BaseResource
+{
+    [Write, Description("The description of the app.")] String Description;
+    [Write, Description("The developer of the app.")] String Developer;
+    [Key, Description("The admin provided or imported title of the app.")] String DisplayName;
+    [Write, Description("The more information Url.")] String InformationUrl;
+    [Write, Description("The value indicating whether the app is marked as featured by the admin.")] Boolean IsFeatured;
+    [Write, Description("The large icon, to be displayed in the app details and used for upload of the icon."), EmbeddedInstance("MSFT_DeviceManagementMimeContent")] String LargeIcon;
+    [Write, Description("Notes for the app.")] String Notes;
+    [Write, Description("The owner of the app.")] String Owner;
+    [Write, Description("The privacy statement Url.")] String PrivacyInformationUrl;
+    [Write, Description("The publisher of the app.")] String Publisher;
+    [Write, Description("The list of categories for this app."), EmbeddedInstance("MSFT_DeviceManagementMobileAppCategory")] String Categories[];
+    [Write, Description("List of scope tag ids for this mobile app.")] String RoleScopeTagIds[];
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
+    [Key, Description("The target platform of the mobile app."), ValueMap{"Android","IOS"}, Values{"Android","IOS"}] String TargetPlatform;
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
+    [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
+    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
+    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
+    [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
+    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Access token used for authentication.")] String AccessTokens[];
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/readme.md
@@ -1,0 +1,6 @@
+
+# IntuneMobileAppsBuiltInStoreApp
+
+## Description
+
+Intune Mobile Apps Built In Store App for Android and iOS

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/settings.json
@@ -1,0 +1,61 @@
+{
+  "resourceName": "IntuneMobileAppsBuiltInStoreApp",
+  "description": "This resource configures an Intune Mobile Apps Built In Store App for Android and iOS.",
+  "permissions": {
+    "graph": {
+      "delegated": {
+        "update": [
+          {
+            "name": "DeviceManagementApps.ReadWrite.All"
+          },
+          {
+            "name": "DeviceManagementApps.ReadWrite.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ],
+        "read": [
+          {
+            "name": "DeviceManagementApps.Read.All"
+          },
+          {
+            "name": "DeviceManagementApps.Read.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ]
+      },
+      "application": {
+        "update": [
+          {
+            "name": "DeviceManagementApps.ReadWrite.All"
+          },
+          {
+            "name": "DeviceManagementApps.ReadWrite.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ],
+        "read": [
+          {
+            "name": "DeviceManagementApps.Read.All"
+          },
+          {
+            "name": "DeviceManagementApps.Read.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ]
+      }
+    }
+  },
+  "requiredModules": [
+    "Microsoft.Graph.Authentication",
+    "Microsoft.Graph.Beta.Devices.CorporateManagement",
+    "Microsoft.Graph.Groups"
+  ]
+}

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsDefenderForEndpointMacOS/MSFT_IntuneMobileAppsDefenderForEndpointMacOS.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsDefenderForEndpointMacOS/MSFT_IntuneMobileAppsDefenderForEndpointMacOS.schema.mof
@@ -1,4 +1,4 @@
-[ClassVersion("1.0.0")]
+[ClassVersion("1.0.0.1")]
 class MSFT_DeviceManagementMobileAppAssignment
 {
     [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}] String dataType;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.schema.mof
@@ -1,4 +1,4 @@
-[ClassVersion("1.0.0")]
+[ClassVersion("1.0.0.1")]
 class MSFT_DeviceManagementMobileAppAssignment
 {
     [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}] String dataType;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMicrosoft365SuiteMacOS/MSFT_IntuneMobileAppsMicrosoft365SuiteMacOS.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMicrosoft365SuiteMacOS/MSFT_IntuneMobileAppsMicrosoft365SuiteMacOS.schema.mof
@@ -1,4 +1,4 @@
-[ClassVersion("1.0.0")]
+[ClassVersion("1.0.0.1")]
 class MSFT_DeviceManagementMobileAppAssignment
 {
     [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}] String dataType;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMicrosoftEdge/MSFT_IntuneMobileAppsMicrosoftEdge.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMicrosoftEdge/MSFT_IntuneMobileAppsMicrosoftEdge.schema.mof
@@ -1,4 +1,4 @@
-[ClassVersion("1.0.0")]
+[ClassVersion("1.0.0.1")]
 class MSFT_DeviceManagementMobileAppAssignment
 {
     [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}] String dataType;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWebLink/MSFT_IntuneMobileAppsWebLink.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWebLink/MSFT_IntuneMobileAppsWebLink.schema.mof
@@ -1,4 +1,4 @@
-[ClassVersion("1.0.0")]
+[ClassVersion("1.0.0.1")]
 class MSFT_DeviceManagementMobileAppAssignment
 {
     [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}] String dataType;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp/MSFT_IntuneMobileAppsWindowsOfficeSuiteApp.schema.mof
@@ -1,4 +1,4 @@
-[ClassVersion("1.0.0")]
+[ClassVersion("1.0.0.1")]
 class MSFT_DeviceManagementMobileAppAssignment
 {
     [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}] String dataType;

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBuiltInStoreApp/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBuiltInStoreApp/1-Create.ps1
@@ -1,0 +1,57 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneMobileAppsBuiltInStoreApp "IntuneMobileAppsBuiltInStoreApp-Store App"
+        {
+            TargetPlatform        = "Android";
+            Description           = "Store App Description";
+            Developer             = "Contoso";
+            DisplayName           = "Builtin Store App";
+            Ensure                = "Present";
+            InformationUrl        = "";
+            IsFeatured            = $False;
+            Notes                 = "";
+            Owner                 = "";
+            PrivacyInformationUrl = "";
+            Publisher             = "Contoso";
+            Assignments          = @(
+                MSFT_DeviceManagementMobileAppAssignment {
+                    groupDisplayName = 'All devices'
+                    deviceAndAppManagementAssignmentFilterType = 'none'
+                    dataType = '#microsoft.graph.allDevicesAssignmentTarget'
+                    intent = 'required'
+                }
+            );
+            Categories             = @(
+                MSFT_DeviceManagementMobileAppCategory{
+                    Id = "2185c6bf-1b3d-4daa-a0bc-79cb4fad9c87"
+                    DisplayName = "App Category 1"
+                }
+            );
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBuiltInStoreApp/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBuiltInStoreApp/1-Create.ps1
@@ -24,6 +24,8 @@ Configuration Example
     {
         IntuneMobileAppsBuiltInStoreApp "IntuneMobileAppsBuiltInStoreApp-Store App"
         {
+            AppStoreUrl           = "https://play.google.com/store/apps/details?id=com.contoso.app";
+            BundleId              = "com.contoso.app";
             TargetPlatform        = "Android";
             Description           = "Store App Description";
             Developer             = "Contoso";
@@ -35,6 +37,28 @@ Configuration Example
             Owner                 = "";
             PrivacyInformationUrl = "";
             Publisher             = "Contoso";
+            MinimumSupportedOperatingSystem = MSFT_MicrosoftGraphMinimumOperatingSystem{
+                V4_0 = $False
+                V4_0_3 = $False
+                V4_1 = $False
+                V4_2 = $False
+                V4_3 = $False
+                V4_4 = $False
+                V5_0 = $False
+                V5_1 = $False
+                V6_0 = $False
+                V7_0 = $False
+                V7_1 = $False
+                V8_0 = $True
+                V8_1 = $False
+                V9_0 = $False
+                V10_0 = $False
+                V11_0 = $False
+                V12_0 = $False
+                V13_0 = $False
+                V14_0 = $False
+                V15_0 = $False
+            };
             Assignments          = @(
                 MSFT_DeviceManagementMobileAppAssignment {
                     groupDisplayName = 'All devices'

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBuiltInStoreApp/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBuiltInStoreApp/2-Update.ps1
@@ -24,6 +24,8 @@ Configuration Example
     {
         IntuneMobileAppsBuiltInStoreApp "IntuneMobileAppsBuiltInStoreApp-Store App"
         {
+            AppStoreUrl           = "https://play.google.com/store/apps/details?id=com.contoso.app";
+            BundleId              = "com.contoso.app";
             TargetPlatform        = "Android";
             Description           = "Store App Description";
             Developer             = "Contoso";
@@ -35,6 +37,28 @@ Configuration Example
             Owner                 = "";
             PrivacyInformationUrl = "";
             Publisher             = "Contoso";
+            MinimumSupportedOperatingSystem = MSFT_MicrosoftGraphMinimumOperatingSystem{
+                V4_0 = $False
+                V4_0_3 = $False
+                V4_1 = $False
+                V4_2 = $False
+                V4_3 = $False
+                V4_4 = $False
+                V5_0 = $False
+                V5_1 = $False
+                V6_0 = $False
+                V7_0 = $False
+                V7_1 = $False
+                V8_0 = $True
+                V8_1 = $False
+                V9_0 = $False
+                V10_0 = $False
+                V11_0 = $False
+                V12_0 = $False
+                V13_0 = $False
+                V14_0 = $False
+                V15_0 = $False
+            };
             Assignments          = @(
                 MSFT_DeviceManagementMobileAppAssignment {
                     groupDisplayName = 'All devices'

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBuiltInStoreApp/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBuiltInStoreApp/2-Update.ps1
@@ -1,0 +1,57 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Import-DscResource -ModuleName Microsoft365DSC
+    node localhost
+    {
+        IntuneMobileAppsBuiltInStoreApp "IntuneMobileAppsBuiltInStoreApp-Store App"
+        {
+            TargetPlatform        = "Android";
+            Description           = "Store App Description";
+            Developer             = "Contoso";
+            DisplayName           = "Builtin Store App";
+            Ensure                = "Present";
+            InformationUrl        = "";
+            IsFeatured            = $True; # Drift
+            Notes                 = "";
+            Owner                 = "";
+            PrivacyInformationUrl = "";
+            Publisher             = "Contoso";
+            Assignments          = @(
+                MSFT_DeviceManagementMobileAppAssignment {
+                    groupDisplayName = 'All devices'
+                    deviceAndAppManagementAssignmentFilterType = 'none'
+                    dataType = '#microsoft.graph.allDevicesAssignmentTarget'
+                    intent = 'required'
+                }
+            );
+            Categories             = @(
+                MSFT_DeviceManagementMobileAppCategory{
+                    Id = "2185c6bf-1b3d-4daa-a0bc-79cb4fad9c87"
+                    DisplayName = "App Category 1"
+                }
+            );
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBuiltInStoreApp/3-Remove.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBuiltInStoreApp/3-Remove.ps1
@@ -1,0 +1,37 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneMobileAppsBuiltInStoreApp "IntuneMobileAppsBuiltInStoreApp-Store App"
+        {
+            Id                    = "8d027f94-0682-431e-97c1-827d1879fa79";
+            DisplayName           = "Store App";
+            TargetPlatform        = "Android";
+            Ensure                = "Absent";
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsBuiltInStoreApp.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsBuiltInStoreApp.Tests.ps1
@@ -1,0 +1,309 @@
+[CmdletBinding()]
+param(
+)
+$M365DSCTestFolder = Join-Path -Path $PSScriptRoot `
+                        -ChildPath '..\..\Unit' `
+                        -Resolve
+$CmdletModule = (Join-Path -Path $M365DSCTestFolder `
+            -ChildPath '\Stubs\Microsoft365.psm1' `
+            -Resolve)
+$GenericStubPath = (Join-Path -Path $M365DSCTestFolder `
+    -ChildPath '\Stubs\Generic.psm1' `
+    -Resolve)
+Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\UnitTestHelper.psm1' `
+        -Resolve)
+
+$Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
+    -DscResource "IntuneMobileAppsBuiltInStoreApp" -GenericStubModule $GenericStubPath
+Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
+        BeforeAll {
+
+            $secpasswd = ConvertTo-SecureString (New-Guid | Out-String) -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
+
+            Mock -ModuleName M365DSCUtil -CommandName Confirm-M365DSCDependencies -MockWith {
+            }
+
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
+            Mock -CommandName Reset-MSCloudLoginConnectionProfileContext -MockWith {
+            }
+
+            Mock -CommandName Get-PSSession -MockWith {
+            }
+
+            Mock -CommandName Remove-PSSession -MockWith {
+            }
+
+            Mock -CommandName Update-DeviceAppManagementAppCategory -MockWith {
+            }
+
+            Mock -CommandName Update-DeviceAppManagementPolicyAssignment -MockWith {
+            }
+
+            Mock -CommandName Update-MgBetaDeviceAppManagementMobileApp -MockWith {
+            }
+
+            Mock -CommandName Invoke-MgGraphRequest -MockWith {
+                return @{
+                    AdditionalProperties = @{
+                        '@odata.type' = "#microsoft.graph.managedAndroidStoreApp"
+                    }
+                    DependentAppCount = 25
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = @{
+                        Type = "FakeStringValue"
+                        Value = [System.Convert]::FromBase64String("VGVzdA==")
+                    }
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    PublishingState = "notPublished"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    SupersededAppCount = 25
+                    SupersedingAppCount = 25
+                    UploadState = 25
+                }
+            }
+
+            Mock -CommandName Remove-MgBetaDeviceAppManagementMobileApp -MockWith {
+            }
+
+            Mock -CommandName Get-MgBetaDeviceAppManagementMobileApp -MockWith {
+                return @{
+                    AdditionalProperties = @{
+                        '@odata.type' = "#microsoft.graph.managedAndroidStoreApp"
+                    }
+                    Categories = @(
+                        @{
+                            Id = "FakeStringValue"
+                            DisplayName = "FakeStringValue"
+                        }
+                    )
+                    DependentAppCount = 25
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = @{
+                        Type = "FakeStringValue"
+                        Value = [System.Convert]::FromBase64String("VGVzdA==")
+                    }
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    PublishingState = "notPublished"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    SupersededAppCount = 25
+                    SupersedingAppCount = 25
+                    UploadState = 25
+                }
+            }
+
+            Mock -CommandName New-M365DSCConnection -MockWith {
+                return "Credentials"
+            }
+
+            # Mock Write-M365DSCHost to hide output during the tests
+            Mock -CommandName Write-M365DSCHost -MockWith {
+            }
+            $Script:exportedInstance = $null
+            $Script:ExportMode = $false
+
+            Mock -CommandName Get-MgBetaDeviceAppManagementMobileAppAssignment -MockWith {
+            }
+
+        }
+
+        # Test contexts
+        Context -Name "The IntuneMobileAppsBuiltInStoreApp should exist but it DOES NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    TargetPlatform = "Android"
+                    Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
+                        Id = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                    } -ClientOnly))
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent -Property @{
+                        Type = "FakeStringValue"
+                        Value = "VGVzdA==" # Base64 encoded string for "Test"
+                    } -ClientOnly)
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+
+                Mock -CommandName Get-MgBetaDeviceAppManagementMobileApp -MockWith {
+                    return $null
+                }
+            }
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
+            }
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+            It 'Should Create the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Invoke-MgGraphRequest -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneMobileAppsBuiltInStoreApp exists but it SHOULD NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    TargetPlatform = "Android"
+                    Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
+                        Id = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                    } -ClientOnly))
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent -Property @{
+                        Type = "FakeStringValue"
+                        Value = "VGVzdA==" # Base64 encoded string for "Test"
+                    } -ClientOnly)
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Absent"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should Remove the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Remove-MgBetaDeviceAppManagementMobileApp -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneMobileAppsBuiltInStoreApp Exists and Values are already in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    TargetPlatform = "Android"
+                    Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
+                        Id = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                    } -ClientOnly))
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent -Property @{
+                        Type = "FakeStringValue"
+                        Value = "VGVzdA==" # Base64 encoded string for "Test"
+                    } -ClientOnly)
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+        }
+
+        Context -Name "The IntuneMobileAppsBuiltInStoreApp exists and values are NOT in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    TargetPlatform = "Android"
+                    Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
+                        Id = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                    } -ClientOnly))
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $False # Drift
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent -Property @{
+                        Type = "FakeStringValue"
+                        Value = "VGVzdA==" # Base64 encoded string for "Test"
+                    } -ClientOnly)
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Invoke-MgGraphRequest -Exactly 1
+            }
+        }
+
+        Context -Name 'ReverseDSC Tests' -Fixture {
+            BeforeAll {
+                $Global:CurrentModeIsExport = $true
+                $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
+                $testParams = @{
+                    Credential = $Credential
+                }
+            }
+
+            It 'Should Reverse Engineer resource from the Export method' {
+                $result = Export-TargetResource @testParams
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}
+
+Invoke-Command -ScriptBlock $Global:DscHelper.CleanupScript -NoNewScope

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsBuiltInStoreApp.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsBuiltInStoreApp.Tests.ps1
@@ -83,6 +83,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 return @{
                     AdditionalProperties = @{
                         '@odata.type' = "#microsoft.graph.managedAndroidStoreApp"
+                        packageId = "FakeStringValue"
+                        appStoreUrl = "FakeStringValue"
                     }
                     Categories = @(
                         @{
@@ -132,6 +134,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "The IntuneMobileAppsBuiltInStoreApp should exist but it DOES NOT" -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AppStoreUrl = "FakeStringValue"
                     TargetPlatform = "Android"
                     Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
                         Id = "FakeStringValue"
@@ -149,6 +152,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     } -ClientOnly)
                     Notes = "FakeStringValue"
                     Owner = "FakeStringValue"
+                    PackageId = "FakeStringValue"
                     PrivacyInformationUrl = "FakeStringValue"
                     Publisher = "FakeStringValue"
                     RoleScopeTagIds = @("FakeStringValue")
@@ -175,6 +179,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "The IntuneMobileAppsBuiltInStoreApp exists but it SHOULD NOT" -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AppStoreUrl = "FakeStringValue"
                     TargetPlatform = "Android"
                     Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
                         Id = "FakeStringValue"
@@ -192,6 +197,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     } -ClientOnly)
                     Notes = "FakeStringValue"
                     Owner = "FakeStringValue"
+                    PackageId = "FakeStringValue"
                     PrivacyInformationUrl = "FakeStringValue"
                     Publisher = "FakeStringValue"
                     RoleScopeTagIds = @("FakeStringValue")
@@ -217,6 +223,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "The IntuneMobileAppsBuiltInStoreApp Exists and Values are already in the desired state" -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AppStoreUrl = "FakeStringValue"
                     TargetPlatform = "Android"
                     Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
                         Id = "FakeStringValue"
@@ -234,6 +241,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     } -ClientOnly)
                     Notes = "FakeStringValue"
                     Owner = "FakeStringValue"
+                    PackageId = "FakeStringValue"
                     PrivacyInformationUrl = "FakeStringValue"
                     Publisher = "FakeStringValue"
                     RoleScopeTagIds = @("FakeStringValue")
@@ -250,6 +258,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "The IntuneMobileAppsBuiltInStoreApp exists and values are NOT in the desired state" -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AppStoreUrl = "FakeStringValue"
                     TargetPlatform = "Android"
                     Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
                         Id = "FakeStringValue"
@@ -267,6 +276,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     } -ClientOnly)
                     Notes = "FakeStringValue"
                     Owner = "FakeStringValue"
+                    PackageId = "FakeStringValue"
                     PrivacyInformationUrl = "FakeStringValue"
                     Publisher = "FakeStringValue"
                     RoleScopeTagIds = @("FakeStringValue")


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds the `IntuneMobileAppsBuiltInStoreApp` resource. This one is similary to the `IntuneMobileAppsStoreApp` resource, but it is only available for the "Built in" apps in both Android and iOS stores. 

<img width="281" height="129" alt="image" src="https://github.com/user-attachments/assets/4389d88f-ea57-4351-9701-73141c32bf91" />


#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
