### PR TITLE
Add Intune Win32 Application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Initial release.
 * IntuneMobileAppsStoreApp
   * Initial release.
+* IntuneMobileAppsWin32AppWindows10
+  * Initial release.
 
 # 1.25.716.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/MSFT_IntuneMobileAppsWin32AppWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/MSFT_IntuneMobileAppsWin32AppWindows10.psm1
@@ -50,6 +50,10 @@ function Get-TargetResource
         $Publisher,
 
         [Parameter()]
+        [System.String]
+        $FileName,
+
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Categories,
 
@@ -66,10 +70,6 @@ function Get-TargetResource
         $AllowedArchitectures,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
-        $MinimumSupportedOperatingSystem,
-
-        [Parameter()]
         [System.Int32]
         $MinimumFreeDiskSpaceInMB,
 
@@ -84,14 +84,6 @@ function Get-TargetResource
         [Parameter()]
         [System.Int32]
         $MinimumCpuSpeedInMHz,
-
-        [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
-        $DetectionRules,
-
-        [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
-        $RequirementRules,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
@@ -220,10 +212,12 @@ function Get-TargetResource
                 Write-Verbose -Message "Could not find an Intune Mobile Apps Win32 App for Windows10 with DisplayName {$DisplayName}."
                 return $nullResult
             }
+
+            $getValue = Get-MgBetaDeviceAppManagementMobileApp -MobileAppId $getValue.Id -ExpandProperty 'Categories'
         }
         else
         {
-            $getValue = Get-MgBetaDeviceAppManagementMobileApp -MobileAppId $getValue.Id -ExpandProperty 'Categories'
+            $getValue = Get-MgBetaDeviceAppManagementMobileApp -MobileAppId $Script:exportedInstance.Id -ExpandProperty 'Categories'
         }
         $Id = $getValue.Id
         Write-Verbose -Message "An Intune Mobile Apps Win32 App for Windows10 with Id {$Id} and DisplayName {$DisplayName} was found"
@@ -245,102 +239,55 @@ function Get-TargetResource
             $complexLargeIcon.Add('Value', [System.Convert]::ToBase64String($getValue.LargeIcon.Value))
         }
 
-        $complexMinimumSupportedOperatingSystem = [ordered]@{}
-        $complexMinimumSupportedOperatingSystem.Add('V8_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v8_0)
-        $complexMinimumSupportedOperatingSystem.Add('V8_1', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v8_1)
-        $complexMinimumSupportedOperatingSystem.Add('V10_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_0)
-        $complexMinimumSupportedOperatingSystem.Add('V10_1607', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1607)
-        $complexMinimumSupportedOperatingSystem.Add('V10_1703', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1703)
-        $complexMinimumSupportedOperatingSystem.Add('V10_1709', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1709)
-        $complexMinimumSupportedOperatingSystem.Add('V10_1803', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1803)
-        $complexMinimumSupportedOperatingSystem.Add('V10_1809', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1809)
-        $complexMinimumSupportedOperatingSystem.Add('V10_1903', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1903)
-        $complexMinimumSupportedOperatingSystem.Add('V10_1909', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1909)
-        $complexMinimumSupportedOperatingSystem.Add('V10_2004', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_2004)
-        $complexMinimumSupportedOperatingSystem.Add('V10_2H20', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_2H20)
-        $complexMinimumSupportedOperatingSystem.Add('V10_21H1', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_21H1)
-        if ($complexMinimumSupportedOperatingSystem.Values.Where({ $null -ne $_ }).Count -eq 0)
+        $complexRules = @()
+        foreach ($rule in $getValue.AdditionalProperties.rules)
         {
-            $complexMinimumSupportedOperatingSystem = $null
-        }
-
-        $complexDetectionRules = @()
-        foreach ($detectionRule in $getValue.AdditionalProperties.detectionRules)
-        {
-            $detectionType = $detectionRule.'@odata.type'.Replace('#microsoft.graph.win32LobApp', '').Replace('Detection', '')
-            $baseDetectionRule = @{
-                OdataType      = $detectionType
-                Operator       = $detectionRule.operator
-                DetectionValue = $detectionRule.detectionValue
+            $ruleType = $rule.'@odata.type'.Replace('#microsoft.graph.win32LobApp', '').Replace('Rule', '')
+            $baseRule = @{
+                OdataType       = $ruleType
+                RuleType        = $rule.ruleType
+                Operator        = $rule.operator
+                ComparisonValue = $rule.comparisonValue
             }
-            switch ($detectionType)
+            switch ($ruleType)
             {
                 'FileSystem' {
-                    $baseDetectionRule.Add('Check32BitOn64System', $detectionRule.check32BitOn64System)
-                    $baseDetectionRule.Add('Path', $detectionRule.path)
-                    $baseDetectionRule.Add('FileOrFolderName', $detectionRule.fileOrFolderName)
-                    $baseDetectionRule.Add('FileSystemDetectionType', $detectionRule.detectionType)
+                    $baseRule.Add('Check32BitOn64System', $rule.check32BitOn64System)
+                    $baseRule.Add('Path', $rule.path)
+                    $baseRule.Add('FileOrFolderName', $rule.fileOrFolderName)
+                    $baseRule.Add('FileSystemOperationType', $rule.operationType)
                 }
                 'Registry' {
-                    $baseDetectionRule.Add('Check32BitOn64System', $detectionRule.check32BitOn64System)
-                    $baseDetectionRule.Add('KeyPath', $detectionRule.keyPath)
-                    $baseDetectionRule.Add('RegistryDetectionType', $detectionRule.detectionType)
-                    $baseDetectionRule.Add('ValueName', $detectionRule.registryValueName)
+                    $baseRule.Add('Check32BitOn64System', $rule.check32BitOn64System)
+                    $baseRule.Add('KeyPath', $rule.keyPath)
+                    $baseRule.Add('RegistryOperationType', $rule.operationType)
+                    $baseRule.Add('ValueName', $rule.valueName)
                 }
                 "ProductCode" {
-                    $baseDetectionRule.Add('ProductCode', $detectionRule.productCode)
-                    $baseDetectionRule.Add('ProductVersionOperator', $detectionRule.productVersionOperator)
-                    $baseDetectionRule.Add('ProductVersion', $detectionRule.productVersion)
+                    $baseRule.Add('ProductCode', $rule.productCode)
+                    $baseRule.Add('ProductVersionOperator', $rule.productVersionOperator)
+                    $baseRule.Add('ProductVersion', $rule.productVersion)
+                    $baseRule.Remove('Operator') | Out-Null
+                    $baseRule.Remove('ComparisonValue') | Out-Null
                 }
                 "PowerShellScript" {
-                    $baseDetectionRule.Add('Script', [System.Convert]::FromBase64String($detectionRule.scriptContent))
-                    $baseDetectionRule.Add('RunAs32Bit', $detectionRule.runAs32Bit)
-                    $baseDetectionRule.Add('EnforceSignatureCheck', $detectionRule.enforceSignatureCheck)
+                    $baseRule.Add('DisplayName', $rule.displayName)
+                    $baseRule.Add('Script', [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($rule.scriptContent)))
+                    $baseRule.Add('RunAs32Bit', $rule.runAs32Bit)
+                    $baseRule.Add('EnforceSignatureCheck', $rule.enforceSignatureCheck)
+                    $baseRule.Add('RunAsAccount', $rule.runAsAccount)
+                    $baseRule.Add('PowerShellScriptOperationType', $rule.operationType)
                 }
             }
-            $complexDetectionRules += $baseDetectionRule
+            $complexRules += $baseRule
         }
 
-        $complexRequirementRules = @()
-        foreach ($requirementRule in $getValue.AdditionalProperties.requirementRules)
-        {
-            $requirementType = $requirementRule.'@odata.type'.Replace('#microsoft.graph.win32LobApp', '').Replace('Requirement', '')
-            $baseRequirementRule = @{
-                OdataType      = $requirementType
-                Operator       = $requirementRule.operator
-                DetectionValue = $requirementRule.detectionValue
-            }
-            switch ($requirementType)
-            {
-                'FileSystem' {
-                    $baseRequirementRule.Add('Check32BitOn64System', $requirementRule.check32BitOn64System)
-                    $baseRequirementRule.Add('Path', $requirementRule.path)
-                    $baseRequirementRule.Add('FileOrFolderName', $requirementRule.fileOrFolderName)
-                    $baseRequirementRule.Add('FileSystemDetectionType', $requirementRule.detectionType)
-                }
-                'Registry' {
-                    $baseRequirementRule.Add('Check32BitOn64System', $requirementRule.check32BitOn64System)
-                    $baseRequirementRule.Add('KeyPath', $requirementRule.keyPath)
-                    $baseRequirementRule.Add('RegistryDetectionType', $requirementRule.detectionType)
-                    $baseRequirementRule.Add('ValueName', $requirementRule.registryValueName)
-                }
-                "PowerShellScript" {
-                    $baseRequirementRule.Add('Script', [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($requirementRule.scriptContent)))
-                    $baseRequirementRule.Add('RunAs32Bit', $requirementRule.runAs32Bit)
-                    $baseRequirementRule.Add('EnforceSignatureCheck', $requirementRule.enforceSignatureCheck)
-                    $baseRequirementRule.Add('RunAsAccountType', $requirementRule.runAsAccountType)
-                    $baseRequirementRule.Add('PowerShellScriptDetectionType', $requirementRule.detectionType)
-                }
-            }
-            $complexRequirementRules += $baseRequirementRule
-        }
-
-        if ($null -ne $getValue.AdditionalProperties.InstallExperience)
+        if ($null -ne $getValue.AdditionalProperties.installExperience)
         {
             $complexInstallExperience = @{}
             $complexInstallExperience.Add('DeviceRestartBehavior', $getValue.AdditionalProperties.installExperience.deviceRestartBehavior)
             $complexInstallExperience.Add('MaxRunTimeInMinutes', $getValue.AdditionalProperties.installExperience.maxRunTimeInMinutes)
-            $complexInstallExperience.Add('RunAsAccountType', $getValue.AdditionalProperties.installExperience.runAsAccountType)
+            $complexInstallExperience.Add('RunAsAccount', $getValue.AdditionalProperties.installExperience.runAsAccount)
         }
 
         $complexReturnCodes = @()
@@ -372,18 +319,17 @@ function Get-TargetResource
             Description                     = $getValue.Description
             Developer                       = $getValue.Developer
             DisplayName                     = $getValue.DisplayName
+            FileName                        = $getValue.AdditionalProperties.fileName
             InformationUrl                  = $getValue.InformationUrl
             InstallCommandLine              = $getValue.AdditionalProperties.installCommandLine
             UninstallCommandLine            = $getValue.AdditionalProperties.uninstallCommandLine
-            MinimumSupportedOperatingSystem = $complexMinimumSupportedOperatingSystem
             MinimumFreeDiskSpaceInMB        = $getValue.AdditionalProperties.minimumFreeDiskSpaceInMB
             MinimumMemoryInMB               = $getValue.AdditionalProperties.minimumMemoryInMB
             MinimumNumberOfProcessors       = $getValue.AdditionalProperties.minimumNumberOfProcessors
             MinimumCpuSpeedInMHz            = $getValue.AdditionalProperties.minimumCpuSpeedInMHz
-            DetectionRules                  = $complexDetectionRules
-            RequirementRules                = $complexRequirementRules
             InstallExperience               = $complexInstallExperience
             ReturnCodes                     = $complexReturnCodes
+            Rules                           = $complexRules
             MsiInformation                  = $complexMsiInformation
             SetupFilePath                   = $getValue.AdditionalProperties.setupFilePath
             MinimumSupportedWindowsRelease  = $getValue.AdditionalProperties.minimumSupportedWindowsRelease
@@ -410,7 +356,7 @@ function Get-TargetResource
         $assignmentResult = @()
         if ($assignmentsValues.Count -gt 0)
         {
-            $assignmentResult += ConvertFrom-IntunePolicyAssignment -Assignments $assignmentsValues -IncludeDeviceFilter $true
+            $assignmentResult += ConvertFrom-IntuneMobileAppAssignment -Assignments $assignmentsValues -IncludeDeviceFilter $true
         }
         $results.Add('Assignments', $assignmentResult)
 
@@ -479,6 +425,10 @@ function Set-TargetResource
         $Publisher,
 
         [Parameter()]
+        [System.String]
+        $FileName,
+
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Categories,
 
@@ -495,10 +445,6 @@ function Set-TargetResource
         $AllowedArchitectures,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
-        $MinimumSupportedOperatingSystem,
-
-        [Parameter()]
         [System.Int32]
         $MinimumFreeDiskSpaceInMB,
 
@@ -513,14 +459,6 @@ function Set-TargetResource
         [Parameter()]
         [System.Int32]
         $MinimumCpuSpeedInMHz,
-
-        [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
-        $DetectionRules,
-
-        [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
-        $RequirementRules,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
@@ -614,6 +552,7 @@ function Set-TargetResource
     $currentInstance = Get-TargetResource @PSBoundParameters
 
     $boundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+    $boundParameters.Remove('Categories') | Out-Null
 
     if ($boundParameters.ContainsKey('AllowedArchitectures'))
     {
@@ -624,6 +563,13 @@ function Set-TargetResource
 
         $boundParameters.Remove('AllowedArchitectures') | Out-Null
         $boundParameters.Add('AllowedArchitectures', ($PSBoundParameters.AllowedArchitectures -join ','))
+        $PSBoundParameters.Add('ApplicableArchitectures', 'none')
+        $boundParameters.Add('ApplicableArchitectures', 'none')
+
+        if ([System.String]::IsNullOrEmpty($boundParameters.AllowedArchitectures))
+        {
+            $boundParameters.AllowedArchitectures = $null
+        }
     }
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
@@ -636,56 +582,51 @@ function Set-TargetResource
         $createParameters.Remove('Id') | Out-Null
 
         $keys = (([Hashtable]$createParameters).Clone()).Keys
+        $allRules = @()
         foreach ($key in $keys)
         {
-            if ($null -ne $createParameters.$key -and $createParameters.$key.GetType().Name -like '*CimInstance*')
+            if ($null -ne $createParameters.$key -and $PSBoundParameters.$key.GetType().Name -like '*CimInstance*')
             {
                 $createParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $createParameters.$key
 
-                $rulesToProcess = @()
-                $isDetectionRule = $false
-                if ($key -eq 'DetectionRules')
+                if ($key -eq 'Rules')
                 {
-                    $isDetectionRule = $true
-                    $rulesToProcess = $createParameters.DetectionRules
-                }
-                elseif ($key -eq 'RequirementRules')
-                {
-                    $rulesToProcess = $createParameters.RequirementRules
-                }
-                foreach ($rule in $rulesToProcess)
-                {
-                    $odataType = $rule.OdataType
-                    $rule.Remove('OdataType') | Out-Null
-                    if ($isDetectionRule)
+                    $rulesToProcess = @()
+                    $rulesToProcess = $createParameters.$key
+
+                    foreach ($rule in $rulesToProcess)
                     {
-                        $rule.Add('@odata.type', "#microsoft.graph.win32LobApp$odataType" + 'Detection')
-                    }
-                    else
-                    {
-                        $rule.Add('@odata.type', "#microsoft.graph.win32LobApp$odataType" + 'Requirement')
-                    }
-                    switch ($odataType)
-                    {
-                        'FileSystem' {
-                            $rule.Add('DetectionType', $rule.FileSystemDetectionType)
-                            $rule.Remove('FileSystemDetectionType') | Out-Null
-                        }
-                        'Registry' {
-                            $rule.Add('DetectionType', $rule.RegistryDetectionType)
-                            $rule.Remove('RegistryDetectionType') | Out-Null
-                        }
-                        'PowerShellScript' {
-                            $rule.Add('ScriptContent', [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($rule.Script)))
-                            $rule.Remove('Script') | Out-Null
+                        $odataType = $rule.'@odata.type'
+                        $rule.'@odata.type' = "#microsoft.graph.win32LobApp$($odataType)Rule"
+                        switch ($odataType)
+                        {
+                            'FileSystem' {
+                                $rule.Add('operationType', $rule.fileSystemOperationType)
+                                $rule.Remove('fileSystemOperationType') | Out-Null
+                            }
+                            'Registry' {
+                                $rule.Add('operationType', $rule.registryOperationType)
+                                $rule.Remove('registryOperationType') | Out-Null
+                            }
+                            'PowerShellScript' {
+                                $rule.Add('scriptContent', [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($rule.script)))
+                                $rule.Remove('script') | Out-Null
+                                $rule.Add('operationType', $rule.powerShellScriptOperationType)
+                                $rule.Remove('powerShellScriptOperationType') | Out-Null
+                            }
                         }
                     }
+
+                    $createParameters.$key = $rulesToProcess
+                    $allRules += $rulesToProcess
                 }
             }
         }
         #region resource generator code
         $createParameters.Add("@odata.type", "#microsoft.graph.win32LobApp")
         $policy = Invoke-MgGraphRequest -Method POST -Uri "/beta/deviceAppManagement/mobileApps" -Body ($createParameters | ConvertTo-Json -Depth 10)
+
+        Invoke-M365DSCIntuneMobileAppInitialUpload -AppId $policy.Id -OdataType "#microsoft.graph.win32LobApp" -FileExtension "intunewin"
 
         if ($PSBoundParameters.ContainsKey('Categories'))
         {
@@ -712,50 +653,43 @@ function Set-TargetResource
         $updateParameters.Remove('Id') | Out-Null
 
         $keys = (([Hashtable]$updateParameters).Clone()).Keys
+        $allRules = @()
         foreach ($key in $keys)
         {
-            if ($null -ne $createParameters.$key -and $createParameters.$key.GetType().Name -like '*CimInstance*')
+            if ($null -ne $updateParameters.$key -and $PSBoundParameters.$key.GetType().Name -like '*CimInstance*')
             {
-                $createParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $createParameters.$key
+                $updateParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $updateParameters.$key
 
-                $rulesToProcess = @()
-                $isDetectionRule = $false
-                if ($key -eq 'DetectionRules')
+                if ($key -eq 'Rules')
                 {
-                    $isDetectionRule = $true
-                    $rulesToProcess = $createParameters.DetectionRules
-                }
-                elseif ($key -eq 'RequirementRules')
-                {
-                    $rulesToProcess = $createParameters.RequirementRules
-                }
-                foreach ($rule in $rulesToProcess)
-                {
-                    $odataType = $rule.OdataType
-                    $rule.Remove('OdataType') | Out-Null
-                    if ($isDetectionRule)
+                    $rulesToProcess = @()
+                    $rulesToProcess = $updateParameters.$key
+
+                    foreach ($rule in $rulesToProcess)
                     {
-                        $rule.Add('@odata.type', "#microsoft.graph.win32LobApp$odataType" + 'Detection')
-                    }
-                    else
-                    {
-                        $rule.Add('@odata.type', "#microsoft.graph.win32LobApp$odataType" + 'Requirement')
-                    }
-                    switch ($odataType)
-                    {
-                        'FileSystem' {
-                            $rule.Add('DetectionType', $rule.FileSystemDetectionType)
-                            $rule.Remove('FileSystemDetectionType') | Out-Null
-                        }
-                        'Registry' {
-                            $rule.Add('DetectionType', $rule.RegistryDetectionType)
-                            $rule.Remove('RegistryDetectionType') | Out-Null
-                        }
-                        'PowerShellScript' {
-                            $rule.Add('ScriptContent', [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($rule.Script)))
-                            $rule.Remove('Script') | Out-Null
+                        $odataType = $rule.'@odata.type'
+                        $rule.'@odata.type' = "#microsoft.graph.win32LobApp$($odataType)Rule"
+                        switch ($odataType)
+                        {
+                            'FileSystem' {
+                                $rule.Add('operationType', $rule.fileSystemOperationType)
+                                $rule.Remove('fileSystemOperationType') | Out-Null
+                            }
+                            'Registry' {
+                                $rule.Add('operationType', $rule.registryOperationType)
+                                $rule.Remove('registryOperationType') | Out-Null
+                            }
+                            'PowerShellScript' {
+                                $rule.Add('scriptContent', [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($rule.script)))
+                                $rule.Remove('script') | Out-Null
+                                $rule.Add('operationType', $rule.powerShellScriptOperationType)
+                                $rule.Remove('powerShellScriptOperationType') | Out-Null
+                            }
                         }
                     }
+
+                    $updateParameters.$key = $rulesToProcess
+                    $allRules += $rulesToProcess
                 }
             }
         }
@@ -836,6 +770,10 @@ function Test-TargetResource
         $Publisher,
 
         [Parameter()]
+        [System.String]
+        $FileName,
+
+        [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Categories,
 
@@ -852,10 +790,6 @@ function Test-TargetResource
         $AllowedArchitectures,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
-        $MinimumSupportedOperatingSystem,
-
-        [Parameter()]
         [System.Int32]
         $MinimumFreeDiskSpaceInMB,
 
@@ -870,14 +804,6 @@ function Test-TargetResource
         [Parameter()]
         [System.Int32]
         $MinimumCpuSpeedInMHz,
-
-        [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
-        $DetectionRules,
-
-        [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
-        $RequirementRules,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
@@ -981,7 +907,7 @@ function Test-TargetResource
         {
             $testResult = Compare-M365DSCComplexObject `
                 -Source ($source) `
-                -Target ($target)
+                -Target ($target) -Verbose
 
             if (-not $testResult)
             {
@@ -1135,32 +1061,18 @@ function Export-TargetResource
                     $Results.Remove('Categories') | Out-Null
                 }
             }
-            if ($null -ne $Results.DetectionRules)
+            if ($null -ne $Results.Rules)
             {
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
-                    -ComplexObject $Results.DetectionRules `
-                    -CIMInstanceName 'MicrosoftGraphWin32LobAppDetection'
+                    -ComplexObject $Results.Rules `
+                    -CIMInstanceName 'MicrosoftGraphWin32LobAppRule'
                 if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
                 {
-                    $Results.DetectionRules = $complexTypeStringResult
+                    $Results.Rules = $complexTypeStringResult
                 }
                 else
                 {
-                    $Results.Remove('DetectionRules') | Out-Null
-                }
-            }
-            if ($null -ne $Results.RequirementRules)
-            {
-                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
-                    -ComplexObject $Results.RequirementRules `
-                    -CIMInstanceName 'MicrosoftGraphWin32LobAppRequirement'
-                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
-                {
-                    $Results.RequirementRules = $complexTypeStringResult
-                }
-                else
-                {
-                    $Results.Remove('RequirementRules') | Out-Null
+                    $Results.Remove('Rules') | Out-Null
                 }
             }
             if ($null -ne $Results.InstallExperience)
@@ -1219,24 +1131,35 @@ function Export-TargetResource
                     $Results.Remove('LargeIcon') | Out-Null
                 }
             }
-            if ($null -ne $Results.MinimumSupportedOperatingSystem)
-            {
-                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
-                    -ComplexObject $Results.MinimumSupportedOperatingSystem `
-                    -CIMInstanceName 'MicrosoftGraphWindowsMinimumOperatingSystem'
-                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
-                {
-                    $Results.MinimumSupportedOperatingSystem = $complexTypeStringResult
-                }
-                else
-                {
-                    $Results.Remove('MinimumSupportedOperatingSystem') | Out-Null
-                }
-            }
 
             if ($Results.Assignments)
             {
-                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementMobileAppAssignment
+                $complexMapping = @(
+                    @{
+                        Name = 'AssignmentSettings'
+                        CIMInstanceName = 'DeviceManagementWin32MobileAppAssignmentSettings'
+                        IsRequired = $false
+                    },
+                    @{
+                        Name = 'AutoUpdateSettings'
+                        CIMInstanceName = 'DeviceManagementWin32MobileAppAssignmentSettingsAutoUpdateSettings'
+                        IsRequired = $false
+                    },
+                    @{
+                        Name = 'InstallTimeSettings'
+                        CIMInstanceName = 'DeviceManagementWin32MobileAppAssignmentSettingsInstallTimeSettings'
+                        IsRequired = $false
+                    },
+                    @{
+                        Name = 'RestartSettings'
+                        CIMInstanceName = 'DeviceManagementWin32MobileAppAssignmentSettingsRestartSettings'
+                        IsRequired = $false
+                    }
+                )
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.Assignments `
+                    -CIMInstanceName DeviceManagementWin32MobileAppAssignment `
+                    -ComplexTypeMapping $complexMapping
                 if ($complexTypeStringResult)
                 {
                     $Results.Assignments = $complexTypeStringResult
@@ -1252,7 +1175,7 @@ function Export-TargetResource
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
                 -Credential $Credential `
-                -NoEscape @('Assignments', 'Categories', 'DetectionRules', 'RequirementRules', 'LargeIcon', 'InstallExperience', 'ReturnCodes', 'MsiInformation', 'MinimumSupportedOperatingSystem')
+                -NoEscape @('Assignments', 'Categories', 'Rules', 'LargeIcon', 'InstallExperience', 'ReturnCodes', 'MsiInformation')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/MSFT_IntuneMobileAppsWin32AppWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/MSFT_IntuneMobileAppsWin32AppWindows10.psm1
@@ -1,0 +1,1278 @@
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [System.String]
+        $Developer,
+
+        [Parameter()]
+        [System.String]
+        $InformationUrl,
+
+        [Parameter()]
+        [System.Boolean]
+        $IsFeatured,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $LargeIcon,
+
+        [Parameter()]
+        [System.String]
+        $Notes,
+
+        [Parameter()]
+        [System.String]
+        $Owner,
+
+        [Parameter()]
+        [System.String]
+        $PrivacyInformationUrl,
+
+        [Parameter()]
+        [System.String]
+        $Publisher,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Categories,
+
+        [Parameter()]
+        [System.String]
+        $InstallCommandLine,
+
+        [Parameter()]
+        [System.String]
+        $UninstallCommandLine,
+
+        [Parameter()]
+        [System.String[]]
+        $AllowedArchitectures,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $MinimumSupportedOperatingSystem,
+
+        [Parameter()]
+        [System.Int32]
+        $MinimumFreeDiskSpaceInMB,
+
+        [Parameter()]
+        [System.Int32]
+        $MinimumMemoryInMB,
+
+        [Parameter()]
+        [System.Int32]
+        $MinimumNumberOfProcessors,
+
+        [Parameter()]
+        [System.Int32]
+        $MinimumCpuSpeedInMHz,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $DetectionRules,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $RequirementRules,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Rules,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $InstallExperience,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $ReturnCodes,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $MsiInformation,
+
+        [Parameter()]
+        [System.String]
+        $SetupFilePath,
+
+        [Parameter()]
+        [System.String]
+        $MinimumSupportedWindowsRelease,
+
+        [Parameter()]
+        [System.String]
+        $DisplayVersion,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowAvailableUninstall,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    Write-Verbose -Message "Getting configuration for the Intune Mobile Apps Win32 App for Windows10 with Id {$Id} and DisplayName {$DisplayName}"
+
+    try
+    {
+        if (-not $Script:exportedInstance -or $Script:exportedInstance.DisplayName -ne $DisplayName)
+        {
+
+            $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+                -InboundParameters $PSBoundParameters
+
+            #Ensure the proper dependencies are installed in the current environment.
+            Confirm-M365DSCDependencies
+
+            #region Telemetry
+            $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+            $CommandName = $MyInvocation.MyCommand
+            $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+                -CommandName $CommandName `
+                -Parameters $PSBoundParameters
+            Add-M365DSCTelemetryEvent -Data $data
+            #endregion
+
+            $nullResult = $PSBoundParameters
+            $nullResult.Ensure = 'Absent'
+
+            $getValue = $null
+
+            #region resource generator code
+            if (-not [System.String]::IsNullOrEmpty($Id))
+            {
+                $getValue = Get-MgBetaDeviceAppManagementMobileApp -MobileAppId $Id -ExpandProperty 'Categories' -ErrorAction SilentlyContinue
+            }
+
+            if ($null -eq $getValue)
+            {
+                Write-Verbose -Message "Could not find an Intune Mobile Apps Win32 App for Windows10 with Id {$Id}"
+
+                if (-not [System.String]::IsNullOrEmpty($DisplayName))
+                {
+                    $getValue = Get-MgBetaDeviceAppManagementMobileApp `
+                        -Filter "DisplayName eq '$($DisplayName -replace "'", "''")' and isof('microsoft.graph.win32LobApp')" `
+                        -ExpandProperty 'Categories' `
+                        -All `
+                        -ErrorAction SilentlyContinue
+                }
+            }
+            #endregion
+            if ($null -eq $getValue)
+            {
+                Write-Verbose -Message "Could not find an Intune Mobile Apps Win32 App for Windows10 with DisplayName {$DisplayName}."
+                return $nullResult
+            }
+        }
+        else
+        {
+            $getValue = Get-MgBetaDeviceAppManagementMobileApp -MobileAppId $getValue.Id -ExpandProperty 'Categories'
+        }
+        $Id = $getValue.Id
+        Write-Verbose -Message "An Intune Mobile Apps Win32 App for Windows10 with Id {$Id} and DisplayName {$DisplayName} was found"
+
+        #region resource generator code
+        $complexCategories = @()
+        foreach ($category in $getValue.Categories)
+        {
+            $myCategory = @{}
+            $myCategory.Add('Id', $category.id)
+            $myCategory.Add('DisplayName', $category.displayName)
+            $complexCategories += $myCategory
+        }
+        $complexLargeIcon = $null
+        if ($null -ne $getValue.LargeIcon.Value)
+        {
+            $complexLargeIcon = @{}
+            $complexLargeIcon.Add('Type', $getValue.LargeIcon.Type)
+            $complexLargeIcon.Add('Value', [System.Convert]::ToBase64String($getValue.LargeIcon.Value))
+        }
+
+        $complexMinimumSupportedOperatingSystem = [ordered]@{}
+        $complexMinimumSupportedOperatingSystem.Add('V8_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v8_0)
+        $complexMinimumSupportedOperatingSystem.Add('V8_1', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v8_1)
+        $complexMinimumSupportedOperatingSystem.Add('V10_0', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_0)
+        $complexMinimumSupportedOperatingSystem.Add('V10_1607', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1607)
+        $complexMinimumSupportedOperatingSystem.Add('V10_1703', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1703)
+        $complexMinimumSupportedOperatingSystem.Add('V10_1709', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1709)
+        $complexMinimumSupportedOperatingSystem.Add('V10_1803', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1803)
+        $complexMinimumSupportedOperatingSystem.Add('V10_1809', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1809)
+        $complexMinimumSupportedOperatingSystem.Add('V10_1903', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1903)
+        $complexMinimumSupportedOperatingSystem.Add('V10_1909', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_1909)
+        $complexMinimumSupportedOperatingSystem.Add('V10_2004', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_2004)
+        $complexMinimumSupportedOperatingSystem.Add('V10_2H20', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_2H20)
+        $complexMinimumSupportedOperatingSystem.Add('V10_21H1', $getValue.AdditionalProperties.minimumSupportedOperatingSystem.v10_21H1)
+        if ($complexMinimumSupportedOperatingSystem.Values.Where({ $null -ne $_ }).Count -eq 0)
+        {
+            $complexMinimumSupportedOperatingSystem = $null
+        }
+
+        $complexDetectionRules = @()
+        foreach ($detectionRule in $getValue.AdditionalProperties.detectionRules)
+        {
+            $detectionType = $detectionRule.'@odata.type'.Replace('#microsoft.graph.win32LobApp', '').Replace('Detection', '')
+            $baseDetectionRule = @{
+                OdataType      = $detectionType
+                Operator       = $detectionRule.operator
+                DetectionValue = $detectionRule.detectionValue
+            }
+            switch ($detectionType)
+            {
+                'FileSystem' {
+                    $baseDetectionRule.Add('Check32BitOn64System', $detectionRule.check32BitOn64System)
+                    $baseDetectionRule.Add('Path', $detectionRule.path)
+                    $baseDetectionRule.Add('FileOrFolderName', $detectionRule.fileOrFolderName)
+                    $baseDetectionRule.Add('FileSystemDetectionType', $detectionRule.detectionType)
+                }
+                'Registry' {
+                    $baseDetectionRule.Add('Check32BitOn64System', $detectionRule.check32BitOn64System)
+                    $baseDetectionRule.Add('KeyPath', $detectionRule.keyPath)
+                    $baseDetectionRule.Add('RegistryDetectionType', $detectionRule.detectionType)
+                    $baseDetectionRule.Add('ValueName', $detectionRule.registryValueName)
+                }
+                "ProductCode" {
+                    $baseDetectionRule.Add('ProductCode', $detectionRule.productCode)
+                    $baseDetectionRule.Add('ProductVersionOperator', $detectionRule.productVersionOperator)
+                    $baseDetectionRule.Add('ProductVersion', $detectionRule.productVersion)
+                }
+                "PowerShellScript" {
+                    $baseDetectionRule.Add('Script', [System.Convert]::FromBase64String($detectionRule.scriptContent))
+                    $baseDetectionRule.Add('RunAs32Bit', $detectionRule.runAs32Bit)
+                    $baseDetectionRule.Add('EnforceSignatureCheck', $detectionRule.enforceSignatureCheck)
+                }
+            }
+            $complexDetectionRules += $baseDetectionRule
+        }
+
+        $complexRequirementRules = @()
+        foreach ($requirementRule in $getValue.AdditionalProperties.requirementRules)
+        {
+            $requirementType = $requirementRule.'@odata.type'.Replace('#microsoft.graph.win32LobApp', '').Replace('Requirement', '')
+            $baseRequirementRule = @{
+                OdataType      = $requirementType
+                Operator       = $requirementRule.operator
+                DetectionValue = $requirementRule.detectionValue
+            }
+            switch ($requirementType)
+            {
+                'FileSystem' {
+                    $baseRequirementRule.Add('Check32BitOn64System', $requirementRule.check32BitOn64System)
+                    $baseRequirementRule.Add('Path', $requirementRule.path)
+                    $baseRequirementRule.Add('FileOrFolderName', $requirementRule.fileOrFolderName)
+                    $baseRequirementRule.Add('FileSystemDetectionType', $requirementRule.detectionType)
+                }
+                'Registry' {
+                    $baseRequirementRule.Add('Check32BitOn64System', $requirementRule.check32BitOn64System)
+                    $baseRequirementRule.Add('KeyPath', $requirementRule.keyPath)
+                    $baseRequirementRule.Add('RegistryDetectionType', $requirementRule.detectionType)
+                    $baseRequirementRule.Add('ValueName', $requirementRule.registryValueName)
+                }
+                "PowerShellScript" {
+                    $baseRequirementRule.Add('Script', [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($requirementRule.scriptContent)))
+                    $baseRequirementRule.Add('RunAs32Bit', $requirementRule.runAs32Bit)
+                    $baseRequirementRule.Add('EnforceSignatureCheck', $requirementRule.enforceSignatureCheck)
+                    $baseRequirementRule.Add('RunAsAccountType', $requirementRule.runAsAccountType)
+                    $baseRequirementRule.Add('PowerShellScriptDetectionType', $requirementRule.detectionType)
+                }
+            }
+            $complexRequirementRules += $baseRequirementRule
+        }
+
+        if ($null -ne $getValue.AdditionalProperties.InstallExperience)
+        {
+            $complexInstallExperience = @{}
+            $complexInstallExperience.Add('DeviceRestartBehavior', $getValue.AdditionalProperties.installExperience.deviceRestartBehavior)
+            $complexInstallExperience.Add('MaxRunTimeInMinutes', $getValue.AdditionalProperties.installExperience.maxRunTimeInMinutes)
+            $complexInstallExperience.Add('RunAsAccountType', $getValue.AdditionalProperties.installExperience.runAsAccountType)
+        }
+
+        $complexReturnCodes = @()
+        foreach ($returnCode in $getValue.AdditionalProperties.returnCodes)
+        {
+            $complexReturnCodes += @{
+                ReturnCode = $returnCode.returnCode
+                Type = $returnCode.type
+            }
+        }
+
+        if ($null -ne $getValue.AdditionalProperties.msiInformation)
+        {
+            $complexMsiInformation = @{}
+            $complexMsiInformation.Add('ProductCode', $getValue.AdditionalProperties.msiInformation.productCode)
+            $complexMsiInformation.Add('ProductVersion', $getValue.AdditionalProperties.msiInformation.productVersion)
+            $complexMsiInformation.Add('UpgradeCode', $getValue.AdditionalProperties.msiInformation.upgradeCode)
+            $complexMsiInformation.Add('RequiresReboot', $getValue.AdditionalProperties.msiInformation.requiresReboot)
+            $complexMsiInformation.Add('PackageType', $getValue.AdditionalProperties.msiInformation.packageType)
+            $complexMsiInformation.Add('ProductName', $getValue.AdditionalProperties.msiInformation.productName)
+            $complexMsiInformation.Add('Publisher', $getValue.AdditionalProperties.msiInformation.publisher)
+        }
+        #endregion
+
+        $results = @{
+            #region resource generator code
+            AllowedArchitectures            = $getValue.AdditionalProperties.allowedArchitectures -split ","
+            Categories                      = $complexCategories
+            Description                     = $getValue.Description
+            Developer                       = $getValue.Developer
+            DisplayName                     = $getValue.DisplayName
+            InformationUrl                  = $getValue.InformationUrl
+            InstallCommandLine              = $getValue.AdditionalProperties.installCommandLine
+            UninstallCommandLine            = $getValue.AdditionalProperties.uninstallCommandLine
+            MinimumSupportedOperatingSystem = $complexMinimumSupportedOperatingSystem
+            MinimumFreeDiskSpaceInMB        = $getValue.AdditionalProperties.minimumFreeDiskSpaceInMB
+            MinimumMemoryInMB               = $getValue.AdditionalProperties.minimumMemoryInMB
+            MinimumNumberOfProcessors       = $getValue.AdditionalProperties.minimumNumberOfProcessors
+            MinimumCpuSpeedInMHz            = $getValue.AdditionalProperties.minimumCpuSpeedInMHz
+            DetectionRules                  = $complexDetectionRules
+            RequirementRules                = $complexRequirementRules
+            InstallExperience               = $complexInstallExperience
+            ReturnCodes                     = $complexReturnCodes
+            MsiInformation                  = $complexMsiInformation
+            SetupFilePath                   = $getValue.AdditionalProperties.setupFilePath
+            MinimumSupportedWindowsRelease  = $getValue.AdditionalProperties.minimumSupportedWindowsRelease
+            DisplayVersion                  = $getValue.AdditionalProperties.displayVersion
+            AllowAvailableUninstall         = $getValue.AdditionalProperties.allowAvailableUninstall
+            IsFeatured                      = $getValue.IsFeatured
+            LargeIcon                       = $complexLargeIcon
+            Notes                           = $getValue.Notes
+            Owner                           = $getValue.Owner
+            PrivacyInformationUrl           = $getValue.PrivacyInformationUrl
+            Publisher                       = $getValue.Publisher
+            RoleScopeTagIds                 = $getValue.RoleScopeTagIds
+            Id                              = $getValue.Id
+            Ensure                          = 'Present'
+            Credential                      = $Credential
+            ApplicationId                   = $ApplicationId
+            TenantId                        = $TenantId
+            ApplicationSecret               = $ApplicationSecret
+            CertificateThumbprint           = $CertificateThumbprint
+            ManagedIdentity                 = $ManagedIdentity.IsPresent
+            #endregion
+        }
+        $assignmentsValues = Get-MgBetaDeviceAppManagementMobileAppAssignment -MobileAppId $Id
+        $assignmentResult = @()
+        if ($assignmentsValues.Count -gt 0)
+        {
+            $assignmentResult += ConvertFrom-IntunePolicyAssignment -Assignments $assignmentsValues -IncludeDeviceFilter $true
+        }
+        $results.Add('Assignments', $assignmentResult)
+
+        return [System.Collections.Hashtable] $results
+    }
+    catch
+    {
+        New-M365DSCLogEntry -Message 'Error retrieving data:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return $nullResult
+    }
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [System.String]
+        $Developer,
+
+        [Parameter()]
+        [System.String]
+        $InformationUrl,
+
+        [Parameter()]
+        [System.Boolean]
+        $IsFeatured,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $LargeIcon,
+
+        [Parameter()]
+        [System.String]
+        $Notes,
+
+        [Parameter()]
+        [System.String]
+        $Owner,
+
+        [Parameter()]
+        [System.String]
+        $PrivacyInformationUrl,
+
+        [Parameter()]
+        [System.String]
+        $Publisher,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Categories,
+
+        [Parameter()]
+        [System.String]
+        $InstallCommandLine,
+
+        [Parameter()]
+        [System.String]
+        $UninstallCommandLine,
+
+        [Parameter()]
+        [System.String[]]
+        $AllowedArchitectures,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $MinimumSupportedOperatingSystem,
+
+        [Parameter()]
+        [System.Int32]
+        $MinimumFreeDiskSpaceInMB,
+
+        [Parameter()]
+        [System.Int32]
+        $MinimumMemoryInMB,
+
+        [Parameter()]
+        [System.Int32]
+        $MinimumNumberOfProcessors,
+
+        [Parameter()]
+        [System.Int32]
+        $MinimumCpuSpeedInMHz,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $DetectionRules,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $RequirementRules,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Rules,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $InstallExperience,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $ReturnCodes,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $MsiInformation,
+
+        [Parameter()]
+        [System.String]
+        $SetupFilePath,
+
+        [Parameter()]
+        [System.String]
+        $MinimumSupportedWindowsRelease,
+
+        [Parameter()]
+        [System.String]
+        $DisplayVersion,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowAvailableUninstall,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    Write-Verbose -Message "Setting configuration of the Intune Mobile Apps Win32 App for Windows10 with Id {$Id} and DisplayName {$DisplayName}"
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    $currentInstance = Get-TargetResource @PSBoundParameters
+
+    $boundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+
+    if ($boundParameters.ContainsKey('AllowedArchitectures'))
+    {
+        if ($boundParameters.AllowedArchitectures -contains 'none' -and $boundParameters.AllowedArchitectures.Count -gt 1)
+        {
+            throw "AllowedArchitectures cannot contain 'none' when other architectures are specified."
+        }
+
+        $boundParameters.Remove('AllowedArchitectures') | Out-Null
+        $boundParameters.Add('AllowedArchitectures', ($PSBoundParameters.AllowedArchitectures -join ','))
+    }
+
+    if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
+    {
+        Write-Verbose -Message "Creating an Intune Mobile Apps Win32 App for Windows10 with DisplayName {$DisplayName}"
+        $boundParameters.Remove("Assignments") | Out-Null
+
+        $createParameters = ([Hashtable]$boundParameters).Clone()
+        $createParameters = Rename-M365DSCCimInstanceParameter -Properties $createParameters
+        $createParameters.Remove('Id') | Out-Null
+
+        $keys = (([Hashtable]$createParameters).Clone()).Keys
+        foreach ($key in $keys)
+        {
+            if ($null -ne $createParameters.$key -and $createParameters.$key.GetType().Name -like '*CimInstance*')
+            {
+                $createParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $createParameters.$key
+
+                $rulesToProcess = @()
+                $isDetectionRule = $false
+                if ($key -eq 'DetectionRules')
+                {
+                    $isDetectionRule = $true
+                    $rulesToProcess = $createParameters.DetectionRules
+                }
+                elseif ($key -eq 'RequirementRules')
+                {
+                    $rulesToProcess = $createParameters.RequirementRules
+                }
+                foreach ($rule in $rulesToProcess)
+                {
+                    $odataType = $rule.OdataType
+                    $rule.Remove('OdataType') | Out-Null
+                    if ($isDetectionRule)
+                    {
+                        $rule.Add('@odata.type', "#microsoft.graph.win32LobApp$odataType" + 'Detection')
+                    }
+                    else
+                    {
+                        $rule.Add('@odata.type', "#microsoft.graph.win32LobApp$odataType" + 'Requirement')
+                    }
+                    switch ($odataType)
+                    {
+                        'FileSystem' {
+                            $rule.Add('DetectionType', $rule.FileSystemDetectionType)
+                            $rule.Remove('FileSystemDetectionType') | Out-Null
+                        }
+                        'Registry' {
+                            $rule.Add('DetectionType', $rule.RegistryDetectionType)
+                            $rule.Remove('RegistryDetectionType') | Out-Null
+                        }
+                        'PowerShellScript' {
+                            $rule.Add('ScriptContent', [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($rule.Script)))
+                            $rule.Remove('Script') | Out-Null
+                        }
+                    }
+                }
+            }
+        }
+        #region resource generator code
+        $createParameters.Add("@odata.type", "#microsoft.graph.win32LobApp")
+        $policy = Invoke-MgGraphRequest -Method POST -Uri "/beta/deviceAppManagement/mobileApps" -Body ($createParameters | ConvertTo-Json -Depth 10)
+
+        if ($PSBoundParameters.ContainsKey('Categories'))
+        {
+            Update-DeviceAppManagementAppCategory -App $policy -Categories $Categories
+        }
+
+        if ($policy.Id)
+        {
+            $assignmentsHash = ConvertTo-IntuneMobileAppAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
+            Update-DeviceAppManagementPolicyAssignment `
+                -AppManagementPolicyId $policy.Id `
+                -Assignments $assignmentsHash
+        }
+        #endregion
+    }
+    elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Updating the Intune Mobile Apps Win32 App for Windows10 with Id {$($currentInstance.Id)}"
+        $boundParameters.Remove("Assignments") | Out-Null
+
+        $updateParameters = ([Hashtable]$boundParameters).Clone()
+        $updateParameters = Rename-M365DSCCimInstanceParameter -Properties $updateParameters
+
+        $updateParameters.Remove('Id') | Out-Null
+
+        $keys = (([Hashtable]$updateParameters).Clone()).Keys
+        foreach ($key in $keys)
+        {
+            if ($null -ne $createParameters.$key -and $createParameters.$key.GetType().Name -like '*CimInstance*')
+            {
+                $createParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $createParameters.$key
+
+                $rulesToProcess = @()
+                $isDetectionRule = $false
+                if ($key -eq 'DetectionRules')
+                {
+                    $isDetectionRule = $true
+                    $rulesToProcess = $createParameters.DetectionRules
+                }
+                elseif ($key -eq 'RequirementRules')
+                {
+                    $rulesToProcess = $createParameters.RequirementRules
+                }
+                foreach ($rule in $rulesToProcess)
+                {
+                    $odataType = $rule.OdataType
+                    $rule.Remove('OdataType') | Out-Null
+                    if ($isDetectionRule)
+                    {
+                        $rule.Add('@odata.type', "#microsoft.graph.win32LobApp$odataType" + 'Detection')
+                    }
+                    else
+                    {
+                        $rule.Add('@odata.type', "#microsoft.graph.win32LobApp$odataType" + 'Requirement')
+                    }
+                    switch ($odataType)
+                    {
+                        'FileSystem' {
+                            $rule.Add('DetectionType', $rule.FileSystemDetectionType)
+                            $rule.Remove('FileSystemDetectionType') | Out-Null
+                        }
+                        'Registry' {
+                            $rule.Add('DetectionType', $rule.RegistryDetectionType)
+                            $rule.Remove('RegistryDetectionType') | Out-Null
+                        }
+                        'PowerShellScript' {
+                            $rule.Add('ScriptContent', [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($rule.Script)))
+                            $rule.Remove('Script') | Out-Null
+                        }
+                    }
+                }
+            }
+        }
+
+        #region resource generator code
+        $updateParameters.Add("@odata.type", "#microsoft.graph.win32LobApp")
+        Invoke-MgGraphRequest -Method PATCH -Uri "/beta/deviceAppManagement/mobileApps/$($currentInstance.Id)" -Body ($updateParameters | ConvertTo-Json -Depth 10)
+
+        if ($PSBoundParameters.ContainsKey('Categories'))
+        {
+            Update-DeviceAppManagementAppCategory -App $currentInstance -Categories $Categories -Compare
+        }
+
+        $assignmentsHash = ConvertTo-IntuneMobileAppAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
+        Update-DeviceAppManagementPolicyAssignment `
+            -AppManagementPolicyId $currentInstance.Id `
+            -Assignments $assignmentsHash
+        #endregion
+    }
+    elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Removing the Intune Mobile Apps Win32 App for Windows10 with Id {$($currentInstance.Id)}"
+        #region resource generator code
+        Remove-MgBetaDeviceAppManagementMobileApp -MobileAppId $currentInstance.Id
+        #endregion
+    }
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [System.String]
+        $Developer,
+
+        [Parameter()]
+        [System.String]
+        $InformationUrl,
+
+        [Parameter()]
+        [System.Boolean]
+        $IsFeatured,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $LargeIcon,
+
+        [Parameter()]
+        [System.String]
+        $Notes,
+
+        [Parameter()]
+        [System.String]
+        $Owner,
+
+        [Parameter()]
+        [System.String]
+        $PrivacyInformationUrl,
+
+        [Parameter()]
+        [System.String]
+        $Publisher,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Categories,
+
+        [Parameter()]
+        [System.String]
+        $InstallCommandLine,
+
+        [Parameter()]
+        [System.String]
+        $UninstallCommandLine,
+
+        [Parameter()]
+        [System.String[]]
+        $AllowedArchitectures,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $MinimumSupportedOperatingSystem,
+
+        [Parameter()]
+        [System.Int32]
+        $MinimumFreeDiskSpaceInMB,
+
+        [Parameter()]
+        [System.Int32]
+        $MinimumMemoryInMB,
+
+        [Parameter()]
+        [System.Int32]
+        $MinimumNumberOfProcessors,
+
+        [Parameter()]
+        [System.Int32]
+        $MinimumCpuSpeedInMHz,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $DetectionRules,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $RequirementRules,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Rules,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $InstallExperience,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $ReturnCodes,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $MsiInformation,
+
+        [Parameter()]
+        [System.String]
+        $SetupFilePath,
+
+        [Parameter()]
+        [System.String]
+        $MinimumSupportedWindowsRelease,
+
+        [Parameter()]
+        [System.String]
+        $DisplayVersion,
+
+        [Parameter()]
+        [System.Boolean]
+        $AllowAvailableUninstall,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    Write-Verbose -Message "Testing configuration of the Intune Mobile Apps Win32 App for Windows10 with Id {$Id} and DisplayName {$DisplayName}"
+
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+    $ValuesToCheck = ([hashtable]$PSBoundParameters).Clone()
+    $testResult = $true
+
+    #Compare Cim instances
+    foreach ($key in $PSBoundParameters.Keys)
+    {
+        $source = $PSBoundParameters.$key
+        $target = $CurrentValues.$key
+        if ($null -ne $source -and $source.GetType().Name -like '*CimInstance*')
+        {
+            $testResult = Compare-M365DSCComplexObject `
+                -Source ($source) `
+                -Target ($target)
+
+            if (-not $testResult)
+            {
+                break
+            }
+
+            $ValuesToCheck.Remove($key) | Out-Null
+        }
+    }
+
+    $ValuesToCheck.Remove('Id') | Out-Null
+    $ValuesToCheck = Remove-M365DSCAuthenticationParameter -BoundParameters $ValuesToCheck
+
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
+    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $ValuesToCheck)"
+
+    if ($testResult)
+    {
+        $testResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -DesiredValues $PSBoundParameters `
+            -ValuesToCheck $ValuesToCheck.Keys
+    }
+
+    Write-Verbose -Message "Test-TargetResource returned $testResult"
+
+    return $testResult
+}
+
+function Export-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+        -InboundParameters $PSBoundParameters
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    try
+    {
+        #region resource generator code
+        $baseFilter = "isof('microsoft.graph.win32LobApp')"
+        if (-not [String]::IsNullOrEmpty($Filter))
+        {
+            $Filter = "($Filter) and ($baseFilter)"
+        }
+        else
+        {
+            $Filter = $baseFilter
+        }
+        [array]$getValue = Get-MgBetaDeviceAppManagementMobileApp `
+            -Filter $Filter `
+            -All `
+            -ErrorAction Stop
+        #endregion
+
+        $i = 1
+        $dscContent = ''
+        if ($getValue.Length -eq 0)
+        {
+            Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
+        }
+        else
+        {
+            Write-M365DSCHost -Message "`r`n" -DeferWrite
+        }
+        foreach ($config in $getValue)
+        {
+            $displayedKey = $config.Id
+            if (-not [String]::IsNullOrEmpty($config.displayName))
+            {
+                $displayedKey = $config.displayName
+            }
+            elseif (-not [string]::IsNullOrEmpty($config.name))
+            {
+                $displayedKey = $config.name
+            }
+            Write-M365DSCHost -Message "    |---[$i/$($getValue.Count)] $displayedKey" -DeferWrite
+            $params = @{
+                Id                    = $config.Id
+                DisplayName           = $config.DisplayName
+                Ensure                = 'Present'
+                Credential            = $Credential
+                ApplicationId         = $ApplicationId
+                TenantId              = $TenantId
+                ApplicationSecret     = $ApplicationSecret
+                CertificateThumbprint = $CertificateThumbprint
+                ManagedIdentity       = $ManagedIdentity.IsPresent
+                AccessTokens          = $AccessTokens
+            }
+
+            $Script:exportedInstance = $config
+            $Results = Get-TargetResource @Params
+            if ($null -ne $Results.Categories)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.Categories `
+                    -CIMInstanceName 'DeviceManagementMobileAppCategory'
+
+                if (-not [System.String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.Categories = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('Categories') | Out-Null
+                }
+            }
+            if ($null -ne $Results.DetectionRules)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.DetectionRules `
+                    -CIMInstanceName 'MicrosoftGraphWin32LobAppDetection'
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.DetectionRules = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('DetectionRules') | Out-Null
+                }
+            }
+            if ($null -ne $Results.RequirementRules)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.RequirementRules `
+                    -CIMInstanceName 'MicrosoftGraphWin32LobAppRequirement'
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.RequirementRules = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('RequirementRules') | Out-Null
+                }
+            }
+            if ($null -ne $Results.InstallExperience)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.InstallExperience `
+                    -CIMInstanceName 'MicrosoftGraphWin32LobAppInstallExperience'
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.InstallExperience = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('InstallExperience') | Out-Null
+                }
+            }
+            if ($null -ne $Results.ReturnCodes)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.ReturnCodes `
+                    -CIMInstanceName 'MicrosoftGraphWin32LobAppReturnCode'
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.ReturnCodes = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('ReturnCodes') | Out-Null
+                }
+            }
+            if ($null -ne $Results.MsiInformation)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.MsiInformation `
+                    -CIMInstanceName 'MicrosoftGraphWin32LobAppMsiInformation'
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.MsiInformation = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('MsiInformation') | Out-Null
+                }
+            }
+            if ($null -ne $Results.LargeIcon)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.LargeIcon `
+                    -CIMInstanceName 'DeviceManagementMimeContent'
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.LargeIcon = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('LargeIcon') | Out-Null
+                }
+            }
+            if ($null -ne $Results.MinimumSupportedOperatingSystem)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.MinimumSupportedOperatingSystem `
+                    -CIMInstanceName 'MicrosoftGraphWindowsMinimumOperatingSystem'
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.MinimumSupportedOperatingSystem = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('MinimumSupportedOperatingSystem') | Out-Null
+                }
+            }
+
+            if ($Results.Assignments)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementMobileAppAssignment
+                if ($complexTypeStringResult)
+                {
+                    $Results.Assignments = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('Assignments') | Out-Null
+                }
+            }
+
+            $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
+                -ConnectionMode $ConnectionMode `
+                -ModulePath $PSScriptRoot `
+                -Results $Results `
+                -Credential $Credential `
+                -NoEscape @('Assignments', 'Categories', 'DetectionRules', 'RequirementRules', 'LargeIcon', 'InstallExperience', 'ReturnCodes', 'MsiInformation', 'MinimumSupportedOperatingSystem')
+            $dscContent += $currentDSCBlock
+            Save-M365DSCPartialExport -Content $currentDSCBlock `
+                -FileName $Global:PartialExportFileName
+            $i++
+            Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
+        }
+        return $dscContent
+    }
+    catch
+    {
+        Write-M365DSCHost -Message $Global:M365DSCEmojiRedX -CommitWrite
+
+        New-M365DSCLogEntry -Message 'Error during Export:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return ''
+    }
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/MSFT_IntuneMobileAppsWin32AppWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/MSFT_IntuneMobileAppsWin32AppWindows10.schema.mof
@@ -10,6 +10,50 @@ class MSFT_DeviceManagementMobileAppAssignment
     [Write, Description("Possible values for the install intent chosen by the admin."), ValueMap{"available", "required", "uninstall", "availableWithoutEnrollment"}, Values{"available", "required", "uninstall", "availableWithoutEnrollment"}] String intent;
 };
 
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementWin32MobileAppAssignmentSettingsRestartSettings
+{
+    [Write, Description("The number of minutes to wait before restarting the device after an app installation.")] SInt32 countdownDisplayBeforeRestartInMinutes;
+    [Write, Description("The number of minutes before the restart time to display the countdown dialog for pending restarts.")] SInt32 gracePeriodInMinutes;
+    [Write, Description("The number of minutes to snooze the restart notification dialog when the snooze button is selected.")] SInt32 restartNotificationSnoozeDurationInMinutes;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementWin32MobileAppAssignmentSettingsAutoUpdateSettings
+{
+    [Write, Description("The auto-update superseded apps setting for the app assignment. Possible values are notConfigured and enabled. Default value is notConfigured."), ValueMap{"enabled", "notConfigured"}, Values{"enabled", "notConfigured"}] String autoUpdateSupersededApps;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementWin32MobileAppAssignmentSettingsInstallTimeSettings
+{
+    [Write, Description("Whether the local device time or UTC time should be used when determining the available and deadline times.")] Boolean useLocalTime;
+    [Write, Description("The time at which the app should be available for installation.")] String startDateTime;
+    [Write, Description("The time at which the app should be installed.")] String deadlineDateTime;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementMobileAppAssignmentSettings
+{
+    [Write, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.win32LobAppAssignmentSettings"}, Values{"#microsoft.graph.win32LobAppAssignmentSettings"}] String odataType;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementWin32MobileAppAssignmentSettings : MSFT_DeviceManagementMobileAppAssignmentSettings
+{
+    [Write, Description("The auto-update settings to apply for this app assignment."), EmbeddedInstance("MSFT_DeviceManagementWin32MobileAppAssignmentSettingsAutoUpdateSettings")] String autoUpdateSettings;
+    [Write, Description("The delivery optimization priority for this app assignment. This setting is not supported in National Cloud environments. Possible values are: notConfigured, foreground."), ValueMap{"foreground", "notConfigured"}, Values{"foreground", "notConfigured"}] String deliveryOptimizationPriority;
+    [Write, Description("The install time settings to apply for this app assignment."), EmbeddedInstance("MSFT_DeviceManagementWin32MobileAppAssignmentSettingsInstallTimeSettings")] String installTimeSettings;
+    [Write, Description("The notification status for this app assignment. Possible values are: showAll, showReboot, hideAll."), ValueMap{"showAll", "showReboot", "hideAll"}, Values{"showAll", "showReboot", "hideAll"}] String notifications;
+    [Write, Description("The reboot settings to apply for this app assignment."), EmbeddedInstance("MSFT_DeviceManagementWin32MobileAppAssignmentSettingsRestartSettings")] String restartSettings;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementWin32MobileAppAssignment : MSFT_DeviceManagementMobileAppAssignment
+{
+    [Write, Description("The settings of the assignment."), EmbeddedInstance("MSFT_DeviceManagementWin32MobileAppAssignmentSettings")] String assignmentSettings;
+};
+
 [ClassVersion("1.0.0")]
 class MSFT_DeviceManagementMimeContent
 {
@@ -25,77 +69,39 @@ class MSFT_DeviceManagementMobileAppCategory
 };
 
 [ClassVersion("1.0.0.0")]
-class MSFT_MicrosoftGraphWindowsMinimumOperatingSystem
+class MSFT_MicrosoftGraphWin32LobAppRule
 {
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 8.0 or later.")] Boolean V8_0;
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 8.1 or later.")] Boolean V8_1;
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10.0 or later.")] Boolean V10_0;
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1607 or later.")] Boolean V10_1607;
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1703 or later.")] Boolean V10_1703;
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1709 or later.")] Boolean V10_1709;
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1803 or later.")] Boolean V10_1803;
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1809 or later.")] Boolean V10_1809;
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1903 or later.")] Boolean V10_1903;
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1909 or later.")] Boolean V10_1909;
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 2004 or later.")] Boolean V10_2004;
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 20H2 or later.")] Boolean V10_2H20;
-    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 21H1 or later.")] Boolean V10_21H1;
-};
-
-[ClassVersion("1.0.0.0")]
-class MSFT_MicrosoftGraphWin32LobAppDetection
-{
-    [Required, Description("The type of detection. Possible values are: FileSystem, ProductCode (MSI in the policy), PowerShellScript, Registry"), ValueMap{"FileSystem", "ProductCode", "PowerShellScript", "Registry"}, Values{"FileSystem", "ProductCode", "PowerShellScript", "Registry"}] String OdataType;
-    [Write, Description("The operator for detection. Only applicable for the 'FileSystem' and 'Registry' odata type. Possible values are: notConfigured, equal, notEqual, greaterThan, greaterThanOrEqual, lessThan, lessThanOrEqual."), ValueMap{"notConfigured", "equal", "notEqual", "greaterThan", "greaterThanOrEqual", "lessThan", "lessThanOrEqual"}] String Operator;
-    [Write, Description("The detection value. Only applicable for the 'FileSystem' and 'Registry' odata type.")] String DetectionValue;
+    [Required, Description("The provider rule type. Possible values are: FileSystem, PowerShellScript, Registry"), ValueMap{"FileSystem", "PowerShellScript", "ProductCode", "Registry"}, Values{"FileSystem", "PowerShellScript", "ProductCode", "Registry"}] String OdataType;
+    [Required, Description("The type of rule. Possible values are: Detection, Requirement"), ValueMap{"Detection", "Requirement"}, Values{"Detection", "Requirement"}] String RuleType;
+    [Write, Description("The operator of the rule. Not applicable for the 'ProductCode' odata type. Possible values are: notConfigured, equal, notEqual, greaterThan, greaterThanOrEqual, lessThan, lessThanOrEqual."), ValueMap{"notConfigured", "equal", "notEqual", "greaterThan", "greaterThanOrEqual", "lessThan", "lessThanOrEqual"}] String Operator;
+    [Write, Description("The value to compare. Not applicable for the 'ProductCode' odata type.")] String ComparisonValue;
 
     [Write, Description("A value indicating whether to checking 32-bit on 64-bit system. Only applicable for the 'FileSystem' and 'Registry' odata type.")] Boolean Check32BitOn64System;
 
     [Write, Description("The file or folder path to detect Win32 Line of Business (LoB) app. Only applicable for the 'FileSystem' odata type.")] String Path;
     [Write, Description("The file or folder name to detect Win32 Line of Business (LoB) app. Only applicable for the 'FileSystem' odata type.")] String FileOrFolderName;
-    [Write, Description("The file system detection type. Only applicable for the 'FileSystem' odata typ. Possible values are: notConfigured, exists, modifiedDate, createdDate, version, sizeInMB, doesNotExist."), ValueMap{"notConfigured", "exists", "modifiedDate", "createdDate", "version", "sizeInMB", "doesNotExist"}, Values{"notConfigured", "exists", "modifiedDate", "createdDate", "version", "sizeInMB", "doesNotExist"}] String FileSystemDetectionType;
+    [Write, Description("The file system comparison operator type. Only applicable for the 'FileSystem' odata type. Possible values are: notConfigured, exists, modifiedDate, createdDate, version, sizeInMB, doesNotExist, sizeInBytes, appVersion."), ValueMap{"notConfigured", "exists", "modifiedDate", "createdDate", "version", "sizeInMB", "doesNotExist", "sizeInBytes", "appVersion"}, Values{"notConfigured", "exists", "modifiedDate", "createdDate", "version", "sizeInMB", "doesNotExist", "sizeInBytes", "appVersion"}] String FileSystemOperationType;
+
+    [Write, Description("The display name for the rule. Do not specify this value if the rule is used for detection.")] String DisplayName;
+    [Write, Description("A value indicating whether signature check is enforced. Only Applicable for the 'PowerShellScript' odata type.")] Boolean EnforceSignatureCheck;
+    [Write, Description("A value indicating whether this script should run as 32-bit. Only Applicable for the 'PowerShellScript' odata type.")] Boolean RunAs32Bit;
+    [Write, Description("Indicates the type of execution context the script runs in. Only Applicable for the 'PowerShellScript' odata type. Possible values are: system, user."), ValueMap{"system", "user"}, Values{"system", "user"}] String RunAsAccount;
+    [Write, Description("The PowerShell script. Only Applicable for the 'PowerShellScript' odata type.")] String Script;
+    [Write, Description("The comparison operator type for script output. Only Applicable for the 'PowerShellScript' odata type. Possible values are: notConfigured, string, dateTime, integer, float, version, boolean."), ValueMap{"notConfigured", "string", "dateTime", "integer", "float", "version", "boolean"}, Values{"notConfigured", "string", "dateTime", "integer", "float", "version", "boolean"}] String PowerShellScriptOperationType;
 
     [Write, Description("The product code of Win32 Line of Business (LoB) app.")] String ProductCode;
     [Write, Description("The operator for detection. Only applicable for the 'ProductCode' odata typ. Possible values are: notConfigured, equal, notEqual, greaterThan, greaterThanOrEqual, lessThan, lessThanOrEqual."), ValueMap{"notConfigured", "equal", "notEqual", "greaterThan", "greaterThanOrEqual", "lessThan", "lessThanOrEqual"}] String ProductVersionOperator;
     [Write, Description("The product version of Win32 Line of Business (LoB) app.")] String ProductVersion;
 
-    [Write, Description("A value indicating whether signature check is enforced. Only Applicable for the 'PowerShellScript' odata typ.")] Boolean EnforceSignatureCheck;
-    [Write, Description("A value indicating whether this script should run as 32-bit. Only Applicable for the 'PowerShellScript' odata typ.")] Boolean RunAs32Bit;
-    [Write, Description("The PowerShell script. Only Applicable for the 'PowerShellScript' odata typ.")] String Script;
-
     [Write, Description("The registry key path to detect Win32 Line of Business (LoB) app.")] String KeyPath;
     [Write, Description("The registry value name.")] String ValueName;
-    [Write, Description("The registry data odata typ. Possible values are: notConfigured, exists, doesNotExist, string, integer, version."), ValueMap{"notConfigured", "exists", "doesNotExist", "string", "integer", "version"}, Values{"notConfigured", "exists", "doesNotExist", "string", "integer", "version"}] String RegistryDetectionType;
-};
-
-[ClassVersion("1.0.0.0")]
-class MSFT_MicrosoftGraphWin32LobAppRequirement
-{
-    [Required, Description("The type of detection. Possible values are: FileSystem, PowerShellScript, Registry"), ValueMap{"FileSystem", "PowerShellScript", "Registry"}, Values{"FileSystem", "PowerShellScript", "Registry"}] String OdataType;
-    [Write, Description("The operator for detection. Possible values are: notConfigured, equal, notEqual, greaterThan, greaterThanOrEqual, lessThan, lessThanOrEqual."), ValueMap{"notConfigured", "equal", "notEqual", "greaterThan", "greaterThanOrEqual", "lessThan", "lessThanOrEqual"}] String Operator;
-    [Write, Description("The detection value.")] String DetectionValue;
-
-    [Write, Description("A value indicating whether to checking 32-bit on 64-bit system. Only applicable for the 'FileSystem' and 'Registry' odata type.")] Boolean Check32BitOn64System;
-
-    [Write, Description("The file or folder path to detect Win32 Line of Business (LoB) app. Only applicable for the 'FileSystem' odata type.")] String Path;
-    [Write, Description("The file or folder name to detect Win32 Line of Business (LoB) app. Only applicable for the 'FileSystem' odata type.")] String FileOrFolderName;
-    [Write, Description("The file system detection type. Only applicable for the 'FileSystem' odata type. Possible values are: notConfigured, exists, modifiedDate, createdDate, version, sizeInMB, doesNotExist."), ValueMap{"notConfigured", "exists", "modifiedDate", "createdDate", "version", "sizeInMB", "doesNotExist"}, Values{"notConfigured", "exists", "modifiedDate", "createdDate", "version", "sizeInMB", "doesNotExist"}] String FileSystemDetectionType;
-
-    [Write, Description("A value indicating whether signature check is enforced. Only Applicable for the 'PowerShellScript' odata type.")] Boolean EnforceSignatureCheck;
-    [Write, Description("A value indicating whether this script should run as 32-bit. Only Applicable for the 'PowerShellScript' odata type.")] Boolean RunAs32Bit;
-    [Write, Description("Indicates the type of execution context the script runs in. Only Applicable for the 'PowerShellScript' odata type. Possible values are: system, user."), ValueMap{"system", "user"}, Values{"system", "user"}] String RunAsAccountType;
-    [Write, Description("The PowerShell script. Only Applicable for the 'PowerShellScript' odata type.")] String Script;
-    [Write, Description("The detection type for script output. Only Applicable for the 'PowerShellScript' odata type. Possible values are: notConfigured, string, dateTime, integer, float, version, boolean."), ValueMap{"notConfigured", "string", "dateTime", "integer", "float", "version", "boolean"}, Values{"notConfigured", "string", "dateTime", "integer", "float", "version", "boolean"}] String PowerShellScriptDetectionType;
-
-    [Write, Description("The registry key path to detect Win32 Line of Business (LoB) app.")] String KeyPath;
-    [Write, Description("The registry value name.")] String ValueName;
-    [Write, Description("The registry data detection type. Possible values are: notConfigured, exists, doesNotExist, string, integer, version."), ValueMap{"notConfigured", "exists", "doesNotExist", "string", "integer", "version"}, Values{"notConfigured", "exists", "doesNotExist", "string", "integer", "version"}] String RegistryDetectionType;
+    [Write, Description("The registry data comparison operator type. Only applicable for the 'Registry' odata type. Possible values are: notConfigured, exists, doesNotExist, string, integer, version."), ValueMap{"notConfigured", "exists", "doesNotExist", "string", "integer", "version"}, Values{"notConfigured", "exists", "doesNotExist", "string", "integer", "version"}] String RegistryOperationType;
 };
 
 [ClassVersion("1.0.0.0")]
 class MSFT_MicrosoftGraphWin32LobAppInstallExperience
 {
-    [Write, Description("Indicates the type of execution context the app runs in. Possible values are: system, user."), ValueMap{"system", "user"}, Values{"system", "user"}] String RunAsAccountType;
+    [Write, Description("Indicates the type of execution context the app runs in. Possible values are: system, user."), ValueMap{"system", "user"}, Values{"system", "user"}] String RunAsAccount;
     [Write, Description("The number of minutes the system will wait for install program to finish. Default value is 60 minutes.")] SInt32 MaxRunTimeInMinutes;
     [Write, Description("Device restart behavior. Possible values are: basedOnReturnCode, allow, suppress, force."), ValueMap{"basedOnReturnCode", "allow", "suppress", "force"}, Values{"basedOnReturnCode", "allow", "suppress", "force"}] String DeviceRestartBehavior;
 };
@@ -133,25 +139,24 @@ class MSFT_IntuneMobileAppsWin32AppWindows10 : OMI_BaseResource
     [Write, Description("The owner of the app.")] String Owner;
     [Write, Description("The privacy statement Url.")] String PrivacyInformationUrl;
     [Write, Description("The publisher of the app.")] String Publisher;
+    [Write, Description("The file name of the app.")] String FileName;
     [Write, Description("List of scope tag ids for this mobile app.")] String RoleScopeTagIds[];
 
     [Write, Description("The list of categories for this app."), EmbeddedInstance("MSFT_DeviceManagementMobileAppCategory")] String Categories[];
     [Write, Description("Indicates the command line to install this app. Used to install the Win32 app. Example: msiexec /i 'Orca.Msi' /qn.")] String InstallCommandLine;
     [Write, Description("Indicates the command line to uninstall this app. Used to uninstall the app. Example: msiexec /x '{85F4CBCB-9BBC-4B50-A7D8-E1106771498D}' /qn.")] String UninstallCommandLine;
     [Write, Description("Indicates the Windows architecture(s) this app should be installed on. The app will be treated as not applicable for devices with architectures not matching the selected value. The value 'none' cannot be combined with other values."), ValueMap{"none", "x86", "x64", "arm64"}, Values{"none", "x86", "x64", "arm64"}] String AllowedArchitectures[];
-    [Write, Description("Indicates the value for the minimum applicable operating system."), EmbeddedInstance("MSFT_MicrosoftGraphWindowsMinimumOperatingSystem")] String MinimumSupportedOperatingSystem;
     [Write, Description("Indicates the value for the minimum free disk space which is required to install this app.")] SInt32 MinimumFreeDiskSpaceInMB;
     [Write, Description("Indicates the value for the minimum physical memory which is required to install this app.")] SInt32 MinimumMemoryInMB;
     [Write, Description("Indicates the value for the minimum number of processors which is required to install this app.")] SInt32 MinimumNumberOfProcessors;
     [Write, Description("Indicates the value for the minimum CPU speed which is required to install this app.")] SInt32 MinimumCpuSpeedInMHz;
-    [Write, Description("Indicates the detection rules to detect Win32 Line of Business (LoB) app."), EmbeddedInstance("MSFT_MicrosoftGraphWin32LobAppDetection")] String DetectionRules[];
-    [Write, Description("Indicates the requirement rules to detect Win32 Line of Business (LoB) app."), EmbeddedInstance("MSFT_MicrosoftGraphWin32LobAppRequirement")] String RequirementRules[];
+    [Write, Description("Indicates the detection and requirement rules for this app."), EmbeddedInstance("MSFT_MicrosoftGraphWin32LobAppRule")] String Rules[];
     [Write, Description("Indicates the install experience for this app."), EmbeddedInstance("MSFT_MicrosoftGraphWin32LobAppInstallExperience")] String InstallExperience;
     [Write, Description("Indicates the return codes for post installation behavior."), EmbeddedInstance("MSFT_MicrosoftGraphWin32LobAppReturnCode")] String ReturnCodes[];
     [Write, Description("Indicates the MSI details if this Win32 app is an MSI app."), EmbeddedInstance("MSFT_MicrosoftGraphWin32LobAppMsiInformation")] String MsiInformation;
     [Write, Description("Indicates the relative path of the setup file in the encrypted Win32LobApp package.")] String SetupFilePath;
-    [Write, Description("Indicates the value for the minimum supported windows release.")] String MinimumSupportedWindowsRelease;
-    [Write, Description("Indicates the version displayed in the UX for this app. Used to set the version of the app. Example: 1.0.3.215.")] Boolean DisplayVersion;
+    [Write, Description("Indicates the value for the minimum supported windows release. Format for Windows 10: <VersionNumber>, e.g. '1709' or '20H2'. For Windows 11: 'Windows11_<VersionNumber>', e.g. 'Windows11_21H2'")] String MinimumSupportedWindowsRelease;
+    [Write, Description("Indicates the version displayed in the UX for this app. Used to set the version of the app. Example: 1.0.3.215.")] String DisplayVersion;
     [Write, Description("Indicates whether the uninstall is supported from the company portal for the Win32 app with an available assignment. When TRUE, indicates that uninstall is supported from the company portal for the Windows app (Win32) with an available assignment. When FALSE, indicates that uninstall is not supported for the Windows app (Win32) with an Available assignment.")] Boolean AllowAvailableUninstall;
 
     [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementMobileAppAssignment")] String Assignments[];

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/MSFT_IntuneMobileAppsWin32AppWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/MSFT_IntuneMobileAppsWin32AppWindows10.schema.mof
@@ -1,0 +1,166 @@
+[ClassVersion("1.0.0.1")]
+class MSFT_DeviceManagementMobileAppAssignment
+{
+    [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget", "#microsoft.graph.mobileAppAssignment"}] String dataType;
+    [Write, Description("The Id of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterId;
+    [Write, Description("The display name of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterDisplayName;
+    [Write, Description("The type of filter of the target assignment i.e. Exclude or Include. Possible values are: none, include, exclude."), ValueMap{"none", "include", "exclude"}, Values{"none", "include", "exclude"}] String deviceAndAppManagementAssignmentFilterType;
+    [Write, Description("The group Id that is the target of the assignment.")] String groupId;
+    [Write, Description("The group Display Name that is the target of the assignment.")] String groupDisplayName;
+    [Write, Description("Possible values for the install intent chosen by the admin."), ValueMap{"available", "required", "uninstall", "availableWithoutEnrollment"}, Values{"available", "required", "uninstall", "availableWithoutEnrollment"}] String intent;
+};
+
+[ClassVersion("1.0.0")]
+class MSFT_DeviceManagementMimeContent
+{
+    [Write, Description("Indicates the type of content mime.")] String Type;
+    [Write, Description("The Base64 encoded string content.")] String Value;
+};
+
+[ClassVersion("1.0.0")]
+class MSFT_DeviceManagementMobileAppCategory
+{
+    [Key, Description("The name of the app category.")] String DisplayName;
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_MicrosoftGraphWindowsMinimumOperatingSystem
+{
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 8.0 or later.")] Boolean V8_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 8.1 or later.")] Boolean V8_1;
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10.0 or later.")] Boolean V10_0;
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1607 or later.")] Boolean V10_1607;
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1703 or later.")] Boolean V10_1703;
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1709 or later.")] Boolean V10_1709;
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1803 or later.")] Boolean V10_1803;
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1809 or later.")] Boolean V10_1809;
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1903 or later.")] Boolean V10_1903;
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 1909 or later.")] Boolean V10_1909;
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 2004 or later.")] Boolean V10_2004;
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 20H2 or later.")] Boolean V10_2H20;
+    [Write, Description("Indicates the minimum version support required for the managed device. Requires at least Windows version 10 21H1 or later.")] Boolean V10_21H1;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_MicrosoftGraphWin32LobAppDetection
+{
+    [Required, Description("The type of detection. Possible values are: FileSystem, ProductCode (MSI in the policy), PowerShellScript, Registry"), ValueMap{"FileSystem", "ProductCode", "PowerShellScript", "Registry"}, Values{"FileSystem", "ProductCode", "PowerShellScript", "Registry"}] String OdataType;
+    [Write, Description("The operator for detection. Only applicable for the 'FileSystem' and 'Registry' odata type. Possible values are: notConfigured, equal, notEqual, greaterThan, greaterThanOrEqual, lessThan, lessThanOrEqual."), ValueMap{"notConfigured", "equal", "notEqual", "greaterThan", "greaterThanOrEqual", "lessThan", "lessThanOrEqual"}] String Operator;
+    [Write, Description("The detection value. Only applicable for the 'FileSystem' and 'Registry' odata type.")] String DetectionValue;
+
+    [Write, Description("A value indicating whether to checking 32-bit on 64-bit system. Only applicable for the 'FileSystem' and 'Registry' odata type.")] Boolean Check32BitOn64System;
+
+    [Write, Description("The file or folder path to detect Win32 Line of Business (LoB) app. Only applicable for the 'FileSystem' odata type.")] String Path;
+    [Write, Description("The file or folder name to detect Win32 Line of Business (LoB) app. Only applicable for the 'FileSystem' odata type.")] String FileOrFolderName;
+    [Write, Description("The file system detection type. Only applicable for the 'FileSystem' odata typ. Possible values are: notConfigured, exists, modifiedDate, createdDate, version, sizeInMB, doesNotExist."), ValueMap{"notConfigured", "exists", "modifiedDate", "createdDate", "version", "sizeInMB", "doesNotExist"}, Values{"notConfigured", "exists", "modifiedDate", "createdDate", "version", "sizeInMB", "doesNotExist"}] String FileSystemDetectionType;
+
+    [Write, Description("The product code of Win32 Line of Business (LoB) app.")] String ProductCode;
+    [Write, Description("The operator for detection. Only applicable for the 'ProductCode' odata typ. Possible values are: notConfigured, equal, notEqual, greaterThan, greaterThanOrEqual, lessThan, lessThanOrEqual."), ValueMap{"notConfigured", "equal", "notEqual", "greaterThan", "greaterThanOrEqual", "lessThan", "lessThanOrEqual"}] String ProductVersionOperator;
+    [Write, Description("The product version of Win32 Line of Business (LoB) app.")] String ProductVersion;
+
+    [Write, Description("A value indicating whether signature check is enforced. Only Applicable for the 'PowerShellScript' odata typ.")] Boolean EnforceSignatureCheck;
+    [Write, Description("A value indicating whether this script should run as 32-bit. Only Applicable for the 'PowerShellScript' odata typ.")] Boolean RunAs32Bit;
+    [Write, Description("The PowerShell script. Only Applicable for the 'PowerShellScript' odata typ.")] String Script;
+
+    [Write, Description("The registry key path to detect Win32 Line of Business (LoB) app.")] String KeyPath;
+    [Write, Description("The registry value name.")] String ValueName;
+    [Write, Description("The registry data odata typ. Possible values are: notConfigured, exists, doesNotExist, string, integer, version."), ValueMap{"notConfigured", "exists", "doesNotExist", "string", "integer", "version"}, Values{"notConfigured", "exists", "doesNotExist", "string", "integer", "version"}] String RegistryDetectionType;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_MicrosoftGraphWin32LobAppRequirement
+{
+    [Required, Description("The type of detection. Possible values are: FileSystem, PowerShellScript, Registry"), ValueMap{"FileSystem", "PowerShellScript", "Registry"}, Values{"FileSystem", "PowerShellScript", "Registry"}] String OdataType;
+    [Write, Description("The operator for detection. Possible values are: notConfigured, equal, notEqual, greaterThan, greaterThanOrEqual, lessThan, lessThanOrEqual."), ValueMap{"notConfigured", "equal", "notEqual", "greaterThan", "greaterThanOrEqual", "lessThan", "lessThanOrEqual"}] String Operator;
+    [Write, Description("The detection value.")] String DetectionValue;
+
+    [Write, Description("A value indicating whether to checking 32-bit on 64-bit system. Only applicable for the 'FileSystem' and 'Registry' odata type.")] Boolean Check32BitOn64System;
+
+    [Write, Description("The file or folder path to detect Win32 Line of Business (LoB) app. Only applicable for the 'FileSystem' odata type.")] String Path;
+    [Write, Description("The file or folder name to detect Win32 Line of Business (LoB) app. Only applicable for the 'FileSystem' odata type.")] String FileOrFolderName;
+    [Write, Description("The file system detection type. Only applicable for the 'FileSystem' odata type. Possible values are: notConfigured, exists, modifiedDate, createdDate, version, sizeInMB, doesNotExist."), ValueMap{"notConfigured", "exists", "modifiedDate", "createdDate", "version", "sizeInMB", "doesNotExist"}, Values{"notConfigured", "exists", "modifiedDate", "createdDate", "version", "sizeInMB", "doesNotExist"}] String FileSystemDetectionType;
+
+    [Write, Description("A value indicating whether signature check is enforced. Only Applicable for the 'PowerShellScript' odata type.")] Boolean EnforceSignatureCheck;
+    [Write, Description("A value indicating whether this script should run as 32-bit. Only Applicable for the 'PowerShellScript' odata type.")] Boolean RunAs32Bit;
+    [Write, Description("Indicates the type of execution context the script runs in. Only Applicable for the 'PowerShellScript' odata type. Possible values are: system, user."), ValueMap{"system", "user"}, Values{"system", "user"}] String RunAsAccountType;
+    [Write, Description("The PowerShell script. Only Applicable for the 'PowerShellScript' odata type.")] String Script;
+    [Write, Description("The detection type for script output. Only Applicable for the 'PowerShellScript' odata type. Possible values are: notConfigured, string, dateTime, integer, float, version, boolean."), ValueMap{"notConfigured", "string", "dateTime", "integer", "float", "version", "boolean"}, Values{"notConfigured", "string", "dateTime", "integer", "float", "version", "boolean"}] String PowerShellScriptDetectionType;
+
+    [Write, Description("The registry key path to detect Win32 Line of Business (LoB) app.")] String KeyPath;
+    [Write, Description("The registry value name.")] String ValueName;
+    [Write, Description("The registry data detection type. Possible values are: notConfigured, exists, doesNotExist, string, integer, version."), ValueMap{"notConfigured", "exists", "doesNotExist", "string", "integer", "version"}, Values{"notConfigured", "exists", "doesNotExist", "string", "integer", "version"}] String RegistryDetectionType;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_MicrosoftGraphWin32LobAppInstallExperience
+{
+    [Write, Description("Indicates the type of execution context the app runs in. Possible values are: system, user."), ValueMap{"system", "user"}, Values{"system", "user"}] String RunAsAccountType;
+    [Write, Description("The number of minutes the system will wait for install program to finish. Default value is 60 minutes.")] SInt32 MaxRunTimeInMinutes;
+    [Write, Description("Device restart behavior. Possible values are: basedOnReturnCode, allow, suppress, force."), ValueMap{"basedOnReturnCode", "allow", "suppress", "force"}, Values{"basedOnReturnCode", "allow", "suppress", "force"}] String DeviceRestartBehavior;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_MicrosoftGraphWin32LobAppReturnCode
+{
+    [Write, Description("Return code.")] SInt32 ReturnCode;
+    [Write, Description("The type of return code. Possible values are: failed, success, softReboot, hardReboot, retry."), ValueMap{"failed", "success", "softReboot", "hardReboot", "retry"}, Values{"failed", "success", "softReboot", "hardReboot", "retry"}] String Type;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_MicrosoftGraphWin32LobAppMsiInformation
+{
+    [Write, Description("The MSI product code.")] String ProductCode;
+    [Write, Description("The MSI product version.")] String ProductVersion;
+    [Write, Description("The MSI upgrade code.")] String UpgradeCode;
+    [Write, Description("Whether the MSI app requires the machine to reboot to complete installation.")] Boolean RequiresReboot;
+    [Write, Description("The MSI package type. Possible values are: perMachine, perUser, dualPurpose."), ValueMap{"perMachine", "perUser", "dualPurpose"}, Values{"perMachine", "perUser", "dualPurpose"}] String PackageType;
+    [Write, Description("The MSI product name.")] String ProductName;
+    [Write, Description("The MSI publisher")] String Publisher;
+};
+
+[ClassVersion("1.0.0.0"), FriendlyName("IntuneMobileAppsWin32AppWindows10")]
+class MSFT_IntuneMobileAppsWin32AppWindows10 : OMI_BaseResource
+{
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
+    [Key, Description("The admin provided or imported title of the app.")] String DisplayName;
+    [Write, Description("The description of the app.")] String Description;
+    [Write, Description("The developer of the app.")] String Developer;
+    [Write, Description("The more information Url.")] String InformationUrl;
+    [Write, Description("The value indicating whether the app is marked as featured by the admin.")] Boolean IsFeatured;
+    [Write, Description("The large icon, to be displayed in the app details and used for upload of the icon."), EmbeddedInstance("MSFT_DeviceManagementMimeContent")] String LargeIcon;
+    [Write, Description("Notes for the app.")] String Notes;
+    [Write, Description("The owner of the app.")] String Owner;
+    [Write, Description("The privacy statement Url.")] String PrivacyInformationUrl;
+    [Write, Description("The publisher of the app.")] String Publisher;
+    [Write, Description("List of scope tag ids for this mobile app.")] String RoleScopeTagIds[];
+
+    [Write, Description("The list of categories for this app."), EmbeddedInstance("MSFT_DeviceManagementMobileAppCategory")] String Categories[];
+    [Write, Description("Indicates the command line to install this app. Used to install the Win32 app. Example: msiexec /i 'Orca.Msi' /qn.")] String InstallCommandLine;
+    [Write, Description("Indicates the command line to uninstall this app. Used to uninstall the app. Example: msiexec /x '{85F4CBCB-9BBC-4B50-A7D8-E1106771498D}' /qn.")] String UninstallCommandLine;
+    [Write, Description("Indicates the Windows architecture(s) this app should be installed on. The app will be treated as not applicable for devices with architectures not matching the selected value. The value 'none' cannot be combined with other values."), ValueMap{"none", "x86", "x64", "arm64"}, Values{"none", "x86", "x64", "arm64"}] String AllowedArchitectures[];
+    [Write, Description("Indicates the value for the minimum applicable operating system."), EmbeddedInstance("MSFT_MicrosoftGraphWindowsMinimumOperatingSystem")] String MinimumSupportedOperatingSystem;
+    [Write, Description("Indicates the value for the minimum free disk space which is required to install this app.")] SInt32 MinimumFreeDiskSpaceInMB;
+    [Write, Description("Indicates the value for the minimum physical memory which is required to install this app.")] SInt32 MinimumMemoryInMB;
+    [Write, Description("Indicates the value for the minimum number of processors which is required to install this app.")] SInt32 MinimumNumberOfProcessors;
+    [Write, Description("Indicates the value for the minimum CPU speed which is required to install this app.")] SInt32 MinimumCpuSpeedInMHz;
+    [Write, Description("Indicates the detection rules to detect Win32 Line of Business (LoB) app."), EmbeddedInstance("MSFT_MicrosoftGraphWin32LobAppDetection")] String DetectionRules[];
+    [Write, Description("Indicates the requirement rules to detect Win32 Line of Business (LoB) app."), EmbeddedInstance("MSFT_MicrosoftGraphWin32LobAppRequirement")] String RequirementRules[];
+    [Write, Description("Indicates the install experience for this app."), EmbeddedInstance("MSFT_MicrosoftGraphWin32LobAppInstallExperience")] String InstallExperience;
+    [Write, Description("Indicates the return codes for post installation behavior."), EmbeddedInstance("MSFT_MicrosoftGraphWin32LobAppReturnCode")] String ReturnCodes[];
+    [Write, Description("Indicates the MSI details if this Win32 app is an MSI app."), EmbeddedInstance("MSFT_MicrosoftGraphWin32LobAppMsiInformation")] String MsiInformation;
+    [Write, Description("Indicates the relative path of the setup file in the encrypted Win32LobApp package.")] String SetupFilePath;
+    [Write, Description("Indicates the value for the minimum supported windows release.")] String MinimumSupportedWindowsRelease;
+    [Write, Description("Indicates the version displayed in the UX for this app. Used to set the version of the app. Example: 1.0.3.215.")] Boolean DisplayVersion;
+    [Write, Description("Indicates whether the uninstall is supported from the company portal for the Win32 app with an available assignment. When TRUE, indicates that uninstall is supported from the company portal for the Windows app (Win32) with an available assignment. When FALSE, indicates that uninstall is not supported for the Windows app (Win32) with an Available assignment.")] Boolean AllowAvailableUninstall;
+
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementMobileAppAssignment")] String Assignments[];
+    [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
+    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
+    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
+    [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
+    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Access token used for authentication.")] String AccessTokens[];
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/readme.md
@@ -1,0 +1,6 @@
+
+# IntuneMobileAppsWin32AppWindows10
+
+## Description
+
+Intune Mobile Apps Win32 App for Windows10

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/settings.json
@@ -1,0 +1,50 @@
+{
+  "resourceName": "IntuneMobileAppsWin32AppWindows10",
+  "description": "This resource configures an Intune Mobile Apps Win32 App for Windows10.",
+  "permissions": {
+    "graph": {
+      "application": {
+        "update": [
+          {
+            "name": "DeviceManagementApps.ReadWrite.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ],
+        "read": [
+          {
+            "name": "DeviceManagementApps.Read.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ]
+      },
+      "delegated": {
+        "update": [
+          {
+            "name": "DeviceManagementApps.ReadWrite.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ],
+        "read": [
+          {
+            "name": "DeviceManagementApps.Read.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ]
+      }
+    }
+  },
+  "requiredModules": [
+    "Microsoft.Graph.Authentication",
+    "Microsoft.Graph.Beta.Devices.CorporateManagement",
+    "Microsoft.Graph.Groups"
+  ],
+  "mode": "Data"
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsWin32AppWindows10/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsWin32AppWindows10/1-Create.ps1
@@ -1,0 +1,149 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneMobileAppsWin32AppWindows10 "IntuneMobileAppsWin32AppWindows10-Win32 App - IntuneWinAppUtil.exe"
+        {
+            AllowAvailableUninstall         = $True;
+            AllowedArchitectures            = @("x86","x64","arm64");
+            ApplicationId                   = $ApplicationId;
+            Assignments                     = @();
+            Categories                      = @(
+                MSFT_DeviceManagementMobileAppCategory{
+                    Id = "2185c6bf-1b3d-4daa-a0bc-79cb4fad9c87"
+                    DisplayName = "App Category 1"
+                }
+            );
+            CertificateThumbprint           = $CertificateThumbprint;
+            Description                     = "IntuneWinAppUtil.exe";
+            DetectionRules                  = @(
+                MSFT_MicrosoftGraphWin32LobAppDetection{
+                    Check32BitOn64System = $False
+                    DetectionValue = "1.0.0.0"
+                    FileOrFolderName = "asdf.exe"
+                    FileSystemDetectionType = "version"
+                    Operator = "equal"
+                    Path = "C:\temp\Dev"
+                    OdataType = "FileSystem"
+                }
+                MSFT_MicrosoftGraphWin32LobAppDetection{
+                    Check32BitOn64System = $False
+                    RegistryDetectionType = "integer"
+                    DetectionValue = "100"
+                    Operator = "greaterThanOrEqual"
+                    OdataType = "Registry"
+                    KeyPath = "HKLM:\Software\Microsoft\Windows\CurrentVersion"
+                }
+                MSFT_MicrosoftGraphWin32LobAppDetection{
+                    ProductVersionOperator = "lessThan"
+                    ProductVersion = "2.0.0.0"
+                    ProductCode = "{00000000-0000-0000-0000-000000000000}"
+                    OdataType = "ProductCode"
+                }
+            );
+            Developer                       = "";
+            DisplayName                     = "Win32 App - IntuneWinAppUtil.exe";
+            DisplayVersion                  = "1.0.0.0";
+            Ensure                          = "Present";
+            Id                              = "63271b78-0fa4-46b8-9ac0-d4b777555dde";
+            InstallCommandLine              = "IntuneWinAppUtil.exe -s -t 0";
+            IsFeatured                      = $False;
+            MinimumCpuSpeedInMHz            = 2500;
+            MinimumFreeDiskSpaceInMB        = 1;
+            MinimumMemoryInMB               = 200;
+            MinimumNumberOfProcessors       = 1;
+            MinimumSupportedOperatingSystem = MSFT_MicrosoftGraphWindowsMinimumOperatingSystem{
+                V8_0 = $False
+                V8_1 = $False
+                V10_0 = $False
+                V10_1607 = $True
+                V10_1703 = $False
+                V10_1709 = $False
+                V10_1803 = $False
+                V10_1809 = $False
+                V10_1903 = $False
+                V10_1909 = $False
+                V10_2004 = $False
+                V10_2H20 = $False
+                V10_21H1 = $False
+            };
+            MinimumSupportedWindowsRelease  = "1607";
+            Notes                           = "";
+            Owner                           = "";
+            Publisher                       = "Microsoft";
+            RequirementRules                = @(
+                MSFT_MicrosoftGraphWin32LobAppRequirement{
+                    Check32BitOn64System = $False
+                    FileOrFolderName = "asdf.exe"
+                    FileSystemDetectionType = "exists"
+                    Operator = "notConfigured"
+                    Path = "C:\temp\Dev"
+                    OdataType = "FileSystem"
+                }
+                MSFT_MicrosoftGraphWin32LobAppRequirement{
+                    Check32BitOn64System = $False
+                    RegistryDetectionType = "string"
+                    DetectionValue = "1.0.0.0"
+                    Operator = "equal"
+                    OdataType = "Registry"
+                    KeyPath = "HKLM:\Software\Microsoft\Windows\CurrentVersion"
+                }
+                MSFT_MicrosoftGraphWin32LobAppRequirement{
+                    DetectionValue = "Hello World"
+                    PowerShellScriptDetectionType = "string"
+                    EnforceSignatureCheck = $False
+                    Operator = "equal"
+                    RunAs32Bit = $False
+                    OdataType = "PowerShellScript"
+                    Script = "Write-Output `"Hello World`""
+                }
+            );
+            ReturnCodes                     = @(
+                MSFT_MicrosoftGraphWin32LobAppReturnCode{
+                    ReturnCode = 0
+                    Type = "success"
+                }
+                MSFT_MicrosoftGraphWin32LobAppReturnCode{
+                    ReturnCode = 1707
+                    Type = "success"
+                }
+                MSFT_MicrosoftGraphWin32LobAppReturnCode{
+                    ReturnCode = 3010
+                    Type = "softReboot"
+                }
+                MSFT_MicrosoftGraphWin32LobAppReturnCode{
+                    ReturnCode = 1641
+                    Type = "hardReboot"
+                }
+                MSFT_MicrosoftGraphWin32LobAppReturnCode{
+                    ReturnCode = 1618
+                    Type = "retry"
+                }
+            );
+            RoleScopeTagIds                 = @("0");
+            SetupFilePath                   = "IntuneWinAppUtil.exe";
+            TenantId                        = $TenantId;
+            UninstallCommandLine            = "IntuneWinAppUtil.exe -t -s 0";
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsWin32AppWindows10/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsWin32AppWindows10/1-Create.ps1
@@ -36,88 +36,67 @@ Configuration Example
             );
             CertificateThumbprint           = $CertificateThumbprint;
             Description                     = "IntuneWinAppUtil.exe";
-            DetectionRules                  = @(
-                MSFT_MicrosoftGraphWin32LobAppDetection{
+            Rules                           = @(
+                MSFT_MicrosoftGraphWin32LobAppRule{
                     Check32BitOn64System = $False
-                    DetectionValue = "1.0.0.0"
+                    ComparisonValue = "1.0.0.0"
                     FileOrFolderName = "asdf.exe"
-                    FileSystemDetectionType = "version"
+                    FileSystemOperationType = "version"
                     Operator = "equal"
                     Path = "C:\temp\Dev"
+                    RuleType = "detection"
                     OdataType = "FileSystem"
                 }
-                MSFT_MicrosoftGraphWin32LobAppDetection{
+                MSFT_MicrosoftGraphWin32LobAppRule{
                     Check32BitOn64System = $False
-                    RegistryDetectionType = "integer"
-                    DetectionValue = "100"
+                    RegistryOperationType = "integer"
+                    ComparisonValue = "100"
                     Operator = "greaterThanOrEqual"
                     OdataType = "Registry"
+                    RuleType = "detection"
                     KeyPath = "HKLM:\Software\Microsoft\Windows\CurrentVersion"
                 }
-                MSFT_MicrosoftGraphWin32LobAppDetection{
+                MSFT_MicrosoftGraphWin32LobAppRule{
                     ProductVersionOperator = "lessThan"
                     ProductVersion = "2.0.0.0"
                     ProductCode = "{00000000-0000-0000-0000-000000000000}"
                     OdataType = "ProductCode"
+                    RuleType = "requirement"
+                }
+                MSFT_MicrosoftGraphWin32LobAppRule{
+                    Script = "Write-Output 'Hello World'"
+                    DisplayName = "PowerShell Script Rule.ps1"
+                    Operator = "equals"
+                    RunAs32Bit = $False
+                    EnforceSignatureCheck = $False
+                    RunAsAccount = "system"
+                    OdataType = "PowerShellScript"
+                    RuleType = "requirement"
+                    PowerShellScriptOperationType = "string"
+                    ComparisonValue = "Hello World"
                 }
             );
             Developer                       = "";
             DisplayName                     = "Win32 App - IntuneWinAppUtil.exe";
             DisplayVersion                  = "1.0.0.0";
             Ensure                          = "Present";
+            FileName                        = "IntuneWinAppUtil.intunewin";
             Id                              = "63271b78-0fa4-46b8-9ac0-d4b777555dde";
             InstallCommandLine              = "IntuneWinAppUtil.exe -s -t 0";
+            InstallExperience               = MSFT_MicrosoftGraphWin32LobAppInstallExperience{
+                DeviceRestartBehavior = "suppress"
+                RunAsAccount = "system"
+                MaxRunTimeInMinutes = 60
+            };
             IsFeatured                      = $False;
             MinimumCpuSpeedInMHz            = 2500;
             MinimumFreeDiskSpaceInMB        = 1;
             MinimumMemoryInMB               = 200;
             MinimumNumberOfProcessors       = 1;
-            MinimumSupportedOperatingSystem = MSFT_MicrosoftGraphWindowsMinimumOperatingSystem{
-                V8_0 = $False
-                V8_1 = $False
-                V10_0 = $False
-                V10_1607 = $True
-                V10_1703 = $False
-                V10_1709 = $False
-                V10_1803 = $False
-                V10_1809 = $False
-                V10_1903 = $False
-                V10_1909 = $False
-                V10_2004 = $False
-                V10_2H20 = $False
-                V10_21H1 = $False
-            };
             MinimumSupportedWindowsRelease  = "1607";
             Notes                           = "";
             Owner                           = "";
             Publisher                       = "Microsoft";
-            RequirementRules                = @(
-                MSFT_MicrosoftGraphWin32LobAppRequirement{
-                    Check32BitOn64System = $False
-                    FileOrFolderName = "asdf.exe"
-                    FileSystemDetectionType = "exists"
-                    Operator = "notConfigured"
-                    Path = "C:\temp\Dev"
-                    OdataType = "FileSystem"
-                }
-                MSFT_MicrosoftGraphWin32LobAppRequirement{
-                    Check32BitOn64System = $False
-                    RegistryDetectionType = "string"
-                    DetectionValue = "1.0.0.0"
-                    Operator = "equal"
-                    OdataType = "Registry"
-                    KeyPath = "HKLM:\Software\Microsoft\Windows\CurrentVersion"
-                }
-                MSFT_MicrosoftGraphWin32LobAppRequirement{
-                    DetectionValue = "Hello World"
-                    PowerShellScriptDetectionType = "string"
-                    EnforceSignatureCheck = $False
-                    Operator = "equal"
-                    RunAs32Bit = $False
-                    OdataType = "PowerShellScript"
-                    Script = "Write-Output `"Hello World`""
-                }
-            );
             ReturnCodes                     = @(
                 MSFT_MicrosoftGraphWin32LobAppReturnCode{
                     ReturnCode = 0

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsWin32AppWindows10/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsWin32AppWindows10/2-Update.ps1
@@ -1,0 +1,149 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Import-DscResource -ModuleName Microsoft365DSC
+    node localhost
+    {
+        IntuneMobileAppsWin32AppWindows10 "IntuneMobileAppsWin32AppWindows10-Win32 App - IntuneWinAppUtil.exe"
+        {
+            AllowAvailableUninstall         = $True;
+            AllowedArchitectures            = @("x86","x64","arm64");
+            ApplicationId                   = $ApplicationId;
+            Assignments                     = @();
+            Categories                      = @(
+                MSFT_DeviceManagementMobileAppCategory{
+                    Id = "2185c6bf-1b3d-4daa-a0bc-79cb4fad9c87"
+                    DisplayName = "App Category 1"
+                }
+            );
+            CertificateThumbprint           = $CertificateThumbprint;
+            Description                     = "IntuneWinAppUtil.exe";
+            DetectionRules                  = @(
+                MSFT_MicrosoftGraphWin32LobAppDetection{
+                    Check32BitOn64System = $False
+                    DetectionValue = "1.0.0.0"
+                    FileOrFolderName = "asdf.exe"
+                    FileSystemDetectionType = "version"
+                    Operator = "equal"
+                    Path = "C:\temp\Dev"
+                    OdataType = "FileSystem"
+                }
+                MSFT_MicrosoftGraphWin32LobAppDetection{
+                    Check32BitOn64System = $False
+                    RegistryDetectionType = "integer"
+                    DetectionValue = "100"
+                    Operator = "greaterThanOrEqual"
+                    OdataType = "Registry"
+                    KeyPath = "HKLM:\Software\Microsoft\Windows\CurrentVersion"
+                }
+                MSFT_MicrosoftGraphWin32LobAppDetection{
+                    ProductVersionOperator = "greaterThan" # Drift
+                    ProductVersion = "2.0.0.0"
+                    ProductCode = "{00000000-0000-0000-0000-000000000000}"
+                    OdataType = "ProductCode"
+                }
+            );
+            Developer                       = "";
+            DisplayName                     = "Win32 App - IntuneWinAppUtil.exe";
+            DisplayVersion                  = "1.0.0.0";
+            Ensure                          = "Present";
+            Id                              = "63271b78-0fa4-46b8-9ac0-d4b777555dde";
+            InstallCommandLine              = "IntuneWinAppUtil.exe -s -t 0";
+            IsFeatured                      = $False;
+            MinimumCpuSpeedInMHz            = 2500;
+            MinimumFreeDiskSpaceInMB        = 1;
+            MinimumMemoryInMB               = 200;
+            MinimumNumberOfProcessors       = 1;
+            MinimumSupportedOperatingSystem = MSFT_MicrosoftGraphWindowsMinimumOperatingSystem{
+                V8_0 = $False
+                V8_1 = $False
+                V10_0 = $False
+                V10_1607 = $True
+                V10_1703 = $False
+                V10_1709 = $False
+                V10_1803 = $False
+                V10_1809 = $False
+                V10_1903 = $False
+                V10_1909 = $False
+                V10_2004 = $False
+                V10_2H20 = $False
+                V10_21H1 = $False
+            };
+            MinimumSupportedWindowsRelease  = "1607";
+            Notes                           = "";
+            Owner                           = "";
+            Publisher                       = "Microsoft";
+            RequirementRules                = @(
+                MSFT_MicrosoftGraphWin32LobAppRequirement{
+                    Check32BitOn64System = $False
+                    FileOrFolderName = "asdf.exe"
+                    FileSystemDetectionType = "exists"
+                    Operator = "notConfigured"
+                    Path = "C:\temp\Dev"
+                    OdataType = "FileSystem"
+                }
+                MSFT_MicrosoftGraphWin32LobAppRequirement{
+                    Check32BitOn64System = $False
+                    RegistryDetectionType = "string"
+                    DetectionValue = "1.0.0.0"
+                    Operator = "equal"
+                    OdataType = "Registry"
+                    KeyPath = "HKLM:\Software\Microsoft\Windows\CurrentVersion"
+                }
+                MSFT_MicrosoftGraphWin32LobAppRequirement{
+                    DetectionValue = "Hello World"
+                    PowerShellScriptDetectionType = "string"
+                    EnforceSignatureCheck = $False
+                    Operator = "equal"
+                    RunAs32Bit = $False
+                    OdataType = "PowerShellScript"
+                    Script = "Write-Output `"Hello World`""
+                }
+            );
+            ReturnCodes                     = @(
+                MSFT_MicrosoftGraphWin32LobAppReturnCode{
+                    ReturnCode = 0
+                    Type = "success"
+                }
+                MSFT_MicrosoftGraphWin32LobAppReturnCode{
+                    ReturnCode = 1707
+                    Type = "success"
+                }
+                MSFT_MicrosoftGraphWin32LobAppReturnCode{
+                    ReturnCode = 3010
+                    Type = "softReboot"
+                }
+                MSFT_MicrosoftGraphWin32LobAppReturnCode{
+                    ReturnCode = 1641
+                    Type = "hardReboot"
+                }
+                MSFT_MicrosoftGraphWin32LobAppReturnCode{
+                    ReturnCode = 1618
+                    Type = "retry"
+                }
+            );
+            RoleScopeTagIds                 = @("0");
+            SetupFilePath                   = "IntuneWinAppUtil.exe";
+            TenantId                        = $TenantId;
+            UninstallCommandLine            = "IntuneWinAppUtil.exe -t -s 0";
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsWin32AppWindows10/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsWin32AppWindows10/2-Update.ps1
@@ -36,88 +36,67 @@ Configuration Example
             );
             CertificateThumbprint           = $CertificateThumbprint;
             Description                     = "IntuneWinAppUtil.exe";
-            DetectionRules                  = @(
-                MSFT_MicrosoftGraphWin32LobAppDetection{
+            Rules                           = @(
+                MSFT_MicrosoftGraphWin32LobAppRule{
                     Check32BitOn64System = $False
-                    DetectionValue = "1.0.0.0"
+                    ComparisonValue = "1.0.0.0"
                     FileOrFolderName = "asdf.exe"
-                    FileSystemDetectionType = "version"
+                    FileSystemOperationType = "version"
                     Operator = "equal"
                     Path = "C:\temp\Dev"
+                    RuleType = "detection"
                     OdataType = "FileSystem"
                 }
-                MSFT_MicrosoftGraphWin32LobAppDetection{
+                MSFT_MicrosoftGraphWin32LobAppRule{
                     Check32BitOn64System = $False
-                    RegistryDetectionType = "integer"
-                    DetectionValue = "100"
+                    RegistryOperationType = "integer"
+                    ComparisonValue = "100"
                     Operator = "greaterThanOrEqual"
                     OdataType = "Registry"
+                    RuleType = "detection"
                     KeyPath = "HKLM:\Software\Microsoft\Windows\CurrentVersion"
                 }
-                MSFT_MicrosoftGraphWin32LobAppDetection{
-                    ProductVersionOperator = "greaterThan" # Drift
+                MSFT_MicrosoftGraphWin32LobAppRule{
+                    ProductVersionOperator = "lessThan"
                     ProductVersion = "2.0.0.0"
                     ProductCode = "{00000000-0000-0000-0000-000000000000}"
                     OdataType = "ProductCode"
+                    RuleType = "requirement"
+                }
+                MSFT_MicrosoftGraphWin32LobAppRule{
+                    Script = "Write-Output 'Hello World'"
+                    DisplayName = "PowerShell Script Rule.ps1"
+                    Operator = "equals"
+                    RunAs32Bit = $False
+                    EnforceSignatureCheck = $False
+                    RunAsAccount = "system"
+                    OdataType = "PowerShellScript"
+                    RuleType = "requirement"
+                    PowerShellScriptOperationType = "string"
+                    ComparisonValue = "Hello World"
                 }
             );
             Developer                       = "";
             DisplayName                     = "Win32 App - IntuneWinAppUtil.exe";
             DisplayVersion                  = "1.0.0.0";
             Ensure                          = "Present";
+            FileName                        = "IntuneWinAppUtil.intunewin";
             Id                              = "63271b78-0fa4-46b8-9ac0-d4b777555dde";
             InstallCommandLine              = "IntuneWinAppUtil.exe -s -t 0";
+            InstallExperience               = MSFT_MicrosoftGraphWin32LobAppInstallExperience{
+                DeviceRestartBehavior = "suppress"
+                RunAsAccount = "system"
+                MaxRunTimeInMinutes = 120 # Drift
+            };
             IsFeatured                      = $False;
             MinimumCpuSpeedInMHz            = 2500;
             MinimumFreeDiskSpaceInMB        = 1;
             MinimumMemoryInMB               = 200;
             MinimumNumberOfProcessors       = 1;
-            MinimumSupportedOperatingSystem = MSFT_MicrosoftGraphWindowsMinimumOperatingSystem{
-                V8_0 = $False
-                V8_1 = $False
-                V10_0 = $False
-                V10_1607 = $True
-                V10_1703 = $False
-                V10_1709 = $False
-                V10_1803 = $False
-                V10_1809 = $False
-                V10_1903 = $False
-                V10_1909 = $False
-                V10_2004 = $False
-                V10_2H20 = $False
-                V10_21H1 = $False
-            };
             MinimumSupportedWindowsRelease  = "1607";
             Notes                           = "";
             Owner                           = "";
             Publisher                       = "Microsoft";
-            RequirementRules                = @(
-                MSFT_MicrosoftGraphWin32LobAppRequirement{
-                    Check32BitOn64System = $False
-                    FileOrFolderName = "asdf.exe"
-                    FileSystemDetectionType = "exists"
-                    Operator = "notConfigured"
-                    Path = "C:\temp\Dev"
-                    OdataType = "FileSystem"
-                }
-                MSFT_MicrosoftGraphWin32LobAppRequirement{
-                    Check32BitOn64System = $False
-                    RegistryDetectionType = "string"
-                    DetectionValue = "1.0.0.0"
-                    Operator = "equal"
-                    OdataType = "Registry"
-                    KeyPath = "HKLM:\Software\Microsoft\Windows\CurrentVersion"
-                }
-                MSFT_MicrosoftGraphWin32LobAppRequirement{
-                    DetectionValue = "Hello World"
-                    PowerShellScriptDetectionType = "string"
-                    EnforceSignatureCheck = $False
-                    Operator = "equal"
-                    RunAs32Bit = $False
-                    OdataType = "PowerShellScript"
-                    Script = "Write-Output `"Hello World`""
-                }
-            );
             ReturnCodes                     = @(
                 MSFT_MicrosoftGraphWin32LobAppReturnCode{
                     ReturnCode = 0

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsWin32AppWindows10/3-Remove.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsWin32AppWindows10/3-Remove.ps1
@@ -1,0 +1,35 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param(
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneMobileAppsWin32AppWindows10 "IntuneMobileAppsWin32AppWindows10-Win32 App - IntuneWinAppUtil.exe"
+        {
+            DisplayName           = "Store App";
+            Ensure                = "Absent";
+            ApplicationId         = $ApplicationId;
+            TenantId              = $TenantId;
+            CertificateThumbprint = $CertificateThumbprint;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1788,6 +1788,12 @@ function ConvertFrom-IntuneMobileAppAssignment
             }
         }
 
+        if ($null -ne $assignment.settings)
+        {
+            $settings = (Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $assignment.settings.AdditionalProperties)
+            $hashAssignment.Add('assignmentSettings', $settings)
+        }
+
         $assignmentResult += $hashAssignment
     }
 
@@ -1893,6 +1899,14 @@ function ConvertTo-IntuneMobileAppAssignment
         if ($target)
         {
             $formattedAssignment.Add('target', $target)
+        }
+
+        if ($null -ne $assignment.assignmentSettings)
+        {
+            $settings = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $assignment.assignmentSettings
+            $formattedAssignment.Add('settings', $settings)
+            $formattedAssignment.settings.Add('@odata.type', $formattedAssignment.settings.odataType)
+            $formattedAssignment.settings.Remove('odataType') | Out-Null
         }
         $assignmentResult += $formattedAssignment
     }
@@ -2234,6 +2248,10 @@ function Update-DeviceAppManagementPolicyAssignment
                 $formattedTarget.Add('deviceAndAppManagementAssignmentFilterId',$target.deviceAndAppManagementAssignmentFilterId)
             }
             $formattedAssignment.Add('target', $formattedTarget)
+            if ($assignment.settings)
+            {
+                $formattedAssignment.Add('settings', $assignment.settings)
+            }
             $appManagementPolicyAssignments += $formattedAssignment
         }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsWin32AppWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsWin32AppWindows10.Tests.ps1
@@ -48,6 +48,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Update-MgBetaDeviceAppManagementMobileApp -MockWith {
             }
 
+            Mock -CommandName Invoke-M365DSCIntuneMobileAppInitialUpload -MockWith {
+            }
+
             Mock -CommandName Invoke-MgGraphRequest -MockWith {
                 return @{
                     AdditionalProperties = @{
@@ -55,12 +58,17 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         allowedArchitectures = "x86,x64"
                         installCommandLine = "IntuneWinAppUtil.exe -s -t 0"
                         uninstallCommandLine = "IntuneWinAppUtil.exe -s -u -t 0"
+                        installExperience = @{
+                            deviceRestartBehavior = "suppress"
+                            maxRunTimeInMinutes = 60
+                            runAsAccount = "system"
+                        }
                         setupFilePath = "IntuneWinAppUtil.exe"
-                        minimumSupportedWindowsRelease = @{
+                        minimumSupportedOperatingSystem = @{
                             v8_0 = $False
                             v8_1 = $False
                             v10_0 = $False
-                            v10_1607 = $False
+                            v10_1607 = $True
                             v10_1703 = $False
                             v10_1709 = $False
                             v10_1803 = $False
@@ -71,27 +79,37 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             v10_2H20 = $False
                             v10_21H1 = $False
                         }
+                        minimumSupportedWindowsRelease = "1607"
+                        msiInformation = @{
+                            productCode = "{00000000-0000-0000-0000-000000000000}"
+                            productVersion = "1.0.0.0"
+                            upgradeCode = "{00000000-0000-0000-0000-000000000000}"
+                            requiresReboot = $False
+                            packageType = "dualPurpose"
+                            productName = "IntuneWinAppUtil"
+                            publisher = "FakeStringValue"
+                        }
                         displayVersion = "1.0.0.0"
                         allowAvailableUninstall = $False
-                        detectionRules = @(
+                        rules = @(
                             @{
-                                '@odata.type' = "#microsoft.graph.win32LobAppFileSystemDetection"
+                                '@odata.type' = "#microsoft.graph.win32LobAppFileSystemRule"
                                 check32BitOn64System = $False
-                                detectionType = "version"
-                                detectionValue = "1.0.0.0"
+                                operationType = "version"
                                 fileOrFolderName = "test.exe"
                                 operator = "equal"
-                                path = "C:\temp\Dev"
+                                comparisonValue = "1.0.0.0"
+                                path = "C:\Path"
+                                ruleType = "detection"
                             }
-                        )
-                        requirementRules = @(
                             @{
-                                '@odata.type' = "#microsoft.graph.win32LobAppFileSystemRequirement"
+                                '@odata.type' = "#microsoft.graph.win32LobAppFileSystemRule"
                                 check32BitOn64System = $False
-                                detectionType = "exists"
+                                operationType = "exists"
                                 fileOrFolderName = "test.exe"
                                 operator = "notConfigured"
-                                path = "C:\temp\Dev"
+                                path = "C:\Path"
+                                ruleType = "requirement"
                             }
                         )
                         returnCodes = @(
@@ -142,12 +160,17 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         allowedArchitectures = "x86,x64"
                         installCommandLine = "IntuneWinAppUtil.exe -s -t 0"
                         uninstallCommandLine = "IntuneWinAppUtil.exe -s -u -t 0"
+                        installExperience = @{
+                            deviceRestartBehavior = "suppress"
+                            maxRunTimeInMinutes = 60
+                            runAsAccount = "system"
+                        }
                         setupFilePath = "IntuneWinAppUtil.exe"
-                        minimumSupportedWindowsRelease = @{
+                        minimumSupportedOperatingSystem = @{
                             v8_0 = $False
                             v8_1 = $False
                             v10_0 = $False
-                            v10_1607 = $False
+                            v10_1607 = $True
                             v10_1703 = $False
                             v10_1709 = $False
                             v10_1803 = $False
@@ -158,24 +181,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             v10_2H20 = $False
                             v10_21H1 = $False
                         }
-                        displayVersion = "1.0.0.0"
-                        allowAvailableUninstall = $False
-                        detectionRules = @(
-                            @{
-                                '@odata.type' = "#microsoft.graph.win32LobAppFileSystemDetection"
-                                check32BitOn64System = $False
-                                detectionType = "version"
-                                detectionValue = "1.0.0.0"
-                                fileOrFolderName = "test.exe"
-                                operator = "equal"
-                                path = "C:\temp\Dev"
-                            }
-                        )
-                        installExperience = @{
-                            deviceRestartBehavior = "suppress"
-                            maxRunTimeInMinutes = 60
-                            runAsAccountType = "system"
-                        }
+                        minimumSupportedWindowsRelease = "1607"
                         msiInformation = @{
                             productCode = "{00000000-0000-0000-0000-000000000000}"
                             productVersion = "1.0.0.0"
@@ -185,14 +191,27 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             productName = "IntuneWinAppUtil"
                             publisher = "FakeStringValue"
                         }
-                        requirementRules = @(
+                        displayVersion = "1.0.0.0"
+                        allowAvailableUninstall = $False
+                        rules = @(
                             @{
-                                '@odata.type' = "#microsoft.graph.win32LobAppFileSystemRequirement"
+                                '@odata.type' = "#microsoft.graph.win32LobAppFileSystemRule"
                                 check32BitOn64System = $False
-                                detectionType = "exists"
+                                operationType = "version"
+                                fileOrFolderName = "test.exe"
+                                operator = "equal"
+                                comparisonValue = "1.0.0.0"
+                                path = "C:\Path"
+                                ruleType = "detection"
+                            }
+                            @{
+                                '@odata.type' = "#microsoft.graph.win32LobAppFileSystemRule"
+                                check32BitOn64System = $False
+                                operationType = "exists"
                                 fileOrFolderName = "test.exe"
                                 operator = "notConfigured"
-                                path = "C:\temp\Dev"
+                                path = "C:\Path"
+                                ruleType = "requirement"
                             }
                         )
                         returnCodes = @(
@@ -244,8 +263,35 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             $Script:ExportMode = $false
 
             Mock -CommandName Get-MgBetaDeviceAppManagementMobileAppAssignment -MockWith {
+                return @(
+                    @{
+                        Id = "12345-12345-12345-12345-12345"
+                        Intent = "required"
+                        Source = "direct"
+                        SourceId = "12345-12345-12345-12345-12345"
+                        Target = @{
+                            AdditionalProperties = @{
+                                "@odata.type" = "#microsoft.graph.groupAssignmentTarget"
+                                groupId = "26d60dd1-fab6-47bf-8656-358194c1a49d"
+                            }
+                            "deviceAndAppManagementAssignmentFilterId" = '12345-12345-12345-12345-12345'
+                            "deviceAndAppManagementAssignmentFilterType" = "none"
+                        }
+                        Settings = @{
+                            AdditionalProperties = @{
+                                "@odata.type" = "#microsoft.graph.win32LobAppAssignmentSettings"
+                                notifications = "showAll"
+                                deliveryOptimizationPriority = "notConfigured"
+                                restartSettings = @{
+                                    gracePeriodInMinutes = 1440
+                                    countdownDisplayBeforeRestartInMinutes = 15
+                                    restartNotificationSnoozeDurationInMinutes = 240
+                                }
+                            }
+                        }
+                    }
+                )
             }
-
         }
 
         # Test contexts
@@ -253,6 +299,23 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             BeforeAll {
                 $testParams = @{
                     AllowedArchitectures = @("x86", "x64")
+                    Assignments = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_DeviceManagementWin32MobileAppAssignment -Property @{
+                            Id = "12345-12345-12345-12345-12345"
+                            Intent = "required"
+                            DeviceAndAppManagementAssignmentFilterType = "none"
+                            GroupId = "26d60dd1-fab6-47bf-8656-358194c1a49d"
+                            assignmentSettings = (New-CimInstance -ClassName MSFT_DeviceManagementWin32MobileAppAssignmentSettings -Property @{
+                                Notifications = "showAll"
+                                DeliveryOptimizationPriority = "notConfigured"
+                                RestartSettings = (New-CimInstance -ClassName MSFT_DeviceManagementWin32MobileAppAssignmentSettingsRestartSettings -Property @{
+                                    GracePeriodInMinutes = 1440
+                                    CountdownDisplayBeforeRestartInMinutes = 15
+                                    RestartNotificationSnoozeDurationInMinutes = 240
+                                } -ClientOnly)
+                            } -ClientOnly)
+                        } -ClientOnly)
+                    )
                     Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
                         Id = "FakeStringValue"
                         DisplayName = "FakeStringValue"
@@ -271,25 +334,24 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         ProductName = "IntuneWinAppUtil"
                         Publisher = "FakeStringValue"
                     } -ClientOnly)
-                    DetectionRules = [CimInstance[]]@(
-                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemDetection -Property @{
-                            Check32BitOn64System = $False
-                            DetectionType = "version"
-                            DetectionValue = "1.0.0.0"
+                    Rules = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppRule -Property @{
+                            Path = "C:\Path"
                             FileOrFolderName = "test.exe"
                             OdataType = "FileSystem"
-                            Operator = "equal"
-                            Path = "C:\temp\Dev"
-                        } -ClientOnly)
-                    )
-                    RequirementRules = [CimInstance[]]@(
-                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemRequirement -Property @{
-                            Check32BitOn64System = $False
-                            DetectionType = "exists"
-                            FileOrFolderName = "test.exe"
+                            RuleType = "requirement"
+                            FileSystemOperationType = "exists"
                             Operator = "notConfigured"
-                            Path = "C:\temp\Dev"
+                            Check32BitOn64System = $False
+                        } -ClientOnly)
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppRule -Property @{
+                            Path = "C:\Path"
+                            FileOrFolderName = "test.exe"
                             OdataType = "FileSystem"
+                            RuleType = "detection"
+                            FileSystemOperationType = "version"
+                            Operator = "equal"
+                            ComparisonValue = "1.0.0.0"
                         } -ClientOnly)
                     )
                     ReturnCodes = [CimInstance[]]@(
@@ -340,6 +402,23 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             BeforeAll {
                 $testParams = @{
                     AllowedArchitectures = @("x86", "x64")
+                    Assignments = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_DeviceManagementWin32MobileAppAssignment -Property @{
+                            Id = "12345-12345-12345-12345-12345"
+                            Intent = "required"
+                            DeviceAndAppManagementAssignmentFilterType = "none"
+                            GroupId = "26d60dd1-fab6-47bf-8656-358194c1a49d"
+                            assignmentSettings = (New-CimInstance -ClassName MSFT_DeviceManagementWin32MobileAppAssignmentSettings -Property @{
+                                Notifications = "showAll"
+                                DeliveryOptimizationPriority = "notConfigured"
+                                RestartSettings = (New-CimInstance -ClassName MSFT_DeviceManagementWin32MobileAppAssignmentSettingsRestartSettings -Property @{
+                                    GracePeriodInMinutes = 1440
+                                    CountdownDisplayBeforeRestartInMinutes = 15
+                                    RestartNotificationSnoozeDurationInMinutes = 240
+                                } -ClientOnly)
+                            } -ClientOnly)
+                        } -ClientOnly)
+                    )
                     Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
                         Id = "FakeStringValue"
                         DisplayName = "FakeStringValue"
@@ -358,25 +437,24 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         ProductName = "IntuneWinAppUtil"
                         Publisher = "FakeStringValue"
                     } -ClientOnly)
-                    DetectionRules = [CimInstance[]]@(
-                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemDetection -Property @{
-                            Check32BitOn64System = $False
-                            DetectionType = "version"
-                            DetectionValue = "1.0.0.0"
+                    Rules = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppRule -Property @{
+                            Path = "C:\Path"
                             FileOrFolderName = "test.exe"
                             OdataType = "FileSystem"
-                            Operator = "equal"
-                            Path = "C:\temp\Dev"
-                        } -ClientOnly)
-                    )
-                    RequirementRules = [CimInstance[]]@(
-                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemRequirement -Property @{
-                            Check32BitOn64System = $False
-                            DetectionType = "exists"
-                            FileOrFolderName = "test.exe"
+                            RuleType = "requirement"
+                            FileSystemOperationType = "exists"
                             Operator = "notConfigured"
-                            Path = "C:\temp\Dev"
+                            Check32BitOn64System = $False
+                        } -ClientOnly)
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppRule -Property @{
+                            Path = "C:\Path"
+                            FileOrFolderName = "test.exe"
                             OdataType = "FileSystem"
+                            RuleType = "detection"
+                            FileSystemOperationType = "version"
+                            Operator = "equal"
+                            ComparisonValue = "1.0.0.0"
                         } -ClientOnly)
                     )
                     ReturnCodes = [CimInstance[]]@(
@@ -426,6 +504,23 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             BeforeAll {
                 $testParams = @{
                     AllowedArchitectures = @("x86", "x64")
+                    Assignments = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_DeviceManagementWin32MobileAppAssignment -Property @{
+                            Id = "12345-12345-12345-12345-12345"
+                            Intent = "required"
+                            DeviceAndAppManagementAssignmentFilterType = "none"
+                            GroupId = "26d60dd1-fab6-47bf-8656-358194c1a49d"
+                            assignmentSettings = (New-CimInstance -ClassName MSFT_DeviceManagementWin32MobileAppAssignmentSettings -Property @{
+                                Notifications = "showAll"
+                                DeliveryOptimizationPriority = "notConfigured"
+                                RestartSettings = (New-CimInstance -ClassName MSFT_DeviceManagementWin32MobileAppAssignmentSettingsRestartSettings -Property @{
+                                    GracePeriodInMinutes = 1440
+                                    CountdownDisplayBeforeRestartInMinutes = 15
+                                    RestartNotificationSnoozeDurationInMinutes = 240
+                                } -ClientOnly)
+                            } -ClientOnly)
+                        } -ClientOnly)
+                    )
                     Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
                         Id = "FakeStringValue"
                         DisplayName = "FakeStringValue"
@@ -444,25 +539,24 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         ProductName = "IntuneWinAppUtil"
                         Publisher = "FakeStringValue"
                     } -ClientOnly)
-                    DetectionRules = [CimInstance[]]@(
-                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemDetection -Property @{
-                            Check32BitOn64System = $False
-                            DetectionType = "version"
-                            DetectionValue = "1.0.0.0"
+                    Rules = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppRule -Property @{
+                            Path = "C:\Path"
                             FileOrFolderName = "test.exe"
                             OdataType = "FileSystem"
-                            Operator = "equal"
-                            Path = "C:\temp\Dev"
-                        } -ClientOnly)
-                    )
-                    RequirementRules = [CimInstance[]]@(
-                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemRequirement -Property @{
-                            Check32BitOn64System = $False
-                            DetectionType = "exists"
-                            FileOrFolderName = "test.exe"
+                            RuleType = "requirement"
+                            FileSystemOperationType = "exists"
                             Operator = "notConfigured"
-                            Path = "C:\temp\Dev"
+                            Check32BitOn64System = $False
+                        } -ClientOnly)
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppRule -Property @{
+                            Path = "C:\Path"
+                            FileOrFolderName = "test.exe"
                             OdataType = "FileSystem"
+                            RuleType = "detection"
+                            FileSystemOperationType = "version"
+                            Operator = "equal"
+                            ComparisonValue = "1.0.0.0"
                         } -ClientOnly)
                     )
                     ReturnCodes = [CimInstance[]]@(
@@ -503,6 +597,23 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             BeforeAll {
                 $testParams = @{
                     AllowedArchitectures = @("x86", "x64")
+                    Assignments = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_DeviceManagementWin32MobileAppAssignment -Property @{
+                            Id = "12345-12345-12345-12345-12345"
+                            Intent = "required"
+                            DeviceAndAppManagementAssignmentFilterType = "none"
+                            GroupId = "26d60dd1-fab6-47bf-8656-358194c1a49d"
+                            assignmentSettings = (New-CimInstance -ClassName MSFT_DeviceManagementWin32MobileAppAssignmentSettings -Property @{
+                                Notifications = "showAll"
+                                DeliveryOptimizationPriority = "notConfigured"
+                                RestartSettings = (New-CimInstance -ClassName MSFT_DeviceManagementWin32MobileAppAssignmentSettingsRestartSettings -Property @{
+                                    GracePeriodInMinutes = 1440
+                                    CountdownDisplayBeforeRestartInMinutes = 30 # Drift
+                                    RestartNotificationSnoozeDurationInMinutes = 240
+                                } -ClientOnly)
+                            } -ClientOnly)
+                        } -ClientOnly)
+                    )
                     Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
                         Id = "FakeStringValue"
                         DisplayName = "FakeStringValue"
@@ -521,25 +632,24 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         ProductName = "IntuneWinAppUtil"
                         Publisher = "FakeStringValue"
                     } -ClientOnly)
-                    DetectionRules = [CimInstance[]]@(
-                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemDetection -Property @{
-                            Check32BitOn64System = $False
-                            DetectionType = "version"
-                            DetectionValue = "1.0.0.1" # Drift
+                    Rules = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppRule -Property @{
+                            Path = "C:\Path"
                             FileOrFolderName = "test.exe"
                             OdataType = "FileSystem"
-                            Operator = "equal"
-                            Path = "C:\temp\Dev"
-                        } -ClientOnly)
-                    )
-                    RequirementRules = [CimInstance[]]@(
-                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemRequirement -Property @{
-                            Check32BitOn64System = $False
-                            DetectionType = "exists"
-                            FileOrFolderName = "test.exe"
+                            RuleType = "requirement"
+                            FileSystemOperationType = "exists"
                             Operator = "notConfigured"
-                            Path = "C:\temp\Dev"
+                            Check32BitOn64System = $False
+                        } -ClientOnly)
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppRule -Property @{
+                            Path = "C:\Path"
+                            FileOrFolderName = "test.exe"
                             OdataType = "FileSystem"
+                            RuleType = "detection"
+                            FileSystemOperationType = "version"
+                            Operator = "equal"
+                            ComparisonValue = "1.0.0.0"
                         } -ClientOnly)
                     )
                     ReturnCodes = [CimInstance[]]@(

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsWin32AppWindows10.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsWin32AppWindows10.Tests.ps1
@@ -1,0 +1,605 @@
+[CmdletBinding()]
+param(
+)
+$M365DSCTestFolder = Join-Path -Path $PSScriptRoot `
+                        -ChildPath '..\..\Unit' `
+                        -Resolve
+$CmdletModule = (Join-Path -Path $M365DSCTestFolder `
+            -ChildPath '\Stubs\Microsoft365.psm1' `
+            -Resolve)
+$GenericStubPath = (Join-Path -Path $M365DSCTestFolder `
+    -ChildPath '\Stubs\Generic.psm1' `
+    -Resolve)
+Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\UnitTestHelper.psm1' `
+        -Resolve)
+
+$Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
+    -DscResource "IntuneMobileAppsWin32AppWindows10" -GenericStubModule $GenericStubPath
+Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
+        BeforeAll {
+
+            $secpasswd = ConvertTo-SecureString (New-Guid | Out-String) -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
+
+            Mock -ModuleName M365DSCUtil -CommandName Confirm-M365DSCDependencies -MockWith {
+            }
+
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
+            Mock -CommandName Reset-MSCloudLoginConnectionProfileContext -MockWith {
+            }
+
+            Mock -CommandName Get-PSSession -MockWith {
+            }
+
+            Mock -CommandName Remove-PSSession -MockWith {
+            }
+
+            Mock -CommandName Update-DeviceAppManagementAppCategory -MockWith {
+            }
+
+            Mock -CommandName Update-DeviceAppManagementPolicyAssignment -MockWith {
+            }
+
+            Mock -CommandName Update-MgBetaDeviceAppManagementMobileApp -MockWith {
+            }
+
+            Mock -CommandName Invoke-MgGraphRequest -MockWith {
+                return @{
+                    AdditionalProperties = @{
+                        '@odata.type' = "#microsoft.graph.win32LobApp"
+                        allowedArchitectures = "x86,x64"
+                        installCommandLine = "IntuneWinAppUtil.exe -s -t 0"
+                        uninstallCommandLine = "IntuneWinAppUtil.exe -s -u -t 0"
+                        setupFilePath = "IntuneWinAppUtil.exe"
+                        minimumSupportedWindowsRelease = @{
+                            v8_0 = $False
+                            v8_1 = $False
+                            v10_0 = $False
+                            v10_1607 = $False
+                            v10_1703 = $False
+                            v10_1709 = $False
+                            v10_1803 = $False
+                            v10_1809 = $False
+                            v10_1903 = $False
+                            v10_1909 = $False
+                            v10_2004 = $False
+                            v10_2H20 = $False
+                            v10_21H1 = $False
+                        }
+                        displayVersion = "1.0.0.0"
+                        allowAvailableUninstall = $False
+                        detectionRules = @(
+                            @{
+                                '@odata.type' = "#microsoft.graph.win32LobAppFileSystemDetection"
+                                check32BitOn64System = $False
+                                detectionType = "version"
+                                detectionValue = "1.0.0.0"
+                                fileOrFolderName = "test.exe"
+                                operator = "equal"
+                                path = "C:\temp\Dev"
+                            }
+                        )
+                        requirementRules = @(
+                            @{
+                                '@odata.type' = "#microsoft.graph.win32LobAppFileSystemRequirement"
+                                check32BitOn64System = $False
+                                detectionType = "exists"
+                                fileOrFolderName = "test.exe"
+                                operator = "notConfigured"
+                                path = "C:\temp\Dev"
+                            }
+                        )
+                        returnCodes = @(
+                            @{
+                                returnCode = 0
+                                type = "success"
+                            }
+                        )
+                    }
+                    Categories = @(
+                        @{
+                            Id = "FakeStringValue"
+                            DisplayName = "FakeStringValue"
+                        }
+                    )
+                    CommittedContentVersion = "FakeStringValue"
+                    DependentAppCount = 25
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    FileName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = @{
+                        Type = "FakeStringValue"
+                        Value = [System.Convert]::FromBase64String("VGVzdA==")
+                    }
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    PublishingState = "notPublished"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    SupersededAppCount = 25
+                    SupersedingAppCount = 25
+                    UploadState = 25
+                }
+            }
+
+            Mock -CommandName Remove-MgBetaDeviceAppManagementMobileApp -MockWith {
+            }
+
+            Mock -CommandName Get-MgBetaDeviceAppManagementMobileApp -MockWith {
+                return @{
+                    AdditionalProperties = @{
+                        '@odata.type' = "#microsoft.graph.win32LobApp"
+                        allowedArchitectures = "x86,x64"
+                        installCommandLine = "IntuneWinAppUtil.exe -s -t 0"
+                        uninstallCommandLine = "IntuneWinAppUtil.exe -s -u -t 0"
+                        setupFilePath = "IntuneWinAppUtil.exe"
+                        minimumSupportedWindowsRelease = @{
+                            v8_0 = $False
+                            v8_1 = $False
+                            v10_0 = $False
+                            v10_1607 = $False
+                            v10_1703 = $False
+                            v10_1709 = $False
+                            v10_1803 = $False
+                            v10_1809 = $False
+                            v10_1903 = $False
+                            v10_1909 = $False
+                            v10_2004 = $False
+                            v10_2H20 = $False
+                            v10_21H1 = $False
+                        }
+                        displayVersion = "1.0.0.0"
+                        allowAvailableUninstall = $False
+                        detectionRules = @(
+                            @{
+                                '@odata.type' = "#microsoft.graph.win32LobAppFileSystemDetection"
+                                check32BitOn64System = $False
+                                detectionType = "version"
+                                detectionValue = "1.0.0.0"
+                                fileOrFolderName = "test.exe"
+                                operator = "equal"
+                                path = "C:\temp\Dev"
+                            }
+                        )
+                        installExperience = @{
+                            deviceRestartBehavior = "suppress"
+                            maxRunTimeInMinutes = 60
+                            runAsAccountType = "system"
+                        }
+                        msiInformation = @{
+                            productCode = "{00000000-0000-0000-0000-000000000000}"
+                            productVersion = "1.0.0.0"
+                            upgradeCode = "{00000000-0000-0000-0000-000000000000}"
+                            requiresReboot = $False
+                            packageType = "dualPurpose"
+                            productName = "IntuneWinAppUtil"
+                            publisher = "FakeStringValue"
+                        }
+                        requirementRules = @(
+                            @{
+                                '@odata.type' = "#microsoft.graph.win32LobAppFileSystemRequirement"
+                                check32BitOn64System = $False
+                                detectionType = "exists"
+                                fileOrFolderName = "test.exe"
+                                operator = "notConfigured"
+                                path = "C:\temp\Dev"
+                            }
+                        )
+                        returnCodes = @(
+                            @{
+                                returnCode = 0
+                                type = "success"
+                            }
+                        )
+                    }
+                    Categories = @(
+                        @{
+                            Id = "FakeStringValue"
+                            DisplayName = "FakeStringValue"
+                        }
+                    )
+                    CommittedContentVersion = "FakeStringValue"
+                    DependentAppCount = 25
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    FileName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = @{
+                        Type = "FakeStringValue"
+                        Value = [System.Convert]::FromBase64String("VGVzdA==")
+                    }
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    PublishingState = "notPublished"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    SupersededAppCount = 25
+                    SupersedingAppCount = 25
+                    UploadState = 25
+                }
+            }
+
+            Mock -CommandName New-M365DSCConnection -MockWith {
+                return "Credentials"
+            }
+
+            # Mock Write-M365DSCHost to hide output during the tests
+            Mock -CommandName Write-M365DSCHost -MockWith {
+            }
+            $Script:exportedInstance = $null
+            $Script:ExportMode = $false
+
+            Mock -CommandName Get-MgBetaDeviceAppManagementMobileAppAssignment -MockWith {
+            }
+
+        }
+
+        # Test contexts
+        Context -Name "The IntuneMobileAppsWin32AppWindows10 should exist but it DOES NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    AllowedArchitectures = @("x86", "x64")
+                    Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
+                        Id = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                    } -ClientOnly))
+                    InstallExperience = (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppInstallExperience -Property @{
+                        DeviceRestartBehavior = "suppress"
+                        MaxRunTimeInMinutes = 60
+                        RunAsAccountType = "system"
+                    } -ClientOnly)
+                    MsiInformation = (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppMsiInformation -Property @{
+                        ProductCode = "{00000000-0000-0000-0000-000000000000}"
+                        ProductVersion = "1.0.0.0"
+                        UpgradeCode = "{00000000-0000-0000-0000-000000000000}"
+                        RequiresReboot = $False
+                        PackageType = "dualPurpose"
+                        ProductName = "IntuneWinAppUtil"
+                        Publisher = "FakeStringValue"
+                    } -ClientOnly)
+                    DetectionRules = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemDetection -Property @{
+                            Check32BitOn64System = $False
+                            DetectionType = "version"
+                            DetectionValue = "1.0.0.0"
+                            FileOrFolderName = "test.exe"
+                            OdataType = "FileSystem"
+                            Operator = "equal"
+                            Path = "C:\temp\Dev"
+                        } -ClientOnly)
+                    )
+                    RequirementRules = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemRequirement -Property @{
+                            Check32BitOn64System = $False
+                            DetectionType = "exists"
+                            FileOrFolderName = "test.exe"
+                            Operator = "notConfigured"
+                            Path = "C:\temp\Dev"
+                            OdataType = "FileSystem"
+                        } -ClientOnly)
+                    )
+                    ReturnCodes = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppReturnCode -Property @{
+                            ReturnCode = 0
+                            Type = "success"
+                        } -ClientOnly)
+                    )
+                    InstallCommandLine = "IntuneWinAppUtil.exe -s -t 0"
+                    UninstallCommandLine = "IntuneWinAppUtil.exe -s -u -t 0"
+                    SetupFilePath = "IntuneWinAppUtil.exe"
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent -Property @{
+                        Type = "FakeStringValue"
+                        Value = "VGVzdA==" # Base64 encoded string for "Test"
+                    } -ClientOnly)
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+
+                Mock -CommandName Get-MgBetaDeviceAppManagementMobileApp -MockWith {
+                    return $null
+                }
+            }
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
+            }
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+            It 'Should Create the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Invoke-MgGraphRequest -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneMobileAppsWin32AppWindows10 exists but it SHOULD NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    AllowedArchitectures = @("x86", "x64")
+                    Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
+                        Id = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                    } -ClientOnly))
+                    InstallExperience = (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppInstallExperience -Property @{
+                        DeviceRestartBehavior = "suppress"
+                        MaxRunTimeInMinutes = 60
+                        RunAsAccountType = "system"
+                    } -ClientOnly)
+                    MsiInformation = (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppMsiInformation -Property @{
+                        ProductCode = "{00000000-0000-0000-0000-000000000000}"
+                        ProductVersion = "1.0.0.0"
+                        UpgradeCode = "{00000000-0000-0000-0000-000000000000}"
+                        RequiresReboot = $False
+                        PackageType = "dualPurpose"
+                        ProductName = "IntuneWinAppUtil"
+                        Publisher = "FakeStringValue"
+                    } -ClientOnly)
+                    DetectionRules = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemDetection -Property @{
+                            Check32BitOn64System = $False
+                            DetectionType = "version"
+                            DetectionValue = "1.0.0.0"
+                            FileOrFolderName = "test.exe"
+                            OdataType = "FileSystem"
+                            Operator = "equal"
+                            Path = "C:\temp\Dev"
+                        } -ClientOnly)
+                    )
+                    RequirementRules = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemRequirement -Property @{
+                            Check32BitOn64System = $False
+                            DetectionType = "exists"
+                            FileOrFolderName = "test.exe"
+                            Operator = "notConfigured"
+                            Path = "C:\temp\Dev"
+                            OdataType = "FileSystem"
+                        } -ClientOnly)
+                    )
+                    ReturnCodes = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppReturnCode -Property @{
+                            ReturnCode = 0
+                            Type = "success"
+                        } -ClientOnly)
+                    )
+                    InstallCommandLine = "IntuneWinAppUtil.exe -s -t 0"
+                    UninstallCommandLine = "IntuneWinAppUtil.exe -s -u -t 0"
+                    SetupFilePath = "IntuneWinAppUtil.exe"
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent -Property @{
+                        Type = "FakeStringValue"
+                        Value = "VGVzdA==" # Base64 encoded string for "Test"
+                    } -ClientOnly)
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Absent"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should Remove the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Remove-MgBetaDeviceAppManagementMobileApp -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneMobileAppsWin32AppWindows10 Exists and Values are already in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    AllowedArchitectures = @("x86", "x64")
+                    Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
+                        Id = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                    } -ClientOnly))
+                    InstallExperience = (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppInstallExperience -Property @{
+                        DeviceRestartBehavior = "suppress"
+                        MaxRunTimeInMinutes = 60
+                        RunAsAccountType = "system"
+                    } -ClientOnly)
+                    MsiInformation = (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppMsiInformation -Property @{
+                        ProductCode = "{00000000-0000-0000-0000-000000000000}"
+                        ProductVersion = "1.0.0.0"
+                        UpgradeCode = "{00000000-0000-0000-0000-000000000000}"
+                        RequiresReboot = $False
+                        PackageType = "dualPurpose"
+                        ProductName = "IntuneWinAppUtil"
+                        Publisher = "FakeStringValue"
+                    } -ClientOnly)
+                    DetectionRules = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemDetection -Property @{
+                            Check32BitOn64System = $False
+                            DetectionType = "version"
+                            DetectionValue = "1.0.0.0"
+                            FileOrFolderName = "test.exe"
+                            OdataType = "FileSystem"
+                            Operator = "equal"
+                            Path = "C:\temp\Dev"
+                        } -ClientOnly)
+                    )
+                    RequirementRules = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemRequirement -Property @{
+                            Check32BitOn64System = $False
+                            DetectionType = "exists"
+                            FileOrFolderName = "test.exe"
+                            Operator = "notConfigured"
+                            Path = "C:\temp\Dev"
+                            OdataType = "FileSystem"
+                        } -ClientOnly)
+                    )
+                    ReturnCodes = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppReturnCode -Property @{
+                            ReturnCode = 0
+                            Type = "success"
+                        } -ClientOnly)
+                    )
+                    InstallCommandLine = "IntuneWinAppUtil.exe -s -t 0"
+                    UninstallCommandLine = "IntuneWinAppUtil.exe -s -u -t 0"
+                    SetupFilePath = "IntuneWinAppUtil.exe"
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent -Property @{
+                        Type = "FakeStringValue"
+                        Value = "VGVzdA==" # Base64 encoded string for "Test"
+                    } -ClientOnly)
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+        }
+
+        Context -Name "The IntuneMobileAppsWin32AppWindows10 exists and values are NOT in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    AllowedArchitectures = @("x86", "x64")
+                    Categories = [CimInstance[]]@((New-CimInstance -ClassName MSFT_DeviceManagementMobileAppCategory -Property @{
+                        Id = "FakeStringValue"
+                        DisplayName = "FakeStringValue"
+                    } -ClientOnly))
+                    InstallExperience = (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppInstallExperience -Property @{
+                        DeviceRestartBehavior = "suppress"
+                        MaxRunTimeInMinutes = 60
+                        RunAsAccountType = "system"
+                    } -ClientOnly)
+                    MsiInformation = (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppMsiInformation -Property @{
+                        ProductCode = "{00000000-0000-0000-0000-000000000000}"
+                        ProductVersion = "1.0.0.0"
+                        UpgradeCode = "{00000000-0000-0000-0000-000000000000}"
+                        RequiresReboot = $False
+                        PackageType = "dualPurpose"
+                        ProductName = "IntuneWinAppUtil"
+                        Publisher = "FakeStringValue"
+                    } -ClientOnly)
+                    DetectionRules = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemDetection -Property @{
+                            Check32BitOn64System = $False
+                            DetectionType = "version"
+                            DetectionValue = "1.0.0.1" # Drift
+                            FileOrFolderName = "test.exe"
+                            OdataType = "FileSystem"
+                            Operator = "equal"
+                            Path = "C:\temp\Dev"
+                        } -ClientOnly)
+                    )
+                    RequirementRules = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppFileSystemRequirement -Property @{
+                            Check32BitOn64System = $False
+                            DetectionType = "exists"
+                            FileOrFolderName = "test.exe"
+                            Operator = "notConfigured"
+                            Path = "C:\temp\Dev"
+                            OdataType = "FileSystem"
+                        } -ClientOnly)
+                    )
+                    ReturnCodes = [CimInstance[]]@(
+                        (New-CimInstance -ClassName MSFT_MicrosoftGraphWin32LobAppReturnCode -Property @{
+                            ReturnCode = 0
+                            Type = "success"
+                        } -ClientOnly)
+                    )
+                    InstallCommandLine = "IntuneWinAppUtil.exe -s -t 0"
+                    UninstallCommandLine = "IntuneWinAppUtil.exe -s -u -t 0"
+                    SetupFilePath = "IntuneWinAppUtil.exe"
+                    Description = "FakeStringValue"
+                    Developer = "FakeStringValue"
+                    DisplayName = "FakeStringValue"
+                    Id = "FakeStringValue"
+                    InformationUrl = "FakeStringValue"
+                    IsFeatured = $True
+                    LargeIcon = (New-CimInstance -ClassName MSFT_MicrosoftGraphmimeContent -Property @{
+                        Type = "FakeStringValue"
+                        Value = "VGVzdA==" # Base64 encoded string for "Test"
+                    } -ClientOnly)
+                    Notes = "FakeStringValue"
+                    Owner = "FakeStringValue"
+                    PrivacyInformationUrl = "FakeStringValue"
+                    Publisher = "FakeStringValue"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Invoke-MgGraphRequest -Exactly 1
+            }
+        }
+
+        Context -Name 'ReverseDSC Tests' -Fixture {
+            BeforeAll {
+                $Global:CurrentModeIsExport = $true
+                $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
+                $testParams = @{
+                    Credential = $Credential
+                }
+            }
+
+            It 'Should Reverse Engineer resource from the Export method' {
+                $result = Export-TargetResource @testParams
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}
+
+Invoke-Command -ScriptBlock $Global:DscHelper.CleanupScript -NoNewScope


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds the `IntuneMobileAppsWin32AppWindows10` resource. It contains the core application without the binary content. During upload, a sample file will be uploaded and the rest of the app is configured. For a complete application, manual binary upload in the Intune Portal is required. 

Does not configure Dependencies or Supersedence of the app. Can be added if requested, but is not required for the app to function. Supersedence and dependencies should be used as few as possible.

**Attention**
Depends on #6351 for sample app upload and processing.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
