### PR TITLE
Fix: Always export AdvancedSettings as array in SCSensitivityLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 * IntuneSettingCatalogCustomPolicyWindows10
   * Add `RoleScopeTagIds` property to functions.
     FIXES [#6348](https://github.com/microsoft/Microsoft365DSC/issues/6348)
+* SCSensitivityLabel
+  * Fixes issue where AdvancedSettings in MSFT_SCSensitivityLabel was not always exported as an array block. [#6321](https://github.com/microsoft/Microsoft365DSC/issues/6321)
 * M365DSCDRGUtil
   * Added new function `Invoke-M365DSCIntuneMobileAppInitialUpload` for initial mobile app content upload.
 * MISC

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
@@ -1612,28 +1612,34 @@ function Export-TargetResource
             $Script:exportedInstance = $label
             $Results = Get-TargetResource @PSBoundParameters -Name $label.Name
 
-            if ($null -ne $Results.AdvancedSettings)
-            {
-                $complexMapping = @(
-                    @{
-                        Name            = 'AdvancedSettings'
-                        CimInstanceName = 'MSFT_SCLabelSetting'
-                        IsRequired      = $False
-                    }
-                )
-                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
-                    -ComplexObject $Results.AdvancedSettings `
-                    -CIMInstanceName 'MSFT_SCLabelSetting' `
-                    -ComplexTypeMapping $complexMapping
 
-                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
-                {
-                    $Results.AdvancedSettings = $complexTypeStringResult
-                }
-                else
-                {
-                    $Results.Remove('AdvancedSettings') | Out-Null
-                }
+
+    # Get the string representation
+    $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+        -ComplexObject $Results.AdvancedSettings `
+        -CIMInstanceName 'MSFT_SCLabelSetting' `
+        -ComplexTypeMapping $complexMapping
+
+
+    if ([string]::IsNullOrWhiteSpace($complexTypeStringResult))
+    {
+        $complexTypeStringResult = "@()"
+    }
+    else
+    {
+        $lines = $complexTypeStringResult -split "`n" | ForEach-Object { $_.TrimEnd() }
+        $lines = $lines | Where-Object { $_ -ne '' }
+        $indented = $lines | ForEach-Object { '    ' + $_ }
+        $complexTypeStringResult = "@(`n$($indented -join "`n")`n)"
+    }
+    if ($complexTypeStringResult -eq '@()')
+    {
+        $Results.Remove('AdvancedSettings') | Out-Null
+    }
+    else
+    {
+        $Results.AdvancedSettings = $complexTypeStringResult
+    }
             }
 
             if ($null -ne $Results.LocaleSettings)
@@ -1798,7 +1804,6 @@ function Convert-StringToAdvancedSettings
                 Value = $values.Trim()
             }
 
-            # Only export the entry if it has a value
             if ([String]::IsNullOrEmpty($entry.Value) -eq $false)
             {
                 $settings += $entry

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
@@ -360,7 +360,7 @@ function Get-TargetResource
         }
         if ($null -ne $label.Settings)
         {
-            $advancedSettingsValue = Convert-StringToAdvancedSettings -AdvancedSettings $label.Settings
+            [array]$advancedSettingsValue = Convert-StringToAdvancedSettings -AdvancedSettings $label.Settings
         }
         Write-Verbose "Found existing Sensitivity Label $($Name)"
 
@@ -1612,34 +1612,28 @@ function Export-TargetResource
             $Script:exportedInstance = $label
             $Results = Get-TargetResource @PSBoundParameters -Name $label.Name
 
+            if ($null -ne $Results.AdvancedSettings)
+            {
+                $complexMapping = @(
+                    @{
+                        Name            = 'AdvancedSettings'
+                        CimInstanceName = 'MSFT_SCLabelSetting'
+                        IsRequired      = $False
+                    }
+                )
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.AdvancedSettings `
+                    -CIMInstanceName 'MSFT_SCLabelSetting' `
+                    -ComplexTypeMapping $complexMapping
 
-
-    # Get the string representation
-    $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
-        -ComplexObject $Results.AdvancedSettings `
-        -CIMInstanceName 'MSFT_SCLabelSetting' `
-        -ComplexTypeMapping $complexMapping
-
-
-    if ([string]::IsNullOrWhiteSpace($complexTypeStringResult))
-    {
-        $complexTypeStringResult = "@()"
-    }
-    else
-    {
-        $lines = $complexTypeStringResult -split "`n" | ForEach-Object { $_.TrimEnd() }
-        $lines = $lines | Where-Object { $_ -ne '' }
-        $indented = $lines | ForEach-Object { '    ' + $_ }
-        $complexTypeStringResult = "@(`n$($indented -join "`n")`n)"
-    }
-    if ($complexTypeStringResult -eq '@()')
-    {
-        $Results.Remove('AdvancedSettings') | Out-Null
-    }
-    else
-    {
-        $Results.AdvancedSettings = $complexTypeStringResult
-    }
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.AdvancedSettings = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('AdvancedSettings') | Out-Null
+                }
             }
 
             if ($null -ne $Results.LocaleSettings)
@@ -1804,6 +1798,7 @@ function Convert-StringToAdvancedSettings
                 Value = $values.Trim()
             }
 
+            # Only export the entry if it has a value
             if ([String]::IsNullOrEmpty($entry.Value) -eq $false)
             {
                 $settings += $entry
@@ -2190,4 +2185,3 @@ function Test-AutoLabelingSettings
 }
 
 Export-ModuleMember -Function *-TargetResource
-


### PR DESCRIPTION
#### Pull Request (PR) description

This PR ensures that the `AdvancedSettings` property in the `SCSensitivityLabel` resource is always exported as an array block in the generated DSC configuration, even when there is only a single item. This improves consistency and prevents downstream issues when consuming the exported configuration.

#### This Pull Request (PR) fixes the following issues

- Fixes #6321

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file `CHANGELOG.md`.
- [ ] Resource parameter descriptions added/updated in the `schema.mof`. *(Not applicable for this PR)*
- [ ] Resource documentation added/updated in `README.md`. *(Not applicable for this PR)*
- [ ] Resource `settings.json` file contains all required permissions. *(Not applicable for this PR)*
- [ ] Examples appropriately added/updated. *(Not applicable for this PR)*
- [ ] Unit tests added/updated. *(Not applicable for this PR)*
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
