### PR TITLE
Add missing property in AADApplication when fetching single instance

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -1,4 +1,5 @@
 Confirm-M365DSCModuleDependency -ModuleName 'MSFT_AADApplication'
+$Script:PropertiesToRetrieve = "displayName, description, groupMembershipClaims, web, api, id, appId, applicationTemplateId, signInAudience, authenticationBehaviors, keyCredentials, requiredResourceAccess"
 
 function Get-TargetResource
 {
@@ -176,7 +177,7 @@ function Get-TargetResource
                 {
                     $AADApp = Get-MgBetaApplication `
                         -Filter "AppId eq '$AppId'" `
-                        -Property "displayName, description, groupMembershipClaims, web, api, id, appId, applicationTemplateId, signInAudience, authenticationBehaviors, keyCredentials" `
+                        -Property $Script:PropertiesToRetrieve `
                         -ExpandProperty "owners"
                 }
             }
@@ -190,7 +191,7 @@ function Get-TargetResource
                 Write-Verbose -Message "Attempting to retrieve Azure AD Application by DisplayName {$DisplayName}"
                 $AADApp = [Array](Get-MgBetaApplication `
                     -Filter "DisplayName eq '$($DisplayName -replace "'", "''")'" `
-                    -Property "displayName, description, groupMembershipClaims, web, api, id, appId, applicationTemplateId, signInAudience, authenticationBehaviors, keyCredentials" `
+                    -Property $Script:PropertiesToRetrieve `
                     -ExpandProperty "owners")
             }
             if ($null -ne $AADApp -and $AADApp.Count -gt 1)
@@ -1562,7 +1563,7 @@ function Export-TargetResource
         $Script:ExportMode = $true
         [array] $Script:exportedInstances = Get-MgBetaApplication `
             -Filter $Filter `
-            -Property "displayName, description, groupMembershipClaims, web, api, id, appId, applicationTemplateId, signInAudience, authenticationBehaviors, keyCredentials, requiredResourceAccess" `
+            -Property $Script:PropertiesToRetrieve `
             -ExpandProperty "owners" `
             -All `
             -ErrorAction Stop


### PR DESCRIPTION
#### Pull Request (PR) description
Adds the missing property `requiredResourceAccess` when fetching a single instance of an application.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
