### PR TITLE
Fix member export in Entra groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
     FIXES [#6476](https://github.com/microsoft/Microsoft365DSC/issues/6476)
   * Fixed an issue where GroupAsMembers not being added during initial group creation.
     FIXES [#6489](https://github.com/microsoft/Microsoft365DSC/issues/6489)
+  * Fixed an issue where not all members were exported.
+    FIXES [#6545](https://github.com/microsoft/Microsoft365DSC/issues/6545)
 * AADGroupEligiblitySchedule
   * Aligned date time format for `Expiration.EndDateTime` with `Expiration.StartDateTime`.
 * EXOAtpPolicyForO365

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -144,12 +144,12 @@ function Get-TargetResource
                 Write-Verbose -Message 'GroupID was specified'
                 try
                 {
-                    $Group = Get-MgGroup -GroupId $Id -ExpandProperty "members" -ErrorAction Stop
+                    $Group = Get-MgBetaGroup -GroupId $Id -ExpandProperty "members" -ErrorAction Stop
                 }
                 catch
                 {
                     Write-Verbose -Message "Couldn't get group by ID, trying by name"
-                    $Group = Get-MgGroup -Filter "DisplayName eq '$($DisplayName -replace "'", "''")'" -ExpandProperty "members" -ErrorAction Stop
+                    $Group = Get-MgBetaGroup -Filter "DisplayName eq '$($DisplayName -replace "'", "''")'" -ExpandProperty "members" -ErrorAction Stop
                     if ($Group.Length -gt 1)
                     {
                         throw "Duplicate AzureAD Groups named $DisplayName exist in tenant"
@@ -160,7 +160,7 @@ function Get-TargetResource
             {
                 Write-Verbose -Message 'Id was NOT specified'
                 ## Can retreive multiple AAD Groups since displayname is not unique
-                $Group = Get-MgGroup -Filter "DisplayName eq '$($DisplayName -replace "'", "''")'" -ExpandProperty "members" -ErrorAction Stop
+                $Group = Get-MgBetaGroup -Filter "DisplayName eq '$($DisplayName -replace "'", "''")'" -ExpandProperty "members" -ErrorAction Stop
                 if ($Group.Length -gt 1)
                 {
                     throw "Duplicate AzureAD Groups named $DisplayName exist in tenant"
@@ -179,7 +179,6 @@ function Get-TargetResource
         }
 
         Write-Verbose -Message 'Found existing AzureAD Group'
-
         $batchRequests = @(
             @{
                 id     = 'Owners'
@@ -219,25 +218,59 @@ function Get-TargetResource
         if ($Group.MembershipRuleProcessingState -ne 'On')
         {
             # Members
-            $MembersValues = @()
-            $GroupAsMembersValues = @()
-            foreach ($member in $Group.Members)
+            $MembersValues = [System.Collections.Generic.List[System.String]]::new()
+            $GroupAsMembersValues = [System.Collections.Generic.List[System.String]]::new()
+            $groupMembers = $Group.Members
+            if ($Group.Members.Count -eq 20)
             {
-                if ($member.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.user')
+                # Fetch all group members
+                $uri = "/beta/groups/$($Group.Id)/members?`$top=999"
+                $groupMembers = [System.Collections.Generic.List[System.Object]]::new()
+                $graphRequest = Invoke-MgGraphRequest -Uri $uri -Method GET
+                $groupMembers.AddRange($graphRequest.value)
+                while (-not [System.String]::IsNullOrEmpty($graphRequest.'@odata.nextLink'))
                 {
-                    $MembersValues += $member.AdditionalProperties.userPrincipalName
+                    $graphRequest = Invoke-MgGraphRequest -Uri $graphRequest.'@odata.nextLink' -Method GET
+                    $groupMembers.AddRange($graphRequest.value)
                 }
-                elseif ($member.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.servicePrincipal')
+            }
+            foreach ($member in $groupMembers)
+            {
+                if ($null -ne $member.AdditionalProperties)
                 {
-                    $MembersValues += $member.AdditionalProperties.displayName
+                    switch ($member.AdditionalProperties.'@odata.type')
+                    {
+                        '#microsoft.graph.user' {
+                            $MembersValues.Add($member.AdditionalProperties.userPrincipalName)
+                        }
+                        '#microsoft.graph.servicePrincipal' {
+                            $MembersValues.Add($member.AdditionalProperties.displayName)
+                        }
+                        '#microsoft.graph.device' {
+                            $MembersValues.Add($member.AdditionalProperties.displayName)
+                        }
+                        '#microsoft.graph.group' {
+                            $GroupAsMembersValues.Add($member.AdditionalProperties.displayName)
+                        }
+                    }
                 }
-                elseif ($member.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.device')
+                else
                 {
-                    $MembersValues += $member.AdditionalProperties.displayName
-                }
-                elseif ($member.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.group')
-                {
-                    $GroupAsMembersValues += $member.AdditionalProperties.displayName
+                    switch ($member.'@odata.type')
+                    {
+                        '#microsoft.graph.user' {
+                            $MembersValues.Add($member.userPrincipalName)
+                        }
+                        '#microsoft.graph.servicePrincipal' {
+                            $MembersValues.Add($member.displayName)
+                        }
+                        '#microsoft.graph.device' {
+                            $MembersValues.Add($member.displayName)
+                        }
+                        '#microsoft.graph.group' {
+                            $GroupAsMembersValues.Add($member.displayName)
+                        }
+                    }
                 }
             }
             $result.Add('Members', $MembersValues)
@@ -588,7 +621,7 @@ function Set-TargetResource
             Write-Verbose -Message "Found an instance of a deleted group {$DisplayName}. Restoring it."
             Restore-MgBetaDirectoryDeletedItem -DirectoryObjectId $groups[0].Id
             $restoringExisting = $true
-            $currentGroup = Get-MgGroup -Filter "DisplayName eq '$($DisplayName -replace "'", "''")'" -ErrorAction Stop
+            $currentGroup = Get-MgBetaGroup -Filter "DisplayName eq '$($DisplayName -replace "'", "''")'" -ErrorAction Stop
         }
 
         if (-not $restoringExisting)
@@ -678,17 +711,12 @@ function Set-TargetResource
         Write-Verbose -Message 'Updating Owners'
         if ($PSBoundParameters.ContainsKey('Owners'))
         {
-            $currentOwnersValue = @()
-            if ($currentParameters.Owners.Length -gt 0)
-            {
-                $currentOwnersValue = $backCurrentOwners
-            }
             $desiredOwnersValue = @()
             if ($Owners.Length -gt 0)
             {
                 $desiredOwnersValue = $Owners
             }
-            if ($backCurrentOwners -eq $null)
+            if ($null -eq $backCurrentOwners)
             {
                 $backCurrentOwners = @()
             }
@@ -748,17 +776,12 @@ function Set-TargetResource
         Write-Verbose -Message 'Updating Members'
         if ($MembershipRuleProcessingState -ne 'On' -and $PSBoundParameters.ContainsKey('Members'))
         {
-            $currentMembersValue = @()
-            if ($currentParameters.Members.Length -ne 0)
-            {
-                $currentMembersValue = $backCurrentMembers
-            }
             $desiredMembersValue = @()
             if ($Members.Length -ne 0)
             {
                 $desiredMembersValue = $Members
             }
-            if ($backCurrentMembers -eq $null)
+            if ($null -eq $backCurrentMembers)
             {
                 $backCurrentMembers = @()
             }
@@ -824,17 +847,12 @@ function Set-TargetResource
         Write-Verbose -Message 'Updating GroupAsMembers'
         if ($MembershipRuleProcessingState -ne 'On' -and $PSBoundParameters.ContainsKey('GroupAsMembers'))
         {
-            $currentGroupAsMembersValue = @()
-            if ($currentParameters.GroupAsMembers.Length -ne 0)
-            {
-                $currentGroupAsMembersValue = $backCurrentGroupAsMembers
-            }
             $desiredGroupAsMembersValue = @()
             if ($GroupAsMembers.Length -ne 0)
             {
                 $desiredGroupAsMembersValue = $GroupAsMembers
             }
-            if ($backCurrentGroupAsMembers -eq $null)
+            if ($null -eq $backCurrentGroupAsMembers)
             {
                 $backCurrentGroupAsMembers = @()
             }
@@ -843,7 +861,7 @@ function Set-TargetResource
             {
                 try
                 {
-                    $groupAsMember = Get-MgGroup -Filter "DisplayName eq '$($diff.InputObject -replace "'", "''")'" -ErrorAction SilentlyContinue
+                    $groupAsMember = Get-MgBetaGroup -Filter "DisplayName eq '$($diff.InputObject -replace "'", "''")'" -ErrorAction SilentlyContinue
                 }
                 catch
                 {
@@ -876,11 +894,6 @@ function Set-TargetResource
         Write-Verbose -Message 'Updating MemberOf'
         if ($PSBoundParameters.ContainsKey('MemberOf'))
         {
-            $currentMemberOfValue = @()
-            if ($currentParameters.MemberOf.Length -ne 0)
-            {
-                $currentMemberOfValue = $backCurrentMemberOf
-            }
             $desiredMemberOfValue = @()
             if ($MemberOf.Length -ne 0)
             {
@@ -895,7 +908,7 @@ function Set-TargetResource
             {
                 try
                 {
-                    $memberOfGroup = Get-MgGroup -Filter "DisplayName eq '$($diff.InputObject -replace "'", "''")'" -ErrorAction Stop
+                    $memberOfGroup = Get-MgBetaGroup -Filter "DisplayName eq '$($diff.InputObject -replace "'", "''")'" -ErrorAction Stop
                 }
                 catch
                 {
@@ -938,12 +951,6 @@ function Set-TargetResource
 
         if ($currentGroup.IsAssignableToRole -eq $true -and $PSBoundParameters.ContainsKey('AssignedToRole'))
         {
-            #AssignedToRole
-            $currentAssignedToRoleValue = @()
-            if ($currentParameters.AssignedToRole.Length -ne 0)
-            {
-                $currentAssignedToRoleValue = $backCurrentAssignedToRole
-            }
             $desiredAssignedToRoleValue = @()
             if ($AssignedToRole.Length -ne 0)
             {
@@ -1209,11 +1216,11 @@ function Export-TargetResource
             $ExportParameters.Add('ConsistencyLevel', 'eventual')
         }
 
-        [array] $Script:exportedGroups = Get-MgGroup @ExportParameters
+        [array] $Script:exportedGroups = Get-MgBetaGroup @ExportParameters
         $Script:exportedGroups = $Script:exportedGroups | Where-Object -FilterScript {
             -not ($_.MailEnabled -and ($null -eq $_.GroupTypes -or $_.GroupTypes.Length -eq 0)) -and `
                 -not ($_.MailEnabled -and $_.SecurityEnabled)
-        }
+        } | Sort-Object -Property DisplayName
 
         $i = 1
         $dscContent = ''

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADGroup.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADGroup.Tests.ps1
@@ -40,6 +40,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Get-MgGroup -MockWith {
             }
 
+            Mock -CommandName Get-MgBetaGroup -MockWith {
+            }
+
             Mock -CommandName Restore-MgBetaDirectoryDeletedItem -MockWith {
             }
 
@@ -132,13 +135,14 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                     return $null
                 }
             }
+
             It 'Should return Values from the Get method' {
                 (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
             }
             It 'Should return false from the Test method' {
                 Test-TargetResource @testParams | Should -Be $false
@@ -167,7 +171,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                     return @{
                         DisplayName = 'DSCGroup'
                         ID          = '12345-12345-12345-12345-12345'
@@ -177,7 +181,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
             }
 
             It 'Should return false from the Test method' {
@@ -210,7 +214,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                     return @{
                         DisplayName     = 'DSCGroup'
                         ID              = '12345-12345-12345-12345-12345'
@@ -226,7 +230,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
             }
 
             It 'Should return true from the Test method' {
@@ -253,7 +257,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -ParameterFilter { $Id -eq '12345-12345-12345-12345-12345' -or $Filter -eq "DisplayName eq 'DSCGroup'" } -MockWith {
+                Mock -CommandName Get-MgBetaGroup -ParameterFilter { $Id -eq '12345-12345-12345-12345-12345' -or $Filter -eq "DisplayName eq 'DSCGroup'" } -MockWith {
                     return @{
                         DisplayName     = 'DSCGroup'
                         ID              = '12345-12345-12345-12345-12345'
@@ -277,7 +281,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         }
                     )
                 }
-                Mock -CommandName Get-MgGroup -ParameterFilter { $Id -eq '67890-67890-67890-67890' -or $Filter -eq "DisplayName -eq 'DSCMemberOfGroup'" } -MockWith {
+                Mock -CommandName Get-MgBetaGroup -ParameterFilter { $Id -eq '67890-67890-67890-67890' -or $Filter -eq "DisplayName -eq 'DSCMemberOfGroup'" } -MockWith {
                     $returnData = @{
                         DisplayName     = 'DSCMemberOfGroup'
                         ID              = '67890-67890-67890-67890'
@@ -295,7 +299,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
                 Should -Invoke -CommandName 'Invoke-M365DSCGraphBatchRequest' -Exactly 1
             }
 
@@ -325,7 +329,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                     return @{
                         DisplayName        = 'DSCGroup'
                         ID                 = '12345-12345-12345-12345-12345'
@@ -355,7 +359,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
                 Should -Invoke -CommandName 'Invoke-M365DSCGraphBatchRequest' -Exactly 1
             }
 
@@ -382,7 +386,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                     return @{
                         DisplayName     = 'DSCGroup'
                         Description     = 'Microsoft DSC' #Drift
@@ -398,7 +402,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
             }
 
             It 'Should return false from the Test method' {
@@ -430,7 +434,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 Mock -CommandName New-M365DSCConnection -MockWith {
                     return 'Credentials'
                 }
-                Mock -CommandName Get-MgGroup -ParameterFilter { $Id -eq '12345-12345-12345-12345-12345' -or $Filter -eq "DisplayName eq 'DSCGroup'" } -MockWith {
+                Mock -CommandName Get-MgBetaGroup -ParameterFilter { $Id -eq '12345-12345-12345-12345-12345' -or $Filter -eq "DisplayName eq 'DSCGroup'" } -MockWith {
                     $returnData = @{
                         DisplayName     = 'DSCGroup'
                         ID              = '12345-12345-12345-12345-12345'
@@ -445,7 +449,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     $returnData.psobject.TypeNames.Insert(0, 'Group')
                     return $returnData
                 }
-                Mock -CommandName Get-MgGroup -ParameterFilter { $Id -eq '67890-67890-67890-67890' -or $Filter -eq "DisplayName -eq 'DSCMemberOfGroup'" } -MockWith {
+                Mock -CommandName Get-MgBetaGroup -ParameterFilter { $Id -eq '67890-67890-67890-67890' -or $Filter -eq "DisplayName -eq 'DSCMemberOfGroup'" } -MockWith {
                     $returnData = @{
                         DisplayName     = 'DSCMemberOfGroup'
                         ID              = '67890-67890-67890-67890'
@@ -463,7 +467,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
             }
 
             It 'Should return false from the Test method' {
@@ -472,7 +476,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should call the Set method' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 2
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 2
             }
         }
 
@@ -496,7 +500,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                     return @{
                         DisplayName        = 'DSCGroupMember'
                         ID                 = '12345-12345-12345-12345-12345'
@@ -517,7 +521,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
             }
 
             It 'Should return false from the Test method' {
@@ -526,7 +530,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should call the Set method' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 2
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 2
                 Should -Invoke -CommandName 'New-MgBetaGroupMemberByRef' -Exactly 1
             }
         }
@@ -552,7 +556,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                     return @{
                         DisplayName        = 'DSCGroup'
                         ID                 = '12345-12345-12345-12345-12345'
@@ -581,7 +585,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
                 Should -Invoke -CommandName 'Invoke-M365DSCGraphBatchRequest' -Exactly 1
             }
 
@@ -591,7 +595,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should call the Set method' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
                 Should -Invoke -CommandName 'Get-MgBetaRoleManagementDirectoryRoleDefinition' -Exactly 1
                 Should -Invoke -CommandName 'Remove-MgBetaRoleManagementDirectoryRoleAssignment' -Exactly 1
             }
@@ -621,7 +625,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                 }
 
                 Mock -CommandName Get-MgBetaSubscribedSku -MockWith {
@@ -640,7 +644,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
             }
 
             It 'Should return false from the Test method' {
@@ -678,7 +682,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                     return @{
                         DisplayName        = 'DSCGroup'
                         ID                 = '12345-12345-12345-12345-12345'
@@ -721,7 +725,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
                 Should -Invoke -CommandName 'Invoke-M365DSCGraphBatchRequest' -Exactly 1
             }
 
@@ -754,7 +758,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                     return @{
                         DisplayName        = 'DSCGroup'
                         ID                 = '12345-12345-12345-12345-12345'
@@ -783,7 +787,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
             }
 
             It 'Should return false from the Test method' {
@@ -792,7 +796,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should call the Set method' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
                 Should -Invoke -CommandName 'Set-MgGroupLicense' -Exactly 1
             }
         }
@@ -815,7 +819,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                     return @{
                         DisplayName        = 'DSCGroup'
                         ID                 = '12345-12345-12345-12345-12345'
@@ -858,7 +862,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
                 Should -Invoke -CommandName 'Invoke-M365DSCGraphBatchRequest' -Exactly 1
             }
 
@@ -868,7 +872,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should call the Set method' {
                 Set-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
                 Should -Invoke -CommandName 'Set-MgGroupLicense' -Exactly 1
             }
         }
@@ -891,7 +895,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                     return @{
                         DisplayName        = 'DSCGroup'
                         ID                 = '12345-12345-12345-12345-12345'
@@ -920,7 +924,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             It 'Should return Values from the Get method' {
                 Get-TargetResource @testParams
-                Should -Invoke -CommandName 'Get-MgGroup' -Exactly 1
+                Should -Invoke -CommandName 'Get-MgBetaGroup' -Exactly 1
             }
 
             It 'Should return true from the Test method' {
@@ -940,7 +944,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     return 'Credentials'
                 }
 
-                Mock -CommandName Get-MgGroup -MockWith {
+                Mock -CommandName Get-MgBetaGroup -MockWith {
                     return @{
                         DisplayName        = 'DSCGroup'
                         ID                 = '12345-12345-12345-12345-12345'

--- a/Tests/Unit/Stubs/Microsoft365.psm1
+++ b/Tests/Unit/Stubs/Microsoft365.psm1
@@ -58102,6 +58102,90 @@ function Update-MgDeviceManagementRoleDefinition
 }
 #endregion
 
+#region Microsoft.Graph.Beta.Groups
+function Get-MgBetaGroup
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.String[]]
+        $Property,
+
+        [Parameter()]
+        [PSObject]
+        $InputObject,
+
+        [Parameter()]
+        [System.Int32]
+        $PageSize,
+
+        [Parameter()]
+        [PSObject]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Int32]
+        $Skip,
+
+        [Parameter()]
+        [System.Int32]
+        $Top,
+
+        [Parameter()]
+        [System.String]
+        $CountVariable,
+
+        [Parameter()]
+        [System.String]
+        $GroupId,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [System.String[]]
+        $Sort,
+
+        [Parameter()]
+        [System.String]
+        $ConsistencyLevel,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $All,
+
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.String]
+        $Search,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.String[]]
+        $ExpandProperty,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [PSObject]
+        $HttpPipelineAppend
+    )
+}
+#endregion
+
 #region Microsoft.Graph.Groups
 function Get-MgGroup
 {


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where not all members were exported from groups. The `$expand` action only enumerates the first 20 instances, and no paging is possible. Therefore, a change is required to directly target the Beta Graph endpoint, because the `Get-MgGroupMember` cmdlet doesn't properly support paging.

#### This Pull Request (PR) fixes the following issues
- Fixes #6545 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
