### PR TITLE
Add new resource IntuneWifiEnterpriseConfigurationPolicyWindows10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,8 @@
 * IntuneWifiConfigurationPolicyAndroidForWork
   * [BREAKING CHANGE] Removed resource because it's not supported anymore.
     Instead, use the `IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile` resource.
+* IntuneWifiEnterpriseConfigurationPolicyWindows10
+  * Added new resource for enterprise wifi profiles
 * O365AdminAuditLogConfig
   * [BREAKING CHANGE] Removed `Ensure` parameter because it is a single instance object.
 * O365OrgSettings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
     Instead, use the `IntuneWifiConfigurationPolicyAndroidEnterpriseWorkProfile` resource.
 * IntuneWifiEnterpriseConfigurationPolicyWindows10
   * Added new resource for enterprise wifi profiles
+  * Fixes #5839
 * O365AdminAuditLogConfig
   * [BREAKING CHANGE] Removed `Ensure` parameter because it is a single instance object.
 * O365OrgSettings

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10/MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10/MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10.psm1
@@ -1,0 +1,1269 @@
+Confirm-M365DSCModuleDependency -ModuleName 'MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10'
+
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Id,#
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [System.Boolean]
+        $ConnectAutomatically,
+
+        [Parameter()]
+        [System.Boolean]
+        $ConnectToPreferredNetwork,
+
+        [Parameter()]
+        [System.Boolean]
+        $ConnectWhenNetworkNameIsHidden,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $DeviceManagementApplicabilityRuleOsEdition,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $DeviceManagementApplicabilityRuleOsVersion,
+
+        [Parameter()]
+        [System.Boolean]
+        $ForceFIPSCompliance,
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('disabled', 'prelogon', 'postlogon')]
+        $networkSingleSignOn,
+
+        [Parameter()]
+        [ValidateSet('unrestricted', 'fixed', 'variable')]
+        [System.String]
+        $MeteredConnectionLimit,
+
+        [Parameter()]
+        [System.String]
+        $NetworkName,
+
+        [Parameter()]
+        [System.String]
+        $PreSharedKey,
+
+        [Parameter()]
+        [System.String]
+        $ProxyAutomaticConfigurationUrl,
+
+        [Parameter()]
+        [System.String]
+        $ProxyManualAddress,
+
+        [Parameter()]
+        [System.Int32]
+        $ProxyManualPort,
+
+        [Parameter()]
+        [ValidateSet('none', 'manual', 'automatic')]
+        [System.String]
+        $ProxySetting,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [System.String]
+        $Ssid,
+
+        [Parameter()]
+        [System.Boolean]
+        $userBasedVirtualLan,
+
+        [Parameter()]
+        [System.Boolean]
+        $promptForAdditionalAuthenticationCredentials,
+
+        [Parameter()]
+        [System.Boolean]
+        $enablePairwiseMasterKeyCaching,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(5,1440)]
+        $maximumPairwiseMasterKeyCacheTimeInMinutes,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,255)]
+        $maximumNumberOfPairwiseMasterKeysInCache,
+
+        [Parameter()]
+        [System.Boolean]
+        $enablePreAuthentication,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,16)]
+        $maximumPreAuthenticationAttempts,
+
+        [Parameter()]
+        [ValidateSet('eapTls', 'leap', 'eapSim', 'eapTtls', 'peap', 'eapFast', 'teap')]
+        [System.String]
+        $eapType,
+
+        [Parameter()]
+        [System.String[]]
+        $trustedServerCertificateNames,#
+
+        [Parameter()]
+        [ValidateSet('certificate', 'usernameAndPassword', 'derivedCredential')]
+        [System.String]
+        $authenticationMethod,
+
+        [Parameter()]
+        [ValidateSet('unencryptedPassword', 'challengeHandshakeAuthenticationProtocol', 'microsoftChap', 'microsoftChapVersionTwo')]
+        [System.String]
+        $innerAuthenticationProtocolForEAPTTLS,
+
+        [Parameter()]
+        [System.String]
+        $outerIdentityPrivacyTemporaryValue,
+
+        [Parameter()]
+        [System.Boolean]
+        $requireCryptographicBinding,
+
+        [Parameter()]
+        [System.Boolean]
+        $performServerValidation,
+
+        [Parameter()]
+        [System.Boolean]
+        $disableUserPromptForServerValidation,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,3600)]
+        $authenticationPeriodInSeconds,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,3600)]
+        $authenticationRetryDelayPeriodInSeconds,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,3600)]
+        $eapolStartPeriodInSeconds,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,100)]
+        $maximumEAPOLStartMessages,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,100)]
+        $maximumAuthenticationFailures,
+
+        [Parameter()]
+        [System.Boolean]
+        $cacheCredentials,
+
+        [Parameter()]
+        [ValidateSet('none', 'user', 'machine', 'machineOrUser', 'guest')]
+        [System.String]
+        $authenticationType,
+
+        [Parameter()]
+        [ValidateSet('open', 'wpaPersonal', 'wpaEnterprise', 'wep', 'wpa2Personal', 'wpa2Enterprise')]
+        [System.String]
+        $WifiSecurityType,#
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    Write-Verbose -Message "Getting configuration of the Intune Wifi Enterprise Configuration Policy for Windows10 with Id {$Id} and DisplayName {$DisplayName}"
+
+    try
+    {
+        if (-not $Script:exportedInstance -or $Script:exportedInstance.DisplayName -ne $DisplayName)
+        {
+            $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+                -InboundParameters $PSBoundParameters
+
+            #Ensure the proper dependencies are installed in the current environment.
+            Confirm-M365DSCDependencies
+
+            #region Telemetry
+            $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+            $CommandName = $MyInvocation.MyCommand
+            $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+                -CommandName $CommandName `
+                -Parameters $PSBoundParameters
+            Add-M365DSCTelemetryEvent -Data $data
+            #endregion
+
+            $nullResult = $PSBoundParameters
+            $nullResult.Ensure = 'Absent'
+
+            $getValue = $null
+            if (-not [string]::IsNullOrEmpty($Id))
+            {
+                $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "Id eq '$Id'" -ErrorAction SilentlyContinue
+            }
+
+            #region resource generator code
+            if ($null -eq $getValue)
+            {
+                $getValue = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "DisplayName eq '$($DisplayName -replace "'", "''")'" -ErrorAction SilentlyContinue | Where-Object `
+                    -FilterScript {
+                        $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.windowsWifiEnterpriseEAPConfiguration'
+                    }
+            }
+            #endregion
+
+            if ($null -eq $getValue)
+            {
+                Write-Verbose -Message "No Intune Wifi Enterprise Configuration Policy for Windows10 with id {$Id} was found"
+                return $nullResult
+            }
+        }
+        else
+        {
+            $getValue = $Script:exportedInstance
+        }
+        $Id = $getValue.Id
+
+        Write-Verbose -Message "Found an Intune Wifi Enterprise Configuration Policy for Windows10 with id {$Id}"
+
+        $complexDeviceManagementApplicabilityRuleOsEdition = @{}
+        $complexDeviceManagementApplicabilityRuleOsEdition.Add('OsEditionTypes', [string[]]$getValue.DeviceManagementApplicabilityRuleOSEdition.OsEditionTypes)
+        $complexDeviceManagementApplicabilityRuleOsEdition.Add('RuleType', [string]$getValue.DeviceManagementApplicabilityRuleOSEdition.RuleType)
+        if ($complexDeviceManagementApplicabilityRuleOsEdition.values.Where({$null -ne $_}).Count -eq 0)
+        {
+            $complexDeviceManagementApplicabilityRuleOsEdition = $null
+        }
+
+        $complexDeviceManagementApplicabilityRuleOsVersion = @{}
+        $complexDeviceManagementApplicabilityRuleOsVersion.Add('MaxOSVersion', $getValue.DeviceManagementApplicabilityRuleOSVersion.MaxOSVersion)
+        $complexDeviceManagementApplicabilityRuleOsVersion.Add('MinOSVersion', $getValue.DeviceManagementApplicabilityRuleOSVersion.MinOSVersion)
+        $complexDeviceManagementApplicabilityRuleOsVersion.Add('RuleType', [string]$getValue.DeviceManagementApplicabilityRuleOSVersion.RuleType)
+        if ($complexDeviceManagementApplicabilityRuleOsVersion.values.Where({$null -ne $_}).Count -eq 0)
+        {
+            $complexDeviceManagementApplicabilityRuleOsVersion = $null
+        }
+
+        $results = @{
+            #region resource generator code
+            Id                                              = $getValue.Id
+            Description                                     = $getValue.Description
+            DisplayName                                     = $getValue.DisplayName
+            ConnectAutomatically                            = $getValue.AdditionalProperties.connectAutomatically
+            ConnectToPreferredNetwork                       = $getValue.AdditionalProperties.connectToPreferredNetwork
+            ConnectWhenNetworkNameIsHidden                  = $getValue.AdditionalProperties.connectWhenNetworkNameIsHidden
+            DeviceManagementApplicabilityRuleOsEdition      = $complexDeviceManagementApplicabilityRuleOsEdition
+            DeviceManagementApplicabilityRuleOsVersion      = $complexDeviceManagementApplicabilityRuleOsVersion
+            ForceFIPSCompliance                             = $getValue.AdditionalProperties.forceFIPSCompliance
+            MeteredConnectionLimit                          = $getValue.AdditionalProperties.meteredConnectionLimit
+            NetworkName                                     = $getValue.AdditionalProperties.networkName
+            PreSharedKey                                    = $getValue.AdditionalProperties.preSharedKey
+            ProxyAutomaticConfigurationUrl                  = $getValue.AdditionalProperties.proxyAutomaticConfigurationUrl
+            ProxyManualAddress                              = $getValue.AdditionalProperties.proxyManualAddress
+            ProxyManualPort                                 = $getValue.AdditionalProperties.proxyManualPort
+            ProxySetting                                    = $getValue.AdditionalProperties.proxySetting
+            RoleScopeTagIds                                 = $getValue.RoleScopeTagIds
+            Ssid                                            = $getValue.AdditionalProperties.ssid
+            WifiSecurityType                                = $getValue.AdditionalProperties.wifiSecurityType
+            networkSingleSignOn                             = $getValue.AdditionalProperties.networkSingleSignOn
+            maximumAuthenticationTimeoutInSeconds           = $getValue.AdditionalProperties.maximumAuthenticationTimeoutInSeconds
+            userBasedVirtualLan                             = $getValue.AdditionalProperties.userBasedVirtualLan
+            promptForAdditionalAuthenticationCredentials    = $getValue.AdditionalProperties.promptForAdditionalAuthenticationCredentials
+            enablePairwiseMasterKeyCaching                  = $getValue.AdditionalProperties.enablePairwiseMasterKeyCaching
+            maximumPairwiseMasterKeyCacheTimeInMinutes      = $getValue.AdditionalProperties.maximumPairwiseMasterKeyCacheTimeInMinutes
+            maximumNumberOfPairwiseMasterKeysInCache        = $getValue.AdditionalProperties.maximumNumberOfPairwiseMasterKeysInCache
+            enablePreAuthentication                         = $getValue.AdditionalProperties.enablePreAuthentication
+            maximumPreAuthenticationAttempts                = $getValue.AdditionalProperties.maximumPreAuthenticationAttempts
+            eapType                                         = $getValue.AdditionalProperties.eapType
+            trustedServerCertificateNames                   = $getValue.AdditionalProperties.trustedServerCertificateNames
+            authenticationMethod                            = $getValue.AdditionalProperties.authenticationMethod
+            innerAuthenticationProtocolForEAPTTLS           = $getValue.AdditionalProperties.innerAuthenticationProtocolForEAPTTLS
+            outerIdentityPrivacyTemporaryValue              = $getValue.AdditionalProperties.outerIdentityPrivacyTemporaryValue
+            requireCryptographicBinding                     = $getValue.AdditionalProperties.requireCryptographicBinding
+            performServerValidation                         = $getValue.AdditionalProperties.performServerValidation
+            disableUserPromptForServerValidation            = $getValue.AdditionalProperties.disableUserPromptForServerValidation
+            authenticationPeriodInSeconds                   = $getValue.AdditionalProperties.authenticationPeriodInSeconds
+            authenticationRetryDelayPeriodInSeconds         = $getValue.AdditionalProperties.authenticationRetryDelayPeriodInSeconds
+            eapolStartPeriodInSeconds                       = $getValue.AdditionalProperties.eapolStartPeriodInSeconds
+            maximumEAPOLStartMessages                       = $getValue.AdditionalProperties.maximumEAPOLStartMessages
+            maximumAuthenticationFailures                   = $getValue.AdditionalProperties.maximumAuthenticationFailures
+            cacheCredentials                                = $getValue.AdditionalProperties.cacheCredentials
+            authenticationType                              = $getValue.AdditionalProperties.authenticationType
+            Ensure                                          = 'Present'
+            Credential                                      = $Credential
+            ApplicationId                                   = $ApplicationId
+            TenantId                                        = $TenantId
+            ApplicationSecret                               = $ApplicationSecret
+            CertificateThumbprint                           = $CertificateThumbprint
+            Managedidentity                                 = $ManagedIdentity.IsPresent
+            AccessTokens                                    = $AccessTokens
+        }
+
+        $assignmentsValues = Get-MgBetaDeviceManagementDeviceConfigurationAssignment -DeviceConfigurationId $Id
+        $assignmentResult = @()
+        if ($assignmentsValues.Count -gt 0)
+        {
+            $assignmentResult += ConvertFrom-IntunePolicyAssignment `
+                -IncludeDeviceFilter:$true `
+                -Assignments ($assignmentsValues)
+        }
+        $results.Add('Assignments', $assignmentResult)
+
+        return [System.Collections.Hashtable] $results
+    }
+    catch
+    {
+        New-M365DSCLogEntry -Message 'Error retrieving data:' `
+            -Exception $_ `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -TenantId $TenantId `
+            -Credential $Credential
+
+        return $nullResult
+    }
+}
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Id,#
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [System.Boolean]
+        $ConnectAutomatically,
+
+        [Parameter()]
+        [System.Boolean]
+        $ConnectToPreferredNetwork,
+
+        [Parameter()]
+        [System.Boolean]
+        $ConnectWhenNetworkNameIsHidden,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $DeviceManagementApplicabilityRuleOsEdition,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $DeviceManagementApplicabilityRuleOsVersion,
+
+        [Parameter()]
+        [System.Boolean]
+        $ForceFIPSCompliance,
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('disabled', 'prelogon', 'postlogon')]
+        $networkSingleSignOn,
+
+        [Parameter()]
+        [ValidateSet('unrestricted', 'fixed', 'variable')]
+        [System.String]
+        $MeteredConnectionLimit,
+
+        [Parameter()]
+        [System.String]
+        $NetworkName,
+
+        [Parameter()]
+        [System.String]
+        $PreSharedKey,
+
+        [Parameter()]
+        [System.String]
+        $ProxyAutomaticConfigurationUrl,
+
+        [Parameter()]
+        [System.String]
+        $ProxyManualAddress,
+
+        [Parameter()]
+        [System.Int32]
+        $ProxyManualPort,
+
+        [Parameter()]
+        [ValidateSet('none', 'manual', 'automatic')]
+        [System.String]
+        $ProxySetting,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [System.String]
+        $Ssid,
+
+        [Parameter()]
+        [System.Boolean]
+        $userBasedVirtualLan,
+
+        [Parameter()]
+        [System.Boolean]
+        $promptForAdditionalAuthenticationCredentials,
+
+        [Parameter()]
+        [System.Boolean]
+        $enablePairwiseMasterKeyCaching,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(5,1440)]
+        $maximumPairwiseMasterKeyCacheTimeInMinutes,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,255)]
+        $maximumNumberOfPairwiseMasterKeysInCache,
+
+        [Parameter()]
+        [System.Boolean]
+        $enablePreAuthentication,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,16)]
+        $maximumPreAuthenticationAttempts,
+
+        [Parameter()]
+        [ValidateSet('eapTls', 'leap', 'eapSim', 'eapTtls', 'peap', 'eapFast', 'teap')]
+        [System.String]
+        $eapType,
+
+        [Parameter()]
+        [System.String[]]
+        $trustedServerCertificateNames,#
+
+        [Parameter()]
+        [ValidateSet('certificate', 'usernameAndPassword', 'derivedCredential')]
+        [System.String]
+        $authenticationMethod,
+
+        [Parameter()]
+        [ValidateSet('unencryptedPassword', 'challengeHandshakeAuthenticationProtocol', 'microsoftChap', 'microsoftChapVersionTwo')]
+        [System.String]
+        $innerAuthenticationProtocolForEAPTTLS,
+
+        [Parameter()]
+        [System.String]
+        $outerIdentityPrivacyTemporaryValue,
+
+        [Parameter()]
+        [System.Boolean]
+        $requireCryptographicBinding,
+
+        [Parameter()]
+        [System.Boolean]
+        $performServerValidation,
+
+        [Parameter()]
+        [System.Boolean]
+        $disableUserPromptForServerValidation,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,3600)]
+        $authenticationPeriodInSeconds,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,3600)]
+        $authenticationRetryDelayPeriodInSeconds,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,3600)]
+        $eapolStartPeriodInSeconds,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,100)]
+        $maximumEAPOLStartMessages,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,100)]
+        $maximumAuthenticationFailures,
+
+        [Parameter()]
+        [System.Boolean]
+        $cacheCredentials,
+
+        [Parameter()]
+        [ValidateSet('none', 'user', 'machine', 'machineOrUser', 'guest')]
+        [System.String]
+        $authenticationType,#
+
+        [Parameter()]
+        [ValidateSet('open', 'wpaPersonal', 'wpaEnterprise', 'wep', 'wpa2Personal', 'wpa2Enterprise')]
+        [System.String]
+        $WifiSecurityType,#
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    if ($ProxySetting -ne 'automatic' -and $ProxyAutomaticConfigurationUrl -ne '') {
+        throw 'ProxyAutomaticConfigurationUrl must be empty if ProxySetting is not "automatic"'
+    }
+
+    if ($WiFiSecurityType -eq 'wpaPersonal' -and [string]::IsNullOrEmpty($PreSharedKey)) {
+        throw 'PreSharedKey is required but was not set.'
+    }
+
+    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+        -InboundParameters $PSBoundParameters
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    $currentInstance = Get-TargetResource @PSBoundParameters
+    $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+
+    if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
+    {
+        Write-Verbose -Message "Creating an Intune Wifi Enterprise Configuration Policy for Windows10 with DisplayName {$DisplayName}"
+
+        $CreateParameters = ([Hashtable]$BoundParameters).Clone()
+        $CreateParameters.Remove('Assignments') | Out-Null
+        $CreateParameters.Remove('Id') | Out-Null
+
+        $AdditionalProperties = Get-M365DSCAdditionalProperties -Properties ($CreateParameters)
+        foreach ($key in $AdditionalProperties.Keys)
+        {
+            if ($key -ne '@odata.type')
+            {
+                $keyName = $key.Substring(0, 1).ToUpper() + $key.Substring(1, $key.Length - 1)
+                $CreateParameters.Remove($keyName)
+            }
+        }
+
+        foreach ($key in ($CreateParameters.Clone()).Keys)
+        {
+            if ($CreateParameters[$key].GetType().Fullname -like '*CimInstance*')
+            {
+                $CreateParameters[$key] = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $CreateParameters[$key]
+            }
+        }
+
+        if ($AdditionalProperties)
+        {
+            if ($AdditionalProperties['proxyAutomaticConfigurationUrl'] -eq '') {
+                $AdditionalProperties['proxyAutomaticConfigurationUrl'] = $null
+            }
+            $CreateParameters.Add('AdditionalProperties', $AdditionalProperties)
+        }
+
+        #region resource generator code
+        $policy = New-MgBetaDeviceManagementDeviceConfiguration @CreateParameters
+        $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
+
+        if ($policy.Id)
+        {
+            Update-DeviceConfigurationPolicyAssignment -DeviceConfigurationPolicyId $policy.Id `
+                -Targets $assignmentsHash `
+                -Repository 'deviceManagement/deviceConfigurations'
+        }
+        #endregion
+    }
+    elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Updating the Intune Wifi Enterprise Configuration Policy with Id {$($currentInstance.Id)} and DisplayName {$DisplayName}"
+
+        $UpdateParameters = ([Hashtable]$BoundParameters).Clone()
+        $UpdateParameters.Remove('Assignments') | Out-Null
+        $UpdateParameters.Remove('Id') | Out-Null
+
+        $AdditionalProperties = Get-M365DSCAdditionalProperties -Properties ($UpdateParameters)
+        foreach ($key in $AdditionalProperties.keys)
+        {
+            if ($key -ne '@odata.type')
+            {
+                $keyName = $key.Substring(0, 1).ToUpper() + $key.Substring(1, $key.Length - 1)
+                $UpdateParameters.Remove($keyName)
+            }
+        }
+
+        foreach ($key in ($UpdateParameters.Clone()).Keys)
+        {
+            if ($UpdateParameters[$key].GetType().Fullname -like '*CimInstance*')
+            {
+                $UpdateParameters[$key] = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $UpdateParameters[$key]
+            }
+        }
+
+        if ($AdditionalProperties)
+        {
+            if ($AdditionalProperties['proxyAutomaticConfigurationUrl'] -eq '') {
+                $AdditionalProperties['proxyAutomaticConfigurationUrl'] = $null
+            }
+            $UpdateParameters.Add('AdditionalProperties', $AdditionalProperties)
+        }
+
+        #region resource generator code
+        Update-MgBetaDeviceManagementDeviceConfiguration @UpdateParameters `
+            -DeviceConfigurationId $currentInstance.Id
+        $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
+        Update-DeviceConfigurationPolicyAssignment -DeviceConfigurationPolicyId $currentInstance.id `
+            -Targets $assignmentsHash `
+            -Repository 'deviceManagement/deviceConfigurations'
+        #endregion
+    }
+    elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
+    {
+        Write-Verbose -Message "Removing {$DisplayName}"
+
+        #region resource generator code
+        Remove-MgBetaDeviceManagementDeviceConfiguration -DeviceConfigurationId $currentInstance.Id
+        #endregion
+    }
+}
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        #region resource generator code
+        [Parameter()]
+        [System.String]
+        $Id,#
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $DisplayName,
+
+        [Parameter()]
+        [System.String]
+        $Description,
+
+        [Parameter()]
+        [System.Boolean]
+        $ConnectAutomatically,
+
+        [Parameter()]
+        [System.Boolean]
+        $ConnectToPreferredNetwork,
+
+        [Parameter()]
+        [System.Boolean]
+        $ConnectWhenNetworkNameIsHidden,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $DeviceManagementApplicabilityRuleOsEdition,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance]
+        $DeviceManagementApplicabilityRuleOsVersion,
+
+        [Parameter()]
+        [System.Boolean]
+        $ForceFIPSCompliance,
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('disabled', 'prelogon', 'postlogon')]
+        $networkSingleSignOn,
+
+        [Parameter()]
+        [ValidateSet('unrestricted', 'fixed', 'variable')]
+        [System.String]
+        $MeteredConnectionLimit,
+
+        [Parameter()]
+        [System.String]
+        $NetworkName,
+
+        [Parameter()]
+        [System.String]
+        $PreSharedKey,
+
+        [Parameter()]
+        [System.String]
+        $ProxyAutomaticConfigurationUrl,
+
+        [Parameter()]
+        [System.String]
+        $ProxyManualAddress,
+
+        [Parameter()]
+        [System.Int32]
+        $ProxyManualPort,
+
+        [Parameter()]
+        [ValidateSet('none', 'manual', 'automatic')]
+        [System.String]
+        $ProxySetting,
+
+        [Parameter()]
+        [System.String[]]
+        $RoleScopeTagIds,
+
+        [Parameter()]
+        [System.String]
+        $Ssid,
+
+        [Parameter()]
+        [System.Boolean]
+        $userBasedVirtualLan,
+
+        [Parameter()]
+        [System.Boolean]
+        $promptForAdditionalAuthenticationCredentials,
+
+        [Parameter()]
+        [System.Boolean]
+        $enablePairwiseMasterKeyCaching,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(5,1440)]
+        $maximumPairwiseMasterKeyCacheTimeInMinutes,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,255)]
+        $maximumNumberOfPairwiseMasterKeysInCache,
+
+        [Parameter()]
+        [System.Boolean]
+        $enablePreAuthentication,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,16)]
+        $maximumPreAuthenticationAttempts,
+
+        [Parameter()]
+        [ValidateSet('eapTls', 'leap', 'eapSim', 'eapTtls', 'peap', 'eapFast', 'teap')]
+        [System.String]
+        $eapType,
+
+        [Parameter()]
+        [System.String[]]
+        $trustedServerCertificateNames,#
+
+        [Parameter()]
+        [ValidateSet('certificate', 'usernameAndPassword', 'derivedCredential')]
+        [System.String]
+        $authenticationMethod,
+
+        [Parameter()]
+        [ValidateSet('unencryptedPassword', 'challengeHandshakeAuthenticationProtocol', 'microsoftChap', 'microsoftChapVersionTwo')]
+        [System.String]
+        $innerAuthenticationProtocolForEAPTTLS,
+
+        [Parameter()]
+        [System.String]
+        $outerIdentityPrivacyTemporaryValue,
+
+        [Parameter()]
+        [System.Boolean]
+        $requireCryptographicBinding,
+
+        [Parameter()]
+        [System.Boolean]
+        $performServerValidation,
+
+        [Parameter()]
+        [System.Boolean]
+        $disableUserPromptForServerValidation,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,3600)]
+        $authenticationPeriodInSeconds,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,3600)]
+        $authenticationRetryDelayPeriodInSeconds,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,3600)]
+        $eapolStartPeriodInSeconds,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,100)]
+        $maximumEAPOLStartMessages,
+
+        [Parameter()]
+        [System.Int32]
+        [ValidateRange(1,100)]
+        $maximumAuthenticationFailures,
+
+        [Parameter()]
+        [System.Boolean]
+        $cacheCredentials,
+
+        [Parameter()]
+        [ValidateSet('none', 'user', 'machine', 'machineOrUser', 'guest')]
+        [System.String]
+        $authenticationType,#
+
+        [Parameter()]
+        [ValidateSet('open', 'wpaPersonal', 'wpaEnterprise', 'wep', 'wpa2Personal', 'wpa2Enterprise')]
+        [System.String]
+        $WifiSecurityType,#
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $Assignments,
+        #endregion
+
+        [Parameter()]
+        [System.String]
+        [ValidateSet('Absent', 'Present')]
+        $Ensure = 'Present',
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    Write-Verbose -Message "Testing configuration of the Intune Wifi Enterprise Configuration Policy for Windows10 with Id {$Id} and DisplayName {$DisplayName}"
+
+    if ($ProxySetting -ne 'automatic' -and $ProxyAutomaticConfigurationUrl -ne '') {
+        throw 'ProxyAutomaticConfigurationUrl must be empty if ProxySetting is not "automatic".'
+    }
+
+    $CurrentValues = Get-TargetResource @PSBoundParameters
+    $ValuesToCheck = ([Hashtable]$PSBoundParameters).Clone()
+    $testResult = $true
+
+    #Compare Cim instances
+    foreach ($key in $PSBoundParameters.Keys)
+    {
+        $source = $PSBoundParameters.$key
+        $target = $CurrentValues.$key
+        if ($null -ne $source -and $source.GetType().Name -like '*CimInstance*')
+        {
+            $testResult = Compare-M365DSCComplexObject `
+                -Source ($source) `
+                -Target ($target)
+
+            if (-not $testResult)
+            {
+                break
+            }
+
+            $ValuesToCheck.Remove($key) | Out-Null
+        }
+    }
+    $ValuesToCheck.Remove('Id') | Out-Null
+    $ValuesToCheck.Remove('PreSharedKey') | Out-Null
+
+    Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
+    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $ValuesToCheck)"
+
+    if ($testResult)
+    {
+        $testResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
+            -Source $($MyInvocation.MyCommand.Source) `
+            -DesiredValues $PSBoundParameters `
+            -ValuesToCheck $ValuesToCheck.Keys
+    }
+
+    Write-Verbose -Message "Test-TargetResource returned $testResult"
+
+    return $testResult
+}
+
+function Export-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $Filter,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ApplicationSecret,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint,
+
+        [Parameter()]
+        [Switch]
+        $ManagedIdentity,
+
+        [Parameter()]
+        [System.String[]]
+        $AccessTokens
+    )
+
+    $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
+        -InboundParameters $PSBoundParameters
+
+    #Ensure the proper dependencies are installed in the current environment.
+    Confirm-M365DSCDependencies
+
+    #region Telemetry
+    $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
+    $CommandName = $MyInvocation.MyCommand
+    $data = Format-M365DSCTelemetryParameters -ResourceName $ResourceName `
+        -CommandName $CommandName `
+        -Parameters $PSBoundParameters
+    Add-M365DSCTelemetryEvent -Data $data
+    #endregion
+
+    try
+    {
+        #region resource generator code
+        [array]$getValue = Get-MgBetaDeviceManagementDeviceConfiguration -Filter $Filter -All `
+            -ErrorAction Stop | Where-Object `
+            -FilterScript { `
+                $_.AdditionalProperties.'@odata.type' -eq '#microsoft.graph.windowsWifiEnterpriseEAPConfiguration'  `
+        }
+        #endregion
+
+        $i = 1
+        $dscContent = ''
+        if ($getValue.Length -eq 0)
+        {
+            Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
+        }
+        else
+        {
+            Write-M365DSCHost -Message "`r`n" -DeferWrite
+        }
+        foreach ($config in $getValue)
+        {
+            if ($null -ne $Global:M365DSCExportResourceInstancesCount)
+            {
+                $Global:M365DSCExportResourceInstancesCount++
+            }
+
+            Write-M365DSCHost -Message "    |---[$i/$($getValue.Count)] $($config.DisplayName)" -DeferWrite
+            $params = @{
+                Id                    = $config.id
+                DisplayName           = $config.DisplayName
+                Ensure                = 'Present'
+                Credential            = $Credential
+                ApplicationId         = $ApplicationId
+                TenantId              = $TenantId
+                ApplicationSecret     = $ApplicationSecret
+                CertificateThumbprint = $CertificateThumbprint
+                Managedidentity       = $ManagedIdentity.IsPresent
+                AccessTokens          = $AccessTokens
+            }
+
+            $Script:exportedInstance = $config
+            $Results = Get-TargetResource @Params
+
+            if ($Results.DeviceManagementApplicabilityRuleOsEdition)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.DeviceManagementApplicabilityRuleOsEdition -CIMInstanceName DeviceManagementApplicabilityRuleOsEdition
+                if ($complexTypeStringResult)
+                {
+                    $Results.DeviceManagementApplicabilityRuleOsEdition = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('DeviceManagementApplicabilityRuleOsEdition') | Out-Null
+                }
+            }
+
+            if ($Results.DeviceManagementApplicabilityRuleOsVersion)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.DeviceManagementApplicabilityRuleOsVersion -CIMInstanceName DeviceManagementApplicabilityRuleOsVersion
+                if ($complexTypeStringResult)
+                {
+                    $Results.DeviceManagementApplicabilityRuleOsVersion = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('DeviceManagementApplicabilityRuleOsVersion') | Out-Null
+                }
+            }
+
+            if ($Results.Assignments)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementConfigurationPolicyAssignments
+                if ($complexTypeStringResult)
+                {
+                    $Results.Assignments = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('Assignments') | Out-Null
+                }
+            }
+
+            $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
+                -ConnectionMode $ConnectionMode `
+                -ModulePath $PSScriptRoot `
+                -Results $Results `
+                -Credential $Credential `
+                -NoEscape @('Assignments', 'DeviceManagementApplicabilityRuleOsEdition', 'DeviceManagementApplicabilityRuleOsVersion') `
+
+            $dscContent += $currentDSCBlock
+            Save-M365DSCPartialExport -Content $currentDSCBlock `
+                -FileName $Global:PartialExportFileName
+            $i++
+            Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
+        }
+        return $dscContent
+    }
+    catch
+    {
+        if ($_.Exception -like '*401*' -or $_.ErrorDetails.Message -like "*`"ErrorCode`":`"Forbidden`"*" -or `
+                $_.Exception -like '*Request not applicable to target tenant*')
+        {
+            Write-M365DSCHost -Message "`r`n    $($Global:M365DSCEmojiYellowCircle) The current tenant is not registered for Intune."
+        }
+        else
+        {
+            Write-M365DSCHost -Message $Global:M365DSCEmojiRedX -CommitWrite
+
+            New-M365DSCLogEntry -Message 'Error during Export:' `
+                -Exception $_ `
+                -Source $($MyInvocation.MyCommand.Source) `
+                -TenantId $TenantId `
+                -Credential $Credential
+        }
+
+        return ''
+    }
+}
+
+function Get-M365DSCAdditionalProperties
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = 'true')]
+        [System.Collections.Hashtable]
+        $Properties
+    )
+
+    $additionalProperties = @(
+        'ConnectAutomatically'
+        'ConnectToPreferredNetwork'
+        'ConnectWhenNetworkNameIsHidden'
+        'DeviceManagementApplicabilityRuleOsEdition'
+        'DeviceManagementApplicabilityRuleOsVersion'
+        'ForceFIPSCompliance'
+        'MeteredConnectionLimit'
+        'NetworkName'
+        'PreSharedKey'
+        'ProxyAutomaticConfigurationUrl'
+        'ProxyManualAddress'
+        'ProxyManualPort'
+        'ProxySetting'
+        'Ssid'
+        'WifiSecurityType'
+    )
+
+    $results = @{'@odata.type' = '#microsoft.graph.windowsWifiEnterpriseEAPConfiguration' }
+    $cloneProperties = $Properties.Clone()
+    foreach ($property in $cloneProperties.Keys)
+    {
+        if ($property -in ($additionalProperties) )
+        {
+            $propertyName = $property[0].ToString().ToLower() + $property.Substring(1, $property.Length - 1)
+            if ($properties.$property -and $properties.$property.GetType().FullName -like '*CIMInstance*')
+            {
+                if ($properties.$property.GetType().FullName -like '*[[\]]')
+                {
+                    $array = @()
+                    foreach ($item in $properties.$property)
+                    {
+                        $array += Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $item
+                    }
+                    $propertyValue = $array
+                }
+                else
+                {
+                    $propertyValue = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $properties.$property
+                }
+            }
+            else
+            {
+                $propertyValue = $properties.$property
+            }
+
+            $results.Add($propertyName, $propertyValue)
+        }
+    }
+    if ($results.Count -eq 1)
+    {
+        return $null
+    }
+    return $results
+}
+
+Export-ModuleMember -Function *-TargetResource
+

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10/MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10/MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10.schema.mof
@@ -1,0 +1,83 @@
+[ClassVersion("1.0.0.1")]
+class MSFT_DeviceManagementConfigurationPolicyAssignments
+{
+    [Write, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}, Values{"#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}] String dataType;
+    [Write, Description("The type of filter of the target assignment i.e. Exclude or Include. Possible values are:none, include, exclude."), ValueMap{"none","include","exclude"}, Values{"none","include","exclude"}] String deviceAndAppManagementAssignmentFilterType;
+    [Write, Description("The Id of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterId;
+    [Write, Description("The display name of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterDisplayName;
+    [Write, Description("The group Id that is the target of the assignment.")] String groupId;
+    [Write, Description("The group Display Name that is the target of the assignment.")] String groupDisplayName;
+    [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
+};
+
+[ClassVersion("1.0.0")]
+class MSFT_DeviceManagementApplicabilityRuleOsEdition
+{
+    [Write, Description("Name for object")] String Name;
+    [Write, Description("Applicability rule OS edition type")] String OsEditionTypes[];
+    [Write, Description("Applicability Rule type"), ValueMap{"include","exclude"}, Values{"include","exclude"}] String RuleType;
+};
+[ClassVersion("1.0.0")]
+class MSFT_DeviceManagementApplicabilityRuleOsVersion
+{
+    [Write, Description("Name for object")] String Name;
+    [Write, Description("Min OS version for Applicability Rule")] String MinOSVersion;
+    [Write, Description("Max OS version for Applicability Rule")] String MaxOSVersion;
+    [Write, Description("Applicability Rule type"), ValueMap{"include","exclude"}, Values{"include","exclude"}] String RuleType;
+};
+
+[ClassVersion("1.0.0.0"), FriendlyName("IntuneWifiEnterpriseConfigurationPolicyWindows10")]
+class MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10 : OMI_BaseResource
+{
+    [Write, Description("Id of the Intune policy.")] String Id;
+    [Key, Description("Display name of the Intune policy.")] String DisplayName;
+    [Write, Description("Description of the Intune policy.")] String Description;
+    [Write, Description("Connect automatically")] Boolean ConnectAutomatically;
+    [Write, Description("Connect to preferred network")] Boolean ConnectToPreferredNetwork;
+    [Write, Description("Connect when network name is hidden")] Boolean ConnectWhenNetworkNameIsHidden;
+    [Write, Description("The OS edition applicability for this Policy. "), EmbeddedInstance("MSFT_DeviceManagementApplicabilityRuleOsEdition")] String DeviceManagementApplicabilityRuleOsEdition;
+    [Write, Description("The OS version applicability rule for this Policy."), EmbeddedInstance("MSFT_DeviceManagementApplicabilityRuleOsVersion")] String DeviceManagementApplicabilityRuleOsVersion;
+    [Write, Description("Force FIPS compliance")] Boolean ForceFIPSCompliance;
+    [Write, Description("Metered connection limit"), ValueMap{"unrestricted","fixed","variable"}, Values{"unrestricted","fixed","variable"}] String MeteredConnectionLimit;
+    [Write, Description("Network name")] String NetworkName;
+    [Write, Description("Pre shared key")] String PreSharedKey;
+    [Write, Description("Proxy automatic configuration url")] String ProxyAutomaticConfigurationUrl;
+    [Write, Description("Proxy manual address")] String ProxyManualAddress;
+    [Write, Description("Proxy manual port")] UInt32 ProxyManualPort;
+    [Write, Description("Proxy setting"), ValueMap{"none","manual","automatic"}, Values{"none","manual","automatic"}] String ProxySetting;
+    [Write, Description("List of Scope Tags for this Entity instance.")] String RoleScopeTagIds[];
+    [Write, Description("SSID")] String Ssid;
+    [Write, Description("Wi-Fi security"), ValueMap{"open","wpaPersonal","wpaEnterprise","wep","wpa2Personal","wpa2Enterprise"}, Values{"open","wpaPersonal","wpaEnterprise","wep","wpa2Personal","wpa2Enterprise"}] String WifiSecurityType;
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
+    [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("Credentials of the Intune Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
+    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
+    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
+    [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
+    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Access token used for authentication.")] String AccessTokens[];
+    [Write, Description("Specify the network single sign on type. Possible values are: disabled, prelogon, postlogon.")] String networkSingleSignOn;
+    [Write, Description("Specify maximum authentication timeout (in seconds). Valid range: 1-120")] UInt32 maximumAuthenticationTimeoutInSeconds;
+    [Write, Description("Specifiy whether to change the virtual LAN used by the device based on the user’s credentials. Cannot be used when NetworkSingleSignOnType is set to Disabled.")] Boolean userBasedVirtualLan;
+    [Write, Description("Specify whether the wifi connection should prompt for additional authentication credentials.")] Boolean promptForAdditionalAuthenticationCredentials;
+    [Write, Description("Specify whether the wifi connection should enable pairwise master key caching.")] Boolean enablePairwiseMasterKeyCaching;
+    [Write, Description("Specify maximum pairwise master key cache time (in minutes). Valid range: 5-1440")] UInt32 maximumPairwiseMasterKeyCacheTimeInMinutes;
+    [Write, Description("Specify maximum number of pairwise master keys in cache. Valid range: 1-255")] UInt32 maximumNumberOfPairwiseMasterKeysInCache;
+    [Write, Description("Specify whether pre-authentication should be enabled.")] Boolean enablePreAuthentication;
+    [Write, Description("Specify maximum pre-authentication attempts. Valid range: 1-16")] UInt32 maximumPreAuthenticationAttempts;
+    [Write, Description("Extensible Authentication Protocol (EAP). Indicates the type of EAP protocol set on the Wi-Fi endpoint (router). Possible values are: eapTls, leap, eapSim, eapTtls, peap, eapFast, teap.")] String eapType;
+    [Write, Description("Specify trusted server certificate names.")] String trustedServerCertificateNames[];
+    [Write, Description("Specify the authentication method. Possible values are: certificate, usernameAndPassword, derivedCredential.")] String authenticationMethod;
+    [Write, Description("Specify inner authentication protocol for EAP TTLS. Possible values are: unencryptedPassword, challengeHandshakeAuthenticationProtocol, microsoftChap, microsoftChapVersionTwo.")] String innerAuthenticationProtocolForEAPTTLS;
+    [Write, Description("Specify the string to replace usernames for privacy when using EAP TTLS or PEAP.")] String outerIdentityPrivacyTemporaryValue;
+    [Write, Description("Specify whether to enable cryptographic binding when EAP type is selected as PEAP.")] Boolean requireCryptographicBinding;
+    [Write, Description("Specify whether to enable verification of server's identity by validating the certificate when EAP type is selected as PEAP.")] Boolean performServerValidation;
+    [Write, Description("Specify whether to prevent the user from being prompted to authorize new servers for trusted certification authorities when EAP type is selected as PEAP.")] Boolean disableUserPromptForServerValidation;
+    [Write, Description("Specify the number of seconds for the client to wait after an authentication attempt before failing. Valid range 1-3600.")] UInt32 authenticationPeriodInSeconds;
+    [Write, Description("Specify the number of seconds between a failed authentication and the next authentication attempt. Valid range 1-3600.")] UInt32 authenticationRetryDelayPeriodInSeconds;
+    [Write, Description("Specify the number of seconds to wait before sending an EAPOL (Extensible Authentication Protocol over LAN) Start message. Valid range 1-3600.")] UInt32 maximumEAPOLStartMessages;
+    [Write, Description("Specifiy the maximum number of EAPOL (Extensible Authentication Protocol over LAN) Start messages to be sent before returning failure. Valid range 1-100.")] UInt32 maximumAuthenticationFailures;
+    [Write, Description("Specify the maximum authentication failures allowed for a set of credentials. Valid range 1-100.")] Boolean cacheCredentials;
+    [Write, Description("Specify whether to authenticate the user, the device, either, or to use guest authentication (none). If you’re using certificate authentication, make sure the certificate type matches the authentication type. Possible values are: none, user, machine, machineOrUser, guest.")] String authenticationType;
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10/readme.md
@@ -1,0 +1,6 @@
+
+# IntuneWifiEnterpriseConfigurationPolicyWindows10
+
+## Description
+
+This resource configures an Intune Wifi Configuration Policy for Windows10 with Enterprise Wi-Fi type.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWifiEnterpriseConfigurationPolicyWindows10/settings.json
@@ -1,0 +1,52 @@
+{
+  "resourceName": "IntuneWifiEnterpriseConfigurationPolicyWindows10",
+  "description": "This resource configures an Intune Wifi Configuration Policy for Windows10 with Enterprise Wi-Fi type.",
+  "permissions": {
+    "graph": {
+      "delegated": {
+        "read": [
+          {
+            "name": "Group.Read.All"
+          },
+          {
+            "name": "DeviceManagementConfiguration.Read.All"
+          }
+        ],
+        "update": [
+          {
+            "name": "Group.Read.All"
+          },
+          {
+            "name": "DeviceManagementConfiguration.ReadWrite.All"
+          }
+        ]
+      },
+      "application": {
+        "read": [
+          {
+            "name": "Group.Read.All"
+          },
+          {
+            "name": "DeviceManagementConfiguration.Read.All"
+          }
+        ],
+        "update": [
+          {
+            "name": "Group.Read.All"
+          },
+          {
+            "name": "DeviceManagementConfiguration.ReadWrite.All"
+          }
+        ]
+      }
+    }
+  },
+  "requiredModules": [
+    "Microsoft.Graph.Authentication",
+    "Microsoft.Graph.Beta.DeviceManagement"
+  ],
+  "supportedEnvironments": [
+    "Global",
+    "USGov"
+  ]
+}


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds a new resource: IntuneWifiEnterpriseConfigurationPolicyWindows10. This resource is used to configure enterprise level wifi profiles based on 801.x.

#### This Pull Request (PR) fixes the following issues
- Fixes #5839

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
