### PR TITLE
EXOIntraOrganizationConnector - fix TargetSharingEPR Empty String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
   * [BREAKING] Renamed the UnifiedGroupWelcomeMessageEnabled parameter to
     WelcomeMessageEnabled.
 * EXOIntraOrganizationConnector
-  * Fix logic to allow empty string for TargetSharingEpr
+  * Fix logic to allow empty string for TargetSharingEpr.
 * EXOHostedContentFilterPolicy
   * [BREAKING CHANGE] Remove deprecated properties `DownloadLink`, `EnableEndUserSpamNotifications`,
     `EndUserSpamNotificationCustomSubject`, `EndUserSpamNotificationFrequency` and `EndUserSpamNotificationLanguage`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
     on update.
   * [BREAKING] Renamed the UnifiedGroupWelcomeMessageEnabled parameter to
     WelcomeMessageEnabled.
+* EXOIntraOrganizationConnector
+  * Fix logic to allow empty string for TargetSharingEpr
 * EXOHostedContentFilterPolicy
   * [BREAKING CHANGE] Remove deprecated properties `DownloadLink`, `EnableEndUserSpamNotifications`,
     `EndUserSpamNotificationCustomSubject`, `EndUserSpamNotificationFrequency` and `EndUserSpamNotificationLanguage`.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIntraOrganizationConnector/MSFT_EXOIntraOrganizationConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIntraOrganizationConnector/MSFT_EXOIntraOrganizationConnector.psm1
@@ -233,9 +233,13 @@ function Set-TargetResource
     $IntraOrganizationConnector = $IntraOrganizationConnectors | Where-Object -FilterScript { $_.Identity -eq $Identity }
     $IntraOrganizationConnectorParams = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
 
+    if ($IntraOrganizationConnectorParams.TargetSharingEpr -eq '')
+    {
+        $IntraOrganizationConnectorParams.TargetSharingEpr = $null
+    }
     if (('Present' -eq $Ensure ) -and ($null -eq $IntraOrganizationConnector))
     {
-        Write-Verbose -Message "Creating IntraOrganizationConnector $($Identity)."
+        Write-Verbose -Message "Creating IntraOrganizationConnector $($Identity) with:`r`n $(ConvertTo-Json $IntraOrganizationConnectorParams -Depth 10)"
         $IntraOrganizationConnectorParams.Add('Name', $Identity)
         $IntraOrganizationConnectorParams.Remove('Identity') | Out-Null
         New-IntraOrganizationConnector @IntraOrganizationConnectorParams


### PR DESCRIPTION
#### Pull Request (PR) description
* EXOIntraOrganizationConnector
  * Fix logic to allow empty string for TargetSharingEpr.

#### This Pull Request (PR) fixes the following issues
* N/A