### PR TITLE
Fix information fetch for permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # UNRELEASED
 
 * AADApplication
+  * Fixed an issue where the permission lookup would return only the Guid for delegated permissions.
   * Reduced export time by up to 75%.
 * AADConditionalAccessPolicy
   * Added support for the ProtocolFlows property.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -1915,7 +1915,7 @@ function Get-M365DSCAzureADAppPermissions
             $currentPermission.Add('SourceAPI', $SourceAPI.DisplayName)
             if ($resourceAccess.Type -eq 'Scope')
             {
-                $scopeInfo = $SourceAPI.Oauth2PermissionScopes | Where-Object -FilterScript { $_.Id -eq $resourceAccess.Id }
+                $scopeInfo = $SourceAPI.publishedPermissionScopes | Where-Object -FilterScript { $_.Id -eq $resourceAccess.Id }
                 $scopeInfoValue = $null
                 if ($null -eq $scopeInfo)
                 {
@@ -1983,4 +1983,3 @@ function Get-M365DSCAzureADAppPermissions
 }
 
 Export-ModuleMember -Function *-TargetResource
-


### PR DESCRIPTION
#### Pull Request (PR) description
Fix information lookup for delegated permissions in `AADApplication`. The previous property `Oauth2PermissionScopes` does not exist (anymore), so `publishedPermissionScopes` is used. It contains all permission scopes for the current source api (e.g. Microsoft Graph oder O365 SharePoint). 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
