### PR TITLE
Remove unused member and fix export of assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@
   * Added filter capability.
 * IntuneMobileAppsMicrosoftStoreAppWindows10
   * Initial release.
+* IntuneMobileAppsStoreApp
+  * Added support for `assignmentSettings` to the assignments.
 * IntuneMobileAppsWebLink
   * Fixed an issue where filtering was applied after fetching all apps.
 * IntuneMobileAppsWindowsOfficeSuiteApp

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyAndroid/MSFT_IntuneAppProtectionPolicyAndroid.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyAndroid/MSFT_IntuneAppProtectionPolicyAndroid.schema.mof
@@ -10,7 +10,7 @@ class MSFT_DeviceManagementConfigurationPolicyAssignments
     [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
 };
 
-[ClassVersion("1.0.0.0"), FriendlyName("IntuneAppProtectionPolicyAndroid")]
+[ClassVersion("1.0.0.1"), FriendlyName("IntuneAppProtectionPolicyAndroid")]
 class MSFT_IntuneAppProtectionPolicyAndroid : OMI_BaseResource
 {
     [Key, Description("Display name of the Android App Protection Policy.")] String DisplayName;
@@ -79,7 +79,6 @@ class MSFT_IntuneAppProtectionPolicyAndroid : OMI_BaseResource
     [Write, Description("Indicates whether use of the fingerprint reader is allowed in place of a pin if PinRequired is set to True.")] Boolean FingerprintBlocked;
     [Write, Description("List of IDs representing the Android apps controlled by this protection policy.")] String Apps[];
     [Write, Description("Assignments of the Android Protection Policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
-    [Write, Description("List of IDs of the groups that are excluded from this Android Protection Policy.")] String ExcludedGroups[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Intune Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("ID of the Azure Active Directory application to authenticate with.")] String ApplicationId;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsLobAppWindows10/MSFT_IntuneMobileAppsLobAppWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsLobAppWindows10/MSFT_IntuneMobileAppsLobAppWindows10.schema.mof
@@ -10,10 +10,10 @@ class MSFT_DeviceManagementMobileAppAssignment
     [Write, Description("Possible values for the install intent chosen by the admin."), ValueMap{"available", "required", "uninstall", "availableWithoutEnrollment"}, Values{"available", "required", "uninstall", "availableWithoutEnrollment"}] String intent;
 };
 
-[ClassVersion("1.0.0.1")]
+[ClassVersion("1.0.0.2")]
 class MSFT_DeviceManagementMobileAppAssignmentSettings
 {
-    [Write, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
+    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
 };
 
 [ClassVersion("1.0.0.0")]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMicrosoftStoreAppWindows10/MSFT_IntuneMobileAppsMicrosoftStoreAppWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMicrosoftStoreAppWindows10/MSFT_IntuneMobileAppsMicrosoftStoreAppWindows10.schema.mof
@@ -26,10 +26,10 @@ class MSFT_DeviceManagementWinGetMobileAppAssignmentSettingsInstallTimeSettings
     [Write, Description("The time at which the app should be installed.")] String deadlineDateTime;
 };
 
-[ClassVersion("1.0.0.1")]
+[ClassVersion("1.0.0.2")]
 class MSFT_DeviceManagementMobileAppAssignmentSettings
 {
-    [Write, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
+    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
 };
 
 [ClassVersion("1.0.0.0")]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsStoreApp/MSFT_IntuneMobileAppsStoreApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsStoreApp/MSFT_IntuneMobileAppsStoreApp.psm1
@@ -272,6 +272,17 @@ function Get-TargetResource
         {
             $assignmentResult += ConvertFrom-IntuneMobileAppAssignment -Assignments $assignmentsValues -IncludeDeviceFilter $true
         }
+        foreach ($assignment in $assignmentResult)
+        {
+            if ($null -ne $assignment.assignmentSettings -and $null -ne $assignment.assignmentSettings.vpnConfigurationId)
+            {
+                $vpnConfiguration = Get-MgBetaDeviceManagementDeviceConfiguration -DeviceConfigurationId $assignment.assignmentSettings.vpnConfigurationId -Property "DisplayName" -ErrorAction SilentlyContinue
+                if ($null -ne $vpnConfiguration)
+                {
+                    $assignment.assignmentSettings.vpnConfigurationId = $vpnConfiguration.DisplayName
+                }
+            }
+        }
         $results.Add('Assignments', $assignmentResult)
 
         return $results
@@ -446,6 +457,25 @@ function Set-TargetResource
     #endregion
 
     $currentInstance = Get-TargetResource @PSBoundParameters
+
+    foreach ($assignment in $Assignments)
+    {
+        if ($null -ne $assignment.assignmentSettings -and -not [System.String]::IsNullOrEmpty($assignment.assignmentSettings.vpnConfigurationId))
+        {
+            $guid = [System.Guid]::Empty
+            if (-not [System.Guid]::TryParse($assignment.assignmentSettings.vpnConfigurationId, [ref]$guid))
+            {
+                $vpnConfiguration = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "displayName eq '$($assignment.assignmentSettings.vpnConfigurationId)'" | Where-Object -FilterScript {
+                    $_.AdditionalProperties.'@odata.type' -like "#microsoft.graph.*VpnConfiguration"
+                }
+                if ($null -eq $vpnConfiguration)
+                {
+                    throw "Could not find a VPN Configuration Policy with DisplayName '$($assignment.assignmentSettings.vpnConfigurationId)'."
+                }
+                $assignment.assignmentSettings.vpnConfigurationId = $vpnConfiguration.Id
+            }
+        }
+    }
 
     $boundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
     $boundParameters.Remove('Categories') | Out-Null
@@ -859,7 +889,17 @@ function Export-TargetResource
 
             if ($Results.Assignments)
             {
-                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementMobileAppAssignment
+                $complexMapping = @(
+                    @{
+                        Name = 'AssignmentSettings'
+                        CIMInstanceName = 'DeviceManagementStoreMobileAppAssignmentSettings'
+                        IsRequired = $false
+                    }
+                )
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.Assignments `
+                    -CIMInstanceName DeviceManagementStoreMobileAppAssignment `
+                    -ComplexTypeMapping $complexMapping
                 if ($complexTypeStringResult)
                 {
                     $Results.Assignments = $complexTypeStringResult

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsStoreApp/MSFT_IntuneMobileAppsStoreApp.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsStoreApp/MSFT_IntuneMobileAppsStoreApp.schema.mof
@@ -10,6 +10,27 @@ class MSFT_DeviceManagementMobileAppAssignment
     [Write, Description("Possible values for the install intent chosen by the admin."), ValueMap{"available", "required", "uninstall", "availableWithoutEnrollment"}, Values{"available", "required", "uninstall", "availableWithoutEnrollment"}] String intent;
 };
 
+[ClassVersion("1.0.0.2")]
+class MSFT_DeviceManagementMobileAppAssignmentSettings
+{
+    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementStoreMobileAppAssignmentSettings : MSFT_DeviceManagementMobileAppAssignmentSettings
+{
+    [Write, Description("Display name or Id of the VPN configuration profile associated with this policy.")] String vpnConfigurationId;
+    [Write, Description("When TRUE, indicates that the app should be uninstalled when the device is removed from Intune. When FALSE, indicates that the app will not be uninstalled when the device is removed from Intune. By default, property is set to null which internally is treated as TRUE.")] Boolean uninstallOnDeviceRemoval;
+    [Write, Description("When TRUE, indicates that the app can be uninstalled by the user. When FALSE, indicates that the app cannot be uninstalled by the user. By default, this property is set to null which internally is treated as TRUE.")] Boolean isRemovable;
+    [Write, Description("When TRUE, indicates that the app should not be backed up to iCloud. When FALSE, indicates that the app may be backed up to iCloud. By default, this property is set to null which internally is treated as FALSE.")] Boolean preventManagedAppBackup;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementStoreMobileAppAssignment : MSFT_DeviceManagementMobileAppAssignment
+{
+    [Write, Description("The settings of the assignment."), EmbeddedInstance("MSFT_DeviceManagementStoreMobileAppAssignmentSettings")] String assignmentSettings;
+};
+
 [ClassVersion("1.0.0")]
 class MSFT_MicrosoftGraphIosDeviceType
 {
@@ -59,7 +80,7 @@ class MSFT_DeviceManagementMobileAppCategory
     [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
 };
 
-[ClassVersion("1.0.0.0"), FriendlyName("IntuneMobileAppsStoreApp")]
+[ClassVersion("1.0.0.1"), FriendlyName("IntuneMobileAppsStoreApp")]
 class MSFT_IntuneMobileAppsStoreApp : OMI_BaseResource
 {
     [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
@@ -80,7 +101,7 @@ class MSFT_IntuneMobileAppsStoreApp : OMI_BaseResource
     [Write, Description("List of scope tag ids for this mobile app.")] String RoleScopeTagIds[];
     [Required, Description("The target platform of the mobile app."), ValueMap{"android","ios"}, Values{"android","ios"}] String TargetPlatform;
     [Write, Description("The list of categories for this app."), EmbeddedInstance("MSFT_DeviceManagementMobileAppCategory")] String Categories[];
-    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementMobileAppAssignment")] String Assignments[];
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementStoreMobileAppAssignment")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/MSFT_IntuneMobileAppsWin32AppWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/MSFT_IntuneMobileAppsWin32AppWindows10.schema.mof
@@ -32,10 +32,10 @@ class MSFT_DeviceManagementWin32MobileAppAssignmentSettingsInstallTimeSettings
     [Write, Description("The time at which the app should be installed.")] String deadlineDateTime;
 };
 
-[ClassVersion("1.0.0.1")]
+[ClassVersion("1.0.0.2")]
 class MSFT_DeviceManagementMobileAppAssignmentSettings
 {
-    [Write, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
+    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
 };
 
 [ClassVersion("1.0.0.0")]

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsStoreApp/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsStoreApp/1-Create.ps1
@@ -64,11 +64,17 @@ Configuration Example
             PrivacyInformationUrl = "";
             Publisher             = "Contoso";
             Assignments          = @(
-                MSFT_DeviceManagementMobileAppAssignment {
+                MSFT_DeviceManagementStoreMobileAppAssignment {
                     groupDisplayName = 'All devices'
                     deviceAndAppManagementAssignmentFilterType = 'none'
                     dataType = '#microsoft.graph.allDevicesAssignmentTarget'
                     intent = 'required'
+                    assignmentSettings = MSFT_DeviceManagementStoreMobileAppAssignmentSettings {
+                        odataType = '#microsoft.graph.iosStoreAppAssignmentSettings'
+                        uninstallOnDeviceRemoval = $False
+                        isRemovable = $True
+                        preventManagedAppBackup = $True
+                    }
                 }
             );
             Categories             = @(

--- a/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsStoreApp/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/IntuneMobileAppsStoreApp/2-Update.ps1
@@ -64,11 +64,17 @@ Configuration Example
             PrivacyInformationUrl = "";
             Publisher             = "Contoso";
             Assignments          = @(
-                MSFT_DeviceManagementMobileAppAssignment {
+                MSFT_DeviceManagementStoreMobileAppAssignment {
                     groupDisplayName = 'All devices'
                     deviceAndAppManagementAssignmentFilterType = 'none'
                     dataType = '#microsoft.graph.allDevicesAssignmentTarget'
                     intent = 'required'
+                    assignmentSettings = MSFT_DeviceManagementStoreMobileAppAssignmentSettings {
+                        odataType = '#microsoft.graph.iosStoreAppAssignmentSettings'
+                        uninstallOnDeviceRemoval = $False
+                        isRemovable = $True
+                        preventManagedAppBackup = $True
+                    }
                 }
             );
             Categories             = @(

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsStoreApp.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneMobileAppsStoreApp.Tests.ps1
@@ -36,6 +36,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Get-PSSession -MockWith {
             }
 
+            Mock -CommandName Get-MgBetaDeviceManagementDeviceConfiguration -MockWith {
+            }
+
             Mock -CommandName Remove-PSSession -MockWith {
             }
 

--- a/docs/docs/resources/intune/IntuneAppProtectionPolicyAndroid.md
+++ b/docs/docs/resources/intune/IntuneAppProtectionPolicyAndroid.md
@@ -70,7 +70,6 @@
 | **FingerprintBlocked** | Write | Boolean | Indicates whether use of the fingerprint reader is allowed in place of a pin if PinRequired is set to True. | |
 | **Apps** | Write | StringArray[] | List of IDs representing the Android apps controlled by this protection policy. | |
 | **Assignments** | Write | MSFT_DeviceManagementConfigurationPolicyAssignments[] | Assignments of the Android Protection Policy. | |
-| **ExcludedGroups** | Write | StringArray[] | List of IDs of the groups that are excluded from this Android Protection Policy. | |
 | **Ensure** | Write | String | Present ensures the policy exists, absent ensures it is removed. | `Present`, `Absent` |
 | **Credential** | Write | PSCredential | Credentials of the Intune Admin | |
 | **ApplicationId** | Write | String | ID of the Azure Active Directory application to authenticate with. | |


### PR DESCRIPTION
#### Pull Request (PR) description
This PR removes the now unused member `ExcludedGroups` from the `IntuneAppProtectionPolicyAndroid` and adds the `assignmentSettings` to the `IntuneMobileAppsStoreApp` resource.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
