### PR TITLE
Add Intune Android System App resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Initial release.
 * IntuneMobileAppsStoreApp
   * Initial release.
+* IntuneMobileAppsSystemAppAndroid
+  * Initial release.
 
 # 1.25.716.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsSystemAppAndroid/MSFT_IntuneMobileAppsSystemAppAndroid.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsSystemAppAndroid/MSFT_IntuneMobileAppsSystemAppAndroid.psm1
@@ -1,3 +1,5 @@
+Confirm-M365DSCModuleDependency -ModuleName "MSFT_IntuneMobileAppsSystemAppAndroid"
+
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -15,7 +17,7 @@ function Get-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $PackageId,
+        $AppIdentifier,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -128,7 +130,7 @@ function Get-TargetResource
 
         $results = @{
             #region resource generator code
-            PackageId             = $getValue.AdditionalProperties.packageId
+            AppIdentifier         = $getValue.AdditionalProperties.appIdentifier
             DisplayName           = $getValue.DisplayName
             Publisher             = $getValue.Publisher
             RoleScopeTagIds       = $getValue.RoleScopeTagIds
@@ -180,7 +182,7 @@ function Set-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $PackageId,
+        $AppIdentifier,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -245,7 +247,7 @@ function Set-TargetResource
 
     $currentInstance = Get-TargetResource @PSBoundParameters
 
-    $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+    $boundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
 
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
@@ -267,8 +269,8 @@ function Set-TargetResource
         }
         #region resource generator code
         $createParameters.Add("@odata.type", "#microsoft.graph.androidManagedStoreApp")
-        $createParameters.Add("IsSystemApp", $true)
-        $policy = New-MgBetaDeviceAppManagementMobileApp -BodyParameter $createParameters
+        $createParameters.Add("isSystemApp", $true)
+        $policy = Invoke-MgGraphRequest -Method POST -Uri '/beta/deviceAppManagement/mobileApps' -Body $($createParameters | ConvertTo-Json -Depth 10)
 
         if ($policy.Id)
         {
@@ -288,7 +290,7 @@ function Set-TargetResource
         $updateParameters = Rename-M365DSCCimInstanceParameter -Properties $updateParameters
 
         $updateParameters.Remove('Id') | Out-Null
-        $updateParameters.Remove('PackageId') | Out-Null
+        $updateParameters.Remove('AppIdentifier') | Out-Null
 
         $keys = (([Hashtable]$updateParameters).Clone()).Keys
         foreach ($key in $keys)
@@ -337,7 +339,7 @@ function Test-TargetResource
 
         [Parameter(Mandatory = $true)]
         [System.String]
-        $PackageId,
+        $AppIdentifier,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -500,7 +502,7 @@ function Export-TargetResource
             $params = @{
                 Id                    = $config.Id
                 DisplayName           = $config.DisplayName
-                PackageId             = $config.AdditionalProperties.packageId
+                AppIdentifier         = $config.AdditionalProperties.appIdentifier
                 Publisher             = $config.Publisher
                 Ensure                = 'Present'
                 Credential            = $Credential
@@ -517,7 +519,7 @@ function Export-TargetResource
 
             if ($Results.Assignments)
             {
-                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementMobileAppAssignment
                 if ($complexTypeStringResult)
                 {
                     $Results.Assignments = $complexTypeStringResult

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsSystemAppAndroid/MSFT_IntuneMobileAppsSystemAppAndroid.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsSystemAppAndroid/MSFT_IntuneMobileAppsSystemAppAndroid.psm1
@@ -1,0 +1,559 @@
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $PackageId,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Publisher,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    Write-Verbose -Message "Getting configuration for the Intune Mobile Apps System App for Android with Id {$Id} and DisplayName {$DisplayName}"
+
+    try
+    {
+        if (-not $Script:exportedInstance -or $Script:exportedInstance.DisplayName -ne $DisplayName)
+        {
+
+            $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+                -InboundParameters $PSBoundParameters
+
+            #Ensure the proper dependencies are installed in the current environment.
+            Confirm-M365DSCDependencies
+
+            #region Telemetry
+            $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+            $CommandName = $MyInvocation.MyCommand
+            $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+                -CommandName $CommandName `
+                -Parameters $PSBoundParameters
+            Add-M365DSCTelemetryEvent -Data $data
+            #endregion
+
+            $nullResult = $PSBoundParameters
+            $nullResult.Ensure = 'Absent'
+
+            $getValue = $null
+
+            #region resource generator code
+            if (-not [System.String]::IsNullOrEmpty($Id))
+            {
+                $getValue = Get-MgBetaDeviceAppManagementMobileApp -MobileAppId $Id -ErrorAction SilentlyContinue
+            }
+
+            if ($null -eq $getValue)
+            {
+                Write-Verbose -Message "Could not find an Intune Mobile Apps System App for Android with Id {$Id}"
+
+                if (-not [System.String]::IsNullOrEmpty($DisplayName))
+                {
+                    $getValue = Get-MgBetaDeviceAppManagementMobileApp `
+                        -Filter "DisplayName eq '$($DisplayName -replace "'", "''")' and isof('microsoft.graph.androidManagedStoreApp')" `
+                        -ErrorAction SilentlyContinue | Where-Object -FilterScript {
+                            $_.AdditionalProperties.isSystemApp -eq $true
+                        }
+                }
+            }
+            #endregion
+            if ($null -eq $getValue)
+            {
+                Write-Verbose -Message "Could not find an Intune Mobile Apps System App for Android with DisplayName {$DisplayName}."
+                return $nullResult
+            }
+
+            $getValue = Get-MgBetadeviceAppManagementMobileApp -MobileAppId $getValue.Id
+        }
+        else
+        {
+            $getValue = $getValue = Get-MgBetadeviceAppManagementMobileApp -MobileAppId $Script:exportedInstance.Id
+        }
+        $Id = $getValue.Id
+        Write-Verbose -Message "An Intune Mobile Apps System App for Android with Id {$Id} and DisplayName {$DisplayName} was found"
+
+        $results = @{
+            #region resource generator code
+            PackageId             = $getValue.AdditionalProperties.packageId
+            DisplayName           = $getValue.DisplayName
+            Publisher             = $getValue.Publisher
+            RoleScopeTagIds       = $getValue.RoleScopeTagIds
+            Id                    = $getValue.Id
+            Ensure                = 'Present'
+            Credential            = $Credential
+            ApplicationId         = $ApplicationId
+            TenantId              = $TenantId
+            ApplicationSecret     = $ApplicationSecret
+            CertificateThumbprint = $CertificateThumbprint
+            ManagedIdentity       = $ManagedIdentity.IsPresent
+            #endregion
+        }
+        $assignmentsValues = Get-MgBetaDeviceAppManagementMobileAppAssignment -MobileAppId $Id
+        $assignmentResult = @()
+        if ($assignmentsValues.Count -gt 0)
+        {
+            $assignmentResult += ConvertFrom-IntuneMobileAppAssignment -Assignments $assignmentsValues -IncludeDeviceFilter $true
+        }
+        $results.Add('Assignments', $assignmentResult)
+
+        return [System.Collections.Hashtable] $results
+    }
+    catch
+    {
+        New-M365DSCLogEntry -Message 'Error retrieving data:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return $nullResult
+    }
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $PackageId,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Publisher,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    Write-Verbose -Message "Setting configuration of the Intune Mobile Apps System App for Android with Id {$Id} and DisplayName {$DisplayName}"
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    $currentInstance = Get-TargetResource @PSBoundParameters
+
+    $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+
+
+    if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
+    {
+        Write-Verbose -Message "Creating an Intune Mobile Apps System App for Android with DisplayName {$DisplayName}"
+        $boundParameters.Remove("Assignments") | Out-Null
+
+        $createParameters = ([Hashtable]$boundParameters).Clone()
+        $createParameters = Rename-M365DSCCimInstanceParameter -Properties $createParameters
+        $createParameters.Remove('Id') | Out-Null
+
+        $keys = (([Hashtable]$createParameters).Clone()).Keys
+        foreach ($key in $keys)
+        {
+            if ($null -ne $createParameters.$key -and $createParameters.$key.GetType().Name -like '*CimInstance*')
+            {
+                $createParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $createParameters.$key
+            }
+        }
+        #region resource generator code
+        $createParameters.Add("@odata.type", "#microsoft.graph.androidManagedStoreApp")
+        $createParameters.Add("IsSystemApp", $true)
+        $policy = New-MgBetaDeviceAppManagementMobileApp -BodyParameter $createParameters
+
+        if ($policy.Id)
+        {
+            $assignmentsHash = ConvertTo-IntuneMobileAppAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
+            Update-DeviceAppManagementPolicyAssignment `
+                -AppManagementPolicyId $policy.Id `
+                -Assignments $assignmentsHash
+        }
+        #endregion
+    }
+    elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Updating the Intune Mobile Apps System App for Android with Id {$($currentInstance.Id)}"
+        $boundParameters.Remove("Assignments") | Out-Null
+
+        $updateParameters = ([Hashtable]$boundParameters).Clone()
+        $updateParameters = Rename-M365DSCCimInstanceParameter -Properties $updateParameters
+
+        $updateParameters.Remove('Id') | Out-Null
+        $updateParameters.Remove('PackageId') | Out-Null
+
+        $keys = (([Hashtable]$updateParameters).Clone()).Keys
+        foreach ($key in $keys)
+        {
+            if ($null -ne $pdateParameters.$key -and $updateParameters.$key.GetType().Name -like '*CimInstance*')
+            {
+                $updateParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $updateParameters.MobileAppId
+            }
+        }
+
+        #region resource generator code
+        $updateParameters.Add("@odata.type", "#microsoft.graph.androidManagedStoreApp")
+        Update-MgBetaDeviceAppManagementMobileApp `
+            -MobileAppId $currentInstance.Id `
+            -BodyParameter $UpdateParameters
+
+        $assignmentsHash = ConvertTo-IntuneMobileAppAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
+        Update-DeviceAppManagementPolicyAssignment `
+            -AppManagementPolicyId $currentInstance.Id `
+            -Assignments $assignmentsHash
+        #endregion
+    }
+    elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Removing the Intune Mobile Apps System App for Android with Id {$($currentInstance.Id)}"
+        #region resource generator code
+        Remove-MgBetaDeviceAppManagementMobileApp -MobileAppId $currentInstance.Id
+        #endregion
+    }
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $PackageId,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Publisher,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
+                                         -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
+    return $result
+}
+
+function Export-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+        -InboundParameters $PSBoundParameters
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    try
+    {
+        #region resource generator code
+        $baseFilter = "isof('microsoft.graph.androidManagedStoreApp')"
+        if (-not [String]::IsNullOrEmpty($Filter))
+        {
+            $Filter = "($Filter) and ($baseFilter)"
+        }
+        else
+        {
+            $Filter = $baseFilter
+        }
+        [array]$getValue = Get-MgBetaDeviceAppManagementMobileApp `
+            -Filter $Filter `
+            -All `
+            -ErrorAction Stop | Where-Object `
+            -FilterScript {
+                $_.AdditionalProperties.isSystemApp -eq $true
+            }
+        #endregion
+
+        $i = 1
+        $dscContent = ''
+        if ($getValue.Length -eq 0)
+        {
+            Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
+        }
+        else
+        {
+            Write-M365DSCHost -Message "`r`n" -DeferWrite
+        }
+        foreach ($config in $getValue)
+        {
+            $displayedKey = $config.Id
+            if (-not [String]::IsNullOrEmpty($config.displayName))
+            {
+                $displayedKey = $config.displayName
+            }
+            elseif (-not [string]::IsNullOrEmpty($config.name))
+            {
+                $displayedKey = $config.name
+            }
+            Write-M365DSCHost -Message "    |---[$i/$($getValue.Count)] $displayedKey" -DeferWrite
+            $params = @{
+                Id                    = $config.Id
+                DisplayName           = $config.DisplayName
+                PackageId             = $config.AdditionalProperties.packageId
+                Publisher             = $config.Publisher
+                Ensure                = 'Present'
+                Credential            = $Credential
+                ApplicationId         = $ApplicationId
+                TenantId              = $TenantId
+                ApplicationSecret     = $ApplicationSecret
+                CertificateThumbprint = $CertificateThumbprint
+                ManagedIdentity       = $ManagedIdentity.IsPresent
+                AccessTokens          = $AccessTokens
+            }
+
+            $Script:exportedInstance = $config
+            $Results = Get-TargetResource @Params
+
+            if ($Results.Assignments)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
+                if ($complexTypeStringResult)
+                {
+                    $Results.Assignments = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('Assignments') | Out-Null
+                }
+            }
+
+            $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
+                -ConnectionMode $ConnectionMode `
+                -ModulePath $PSScriptRoot `
+                -Results $Results `
+                -Credential $Credential `
+                -NoEscape @('Assignments')
+            $dscContent += $currentDSCBlock
+            Save-M365DSCPartialExport -Content $currentDSCBlock `
+                -FileName $Global:PartialExportFileName
+            $i++
+            Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
+        }
+        return $dscContent
+    }
+    catch
+    {
+        Write-M365DSCHost -Message $Global:M365DSCEmojiRedX -CommitWrite
+
+        New-M365DSCLogEntry -Message 'Error during Export:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return ''
+    }
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsSystemAppAndroid/MSFT_IntuneMobileAppsSystemAppAndroid.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsSystemAppAndroid/MSFT_IntuneMobileAppsSystemAppAndroid.schema.mof
@@ -13,12 +13,12 @@ class MSFT_DeviceManagementMobileAppAssignment
 [ClassVersion("1.0.0.0"), FriendlyName("IntuneMobileAppsSystemAppAndroid")]
 class MSFT_IntuneMobileAppsSystemAppAndroid : OMI_BaseResource
 {
-    [Required, Description("The package identifier. Cannot be changed after creation.")] String PackageId;
+    [Required, Description("The app identifier. Cannot be changed after creation.")] String AppIdentifier;
     [Key, Description("The admin provided or imported title of the app.")] String DisplayName;
     [Required, Description("The publisher of the app.")] String Publisher;
     [Write, Description("List of scope tag ids for this mobile app.")] String RoleScopeTagIds[];
     [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
-    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementMobileAppAssignment")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsSystemAppAndroid/MSFT_IntuneMobileAppsSystemAppAndroid.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsSystemAppAndroid/MSFT_IntuneMobileAppsSystemAppAndroid.schema.mof
@@ -1,0 +1,30 @@
+[ClassVersion("1.0.0.1")]
+class MSFT_DeviceManagementMobileAppAssignment
+{
+    [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}] String dataType;
+    [Write, Description("The Id of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterId;
+    [Write, Description("The display name of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterDisplayName;
+    [Write, Description("The type of filter of the target assignment i.e. Exclude or Include. Possible values are: none, include, exclude."), ValueMap{"none", "include", "exclude"}, Values{"none", "include", "exclude"}] String deviceAndAppManagementAssignmentFilterType;
+    [Write, Description("The group Id that is the target of the assignment.")] String groupId;
+    [Write, Description("The group Display Name that is the target of the assignment.")] String groupDisplayName;
+    [Write, Description("Possible values for the install intent chosen by the admin."), ValueMap{"available", "required", "uninstall", "availableWithoutEnrollment"}, Values{"available", "required", "uninstall", "availableWithoutEnrollment"}] String intent;
+};
+
+[ClassVersion("1.0.0.0"), FriendlyName("IntuneMobileAppsSystemAppAndroid")]
+class MSFT_IntuneMobileAppsSystemAppAndroid : OMI_BaseResource
+{
+    [Required, Description("The package identifier. Cannot be changed after creation.")] String PackageId;
+    [Key, Description("The admin provided or imported title of the app.")] String DisplayName;
+    [Required, Description("The publisher of the app.")] String Publisher;
+    [Write, Description("List of scope tag ids for this mobile app.")] String RoleScopeTagIds[];
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
+    [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
+    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
+    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
+    [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
+    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Access token used for authentication.")] String AccessTokens[];
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsSystemAppAndroid/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsSystemAppAndroid/readme.md
@@ -1,0 +1,6 @@
+
+# IntuneMobileAppsSystemAppAndroid
+
+## Description
+
+Intune Mobile Apps System App for Android

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsSystemAppAndroid/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsSystemAppAndroid/settings.json
@@ -1,0 +1,49 @@
+{
+  "resourceName": "IntuneMobileAppsSystemAppAndroid",
+  "description": "This resource configures an Intune Mobile Apps System App for Android.",
+  "permissions": {
+    "graph": {
+      "delegated": {
+        "read": [
+          {
+            "name": "DeviceManagementApps.Read.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ],
+        "update": [
+          {
+            "name": "DeviceManagementApps.ReadWrite.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ]
+      },
+      "application": {
+        "read": [
+          {
+            "name": "DeviceManagementApps.Read.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ],
+        "update": [
+          {
+            "name": "DeviceManagementApps.ReadWrite.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ]
+      }
+    }
+  },
+  "requiredModules": [
+    "Microsoft.Graph.Authentication",
+    "Microsoft.Graph.Beta.Devices.CorporateManagement",
+    "Microsoft.Graph.Groups"
+  ]
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsSystemAppAndroid/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsSystemAppAndroid/1-Create.ps1
@@ -26,7 +26,7 @@ Configuration Example
         {
             DisplayName           = "Office";
             Ensure                = "Present";
-            PackageId             = "com.microsoft.office";
+            AppIdentifier         = "com.microsoft.office";
             Publisher             = "Microsoft";
             RoleScopeTagIds       = @("0")
             Assignments           = @(

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsSystemAppAndroid/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsSystemAppAndroid/1-Create.ps1
@@ -1,0 +1,45 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneMobileAppsSystemAppAndroid "IntuneMobileAppsSystemAppAndroid-Office"
+        {
+            DisplayName           = "Office";
+            Ensure                = "Present";
+            PackageId             = "com.microsoft.office";
+            Publisher             = "Microsoft";
+            RoleScopeTagIds       = @("0")
+            Assignments           = @(
+                MSFT_DeviceManagementMobileAppAssignment {
+                    groupDisplayName = 'All devices'
+                    deviceAndAppManagementAssignmentFilterType = 'none'
+                    dataType = '#microsoft.graph.allDevicesAssignmentTarget'
+                    intent = 'required'
+                }
+            );
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsSystemAppAndroid/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsSystemAppAndroid/2-Update.ps1
@@ -1,0 +1,45 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Import-DscResource -ModuleName Microsoft365DSC
+    node localhost
+    {
+        IntuneMobileAppsSystemAppAndroid "IntuneMobileAppsSystemAppAndroid-Office"
+        {
+            DisplayName           = "Office";
+            Ensure                = "Present";
+            PackageId             = "com.microsoft.office";
+            Publisher             = "Company"; # Drift
+            RoleScopeTagIds       = @("0")
+            Assignments           = @(
+                MSFT_DeviceManagementMobileAppAssignment {
+                    groupDisplayName = 'All devices'
+                    deviceAndAppManagementAssignmentFilterType = 'none'
+                    dataType = '#microsoft.graph.allDevicesAssignmentTarget'
+                    intent = 'required'
+                }
+            );
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsSystemAppAndroid/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsSystemAppAndroid/2-Update.ps1
@@ -26,7 +26,7 @@ Configuration Example
         {
             DisplayName           = "Office";
             Ensure                = "Present";
-            PackageId             = "com.microsoft.office";
+            AppIdentifier         = "com.microsoft.office";
             Publisher             = "Company"; # Drift
             RoleScopeTagIds       = @("0")
             Assignments           = @(

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsSystemAppAndroid/3-Remove.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsSystemAppAndroid/3-Remove.ps1
@@ -26,7 +26,7 @@ Configuration Example
         IntuneMobileAppsSystemAppAndroid "IntuneMobileAppsSystemAppAndroid-Office"
         {
             DisplayName           = "Office";
-            PackageId             = "com.microsoft.office";
+            AppIdentifier         = "com.microsoft.office";
             Publisher             = "Microsoft";
             Ensure                = "Absent";
             ApplicationId         = $ApplicationId;

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsSystemAppAndroid/3-Remove.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsSystemAppAndroid/3-Remove.ps1
@@ -1,0 +1,37 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneMobileAppsSystemAppAndroid "IntuneMobileAppsSystemAppAndroid-Office"
+        {
+            DisplayName           = "Office";
+            PackageId             = "com.microsoft.office";
+            Publisher             = "Microsoft";
+            Ensure                = "Absent";
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1131,6 +1131,8 @@ function Test-M365DSCTargetResource
 
     $CurrentValues = & MSFT_$ResourceName\Get-TargetResource @DesiredValues
     $ValuesToCheck = ([Hashtable]$DesiredValues).Clone()
+    $ValuesToCheck.Remove('Id') | Out-Null
+    $ValuesToCheck.Remove('Identity') | Out-Null
 
     # Remove the key parameters from the comparison
     foreach ($keyToRemove in $resourceKeys)

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsSystemAppAndroid.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsSystemAppAndroid.Tests.ps1
@@ -1,0 +1,262 @@
+[CmdletBinding()]
+param(
+)
+$M365DSCTestFolder = Join-Path -Path $PSScriptRoot `
+                        -ChildPath '..\..\Unit' `
+                        -Resolve
+$CmdletModule = (Join-Path -Path $M365DSCTestFolder `
+            -ChildPath '\Stubs\Microsoft365.psm1' `
+            -Resolve)
+$GenericStubPath = (Join-Path -Path $M365DSCTestFolder `
+    -ChildPath '\Stubs\Generic.psm1' `
+    -Resolve)
+Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\UnitTestHelper.psm1' `
+        -Resolve)
+
+$Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
+    -DscResource "IntuneMobileAppsSystemAppAndroid" -GenericStubModule $GenericStubPath
+Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
+        BeforeAll {
+
+            $secpasswd = ConvertTo-SecureString (New-Guid | Out-String) -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
+
+            Mock -ModuleName M365DSCUtil -CommandName Confirm-M365DSCDependencies -MockWith {
+            }
+
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
+            Mock -CommandName Reset-MSCloudLoginConnectionProfileContext -MockWith {
+            }
+
+            Mock -CommandName Get-PSSession -MockWith {
+            }
+
+            Mock -CommandName Remove-PSSession -MockWith {
+            }
+
+            Mock -CommandName Update-MgBetaDeviceAppManagementMobileApp -MockWith {
+            }
+
+            Mock -CommandName New-MgBetaDeviceAppManagementMobileApp -MockWith {
+                return @{
+                    AdditionalProperties = @{
+                        supportsOemConfig = $True
+                        appStoreUrl = "FakeStringValue"
+                        packageId = "FakeStringValue"
+                        appTracks = @(
+                            @{
+                                trackAlias = "FakeStringValue"
+                                trackId = "FakeStringValue"
+                            }
+                        )
+                        '@odata.type' = "#microsoft.graph.androidManagedStoreApp"
+                        totalLicenseCount = 25
+                        isPrivate = $True
+                        usedLicenseCount = 25
+                        appIdentifier = "FakeStringValue"
+                        isSystemApp = $True
+                    }
+                    dependentAppCount = 25
+                    description = "FakeStringValue"
+                    developer = "FakeStringValue"
+                    displayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    informationUrl = "FakeStringValue"
+                    isFeatured = $True
+                    LargeIcon = @{
+                        Type = "FakeStringValue"
+                    }
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    PublishingState = "notPublished"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    SupersededAppCount = 25
+                    SupersedingAppCount = 25
+                    UploadState = 25
+                }
+            }
+
+            Mock -CommandName Remove-MgBetaDeviceAppManagementMobileApp -MockWith {
+            }
+
+            Mock -CommandName Get-MgBetaDeviceAppManagementMobileApp -MockWith {
+                return @{
+                    AdditionalProperties = @{
+                        supportsOemConfig = $True
+                        appStoreUrl = "FakeStringValue"
+                        packageId = "FakeStringValue"
+                        appTracks = @(
+                            @{
+                                trackAlias = "FakeStringValue"
+                                trackId = "FakeStringValue"
+                            }
+                        )
+                        '@odata.type' = "#microsoft.graph.androidManagedStoreApp"
+                        totalLicenseCount = 25
+                        isPrivate = $True
+                        usedLicenseCount = 25
+                        appIdentifier = "FakeStringValue"
+                        isSystemApp = $True
+                    }
+                    dependentAppCount = 25
+                    description = "FakeStringValue"
+                    developer = "FakeStringValue"
+                    displayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    informationUrl = "FakeStringValue"
+                    isFeatured = $True
+                    LargeIcon = @{
+                        Type = "FakeStringValue"
+                    }
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    PublishingState = "notPublished"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    SupersededAppCount = 25
+                    SupersedingAppCount = 25
+                    UploadState = 25
+                }
+            }
+
+            Mock -CommandName New-M365DSCConnection -MockWith {
+                return "Credentials"
+            }
+
+            # Mock Write-M365DSCHost to hide output during the tests
+            Mock -CommandName Write-M365DSCHost -MockWith {
+            }
+            $Script:exportedInstance = $null
+            $Script:ExportMode = $false
+
+            Mock -CommandName Get-MgBetaDeviceAppManagementMobileAppAssignment -MockWith {
+            }
+        }
+
+        # Test contexts
+        Context -Name "The IntuneMobileAppsSystemAppAndroid should exist but it DOES NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    PackageId = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+
+                Mock -CommandName Get-MgBetaDeviceAppManagementMobileApp -MockWith {
+                    return $null
+                }
+            }
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
+            }
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+            It 'Should Create the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName New-MgBetaDeviceAppManagementMobileApp -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneMobileAppsSystemAppAndroid exists but it SHOULD NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    PackageId = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Absent"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should Remove the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Remove-MgBetaDeviceAppManagementMobileApp -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneMobileAppsSystemAppAndroid Exists and Values are already in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    PackageId = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+        }
+
+        Context -Name "The IntuneMobileAppsSystemAppAndroid exists and values are NOT in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    PackageId = "FakeStringValue"
+                    Publisher = "FakeStringValue_New" # Drift
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Update-MgBetaDeviceAppManagementMobileApp -Exactly 1
+            }
+        }
+
+        Context -Name 'ReverseDSC Tests' -Fixture {
+            BeforeAll {
+                $Global:CurrentModeIsExport = $true
+                $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
+                $testParams = @{
+                    Credential = $Credential
+                }
+            }
+
+            It 'Should Reverse Engineer resource from the Export method' {
+                $result = Export-TargetResource @testParams
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}
+
+Invoke-Command -ScriptBlock $Global:DscHelper.CleanupScript -NoNewScope

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsSystemAppAndroid.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsSystemAppAndroid.Tests.ps1
@@ -42,7 +42,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Update-MgBetaDeviceAppManagementMobileApp -MockWith {
             }
 
-            Mock -CommandName New-MgBetaDeviceAppManagementMobileApp -MockWith {
+            Mock -CommandName Invoke-MgGraphRequest -MockWith {
                 return @{
                     AdditionalProperties = @{
                         supportsOemConfig = $True
@@ -147,7 +147,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     DisplayName = "FakeStringValue"
                     Id = "FakeStringValue"
-                    PackageId = "FakeStringValue"
+                    AppIdentifier = "FakeStringValue"
                     Publisher = "FakeStringValue"
                     RoleScopeTagIds = @("FakeStringValue")
                     Ensure = "Present"
@@ -166,7 +166,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
             It 'Should Create the group from the Set method' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName New-MgBetaDeviceAppManagementMobileApp -Exactly 1
+                Should -Invoke -CommandName Invoke-MgGraphRequest -Exactly 1
             }
         }
 
@@ -175,7 +175,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     DisplayName = "FakeStringValue"
                     Id = "FakeStringValue"
-                    PackageId = "FakeStringValue"
+                    AppIdentifier = "FakeStringValue"
                     Publisher = "FakeStringValue"
                     RoleScopeTagIds = @("FakeStringValue")
                     Ensure = "Absent"
@@ -202,7 +202,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     DisplayName = "FakeStringValue"
                     Id = "FakeStringValue"
-                    PackageId = "FakeStringValue"
+                    AppIdentifier = "FakeStringValue"
                     Publisher = "FakeStringValue"
                     RoleScopeTagIds = @("FakeStringValue")
                     Ensure = "Present"
@@ -220,7 +220,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     DisplayName = "FakeStringValue"
                     Id = "FakeStringValue"
-                    PackageId = "FakeStringValue"
+                    AppIdentifier = "FakeStringValue"
                     Publisher = "FakeStringValue_New" # Drift
                     RoleScopeTagIds = @("FakeStringValue")
                     Ensure = "Present"


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds the `IntuneMobileAppsSystemAppAndroid` resource. It also updates the schema definition because it uses the new `Test-M365DSCTargetResource` function.

@NikCharlebois Is it possible to make that schema definition automatic through the pipeline? I can try and replicate it on my own repository, see if it will create a separate branch and open a PR automatically if it detects changes. Then we don't have to do it manually.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
