### PR TITLE
Fix admin consent from mixed source APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* AADApplication
+  * Fixed an issue with `AdminConsentGranted` not being correct if the
+    permissions are from multiple source APIs.
+
 # 1.25.903.2
 
 * AADEnrichedAuditLogs

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADApplication/MSFT_AADApplication.psm1
@@ -1950,7 +1950,7 @@ function Get-M365DSCAzureADAppPermissions
                 {
                     if ($oAuth2grant.Count -gt 0)
                     {
-                        $scopes = $oAuth2grant[0].Scope.Split(' ')
+                        $scopes = ($oAuth2grant.Scope -join " ").Split(' ')
                         if ($scopes.Contains($scopeInfoValue))
                         {
                             $currentPermission.AdminConsentGranted = $true


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where the `AdminConsentGranted` property would indicated `$false` even if the admin consent was actually granted for that specific permission. This is due to an issue with multiple source APIs being present and how they

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
