### PR TITLE
Fix generic type usage in different PowerShell versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   * Fixed issue retrieving existing rule where the Id parameter was incorrectly provided.
 * AADUser
   * Added new permission requirement `User.EnableDisableAccount.All` for enabling / disabling accounts.
+* ODSettings
+  * Fixed an issue where exporting `DomainGuids` would throw because it is a GUID type.
+    FIXES [#6615](https://github.com/microsoft/Microsoft365DSC/issues/6615)
 * TeamsMeetingPolicy
   * Added support for new properties.
     FIXES [#6606](https://github.com/microsoft/Microsoft365DSC/issues/6606)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * AADFilteringPolicyRule
   * Fixed issue retrieving existing rule where the Id parameter was incorrectly provided.
+* AADUser
+  * Added new permission requirement `User.EnableDisableAccount.All` for enabling / disabling accounts.
 * TeamsMeetingPolicy
   * Added support for new properties.
     FIXES [#6606](https://github.com/microsoft/Microsoft365DSC/issues/6606)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/MSFT_AADUser.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/MSFT_AADUser.psm1
@@ -487,6 +487,7 @@ function Set-TargetResource
             $PasswordPolicies = 'None'
         }
         $CreationParams = @{
+            AccountEnabled           = $AccountEnabled
             City                     = $City
             Country                  = $Country
             Department               = $Department

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADUser/settings.json
@@ -32,6 +32,9 @@
             "name": "RoleManagement.ReadWrite.Directory"
           },
           {
+            "name": "User.EnableDisableAccount.All"
+          },
+          {
             "name": "User.ReadWrite.All"
           },
           {
@@ -57,6 +60,9 @@
           },
           {
             "name": "RoleManagement.ReadWrite.Directory"
+          },
+          {
+            "name": "User.EnableDisableAccount.All"
           },
           {
             "name": "User.ReadWrite.All"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
@@ -165,7 +165,9 @@ function Get-TargetResource
             $FixedExcludedFileExtensions = @()
         }
 
-        $FixedAllowedDomainList = $tenantRestrictions.AllowedDomainList
+        $FixedAllowedDomainList = @($tenantRestrictions.AllowedDomainList | Foreach-Object {
+            $_.ToString()
+        })
         if ($FixedAllowedDomainList.Count -eq 0 -or
             ($FixedAllowedDomainList.Count -eq 1 -and $FixedAllowedDomainList[0] -eq ''))
         {

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1200,7 +1200,7 @@ function Test-M365DSCTargetResource
         $IncludedProperties,
 
         [Parameter()]
-        [Func[Hashtable, Hashtable, Hashtable, Object[], Tuple[Hashtable, Hashtable, Hashtable]]]
+        [System.Func[Hashtable, Hashtable, Hashtable, [Object[]], Tuple[Hashtable, Hashtable, Hashtable]]]
         $PostProcessing,
 
         [Parameter()]

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.ODSettings.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.ODSettings.Tests.ps1
@@ -32,7 +32,28 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 return 'Credentials'
             }
 
+            Mock -CommandName Get-PnPTenant -MockWith {
+                return @{
+                    OneDriveStorageQuota = '1024'
+                }
+            }
+
+            Mock -CommandName Set-PnPTenant -MockWith {
+            }
+
             Mock -CommandName Set-PnPTenantSyncClientRestriction -MockWith {
+            }
+
+            Mock -CommandName Get-PnPTenantSyncClientRestriction -MockWith {
+                return @{
+                    OptOutOfGrooveBlock        = $false
+                    OptOutOfGrooveSoftBlock    = $false
+                    DisableReportProblemDialog = $false
+                    BlockMacSync               = $true
+                    AllowedDomainList          = @([System.Guid]::Empty)
+                    TenantRestrictionEnabled   = $true
+                    ExcludedFileExtensions     = @('.asmx')
+                }
             }
 
             # Mock Write-M365DSCHost to hide output during the tests
@@ -50,10 +71,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     IsSingleInstance     = 'Yes'
                     Ensure               = 'Present'
                     Credential           = $Credential
-                }
-
-                Mock -CommandName Set-PnPTenant -MockWith {
-                    return @{OneDriveStorageQuota = $null }
                 }
 
                 Mock -CommandName Get-PnPTenant -MockWith {
@@ -83,31 +100,10 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     BlockMacSync                              = $true
                     DisableReportProblemDialog                = $true
                     TenantRestrictionEnabled                  = $true
-                    DomainGuids                               = @(New-Guid)
+                    DomainGuids                               = @('00000000-0000-0000-0000-000000000000')
                     ExcludedFileExtensions                    = @('.asmx')
                     GrooveBlockOption                         = 'HardOptIn'
                     Credential                                = $Credential
-                }
-
-                Mock -CommandName Get-PnPTenant -MockWith {
-                    return @{
-                        OneDriveStorageQuota = '1024'
-                    }
-                }
-
-                Mock -CommandName Get-PnPTenantSyncClientRestriction -MockWith {
-                    return @{
-                        OptOutOfGrooveBlock        = $false
-                        OptOutOfGrooveSoftBlock    = $false
-                        DisableReportProblemDialog = $false
-                        BlockMacSync               = $true
-                        AllowedDomainList          = @('')
-                        TenantRestrictionEnabled   = $true
-                        ExcludedFileExtensions     = @('.asmx')
-                    }
-                }
-                Mock -CommandName Set-PnPTenant -MockWith {
-                    return @{OneDriveStorageQuota = $null }
                 }
             }
 
@@ -130,12 +126,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
                     Credential = $Credential
-                }
-
-                Mock -CommandName Get-PnPTenant -MockWith {
-                    return @{
-                        OneDriveStorageQuota = '1024'
-                    }
                 }
             }
 


### PR DESCRIPTION
#### Pull Request (PR) description
@NikCharlebois As requested. Fix for the usage of generic types and the `Func` delegate in Windows PowerShell. PowerShell 7.3+ contained a fix for the syntax, but ofc Windows PowerShell doesn't receive it.

Edit: Added fix for `AccountEnabled` not applying (resp. failing) if the required permission is missing.
Edit2: Added fix for export of `ODSettings` if Guids were excluded.

#### This Pull Request (PR) fixes the following issues
- Fixes #6615 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
