### PR TITLE
Fix export of cross tenant access policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* AADCrossTenantAccessPolicyConfigurationDefault
+  * Fixed an issue where the export returns an invalid value for `Targets`.
+    FIXES [#6397](https://github.com/microsoft/Microsoft365DSC/issues/6397)
+
 # 1.25.730.1
 
 * AADServicePrincipal

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCrossTenantAccessPolicyConfigurationDefault/MSFT_AADCrossTenantAccessPolicyConfigurationDefault.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCrossTenantAccessPolicyConfigurationDefault/MSFT_AADCrossTenantAccessPolicyConfigurationDefault.psm1
@@ -101,11 +101,11 @@ function Get-TargetResource
             $B2BCollaborationInboundValue = @{
                 Applications = @{
                     AccessType = $getValue.B2BCollaborationInbound.Applications.AccessType
-                    Targets    = [System.String[]] $getValue.B2BCollaborationInbound.Applications.Targets
+                    Targets    = [System.Array]$getValue.B2BCollaborationInbound.Applications.Targets
                 }
                 UsersAndGroups =@{
                     AccessType = $getValue.B2BCollaborationInbound.UsersAndGroups.AccessType
-                    Targets    = [System.String[]] $getValue.B2BCollaborationInbound.UsersAndGroups.Targets
+                    Targets    = [System.Array] $getValue.B2BCollaborationInbound.UsersAndGroups.Targets
                 }
             }
         }
@@ -114,11 +114,11 @@ function Get-TargetResource
             $B2BCollaborationOutboundValue = @{
                 Applications = @{
                     AccessType = $getValue.B2BCollaborationOutbound.Applications.AccessType
-                    Targets    = [System.String[]] $getValue.B2BCollaborationOutbound.Applications.Targets
+                    Targets    = [System.Array] $getValue.B2BCollaborationOutbound.Applications.Targets
                 }
                 UsersAndGroups =@{
                     AccessType = $getValue.B2BCollaborationOutbound.UsersAndGroups.AccessType
-                    Targets    = [System.String[]] $getValue.B2BCollaborationOutbound.UsersAndGroups.Targets
+                    Targets    = [System.Array] $getValue.B2BCollaborationOutbound.UsersAndGroups.Targets
                 }
             }
         }
@@ -127,11 +127,11 @@ function Get-TargetResource
             $B2BDirectConnectInboundValue = @{
                 Applications = @{
                     AccessType = $getValue.B2BDirectConnectInbound.Applications.AccessType
-                    Targets    = [System.String[]] $getValue.B2BDirectConnectInbound.Applications.Targets
+                    Targets    = [System.Array] $getValue.B2BDirectConnectInbound.Applications.Targets
                 }
                 UsersAndGroups =@{
                     AccessType = $getValue.B2BDirectConnectInbound.UsersAndGroups.AccessType
-                    Targets    = [System.String[]] $getValue.B2BDirectConnectInbound.UsersAndGroups.Targets
+                    Targets    = [System.Array] $getValue.B2BDirectConnectInbound.UsersAndGroups.Targets
                 }
             }
         }
@@ -140,11 +140,11 @@ function Get-TargetResource
             $B2BDirectConnectOutboundValue = @{
                 Applications = @{
                     AccessType = $getValue.B2BDirectConnectOutbound.Applications.AccessType
-                    Targets    = [System.String[]] $getValue.B2BDirectConnectOutbound.Applications.Targets
+                    Targets    = [System.Array] $getValue.B2BDirectConnectOutbound.Applications.Targets
                 }
                 UsersAndGroups =@{
                     AccessType = $getValue.B2BDirectConnectOutbound.UsersAndGroups.AccessType
-                    Targets    = [System.String[]] $getValue.B2BDirectConnectOutbound.UsersAndGroups.Targets
+                    Targets    = [System.Array] $getValue.B2BDirectConnectOutbound.UsersAndGroups.Targets
                 }
             }
         }
@@ -837,4 +837,3 @@ function Get-M365DSCAADCrossTenantAccessPolicyInboundTrust
 }
 
 Export-ModuleMember -Function *-TargetResource
-


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes the export of `AADCrossTenantAccessPolicyConfigurationDefault`. It casted a hashtable to a string array, resulting in a broken export.

#### This Pull Request (PR) fixes the following issues
- Fixes #6397 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
