### PR TITLE
Fix workload identity serviceprincipalrisklevel incorrect type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     FIXES [#6298](https://github.com/microsoft/Microsoft365DSC/issues/6298)
   * Fixed incorrect ServicePrincipalRiskLevels parameter type
     FIXES [#6325](https://github.com/microsoft/Microsoft365DSC/issues/6325)
+  * Added explample for workload identity and dynamic filter based on CustomSecurityAttribute
 * EXOTransportRule
   * Changed the update logic to handle empty parameters.
 * MISC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
-
 * AADConditionalAccessPolicy
   * Fixed issue with setting empty ExcludePlatform in Target state when current state contains a value
     FIXES [#6298](https://github.com/microsoft/Microsoft365DSC/issues/6298)
+  * Fixed incorrect ServicePrincipalRiskLevels parameter type
+    FIXES [#6325](https://github.com/microsoft/Microsoft365DSC/issues/6325)
 * EXOTransportRule
   * Changed the update logic to handle empty parameters.
 * MISC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
+
 * AADAdministrativeUnit
   * Add detection/support for not filters as they require additional headers (ConsistencyLevel: Eventual). 
 * AADGroup
@@ -12,7 +13,7 @@
     FIXES [#6298](https://github.com/microsoft/Microsoft365DSC/issues/6298)
   * Fixed incorrect ServicePrincipalRiskLevels parameter type
     FIXES [#6325](https://github.com/microsoft/Microsoft365DSC/issues/6325)
-  * Added explample for workload identity and dynamic filter based on CustomSecurityAttribute
+  * Added example for workload identity and dynamic filter based on CustomSecurityAttribute
 * EXOTransportRule
   * Changed the update logic to handle empty parameters.
 * IntuneMobileAppsDefenderForEndpointMacOS

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -672,12 +672,6 @@ function Get-TargetResource
         $InsiderRiskLevelsValue = $Policy.Conditions.InsiderRiskLevels.Split(',')
     }
 
-    $ServicePrincipalRiskLevelsValue = $null
-    if (-not [System.String]::IsNullOrEmpty($Policy.Conditions.ServicePrincipalRiskLevels))
-    {
-        $ServicePrincipalRiskLevelsValue = $Policy.Conditions.ServicePrincipalRiskLevels.Split(',')
-    }
-
     $result = @{
         DisplayName                              = $Policy.DisplayName
         Id                                       = $Policy.Id
@@ -754,10 +748,11 @@ function Get-TargetResource
         AuthenticationStrength                   = $AuthenticationStrengthValue
         AuthenticationContexts                   = $AuthenticationContextsValues
         TransferMethods                          = [System.String]$Policy.Conditions.AuthenticationFlows.TransferMethods
+        #no translation needed, return empty string array if undefined
+        ServicePrincipalRiskLevels               = [System.String[]](@() + $Policy.Conditions.ServicePrincipalRiskLevels)
         #Standard part
         TermsOfUse                               = $termOfUseName
         InsiderRiskLevels                        = $InsiderRiskLevelsValue
-        ServicePrincipalRiskLevels               = $ServicePrincipalRiskLevelsValue
         Ensure                                   = 'Present'
         Credential                               = $Credential
         ApplicationSecret                        = $ApplicationSecret
@@ -1732,9 +1727,9 @@ function Set-TargetResource
             $conditions.Add('insiderRiskLevels', $($InsiderRiskLevels -join ','))
         }
 
-        if ([String]::IsNullOrEmpty($ServicePrincipalRiskLevels) -eq $false)
+        if ($ServicePrincipalRiskLevels -is [string[]] -and $ServicePrincipalRiskLevels.Count -gt 0)
         {
-            $conditions.Add('servicePrincipalRiskLevels', $($ServicePrincipalRiskLevels -join ','))
+            $conditions.Add('servicePrincipalRiskLevels', $ServicePrincipalRiskLevels)
         }
 
         Write-Verbose -Message 'Set-Targetresource: process risk levels and app types'

--- a/docs/docs/resources/azure-ad/AADConditionalAccessPolicy.md
+++ b/docs/docs/resources/azure-ad/AADConditionalAccessPolicy.md
@@ -196,8 +196,56 @@ Configuration Example
     }
 }
 ```
-
 ### Example 3
+
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+
+```powershell
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Import-DscResource -ModuleName 'Microsoft365DSC'
+
+    Node localhost
+    {
+        AADConditionalAccessPolicy "ConditionalAccessPolicy"
+        {
+            TenantId                                 = $tenantID;
+            ApplicationId                            = $ApplicationId;
+            CertificateThumbprint                    = $CertificateThumbprint;
+            BuiltInControls                          = @("block");
+            GrantControlOperator                     = "OR";
+            ClientAppTypes                           = @("all");
+            DisplayName                              = "Example CAP";
+            Ensure                                   = "Present";
+            IncludeApplications                      = @("All");
+            ExcludeApplications                      = @();
+            IncludeServicePrincipals                 = @();
+            ExcludeServicePrincipals                 = @();
+            IncludeUsers                             = @("None");
+            ExcludeUsers                             = @();
+            ServicePrincipalFilterMode               = "include";
+            ServicePrincipalFilterRule               = "CustomSecurityAttribute.custsecattr_apiPermLevel -eq `"high`"";
+	        ServicePrincipalRiskLevels               = @("high","medium");
+            State                                    = "disabled";
+        }
+    }
+}
+```
+### Example 4
 
 This example is used to test new resources and showcase the usage of new resources being worked on.
 It is not meant to use as a production baseline.


### PR DESCRIPTION
#### Pull Request (PR) description
The recently added ServicePrincipalRiskLevels were being evaluated as String instead of an Array of Strings leading to errors in applying the parameter in conditional access

#### This Pull Request (PR) fixes the following issues
 - Fixes #6325

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
