### PR TITLE
Fix Intune Settings Catalog apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@
   * Fixed an issue where group filtering would not find the specified groups.
   * Fixed an issue where 0 requests passed to `Invoke-M365DSCGraphBatchRequests` would fail.
     FIXES [#6521](https://github.com/microsoft/Microsoft365DSC/issues/6521)
+  * Fixed an issue with applying Intune Settings Catalog policies.
 * M365DSCUtil
   * Added parameter `-Parallel` to `Export-M365DSCConfiguration`.
   * Renamed function `Get-M365DSCWorkloadsListFromResourceNames` to `Get-M365DSCConnectedWorkloadList`.

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -2653,6 +2653,11 @@ function Get-IntuneSettingCatalogPolicySetting
         {
             $settingValueType = $settingValueType.Replace('ValueTemplate', 'Value')
         }
+        if ([System.String]::IsNullOrEmpty($settingValueType) -and $settingValueName -eq 'choiceSettingValue')
+        {
+            # Special case for ChoiceSettingValue which does not have a ValueTemplate property
+            $settingValueType = '#microsoft.graph.deviceManagementConfigurationChoiceSettingValue'
+        }
 
         $settingValueTemplateId = $settingInstanceTemplate.AdditionalProperties."$($settingValueName)Template".settingValueTemplateId
 
@@ -3176,7 +3181,7 @@ function Get-IntuneSettingCatalogPolicySettingDSCValue
     }
     elseif ($SettingValueType -like "*ChoiceSetting*" -and $SettingValueType -notlike "*Collection*")
     {
-        $settingValue = ($SettingDefinition.AdditionalProperties.options | Where-Object { $_.optionValue.value -eq "$($DSCParams[$key])" }).itemId
+        $settingValue = ($SettingDefinition.AdditionalProperties.options | Where-Object { $_.optionValue.value -eq $($DSCParams[$key]) }).itemId
         if ([System.String]::IsNullOrEmpty($settingValue))
         {
             $settingValue = ($SettingDefinition.AdditionalProperties.options | Where-Object { $_.itemId -eq "$($SettingDefinition.Id)_$($DSCParams[$key])" }).itemId


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where a choice value template was not found in the Settings Catalog instance template.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
