### PR TITLE
BREAKING CHANGE - Remove ensure parameter from O365 Admin Audit Log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,8 @@
 * IntuneWifiConfigurationPolicyAndroidForWork
   * [BREAKING CHANGE] Removed resource because it's not supported anymore.
     Instead, use the `IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile` resource.
+* O365AdminAuditLogConfig
+  * [BREAKING CHANGE] Removed `Ensure` parameter because it is a single instance object.
 * O365OrgSettings
   * [BREAKING CHANGE] Removed deprecated parameter `MicrosoftVivaBriefingEmail`.
 * ODSettings

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365AdminAuditLogConfig/MSFT_O365AdminAuditLogConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365AdminAuditLogConfig/MSFT_O365AdminAuditLogConfig.psm1
@@ -11,11 +11,6 @@ function Get-TargetResource
         [String]
         $IsSingleInstance,
 
-        [Parameter()]
-        [ValidateSet('Present')]
-        [System.String]
-        $Ensure = 'Present',
-
         [Parameter(Mandatory = $true)]
         [ValidateSet('Enabled', 'Disabled')]
         [System.String]
@@ -132,11 +127,6 @@ function Set-TargetResource
         [String]
         $IsSingleInstance,
 
-        [Parameter()]
-        [ValidateSet('Present')]
-        [System.String]
-        $Ensure = 'Present',
-
         [Parameter(Mandatory = $true)]
         [ValidateSet('Enabled', 'Disabled')]
         [System.String]
@@ -237,11 +227,6 @@ function Test-TargetResource
         [String]
         $IsSingleInstance,
 
-        [Parameter()]
-        [ValidateSet('Present')]
-        [System.String]
-        $Ensure = 'Present',
-
         [Parameter(Mandatory = $true)]
         [ValidateSet('Enabled', 'Disabled')]
         [System.String]
@@ -290,8 +275,7 @@ function Test-TargetResource
     #endregion
 
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-                                         -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
-                                         -ExcludedProperties @('Ensure')
+                                         -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
     return $result
 }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365AdminAuditLogConfig/MSFT_O365AdminAuditLogConfig.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365AdminAuditLogConfig/MSFT_O365AdminAuditLogConfig.schema.mof
@@ -1,8 +1,7 @@
-[ClassVersion("1.0.0.0"), FriendlyName("O365AdminAuditLogConfig")]
+[ClassVersion("1.0.0.1"), FriendlyName("O365AdminAuditLogConfig")]
 class MSFT_O365AdminAuditLogConfig : OMI_BaseResource
 {
     [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'"), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
-    [Write,Description("'Present' is the only value accepted."),ValueMap{"Present"},Values{"Present"}] string Ensure;
     [Required, Description("Determins if Unified Audit Log Ingestion is enabled"),ValueMap{"Enabled","Disabled"}, Values{"Enabled","Disabled"}] string UnifiedAuditLogIngestionEnabled;
     [Write, Description("Credentials of the Global Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;

--- a/Modules/Microsoft365DSC/Examples/Resources/O365AdminAuditLogConfig/1-ConfigureAuditLog.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/O365AdminAuditLogConfig/1-ConfigureAuditLog.ps1
@@ -18,7 +18,6 @@ Configuration Example
         {
             IsSingleInstance                = "Yes"
             UnifiedAuditLogIngestionEnabled = "Enabled"
-            Ensure                          = "Present"
             Credential                      = $Credscredential
         }
     }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.O365AdminAuditLogConfig.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.O365AdminAuditLogConfig.Tests.ps1
@@ -44,7 +44,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             BeforeAll {
                 $testParams = @{
                     IsSingleInstance                = 'Yes'
-                    Ensure                          = 'Present'
                     Credential                      = $Credential
                     UnifiedAuditLogIngestionEnabled = 'Enabled'
                 }
@@ -73,7 +72,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             BeforeAll {
                 $testParams = @{
                     IsSingleInstance                = 'Yes'
-                    Ensure                          = 'Present'
                     Credential                      = $Credential
                     UnifiedAuditLogIngestionEnabled = 'Disabled'
                 }
@@ -103,7 +101,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             BeforeAll {
                 $testParams = @{
                     IsSingleInstance                = 'Yes'
-                    Ensure                          = 'Present'
                     Credential                      = $Credential
                     UnifiedAuditLogIngestionEnabled = 'Disabled'
                 }
@@ -129,7 +126,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             BeforeAll {
                 $testParams = @{
                     IsSingleInstance                = 'Yes'
-                    Ensure                          = 'Present'
                     Credential                      = $Credential
                     UnifiedAuditLogIngestionEnabled = 'Enabled'
                 }


### PR DESCRIPTION
#### Pull Request (PR) description
This PR removes the `Ensure` parameter from the `O365AdminAuditLog` resource because it is a single instance object.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
