### PR TITLE
Add Intune MacOS DMG and PKG file apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * IntuneMobileAppsBuiltInStoreApp
   * Initial release.
+* IntuneMobileAppsBundleMacOS
+  * Initial release.
 * IntuneMobileAppsStoreApp
   * Initial release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   * Initial release.
 * IntuneMobileAppsStoreApp
   * Initial release.
+* M365DSCDRGUtil
+  * Added new function `Invoke-M365DSCIntuneMobileAppInitialUpload` for initial mobile app content upload.
 
 # 1.25.716.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/MSFT_IntuneMobileAppsBundleMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/MSFT_IntuneMobileAppsBundleMacOS.psm1
@@ -23,6 +23,10 @@ function Get-TargetResource
 
         [Parameter()]
         [System.String]
+        $FileName,
+
+        [Parameter()]
+        [System.String]
         $InformationUrl,
 
         [Parameter()]
@@ -48,6 +52,10 @@ function Get-TargetResource
         [Parameter()]
         [System.String]
         $Publisher,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Categories,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
@@ -201,8 +209,8 @@ function Get-TargetResource
         foreach ($complexApp in $getValue.AdditionalProperties.includedApps)
         {
             $complexIncludedApp = @{
-                Id          = $complexApp.id
-                DisplayName = $complexApp.displayName
+                BundleId      = $complexApp.bundleId
+                BundleVersion = $complexApp.bundleVersion
             }
             $complexIncludedApps += $complexIncludedApp
         }
@@ -234,6 +242,7 @@ function Get-TargetResource
             Description                     = $getValue.Description
             Developer                       = $getValue.Developer
             DisplayName                     = $getValue.DisplayName
+            FileName                        = $getValue.AdditionalProperties.fileName
             IgnoreVersionDetection          = $getValue.AdditionalProperties.ignoreVersionDetection
             IncludedApps                    = $complexIncludedApps
             InformationUrl                  = $getValue.InformationUrl
@@ -307,6 +316,10 @@ function Set-TargetResource
 
         [Parameter()]
         [System.String]
+        $FileName,
+
+        [Parameter()]
+        [System.String]
         $InformationUrl,
 
         [Parameter()]
@@ -332,6 +345,10 @@ function Set-TargetResource
         [Parameter()]
         [System.String]
         $Publisher,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Categories,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
@@ -424,6 +441,7 @@ function Set-TargetResource
 
     $boundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
     $boundParameters.Remove('Categories') | Out-Null
+    $boundParameters.Remove('PackageFileType') | Out-Null
 
     if ($boundParameters.ContainsKey('PreInstallScript'))
     {
@@ -451,6 +469,11 @@ function Set-TargetResource
         $createParameters = Rename-M365DSCCimInstanceParameter -Properties $createParameters
         $createParameters.Remove('Id') | Out-Null
 
+        if (-not $createParameters.ContainsKey('FileName') -or -not $createParameters.ContainsKey('IncludedApps'))
+        {
+            throw "FileName and IncludedApps are required parameters."
+        }
+
         $keys = (([Hashtable]$createParameters).Clone()).Keys
         foreach ($key in $keys)
         {
@@ -460,8 +483,13 @@ function Set-TargetResource
             }
         }
         #region resource generator code
-        $createParameters.Add("@odata.type", "#microsoft.graph.macOS$($PackageFileType)App")
+        $odataType = "#microsoft.graph.macOS$($PackageFileType)App"
+        $createParameters.Add("@odata.type", $odataType)
+        $createParameters.Add('primaryBundleId', $createParameters.IncludedApps[0].BundleId)
+        $createParameters.Add('primaryBundleVersion', $createParameters.IncludedApps[0].BundleVersion)
         $policy = Invoke-MgGraphRequest -Method POST -Uri "/beta/deviceAppManagement/mobileApps" -Body ($createParameters | ConvertTo-Json -Depth 10)
+
+        Invoke-M365DSCIntuneMobileAppInitialUpload -AppId $policy.Id -OdataType $odataType -FileExtension $PackageFileType.ToLower()
 
         if ($PSBoundParameters.ContainsKey('Categories'))
         {
@@ -475,6 +503,8 @@ function Set-TargetResource
                 -AppManagementPolicyId $policy.Id `
                 -Assignments $assignmentsHash
         }
+
+        Write-Warning -Message "The Intune Mobile Apps Bundle for macOS resource has been created and the sample content was uploaded. Please ensure to upload the actual content from the Intune portal."
         #endregion
     }
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
@@ -545,6 +575,10 @@ function Test-TargetResource
 
         [Parameter()]
         [System.String]
+        $FileName,
+
+        [Parameter()]
+        [System.String]
         $InformationUrl,
 
         [Parameter()]
@@ -570,6 +604,10 @@ function Test-TargetResource
         [Parameter()]
         [System.String]
         $Publisher,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Categories,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/MSFT_IntuneMobileAppsBundleMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/MSFT_IntuneMobileAppsBundleMacOS.psm1
@@ -1,7 +1,3 @@
-Confirm-M365DSCModuleDependency -ModuleName 'MSFT_IntuneMobileAppsStoreApp'
-$Script:androidExclusive = @('V4_0', 'V4_0_3', 'V4_1', 'V4_2', 'V4_3', 'V4_4', 'V5_0', 'V5_1', 'V6_0', 'V7_0', 'V7_1', 'V8_1')
-$Script:iOSExclusive = @('V16_0', 'V17_0', 'V18_0')
-
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -16,27 +12,6 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $DisplayName,
-
-        [Parameter(Mandatory = $true)]
-        [ValidateSet('Android', 'IOS')]
-        [System.String]
-        $TargetPlatform,
-
-        [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
-        $ApplicableDeviceType,
-
-        [Parameter()]
-        [System.String]
-        $AppStoreUrl,
-
-        [Parameter()]
-        [System.String]
-        $BundleId,
-
-        [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
-        $MinimumSupportedOperatingSystem,
 
         [Parameter()]
         [System.String]
@@ -76,7 +51,28 @@ function Get-TargetResource
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
-        $Categories,
+        $IncludedApps,
+
+        [Parameter()]
+        [System.Boolean]
+        $IgnoreVersionDetection,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $MinimumSupportedOperatingSystem,
+
+        [Parameter()]
+        [System.String]
+        $PreInstallScript,
+
+        [Parameter()]
+        [System.String]
+        $PostInstallScript,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Dmg', 'Pkg')]
+        [System.String]
+        $PackageFileType,
 
         [Parameter()]
         [System.String[]]
@@ -121,7 +117,7 @@ function Get-TargetResource
         $AccessTokens
     )
 
-    Write-Verbose -Message "Getting configuration for the Intune Mobile Apps Store App with Id {$Id} and DisplayName {$DisplayName}"
+    Write-Verbose -Message "Getting configuration for the Intune Mobile Apps Bundle for macOS with Id {$Id} and DisplayName {$DisplayName}"
 
     try
     {
@@ -156,19 +152,21 @@ function Get-TargetResource
 
             if ($null -eq $getValue)
             {
-                Write-Verbose -Message "Could not find an Intune Mobile Apps Store App with Id {$Id}"
+                Write-Verbose -Message "Could not find an Intune Mobile Apps Bundle for macOS with Id {$Id}"
 
                 if (-not [System.String]::IsNullOrEmpty($DisplayName))
                 {
                     $getValue = Get-MgBetaDeviceAppManagementMobileApp `
-                        -Filter "DisplayName eq '$($DisplayName -replace "'", "''")' and (isof('microsoft.graph.androidStoreApp') or isof('microsoft.graph.iosStoreApp'))" `
+                        -Filter "DisplayName eq '$($DisplayName -replace "'", "''")' and (isof('microsoft.graph.macOSDmgApp') or isof('microsoft.graph.macOSPkgApp'))" `
+                        -ExpandProperty 'categories' `
+                        -All `
                         -ErrorAction SilentlyContinue
                 }
             }
             #endregion
             if ($null -eq $getValue)
             {
-                Write-Verbose -Message "Could not find an Intune Mobile Apps Store App with DisplayName {$DisplayName}."
+                Write-Verbose -Message "Could not find an Intune Mobile Apps Bundle for macOS with DisplayName {$DisplayName}."
                 return $nullResult
             }
 
@@ -176,50 +174,12 @@ function Get-TargetResource
         }
         else
         {
-            $getValue = Get-MgBetaDeviceAppManagementMobileApp -MobileAppId $Script:exportedInstance.Id `
-                -ExpandProperty 'categories'
+            $getValue = Get-MgBetaDeviceAppManagementMobileApp -MobileAppId $Script:exportedInstance.Id -ExpandProperty 'categories'
         }
         $Id = $getValue.Id
-        Write-Verbose -Message "An Intune Mobile Apps Store App with Id {$Id} and DisplayName {$DisplayName} was found"
+        Write-Verbose -Message "An Intune Mobile Apps Bundle for macOS with Id {$Id} and DisplayName {$DisplayName} was found"
 
         #region resource generator code
-        $complexApplicableDeviceType = @{}
-        $complexApplicableDeviceType.Add('IPad', $getValue.AdditionalProperties.applicableDeviceType.iPad)
-        $complexApplicableDeviceType.Add('IPhoneAndIPod', $getValue.AdditionalProperties.applicableDeviceType.iPhoneAndIPod)
-        if ($complexApplicableDeviceType.Values.Where({ $null -ne $_ }).Count -eq 0)
-        {
-            $complexApplicableDeviceType = $null
-        }
-
-        $complexMinimumSupportedOperatingSystem = [ordered]@{}
-        $complexMinimumSupportedOperatingSystem.Add('V4_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v4_0)
-        $complexMinimumSupportedOperatingSystem.Add('V4_0_3', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v4_0_3)
-        $complexMinimumSupportedOperatingSystem.Add('V4_1', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v4_1)
-        $complexMinimumSupportedOperatingSystem.Add('V4_2', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v4_2)
-        $complexMinimumSupportedOperatingSystem.Add('V4_3', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v4_3)
-        $complexMinimumSupportedOperatingSystem.Add('V4_4', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v4_4)
-        $complexMinimumSupportedOperatingSystem.Add('V5_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v5_0)
-        $complexMinimumSupportedOperatingSystem.Add('V5_1', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v5_1)
-        $complexMinimumSupportedOperatingSystem.Add('V6_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v6_0)
-        $complexMinimumSupportedOperatingSystem.Add('V7_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v7_0)
-        $complexMinimumSupportedOperatingSystem.Add('V7_1', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v7_1)
-        $complexMinimumSupportedOperatingSystem.Add('V8_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v8_0)
-        $complexMinimumSupportedOperatingSystem.Add('V8_1', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v8_1)
-        $complexMinimumSupportedOperatingSystem.Add('V9_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v9_0)
-        $complexMinimumSupportedOperatingSystem.Add('V10_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_0)
-        $complexMinimumSupportedOperatingSystem.Add('V11_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v11_0)
-        $complexMinimumSupportedOperatingSystem.Add('V12_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v12_0)
-        $complexMinimumSupportedOperatingSystem.Add('V13_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v13_0)
-        $complexMinimumSupportedOperatingSystem.Add('V14_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v14_0)
-        $complexMinimumSupportedOperatingSystem.Add('V15_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v15_0)
-        $complexMinimumSupportedOperatingSystem.Add('V16_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v16_0)
-        $complexMinimumSupportedOperatingSystem.Add('V17_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v17_0)
-        $complexMinimumSupportedOperatingSystem.Add('V18_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v18_0)
-        if ($complexMinimumSupportedOperatingSystem.Values.Where({ $null -ne $_ }).Count -eq 0)
-        {
-            $complexMinimumSupportedOperatingSystem = $null
-        }
-
         $complexCategories = @()
         foreach ($category in $getValue.Categories)
         {
@@ -228,6 +188,7 @@ function Get-TargetResource
             $myCategory.Add('DisplayName', $category.displayName)
             $complexCategories += $myCategory
         }
+
         $complexLargeIcon = $null
         if ($null -ne $getValue.LargeIcon.Value)
         {
@@ -235,27 +196,56 @@ function Get-TargetResource
             $complexLargeIcon.Add('Type', $getValue.LargeIcon.Type)
             $complexLargeIcon.Add('Value', [System.Convert]::ToBase64String($getValue.LargeIcon.Value))
         }
+
+        $complexIncludedApps = @()
+        foreach ($complexApp in $getValue.AdditionalProperties.includedApps)
+        {
+            $complexIncludedApp = @{
+                Id          = $complexApp.id
+                DisplayName = $complexApp.displayName
+            }
+            $complexIncludedApps += $complexIncludedApp
+        }
+
+        $complexMinimumSupportedOperatingSystem = [ordered]@{}
+        $complexMinimumSupportedOperatingSystem.Add('V10_7', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_7)
+        $complexMinimumSupportedOperatingSystem.Add('V10_8', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_8)
+        $complexMinimumSupportedOperatingSystem.Add('V10_9', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_9)
+        $complexMinimumSupportedOperatingSystem.Add('V10_10', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_10)
+        $complexMinimumSupportedOperatingSystem.Add('V10_11', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_11)
+        $complexMinimumSupportedOperatingSystem.Add('V10_12', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_12)
+        $complexMinimumSupportedOperatingSystem.Add('V10_13', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_13)
+        $complexMinimumSupportedOperatingSystem.Add('V10_14', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_14)
+        $complexMinimumSupportedOperatingSystem.Add('V10_15', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_15)
+        $complexMinimumSupportedOperatingSystem.Add('V11_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v11_0)
+        $complexMinimumSupportedOperatingSystem.Add('V12_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v12_0)
+        $complexMinimumSupportedOperatingSystem.Add('V13_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v13_0)
+        $complexMinimumSupportedOperatingSystem.Add('V14_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v14_0)
+        $complexMinimumSupportedOperatingSystem.Add('V15_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v15_0)
+        if ($complexMinimumSupportedOperatingSystem.Values.Where({ $null -ne $_ }).Count -eq 0)
+        {
+            $complexMinimumSupportedOperatingSystem = $null
+        }
         #endregion
 
         $results = @{
             #region resource generator code
-            ApplicableDeviceType            = $complexApplicableDeviceType
-            AppStoreUrl                     = $getValue.AdditionalProperties.appStoreUrl
-            BundleId                        = $getValue.AdditionalProperties.bundleId
             Categories                      = $complexCategories
-            MinimumSupportedOperatingSystem = $complexMinimumSupportedOperatingSystem
             Description                     = $getValue.Description
             Developer                       = $getValue.Developer
             DisplayName                     = $getValue.DisplayName
+            IgnoreVersionDetection          = $getValue.AdditionalProperties.ignoreVersionDetection
+            IncludedApps                    = $complexIncludedApps
             InformationUrl                  = $getValue.InformationUrl
             IsFeatured                      = $getValue.IsFeatured
             LargeIcon                       = $complexLargeIcon
+            MinimumSupportedOperatingSystem = $complexMinimumSupportedOperatingSystem
             Notes                           = $getValue.Notes
             Owner                           = $getValue.Owner
+            PackageFileType                 = $getValue.AdditionalProperties.'@odata.type'.Replace('#microsoft.graph.macOS', '').Replace('App', '')
             PrivacyInformationUrl           = $getValue.PrivacyInformationUrl
             Publisher                       = $getValue.Publisher
             RoleScopeTagIds                 = $getValue.RoleScopeTagIds
-            TargetPlatform                  = $getValue.AdditionalProperties.'@odata.type'.Replace('#microsoft.graph.', '').Replace('StoreApp', '')
             Id                              = $getValue.Id
             Ensure                          = 'Present'
             Credential                      = $Credential
@@ -265,6 +255,11 @@ function Get-TargetResource
             CertificateThumbprint           = $CertificateThumbprint
             ManagedIdentity                 = $ManagedIdentity.IsPresent
             #endregion
+        }
+        if ($results.PackageFileType -eq 'Pkg')
+        {
+            $results.PreInstallScript  = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($getValue.AdditionalProperties.preInstallScript.scriptContent))
+            $results.PostInstallScript = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($getValue.AdditionalProperties.postInstallScript.scriptContent))
         }
         $assignmentsValues = Get-MgBetaDeviceAppManagementMobileAppAssignment -MobileAppId $Id
         $assignmentResult = @()
@@ -302,27 +297,6 @@ function Set-TargetResource
         [System.String]
         $DisplayName,
 
-        [Parameter(Mandatory = $true)]
-        [ValidateSet('Android', 'IOS')]
-        [System.String]
-        $TargetPlatform,
-
-        [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
-        $ApplicableDeviceType,
-
-        [Parameter()]
-        [System.String]
-        $AppStoreUrl,
-
-        [Parameter()]
-        [System.String]
-        $BundleId,
-
-        [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
-        $MinimumSupportedOperatingSystem,
-
         [Parameter()]
         [System.String]
         $Description,
@@ -361,7 +335,28 @@ function Set-TargetResource
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
-        $Categories,
+        $IncludedApps,
+
+        [Parameter()]
+        [System.Boolean]
+        $IgnoreVersionDetection,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $MinimumSupportedOperatingSystem,
+
+        [Parameter()]
+        [System.String]
+        $PreInstallScript,
+
+        [Parameter()]
+        [System.String]
+        $PostInstallScript,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Dmg', 'Pkg')]
+        [System.String]
+        $PackageFileType,
 
         [Parameter()]
         [System.String[]]
@@ -406,31 +401,11 @@ function Set-TargetResource
         $AccessTokens
     )
 
-    Write-Verbose -Message "Setting configuration of the Intune Mobile Apps Store App with Id {$Id} and DisplayName {$DisplayName}"
+    Write-Verbose -Message "Setting configuration of the Intune Mobile Apps Bundle for macOS with Id {$Id} and DisplayName {$DisplayName}"
 
-    if ($PSBoundParameters.ContainsKey('ApplicableDeviceType') -and $PSBoundParameters.TargetPlatform -ne 'iOS')
+    if ($PSBoundParameters.PackageFileType -eq 'Dmg' -and ($PSBoundParameters.ContainsKey('PreInstallScript') -or $PSBoundParameters.ContainsKey('PostInstallScript')))
     {
-        throw "ApplicableDeviceType is only applicable for iOS Store Apps."
-    }
-
-    if ($PSBoundParameters.ContainsKey('BundleId') -and $PSBoundParameters.TargetPlatform -ne 'iOS')
-    {
-        throw "BundleId is only applicable for iOS Store Apps."
-    }
-
-    if ($PSBoundParameters.ContainsKey('MinimumSupportedOperatingSystem'))
-    {
-        foreach ($keyValuePair in $PSBoundParameters.MinimumSupportedOperatingSystem.CimInstanceProperties.GetEnumerator())
-        {
-            if ($keyValuePair.Key -in $Script:androidExclusive -and $TargetPlatform -ne 'Android')
-            {
-                throw "MinimumSupportedOperatingSystem.$($keyValuePair.Key) is only applicable for Android Store Apps."
-            }
-            if ($keyValuePair.Key -in $Script:iOSExclusive -and $TargetPlatform -ne 'IOS')
-            {
-                throw "MinimumSupportedOperatingSystem.$($keyValuePair.Key) is only applicable for iOS Store Apps."
-            }
-        }
+        throw "PreInstallScript and PostInstallScript are not supported for Dmg package type."
     }
 
     #Ensure the proper dependencies are installed in the current environment.
@@ -449,11 +424,27 @@ function Set-TargetResource
 
     $boundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
     $boundParameters.Remove('Categories') | Out-Null
-    $boundParameters.Remove('TargetPlatform') | Out-Null
+
+    if ($boundParameters.ContainsKey('PreInstallScript'))
+    {
+        $convertedPreInstallScript = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($boundParameters.PreInstallScript))
+        $boundParameters.Remove('PreInstallScript') | Out-Null
+        $boundParameters.Add('PreInstallScript', @{
+            scriptContent = $convertedPreInstallScript
+        })
+    }
+    if ($boundParameters.ContainsKey('PostInstallScript'))
+    {
+        $convertedPostInstallScript = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($boundParameters.PostInstallScript))
+        $boundParameters.Remove('PostInstallScript') | Out-Null
+        $boundParameters.Add('PostInstallScript', @{
+            scriptContent = $convertedPostInstallScript
+        })
+    }
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {
-        Write-Verbose -Message "Creating an Intune Mobile Apps Store App with DisplayName {$DisplayName}"
+        Write-Verbose -Message "Creating an Intune Mobile Apps Bundle for macOS with DisplayName {$DisplayName}"
         $boundParameters.Remove("Assignments") | Out-Null
 
         $createParameters = ([Hashtable]$boundParameters).Clone()
@@ -469,7 +460,7 @@ function Set-TargetResource
             }
         }
         #region resource generator code
-        $createParameters.Add("@odata.type", "#microsoft.graph.$($TargetPlatform)StoreApp")
+        $createParameters.Add("@odata.type", "#microsoft.graph.macOS$($PackageFileType)App")
         $policy = Invoke-MgGraphRequest -Method POST -Uri "/beta/deviceAppManagement/mobileApps" -Body ($createParameters | ConvertTo-Json -Depth 10)
 
         if ($PSBoundParameters.ContainsKey('Categories'))
@@ -488,8 +479,7 @@ function Set-TargetResource
     }
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
     {
-        Write-Verbose -Message "Updating the Intune Mobile Apps Store App with Id {$($currentInstance.Id)}"
-        $boundParameters.Remove('AppStoreUrl') | Out-Null
+        Write-Verbose -Message "Updating the Intune Mobile Apps Bundle for macOS with Id {$($currentInstance.Id)}"
         $boundParameters.Remove("Assignments") | Out-Null
 
         $updateParameters = ([Hashtable]$boundParameters).Clone()
@@ -507,7 +497,7 @@ function Set-TargetResource
         }
 
         #region resource generator code
-        $updateParameters.Add("@odata.type", "#microsoft.graph.$($TargetPlatform)StoreApp")
+        $updateParameters.Add("@odata.type", "#microsoft.graph.macOS$($PackageFileType)App")
         Invoke-MgGraphRequest -Method PATCH -Uri "/beta/deviceAppManagement/mobileApps/$($currentInstance.Id)" -Body ($updateParameters | ConvertTo-Json -Depth 10)
 
         if ($PSBoundParameters.ContainsKey('Categories'))
@@ -523,7 +513,7 @@ function Set-TargetResource
     }
     elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
     {
-        Write-Verbose -Message "Removing the Intune Mobile Apps Store App with Id {$($currentInstance.Id)}"
+        Write-Verbose -Message "Removing the Intune Mobile Apps Bundle for macOS with Id {$($currentInstance.Id)}"
         #region resource generator code
         Remove-MgBetaDeviceAppManagementMobileApp -MobileAppId $currentInstance.Id
         #endregion
@@ -545,27 +535,6 @@ function Test-TargetResource
         [System.String]
         $DisplayName,
 
-        [Parameter(Mandatory = $true)]
-        [ValidateSet('Android', 'IOS')]
-        [System.String]
-        $TargetPlatform,
-
-        [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
-        $ApplicableDeviceType,
-
-        [Parameter()]
-        [System.String]
-        $AppStoreUrl,
-
-        [Parameter()]
-        [System.String]
-        $BundleId,
-
-        [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
-        $MinimumSupportedOperatingSystem,
-
         [Parameter()]
         [System.String]
         $Description,
@@ -604,7 +573,28 @@ function Test-TargetResource
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
-        $Categories,
+        $IncludedApps,
+
+        [Parameter()]
+        [System.Boolean]
+        $IgnoreVersionDetection,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $MinimumSupportedOperatingSystem,
+
+        [Parameter()]
+        [System.String]
+        $PreInstallScript,
+
+        [Parameter()]
+        [System.String]
+        $PostInstallScript,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Dmg', 'Pkg')]
+        [System.String]
+        $PackageFileType,
 
         [Parameter()]
         [System.String[]]
@@ -649,29 +639,9 @@ function Test-TargetResource
         $AccessTokens
     )
 
-    if ($PSBoundParameters.ContainsKey('ApplicableDeviceType') -and $PSBoundParameters.TargetPlatform -ne 'iOS')
+    if ($PSBoundParameters.PackageFileType -eq 'Dmg' -and ($PSBoundParameters.ContainsKey('PreInstallScript') -or $PSBoundParameters.ContainsKey('PostInstallScript')))
     {
-        throw "ApplicableDeviceType is only applicable for iOS Store Apps."
-    }
-
-    if ($PSBoundParameters.ContainsKey('BundleId') -and $PSBoundParameters.TargetPlatform -ne 'iOS')
-    {
-        throw "BundleId is only applicable for iOS Store Apps."
-    }
-
-    if ($PSBoundParameters.ContainsKey('MinimumSupportedOperatingSystem'))
-    {
-        foreach ($keyValuePair in $PSBoundParameters.MinimumSupportedOperatingSystem.CimInstanceProperties.GetEnumerator())
-        {
-            if ($keyValuePair.Key -in $Script:androidExclusive -and $TargetPlatform -ne 'Android')
-            {
-                throw "MinimumSupportedOperatingSystem.$($keyValuePair.Key) is only applicable for Android Store Apps."
-            }
-            if ($keyValuePair.Key -in $Script:iOSExclusive -and $TargetPlatform -ne 'IOS')
-            {
-                throw "MinimumSupportedOperatingSystem.$($keyValuePair.Key) is only applicable for iOS Store Apps."
-            }
-        }
+        throw "PreInstallScript and PostInstallScript are not supported for Dmg package type."
     }
 
     #Ensure the proper dependencies are installed in the current environment.
@@ -686,7 +656,7 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    Write-Verbose -Message "Testing configuration of the Intune Mobile Apps Store App with Id {$Id} and DisplayName {$DisplayName}"
+    Write-Verbose -Message "Testing configuration of the Intune Mobile Apps Bundle for macOS with Id {$Id} and DisplayName {$DisplayName}"
 
     $CurrentValues = Get-TargetResource @PSBoundParameters
     $ValuesToCheck = ([hashtable]$PSBoundParameters).Clone()
@@ -713,8 +683,7 @@ function Test-TargetResource
     }
 
     $ValuesToCheck.Remove('Id') | Out-Null
-    $ValuesToCheck.Remove('AppStoreUrl') | Out-Null
-    $ValuesToCheck.Remove('TargetPlatform') | Out-Null
+    $ValuesToCheck.Remove('PackageFileType') | Out-Null
     $ValuesToCheck = Remove-M365DSCAuthenticationParameter -BoundParameters $ValuesToCheck
 
     Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
@@ -790,7 +759,7 @@ function Export-TargetResource
     try
     {
         #region resource generator code
-        $baseFilter = "isof('microsoft.graph.androidStoreApp') or isof('microsoft.graph.iosStoreApp')"
+        $baseFilter = "isof('microsoft.graph.macOSDmgApp') or isof('microsoft.graph.macOSPkgApp')"
         if (-not [String]::IsNullOrEmpty($Filter))
         {
             $Filter = "($Filter) and ($baseFilter)"
@@ -830,7 +799,7 @@ function Export-TargetResource
             $params = @{
                 Id                    = $config.Id
                 DisplayName           = $config.DisplayName
-                TargetPlatform        = $config.AdditionalProperties.'@odata.type'.Replace('#microsoft.graph.', '').Replace('StoreApp', '')
+                PackageFileType       = $config.AdditionalProperties.'@odata.type'.Replace('#microsoft.graph.macOS', '').Replace('App', '')
                 Ensure                = 'Present'
                 Credential            = $Credential
                 ApplicationId         = $ApplicationId
@@ -843,20 +812,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            if ($null -ne $Results.ApplicableDeviceType)
-            {
-                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
-                    -ComplexObject $Results.ApplicableDeviceType `
-                    -CIMInstanceName 'MicrosoftGraphiosDeviceType'
-                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
-                {
-                    $Results.ApplicableDeviceType = $complexTypeStringResult
-                }
-                else
-                {
-                    $Results.Remove('ApplicableDeviceType') | Out-Null
-                }
-            }
             if ($null -ne $Results.Categories)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
@@ -872,11 +827,25 @@ function Export-TargetResource
                     $Results.Remove('Categories') | Out-Null
                 }
             }
+            if ($null -ne $Results.IncludedApps)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.IncludedApps `
+                    -CIMInstanceName 'MicrosoftGraphMacOSIncludedApp'
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.IncludedApps = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('IncludedApps') | Out-Null
+                }
+            }
             if ($null -ne $Results.MinimumSupportedOperatingSystem)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
                     -ComplexObject $Results.MinimumSupportedOperatingSystem `
-                    -CIMInstanceName 'MicrosoftGraphMinimumOperatingSystem'
+                    -CIMInstanceName 'MicrosoftGraphMacOSMinimumOperatingSystem'
                 if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
                 {
                     $Results.MinimumSupportedOperatingSystem = $complexTypeStringResult
@@ -890,7 +859,7 @@ function Export-TargetResource
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
                     -ComplexObject $Results.LargeIcon `
-                    -CIMInstanceName 'MicrosoftGraphmimeContent'
+                    -CIMInstanceName 'MicrosoftGraphMimeContent'
                 if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
                 {
                     $Results.LargeIcon = $complexTypeStringResult
@@ -919,7 +888,7 @@ function Export-TargetResource
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
                 -Credential $Credential `
-                -NoEscape @('Assignments', 'ApplicableDeviceType', 'MinimumSupportedOperatingSystem', 'LargeIcon', 'Categories')
+                -NoEscape @('Assignments', 'IncludedApps', 'LargeIcon', 'MinimumSupportedOperatingSystem', 'Categories')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/MSFT_IntuneMobileAppsBundleMacOS.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/MSFT_IntuneMobileAppsBundleMacOS.schema.mof
@@ -1,0 +1,76 @@
+[ClassVersion("1.0.0.1")]
+class MSFT_DeviceManagementMobileAppAssignment
+{
+    [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}] String dataType;
+    [Write, Description("The Id of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterId;
+    [Write, Description("The display name of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterDisplayName;
+    [Write, Description("The type of filter of the target assignment i.e. Exclude or Include. Possible values are: none, include, exclude."), ValueMap{"none", "include", "exclude"}, Values{"none", "include", "exclude"}] String deviceAndAppManagementAssignmentFilterType;
+    [Write, Description("The group Id that is the target of the assignment.")] String groupId;
+    [Write, Description("The group Display Name that is the target of the assignment.")] String groupDisplayName;
+    [Write, Description("Possible values for the install intent chosen by the admin."), ValueMap{"available", "required", "uninstall", "availableWithoutEnrollment"}, Values{"available", "required", "uninstall", "availableWithoutEnrollment"}] String intent;
+};
+
+[ClassVersion("1.0.0")]
+class MSFT_MicrosoftGraphMimeContent
+{
+    [Write, Description("Indicates the content mime type.")] String Type;
+    [Write, Description("The byte array that contains the actual content.")] String Value;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_MicrosoftGraphMacOSIncludedApp
+{
+    [Write, Description("The bundleId of the app. This maps to the CFBundleIdentifier in the app's bundle configuration.")] String BundleId;
+    [Write, Description("The version of the app. This maps to the CFBundleShortVersion in the app's bundle configuration.")] String BundleVersion;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_MicrosoftGraphMacOSMinimumOperatingSystem
+{
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 10.7 or later is required to install the app. If 'False', Version 10.7 is not the minimum version.")] Boolean V10_7;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 10.8 or later is required to install the app. If 'False', Version 10.8 is not the minimum version.")] Boolean V10_8;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 10.9 or later is required to install the app. If 'False', Version 10.9 is not the minimum version.")] Boolean V10_9;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 10.10 or later is required to install the app. If 'False', Version 10.10 is not the minimum version.")] Boolean V10_10;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 10.11 or later is required to install the app. If 'False', Version 10.11 is not the minimum version.")] Boolean V10_11;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 10.12 or later is required to install the app. If 'False', Version 10.12 is not the minimum version.")] Boolean V10_12;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 10.13 or later is required to install the app. If 'False', Version 10.13 is not the minimum version.")] Boolean V10_13;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 10.14 or later is required to install the app. If 'False', Version 10.14 is not the minimum version.")] Boolean V10_14;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 10.15 or later is required to install the app. If 'False', Version 10.15 is not the minimum version.")] Boolean V10_15;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 11.0 or later is required to install the app. If 'False', Version 11.0 is not the minimum version.")] Boolean V11_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 12.0 or later is required to install the app. If 'False', Version 12.0 is not the minimum version.")] Boolean V12_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 13.0 or later is required to install the app. If 'False', Version 13.0 is not the minimum version.")] Boolean V13_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 14.0 or later is required to install the app. If 'False', Version 14.0 is not the minimum version.")] Boolean V14_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. When 'True', OS Version 15.0 or later is required to install the app. If 'False', Version 15.0 is not the minimum version.")] Boolean V15_0;
+};
+
+[ClassVersion("1.0.0.0"), FriendlyName("IntuneMobileAppsBundleMacOS")]
+class MSFT_IntuneMobileAppsBundleMacOS : OMI_BaseResource
+{
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
+    [Key, Description("The admin provided or imported title of the app.")] String DisplayName;
+    [Write, Description("The bundle type. To change the app type, you have to first delete and then recreate it. Possible values are: Dmg, Pkg"), ValueMap{"Dmg", "Pkg"}, Values{"Dmg", "Pkg"}] String PackageFileType;
+    [Write, Description("The description of the app.")] String Description;
+    [Write, Description("The developer of the app.")] String Developer;
+    [Write, Description("The more information Url.")] String InformationUrl;
+    [Write, Description("The value indicating whether the app is marked as featured by the admin.")] Boolean IsFeatured;
+    [Write, Description("The large icon, to be displayed in the app details and used for upload of the icon."), EmbeddedInstance("MSFT_MicrosoftGraphMimeContent")] String LargeIcon;
+    [Write, Description("Notes for the app.")] String Notes;
+    [Write, Description("The owner of the app.")] String Owner;
+    [Write, Description("The privacy statement Url.")] String PrivacyInformationUrl;
+    [Write, Description("The publisher of the app.")] String Publisher;
+    [Write, Description("The list of apps expected to be installed by the bundle."), EmbeddedInstance("MSFT_MicrosoftGraphMacOSIncludedApp")] String IncludedApps;
+    [Write, Description("When TRUE, indicates that the app's version will NOT be used to detect if the app is installed on a device. When FALSE, indicates that the app's version will be used to detect if the app is installed on a device. Set this to true for apps that use a self update feature.")] Boolean IgnoreVersionDetection;
+    [Write, Description("Indicates the minimum operating system applicable for the application."), EmbeddedInstance("MSFT_MicrosoftGraphMacOSMinimumOperatingSystem")] String MinimumSupportedOperatingSystem;
+    [Write, Description("Contains the pre-install script for the app. This will execute on the macOS device before the app is installed.")] String PreInstallScript;
+    [Write, Description("Contains the post-install script for the app. This will execute on the macOS device after the app is installed.")] String PostInstallScript;
+    [Write, Description("List of scope tag ids for this mobile app.")] String RoleScopeTagIds[];
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementMobileAppAssignment")] String Assignments[];
+    [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
+    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
+    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
+    [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
+    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Access token used for authentication.")] String AccessTokens[];
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/MSFT_IntuneMobileAppsBundleMacOS.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/MSFT_IntuneMobileAppsBundleMacOS.schema.mof
@@ -14,7 +14,14 @@ class MSFT_DeviceManagementMobileAppAssignment
 class MSFT_MicrosoftGraphMimeContent
 {
     [Write, Description("Indicates the content mime type.")] String Type;
-    [Write, Description("The byte array that contains the actual content.")] String Value;
+    [Write, Description("The Base64 encoded string content.")] String Value;
+};
+
+[ClassVersion("1.0.0")]
+class MSFT_DeviceManagementMobileAppCategory
+{
+    [Key, Description("The name of the app category.")] String DisplayName;
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
 };
 
 [ClassVersion("1.0.0.0")]
@@ -51,6 +58,7 @@ class MSFT_IntuneMobileAppsBundleMacOS : OMI_BaseResource
     [Write, Description("The bundle type. To change the app type, you have to first delete and then recreate it. Possible values are: Dmg, Pkg"), ValueMap{"Dmg", "Pkg"}, Values{"Dmg", "Pkg"}] String PackageFileType;
     [Write, Description("The description of the app.")] String Description;
     [Write, Description("The developer of the app.")] String Developer;
+    [Write, Description("The file name of the app.")] String FileName;
     [Write, Description("The more information Url.")] String InformationUrl;
     [Write, Description("The value indicating whether the app is marked as featured by the admin.")] Boolean IsFeatured;
     [Write, Description("The large icon, to be displayed in the app details and used for upload of the icon."), EmbeddedInstance("MSFT_MicrosoftGraphMimeContent")] String LargeIcon;
@@ -58,7 +66,8 @@ class MSFT_IntuneMobileAppsBundleMacOS : OMI_BaseResource
     [Write, Description("The owner of the app.")] String Owner;
     [Write, Description("The privacy statement Url.")] String PrivacyInformationUrl;
     [Write, Description("The publisher of the app.")] String Publisher;
-    [Write, Description("The list of apps expected to be installed by the bundle."), EmbeddedInstance("MSFT_MicrosoftGraphMacOSIncludedApp")] String IncludedApps;
+    [Write, Description("The list of categories for this app."), EmbeddedInstance("MSFT_DeviceManagementMobileAppCategory")] String Categories[];
+    [Write, Description("The list of apps expected to be installed by the bundle."), EmbeddedInstance("MSFT_MicrosoftGraphMacOSIncludedApp")] String IncludedApps[];
     [Write, Description("When TRUE, indicates that the app's version will NOT be used to detect if the app is installed on a device. When FALSE, indicates that the app's version will be used to detect if the app is installed on a device. Set this to true for apps that use a self update feature.")] Boolean IgnoreVersionDetection;
     [Write, Description("Indicates the minimum operating system applicable for the application."), EmbeddedInstance("MSFT_MicrosoftGraphMacOSMinimumOperatingSystem")] String MinimumSupportedOperatingSystem;
     [Write, Description("Contains the pre-install script for the app. This will execute on the macOS device before the app is installed.")] String PreInstallScript;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/readme.md
@@ -1,0 +1,6 @@
+
+# IntuneMobileAppsBundleMacOS
+
+## Description
+
+Intune Mobile Apps Bundle types Dmg and Pkg for macOS

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/readme.md
@@ -3,4 +3,8 @@
 
 ## Description
 
-Intune Mobile Apps Bundle types Dmg and Pkg for macOS
+Intune Mobile Apps Bundle types Dmg and Pkg for macOS.
+
+**ATTENTION**
+
+**After creating an app, the content must be manually uploaded via the Intune portal.**

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBundleMacOS/settings.json
@@ -1,0 +1,50 @@
+{
+  "resourceName": "IntuneMobileAppsBundleMacOS",
+  "description": "This resource configures an Intune Mobile Apps Bundle types Dmg and Pkg for macOS.",
+  "permissions": {
+    "graph": {
+      "application": {
+        "read": [
+          {
+            "name": "DeviceManagementApps.Read.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ],
+        "update": [
+          {
+            "name": "DeviceManagementApps.ReadWrite.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ]
+      },
+      "delegated": {
+        "read": [
+          {
+            "name": "DeviceManagementApps.Read.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ],
+        "update": [
+          {
+            "name": "DeviceManagementApps.ReadWrite.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ]
+      }
+    }
+  },
+  "requiredModules": [
+    "Microsoft.Graph.Authentication",
+    "Microsoft.Graph.Beta.Devices.CorporateManagement",
+    "Microsoft.Graph.Groups"
+  ],
+  "mode": "Data"
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBundleMacOS/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBundleMacOS/1-Create.ps1
@@ -1,0 +1,75 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneMobileAppsBundleMacOS "IntuneMobileAppsBundleMacOS-Pkg App"
+        {
+            Description           = "macOS Pkg App Description";
+            Developer             = "Contoso";
+            DisplayName           = "macOS Pkg App";
+            Ensure                = "Present";
+            InformationUrl        = "";
+            IsFeatured            = $False;
+            MinimumSupportedOperatingSystem = MSFT_MicrosoftGraphMacOSMinimumOperatingSystem{
+                V10_7 = $False
+                V10_8 = $False
+                V10_9 = $False
+                V10_10 = $False
+                V10_11 = $False
+                V10_12 = $False
+                V10_13 = $True
+                V10_14 = $False
+                V10_15 = $False
+                V11_0 = $False
+                V12_0 = $False
+                V13_0 = $False
+                V14_0 = $False
+                V15_0 = $False
+            };
+            Notes                 = "";
+            Owner                 = "";
+            PrivacyInformationUrl = "";
+            Publisher             = "Contoso";
+            Assignments          = @(
+                MSFT_DeviceManagementMobileAppAssignment {
+                    groupDisplayName = 'All devices'
+                    deviceAndAppManagementAssignmentFilterType = 'none'
+                    dataType = '#microsoft.graph.allDevicesAssignmentTarget'
+                    intent = 'required'
+                }
+            );
+            Categories             = @(
+                MSFT_DeviceManagementMobileAppCategory{
+                    Id = "2185c6bf-1b3d-4daa-a0bc-79cb4fad9c87"
+                    DisplayName = "App Category 1"
+                }
+            );
+            PackageFileType       = "Pkg";
+            PostInstallScript     = "#! Post-install script";
+            PreInstallScript      = "#! Pre-install script";
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBundleMacOS/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBundleMacOS/2-Update.ps1
@@ -1,0 +1,75 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Import-DscResource -ModuleName Microsoft365DSC
+    node localhost
+    {
+        IntuneMobileAppsBundleMacOS "IntuneMobileAppsBundleMacOS-Pkg App"
+        {
+            Description           = "macOS Pkg App Description";
+            Developer             = "Contoso";
+            DisplayName           = "macOS Pkg App";
+            Ensure                = "Present";
+            InformationUrl        = "";
+            IsFeatured            = $False;
+            MinimumSupportedOperatingSystem = MSFT_MicrosoftGraphMacOSMinimumOperatingSystem{
+                V10_7 = $False
+                V10_8 = $False
+                V10_9 = $False
+                V10_10 = $False
+                V10_11 = $False
+                V10_12 = $False
+                V10_13 = $False # Drift
+                V10_14 = $True # Drift
+                V10_15 = $False
+                V11_0 = $False
+                V12_0 = $False
+                V13_0 = $False
+                V14_0 = $False
+                V15_0 = $False
+            };
+            Notes                 = "";
+            Owner                 = "";
+            PrivacyInformationUrl = "";
+            Publisher             = "Contoso";
+            Assignments          = @(
+                MSFT_DeviceManagementMobileAppAssignment {
+                    groupDisplayName = 'All devices'
+                    deviceAndAppManagementAssignmentFilterType = 'none'
+                    dataType = '#microsoft.graph.allDevicesAssignmentTarget'
+                    intent = 'required'
+                }
+            );
+            Categories             = @(
+                MSFT_DeviceManagementMobileAppCategory{
+                    Id = "2185c6bf-1b3d-4daa-a0bc-79cb4fad9c87"
+                    DisplayName = "App Category 1"
+                }
+            );
+            PackageFileType       = "Pkg";
+            PostInstallScript     = "#! Post-install script";
+            PreInstallScript      = "#! Pre-install script";
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBundleMacOS/3-Remove.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsBundleMacOS/3-Remove.ps1
@@ -1,0 +1,36 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneMobileAppsBundleMacOS "IntuneMobileAppsBundleMacOS-Pkg App"
+        {
+            DisplayName           = "macOS Pkg App";
+            PackageFileType       = "Pkg";
+            Ensure                = "Absent";
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -3457,7 +3457,8 @@ function Update-IntuneDeviceConfigurationPolicy
     }
 }
 
-function Get-ComplexFunctionsFromFilterQuery {
+function Get-ComplexFunctionsFromFilterQuery
+{
     [CmdletBinding()]
     [OutputType([System.Array])]
     param (
@@ -3472,7 +3473,8 @@ function Get-ComplexFunctionsFromFilterQuery {
     return $complexFunctions
 }
 
-function Remove-ComplexFunctionsFromFilterQuery {
+function Remove-ComplexFunctionsFromFilterQuery
+{
     [CmdletBinding()]
     [OutputType([System.String])]
     param (
@@ -3486,7 +3488,8 @@ function Remove-ComplexFunctionsFromFilterQuery {
     return $basicFilterQuery
 }
 
-function Find-GraphDataUsingComplexFunctions {
+function Find-GraphDataUsingComplexFunctions
+{
     [CmdletBinding()]
     [OutputType([System.Array])]
     param (
@@ -3511,4 +3514,126 @@ function Find-GraphDataUsingComplexFunctions {
     }
 
     return $Policies
+}
+
+function Invoke-M365DSCIntuneMobileAppInitialUpload
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $AppId,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $OdataType,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $FileExtension
+    )
+
+    $OdataType = $OdataType.Replace('#', '')
+    $contentVersionsUri = "beta/deviceAppManagement/mobileApps/$($AppId)/$OdataType/contentVersions"
+    $contentVersion = Invoke-MgGraphRequest -Method POST -Uri $contentVersionsUri -Body @{}
+
+    $fileUri = "beta/deviceAppManagement/mobileApps/$($AppId)/$OdataType/contentVersions/$($contentVersion.id)/files"
+    $file = Invoke-MgGraphRequest -Method POST `
+        -Uri $fileUri `
+        -Body @{
+            '@odata.type' = "#microsoft.graph.mobileAppContentFile"
+            name = "Sample.$($FileExtension)"
+            size = 1
+            sizeEncrypted = 64
+            isDependency = $false
+            manifest = $null
+        }
+
+    $file = Wait-ForFileProcessing -AppId $AppId -OdataType $OdataType -FileId $file.id -ContentVersionId $contentVersion.id -UploadStatePrefix "AzureStorageUriRequest"
+
+    # Upload the encrypted Sample file to Azure Storage
+    Write-Verbose "Uploading file to Azure Storage: $($file.azureStorageUri)"
+    $base64File = "+drh1SKfuLjdp37gfv8EuWqOTt06m0TirqJJ0xQvrd5sm6NkiYBY8vBkFM+9ZwHRskO83NEfsLPtTzLB9FFsKA=="
+    $sasUri = $file.azureStorageUri
+    $uri = "$($sasUri)&comp=block&blockid=0001"
+    $iso = [System.Text.Encoding]::GetEncoding("iso-8859-1");
+    $body = [System.Convert]::FromBase64String($base64File)
+    $encodedBody = $iso.GetString($body)
+    Invoke-WebRequest -Uri $uri -Method PUT -Body $encodedBody -Headers @{
+        "x-ms-blob-type" = "BlockBlob"
+    } | Out-Null
+
+    # Finalize the upload to Azure Storage
+    $uri = "$($sasUri)&comp=blocklist"
+    $xml = '<?xml version="1.0" encoding="utf-8"?><BlockList><Latest>0001</Latest></BlockList>'
+    Invoke-RestMethod -Uri $uri -Method PUT -Body $xml
+
+    # Commit the file and update the app
+    $jsonCommit = @{
+        fileEncryptionInfo = @{
+            fileDigestAlgorithm  = "SHA256"
+            encryptionKey        = "yqjlzT5KYpwU0wkr5eJGGukMB0Ar8iGqYX3B0lJJnKk="
+            initializationVector = "bJujZImAWPLwZBTPvWcB0Q=="
+            fileDigest           = "ypeBEsobvcr6wjGzmiPcTaeG7/gUfE5yuYB3ha/uSLs="
+            mac                  = "+drh1SKfuLjdp37gfv8EuWqOTt06m0TirqJJ0xQvrd4="
+            profileIdentifier    = "ProfileVersion1"
+            macKey               = "mGfhTn/0AB3fftWzENQcoU34xghAfvVq23PoiBD81tM="
+        }
+    }
+    $commitUri = "beta/deviceAppManagement/mobileApps/$AppId/$OdataType/contentVersions/$($contentVersion.id)/files/$($file.id)/commit"
+    Invoke-MgGraphRequest -Method POST -Uri $commitUri -Body $($jsonCommit | ConvertTo-Json -Depth 10)
+
+    Wait-ForFileProcessing -AppId $AppId -OdataType $OdataType -FileId $file.id -ContentVersionId $contentVersion.id -UploadStatePrefix "CommitFile"
+
+    # Update the app with the committed content version
+    Invoke-MgGraphRequest -Method PATCH -Uri "beta/deviceAppManagement/mobileApps/$AppId" -Body @{
+        '@odata.type' = "#$OdataType"
+        committedContentVersion = '1'
+    }
+}
+
+function Wait-ForFileProcessing
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $AppId,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $OdataType,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $FileId,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $ContentVersionId,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $UploadStatePrefix
+    )
+
+    $fileUri = "beta/deviceAppManagement/mobileApps/$($AppId)/$OdataType/contentVersions/$ContentVersionId/files/$($FileId)"
+
+    Write-Verbose "Waiting for file processing to complete for AppId: $AppId, OdataType: $OdataType, FileId: $FileId, ContentVersionId: $ContentVersionId" -Verbose
+    $file = Invoke-MgGraphRequest -Method GET -Uri $fileUri
+
+    while ($file.uploadState -ne "$($UploadStatePrefix)Success")
+    {
+        if ($file.uploadState -like "*Failed")
+        {
+            throw "File upload failed with state: $($file.uploadState). Please check the file and try again."
+        }
+
+        Start-Sleep -Seconds 1
+        Write-Verbose "Current upload state: $($file.uploadState). Waiting for processing to complete..." -Verbose
+        $file = Invoke-MgGraphRequest -Method GET -Uri $fileUri
+    }
+
+    $file
 }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsBundleMacOS.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsBundleMacOS.Tests.ps1
@@ -1,0 +1,278 @@
+[CmdletBinding()]
+param(
+)
+$M365DSCTestFolder = Join-Path -Path $PSScriptRoot `
+                        -ChildPath '..\..\Unit' `
+                        -Resolve
+$CmdletModule = (Join-Path -Path $M365DSCTestFolder `
+            -ChildPath '\Stubs\Microsoft365.psm1' `
+            -Resolve)
+$GenericStubPath = (Join-Path -Path $M365DSCTestFolder `
+    -ChildPath '\Stubs\Generic.psm1' `
+    -Resolve)
+Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\UnitTestHelper.psm1' `
+        -Resolve)
+
+$Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
+    -DscResource "IntuneMobileAppsBundleMacOS" -GenericStubModule $GenericStubPath
+Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
+        BeforeAll {
+
+            $secpasswd = ConvertTo-SecureString (New-Guid | Out-String) -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
+
+            Mock -ModuleName M365DSCUtil -CommandName Confirm-M365DSCDependencies -MockWith {
+            }
+
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
+            Mock -CommandName Reset-MSCloudLoginConnectionProfileContext -MockWith {
+            }
+
+            Mock -CommandName Get-PSSession -MockWith {
+            }
+
+            Mock -CommandName Remove-PSSession -MockWith {
+            }
+
+            Mock -CommandName Update-MgBetaDeviceAppManagementMobileApp -MockWith {
+            }
+
+            Mock -CommandName New-MgBetaDeviceAppManagementMobileApp -MockWith {
+            }
+
+            Mock -CommandName Remove-MgBetaDeviceAppManagementMobileApp -MockWith {
+            }
+
+            Mock -CommandName Get-MgBetaDeviceAppManagementMobileApp -MockWith {
+                return @{
+                        AdditionalProperties = @{
+                            '@odata.type' = "#microsoft.graph.mobileLobApp"
+                        }
+                        CommittedContentVersion = "FakeStringValue"
+                        DependentAppCount = 25
+                        Description = "FakeStringValue"
+                        Developer = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                        FileName = "FakeStringValue"
+                        Id = "FakeStringValue"
+                        InformationUrl = "FakeStringValue"
+                        IsFeatured = $True
+                        LargeIcon = @{
+                            Type = "FakeStringValue"
+                        }
+                        Notes = "FakeStringValue"
+                        Owner = "FakeStringValue"
+                        PrivacyInformationUrl = "FakeStringValue"
+                        Publisher = "FakeStringValue"
+                        PublishingState = "notPublished"
+                        RoleScopeTagIds = @("FakeStringValue")
+                        SupersededAppCount = 25
+                        SupersedingAppCount = 25
+                        UploadState = 25
+
+                }
+            }
+
+            Mock -CommandName New-M365DSCConnection -MockWith {
+                return "Credentials"
+            }
+
+            # Mock Write-M365DSCHost to hide output during the tests
+            Mock -CommandName Write-M365DSCHost -MockWith {
+            }
+            $Script:exportedInstance = $null
+            $Script:ExportMode = $false
+
+            Mock -CommandName Get-MgBetaDeviceAppManagementMobileAppAssignment -MockWith {
+            }
+
+        }
+
+        # Test contexts
+        Context -Name "The IntuneMobileAppsBundleMacOS should exist but it DOES NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    CommittedContentVersion = "FakeStringValue"
+                    DependentAppCount = 25
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    FileName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent1 -Property @{
+                        Type = "FakeStringValue"
+                    } -ClientOnly)
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    PublishingState = "notPublished"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    SupersededAppCount = 25
+                    SupersedingAppCount = 25
+                    UploadState = 25
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+
+                Mock -CommandName Get-MgBetaDeviceAppManagementMobileApp -MockWith {
+                    return $null
+                }
+            }
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
+            }
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+            It 'Should Create the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName New-MgBetaDeviceAppManagementMobileApp -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneMobileAppsBundleMacOS exists but it SHOULD NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    CommittedContentVersion = "FakeStringValue"
+                    DependentAppCount = 25
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    FileName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent1 -Property @{
+                        Type = "FakeStringValue"
+                    } -ClientOnly)
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    PublishingState = "notPublished"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    SupersededAppCount = 25
+                    SupersedingAppCount = 25
+                    UploadState = 25
+                    Ensure = 'Absent'
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should Remove the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Remove-MgBetaDeviceAppManagementMobileApp -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneMobileAppsBundleMacOS Exists and Values are already in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    CommittedContentVersion = "FakeStringValue"
+                    DependentAppCount = 25
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    FileName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent1 -Property @{
+                        Type = "FakeStringValue"
+                    } -ClientOnly)
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    PublishingState = "notPublished"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    SupersededAppCount = 25
+                    SupersedingAppCount = 25
+                    UploadState = 25
+                    Ensure = 'Present'
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+        }
+
+        Context -Name "The IntuneMobileAppsBundleMacOS exists and values are NOT in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    CommittedContentVersion = "FakeStringValue"
+                    DependentAppCount = 25
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    FileName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent1 -Property @{
+                        Type = "FakeStringValue"
+                    } -ClientOnly)
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    PublishingState = "notPublished"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    SupersededAppCount = 25
+                    SupersedingAppCount = 25
+                    UploadState = 25
+                    Ensure = 'Present'
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Update-MgBetaDeviceAppManagementMobileApp -Exactly 1
+            }
+        }
+
+        Context -Name 'ReverseDSC Tests' -Fixture {
+            BeforeAll {
+                $Global:CurrentModeIsExport = $true
+                $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
+                $testParams = @{
+                    Credential = $Credential
+                }
+            }
+
+            It 'Should Reverse Engineer resource from the Export method' {
+                $result = Export-TargetResource @testParams
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}
+
+Invoke-Command -ScriptBlock $Global:DscHelper.CleanupScript -NoNewScope

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsBundleMacOS.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsBundleMacOS.Tests.ps1
@@ -39,10 +39,53 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Remove-PSSession -MockWith {
             }
 
-            Mock -CommandName Update-MgBetaDeviceAppManagementMobileApp -MockWith {
+            Mock -CommandName Update-DeviceAppManagementAppCategory -MockWith {
             }
 
-            Mock -CommandName New-MgBetaDeviceAppManagementMobileApp -MockWith {
+            Mock -CommandName Invoke-M365DSCIntuneMobileAppInitialUpload -MockWith {
+            }
+
+            Mock -CommandName Update-DeviceAppManagementPolicyAssignment -MockWith {
+            }
+
+            Mock -CommandName Invoke-MgGraphRequest -MockWith {
+                return @{
+                    AdditionalProperties = @{
+                        '@odata.type' = "#microsoft.graph.macOSDmgApp"
+                        fileName = "FakeStringValue"
+                        ignoreVersionDetection = $true
+                        includedApps = @(
+                            @{
+                                bundleId = "FakeStringValue"
+                                bundleVersion = "FakeStringValue"
+                            }
+                        )
+                        minimumSupportedOperatingSystem = @{
+                            v10_15 = $true
+                        }
+                    }
+                    CommittedContentVersion = "FakeStringValue"
+                    DependentAppCount = 25
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = @{
+                        Type = "FakeStringValue"
+                        Value = [System.Convert]::FromBase64String("VGVzdA==")
+                    }
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    PublishingState = "notPublished"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    SupersededAppCount = 25
+                    SupersedingAppCount = 25
+                    UploadState = 25
+                }
             }
 
             Mock -CommandName Remove-MgBetaDeviceAppManagementMobileApp -MockWith {
@@ -50,31 +93,47 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             Mock -CommandName Get-MgBetaDeviceAppManagementMobileApp -MockWith {
                 return @{
-                        AdditionalProperties = @{
-                            '@odata.type' = "#microsoft.graph.mobileLobApp"
+                    AdditionalProperties = @{
+                        '@odata.type' = "#microsoft.graph.macOSDmgApp"
+                        fileName = "FakeStringValue"
+                        ignoreVersionDetection = $true
+                        includedApps = @(
+                            @{
+                                bundleId = "FakeStringValue"
+                                bundleVersion = "FakeStringValue"
+                            }
+                        )
+                        minimumSupportedOperatingSystem = @{
+                            v10_15 = $true
                         }
-                        CommittedContentVersion = "FakeStringValue"
-                        DependentAppCount = 25
-                        Description = "FakeStringValue"
-                        Developer = "FakeStringValue"
-                        DisplayName = "FakeStringValue"
-                        FileName = "FakeStringValue"
-                        Id = "FakeStringValue"
-                        InformationUrl = "FakeStringValue"
-                        IsFeatured = $True
-                        LargeIcon = @{
-                            Type = "FakeStringValue"
+                    }
+                    Categories = @(
+                        @{
+                            Id = "FakeStringValue"
+                            DisplayName = "FakeStringValue"
                         }
-                        Notes = "FakeStringValue"
-                        Owner = "FakeStringValue"
-                        PrivacyInformationUrl = "FakeStringValue"
-                        Publisher = "FakeStringValue"
-                        PublishingState = "notPublished"
-                        RoleScopeTagIds = @("FakeStringValue")
-                        SupersededAppCount = 25
-                        SupersedingAppCount = 25
-                        UploadState = 25
-
+                    )
+                    CommittedContentVersion = "FakeStringValue"
+                    DependentAppCount = 25
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = @{
+                        Type = "FakeStringValue"
+                        Value = [System.Convert]::FromBase64String("VGVzdA==")
+                    }
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    PublishingState = "notPublished"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    SupersededAppCount = 25
+                    SupersedingAppCount = 25
+                    UploadState = 25
                 }
             }
 
@@ -97,27 +156,37 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "The IntuneMobileAppsBundleMacOS should exist but it DOES NOT" -Fixture {
             BeforeAll {
                 $testParams = @{
-                    CommittedContentVersion = "FakeStringValue"
-                    DependentAppCount = 25
+                    Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
+                        Id = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                    } -ClientOnly))
                     Description = "FakeStringValue"
                     Developer = "FakeStringValue"
                     DisplayName = "FakeStringValue"
                     FileName = "FakeStringValue"
                     Id = "FakeStringValue"
+                    IgnoreVersionDetection = $true
+                    IncludedApps = [CimInstance[]]@(
+                        New-CimInstance -ClassName MSFT_MicrosoftGraphMacOSIncludedApp -Property @{
+                            BundleId = "FakeStringValue"
+                            BundleVersion = "FakeStringValue"
+                        } -ClientOnly
+                    )
                     InformationUrl = "FakeStringValue"
                     IsFeatured = $True
-                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent1 -Property @{
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent -Property @{
                         Type = "FakeStringValue"
+                        Value = "VGVzdA==" # Base64 encoded string for "Test"
+                    } -ClientOnly)
+                    MinimumSupportedOperatingSystem = (New-CimInstance -ClassName MSFT_MicrosoftGraphMacOSMinimumOperatingSystem -Property @{
+                        V10_15 = $true
                     } -ClientOnly)
                     Notes = "FakeStringValue"
                     Owner = "FakeStringValue"
+                    PackageFileType = "Dmg"
                     PrivacyInformationUrl = "FakeStringValue"
                     Publisher = "FakeStringValue"
-                    PublishingState = "notPublished"
                     RoleScopeTagIds = @("FakeStringValue")
-                    SupersededAppCount = 25
-                    SupersedingAppCount = 25
-                    UploadState = 25
                     Ensure = "Present"
                     Credential = $Credential;
                 }
@@ -134,35 +203,45 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
             It 'Should Create the group from the Set method' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName New-MgBetaDeviceAppManagementMobileApp -Exactly 1
+                Should -Invoke -CommandName Invoke-MgGraphRequest -Exactly 1
             }
         }
 
         Context -Name "The IntuneMobileAppsBundleMacOS exists but it SHOULD NOT" -Fixture {
             BeforeAll {
                 $testParams = @{
-                    CommittedContentVersion = "FakeStringValue"
-                    DependentAppCount = 25
+                    Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
+                        Id = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                    } -ClientOnly))
                     Description = "FakeStringValue"
                     Developer = "FakeStringValue"
                     DisplayName = "FakeStringValue"
                     FileName = "FakeStringValue"
                     Id = "FakeStringValue"
+                    IgnoreVersionDetection = $true
+                    IncludedApps = [CimInstance[]]@(
+                        New-CimInstance -ClassName MSFT_MicrosoftGraphMacOSIncludedApp -Property @{
+                            BundleId = "FakeStringValue"
+                            BundleVersion = "FakeStringValue"
+                        } -ClientOnly
+                    )
                     InformationUrl = "FakeStringValue"
                     IsFeatured = $True
-                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent1 -Property @{
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent -Property @{
                         Type = "FakeStringValue"
+                        Value = "VGVzdA==" # Base64 encoded string for "Test"
+                    } -ClientOnly)
+                    MinimumSupportedOperatingSystem = (New-CimInstance -ClassName MSFT_MicrosoftGraphMacOSMinimumOperatingSystem -Property @{
+                        V10_15 = $true
                     } -ClientOnly)
                     Notes = "FakeStringValue"
                     Owner = "FakeStringValue"
+                    PackageFileType = "Dmg"
                     PrivacyInformationUrl = "FakeStringValue"
                     Publisher = "FakeStringValue"
-                    PublishingState = "notPublished"
                     RoleScopeTagIds = @("FakeStringValue")
-                    SupersededAppCount = 25
-                    SupersedingAppCount = 25
-                    UploadState = 25
-                    Ensure = 'Absent'
+                    Ensure = "Absent"
                     Credential = $Credential;
                 }
             }
@@ -184,28 +263,38 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "The IntuneMobileAppsBundleMacOS Exists and Values are already in the desired state" -Fixture {
             BeforeAll {
                 $testParams = @{
-                    CommittedContentVersion = "FakeStringValue"
-                    DependentAppCount = 25
+                    Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
+                        Id = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                    } -ClientOnly))
                     Description = "FakeStringValue"
                     Developer = "FakeStringValue"
                     DisplayName = "FakeStringValue"
                     FileName = "FakeStringValue"
                     Id = "FakeStringValue"
+                    IgnoreVersionDetection = $true
+                    IncludedApps = [CimInstance[]]@(
+                        New-CimInstance -ClassName MSFT_MicrosoftGraphMacOSIncludedApp -Property @{
+                            BundleId = "FakeStringValue"
+                            BundleVersion = "FakeStringValue"
+                        } -ClientOnly
+                    )
                     InformationUrl = "FakeStringValue"
                     IsFeatured = $True
-                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent1 -Property @{
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent -Property @{
                         Type = "FakeStringValue"
+                        Value = "VGVzdA==" # Base64 encoded string for "Test"
+                    } -ClientOnly)
+                    MinimumSupportedOperatingSystem = (New-CimInstance -ClassName MSFT_MicrosoftGraphMacOSMinimumOperatingSystem -Property @{
+                        V10_15 = $true
                     } -ClientOnly)
                     Notes = "FakeStringValue"
                     Owner = "FakeStringValue"
+                    PackageFileType = "Dmg"
                     PrivacyInformationUrl = "FakeStringValue"
                     Publisher = "FakeStringValue"
-                    PublishingState = "notPublished"
                     RoleScopeTagIds = @("FakeStringValue")
-                    SupersededAppCount = 25
-                    SupersedingAppCount = 25
-                    UploadState = 25
-                    Ensure = 'Present'
+                    Ensure = "Present"
                     Credential = $Credential;
                 }
             }
@@ -218,28 +307,38 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "The IntuneMobileAppsBundleMacOS exists and values are NOT in the desired state" -Fixture {
             BeforeAll {
                 $testParams = @{
-                    CommittedContentVersion = "FakeStringValue"
-                    DependentAppCount = 25
+                    Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
+                        Id = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                    } -ClientOnly))
                     Description = "FakeStringValue"
                     Developer = "FakeStringValue"
                     DisplayName = "FakeStringValue"
                     FileName = "FakeStringValue"
                     Id = "FakeStringValue"
+                    IgnoreVersionDetection = $true
+                    IncludedApps = [CimInstance[]]@(
+                        New-CimInstance -ClassName MSFT_MicrosoftGraphMacOSIncludedApp -Property @{
+                            BundleId = "FakeStringValue"
+                            BundleVersion = "FakeStringValue_NewVersion" # Drift
+                        } -ClientOnly
+                    )
                     InformationUrl = "FakeStringValue"
                     IsFeatured = $True
-                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent1 -Property @{
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent -Property @{
                         Type = "FakeStringValue"
+                        Value = "VGVzdA==" # Base64 encoded string for "Test"
+                    } -ClientOnly)
+                    MinimumSupportedOperatingSystem = (New-CimInstance -ClassName MSFT_MicrosoftGraphMacOSMinimumOperatingSystem -Property @{
+                        V10_15 = $true
                     } -ClientOnly)
                     Notes = "FakeStringValue"
                     Owner = "FakeStringValue"
+                    PackageFileType = "Dmg"
                     PrivacyInformationUrl = "FakeStringValue"
                     Publisher = "FakeStringValue"
-                    PublishingState = "notPublished"
                     RoleScopeTagIds = @("FakeStringValue")
-                    SupersededAppCount = 25
-                    SupersedingAppCount = 25
-                    UploadState = 25
-                    Ensure = 'Present'
+                    Ensure = "Present"
                     Credential = $Credential;
                 }
             }
@@ -254,7 +353,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should call the Set method' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName Update-MgBetaDeviceAppManagementMobileApp -Exactly 1
+                Should -Invoke -CommandName Invoke-MgGraphRequest -Exactly 1
             }
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds the `IntuneMobileAppsBundleMacOS` resource. DMG and PKG files for macOS are "bundle" apps, consisting of a container with one or more apps inside them. 

To create such an app, it is necessary to upload a file to an Azure Storage account and only after that, it can be configured. This means that the app itself is not functional directly after creation and the content for the app (the .dmg or .pkg file) must be manually uploaded via the Intune portal.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
