### PR TITLE
TeamsMeetingBroadcastConfiguration Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* TeamsMeetingBroadcastConfiguration
+  * Fixes an issue where the SdnAPIToken wasn't exported as a string.
+
 # 1.25.827.1
 
 * EXODistributionGroup

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingBroadcastConfiguration/MSFT_TeamsMeetingBroadcastConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingBroadcastConfiguration/MSFT_TeamsMeetingBroadcastConfiguration.psm1
@@ -368,8 +368,7 @@ function Export-TargetResource
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential `
-                -NoEscape @('SdnApiToken')
+                -Credential $Credential
 
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `


### PR DESCRIPTION
#### Pull Request (PR) description
* TeamsMeetingBroadcastConfiguration
  * Fixes an issue where the SdnAPIToken wasn't exported as a string.

#### This Pull Request (PR) fixes the following issues
* N/A