### PR TITLE
Fixes the Group assignment for IntuneMobileApp policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
-
+* M365DSCUtil
+  * Fixed issue of function ConvertTo-IntuneMobileAppAssignment where groupID property was mantatory for the Assignment.
 * AADFilteringPolicyRule
   * Fixed issue retrieving existing rule where the Id parameter was incorrectly provided.
 * TeamsMeetingPolicy

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1870,12 +1870,12 @@ function ConvertTo-IntuneMobileAppAssignment
         [Parameter(Mandatory = $true)]
         [AllowNull()]
         $Assignments,
-
+ 
         [Parameter()]
         [System.Boolean]
         $IncludeDeviceFilter = $true
     )
-
+ 
     if ($null -eq $Script:IntuneAssignmentFilters)
     {
         $Script:IntuneAssignmentFilters = Get-MgBetaDeviceManagementAssignmentFilter -All -ErrorAction SilentlyContinue | ForEach-Object {
@@ -1885,84 +1885,98 @@ function ConvertTo-IntuneMobileAppAssignment
             }
         }
     }
-
+ 
     if ($null -eq $Assignments)
     {
         return ,@()
     }
-
+ 
     $assignmentResult = @()
     foreach ($assignment in $Assignments)
     {
         $formattedAssignment = @{}
         $target = @{"@odata.type" = $assignment.dataType}
+ 
+        # Handle Device Filters
         if ($IncludeDeviceFilter)
         {
-            if ($null -ne $assignment.DeviceAndAppManagementAssignmentFilterType -and $assignment.DeviceAndAppManagementAssignmentFilterType -ne 'none')
+            if ($null -ne $assignment.DeviceAndAppManagementAssignmentFilterType -and 
+                $assignment.DeviceAndAppManagementAssignmentFilterType -ne 'none')
             {
-                $filter = $Script:IntuneAssignmentFilters | Where-Object -FilterScript { $_.FilterId -eq $assignment.DeviceAndAppManagementAssignmentFilterId }
+                $filter = $Script:IntuneAssignmentFilters | Where-Object {
+                    $_.FilterId -eq $assignment.DeviceAndAppManagementAssignmentFilterId
+                }
+ 
                 if ($null -eq $filter)
                 {
-                    $filter = $Script:IntuneAssignmentFilters | Where-Object -FilterScript { $_.DisplayName -eq $assignment.DeviceAndAppManagementAssignmentFilterDisplayName }
-                    if ($null -eq $filter)
-                    {
-                        Write-Warning -Message "Assignment filter with DisplayName {$($assignment.DeviceAndAppManagementAssignmentFilterDisplayName)} not found in the directory. Please update your DSC resource extract with the correct filterId or filterDisplayName."
+                    $filter = $Script:IntuneAssignmentFilters | Where-Object {
+                        $_.DisplayName -eq $assignment.DeviceAndAppManagementAssignmentFilterDisplayName
                     }
                 }
-
+ 
                 if ($null -ne $filter)
                 {
                     $target.Add('deviceAndAppManagementAssignmentFilterType', $assignment.DeviceAndAppManagementAssignmentFilterType)
                     $target.Add('deviceAndAppManagementAssignmentFilterId', $filter.FilterId)
                 }
-            }
-        }
-
-        $formattedAssignment.Add('intent', $assignment.intent)
-
-        if ($assignment.dataType -like '*groupAssignmentTarget')
-        {
-            $group = Get-MgGroup -GroupId ($assignment.groupId) -ErrorAction SilentlyContinue
-            if ($null -eq $group)
-            {
-                if ($assignment.groupDisplayName)
-                {
-                    $group = Get-MgGroup -Filter "DisplayName eq '$($assignment.groupDisplayName -replace "'", "''")'" -All -ErrorAction SilentlyContinue
-                    if ($null -eq $group)
-                    {
-                        $message = "Skipping assignment for the group with DisplayName {$($assignment.groupDisplayName)} as it could not be found in the directory.`r`n"
-                        $message += "Please update your DSC resource extract with the correct groupId or groupDisplayName."
-                        Write-Warning -Message $message
-                        $target = $null
-                    }
-                    if ($group -and $group.Count -gt 1)
-                    {
-                        $message = "Skipping assignment for the group with DisplayName {$($assignment.groupDisplayName)} as it is not unique in the directory.`r`n"
-                        $message += "Please update your DSC resource extract with the correct groupId or a unique group DisplayName."
-                        Write-Warning -Message $message
-                        $group = $null
-                        $target = $null
-                    }
-                }
                 else
                 {
-                    $message = "Skipping assignment for the group with Id {$($assignment.groupId)} as it could not be found in the directory.`r`n"
-                    $message += "Please update your DSC resource extract with the correct groupId or a unique group DisplayName."
-                    Write-Warning -Message $message
+                    Write-Warning "Assignment filter with DisplayName {$($assignment.DeviceAndAppManagementAssignmentFilterDisplayName)} not found."
+                }
+            }
+        }
+ 
+        # Add intent (required for app assignments)
+        $formattedAssignment.Add('intent', $assignment.intent)
+ 
+        # --- Group resolution logic (refactored) ---
+        if ($assignment.dataType -like '*groupAssignmentTarget')
+        {
+            $group = $null
+ 
+            # Only check groupId if it's non-empty and looks valid
+            if (-not [string]::IsNullOrWhiteSpace($assignment.groupId))
+            {
+                $group = Get-MgGroup -GroupId $assignment.groupId -ErrorAction SilentlyContinue
+            }
+ 
+            # If groupId lookup failed, try by display name
+            if ($null -eq $group -and -not [string]::IsNullOrWhiteSpace($assignment.groupDisplayName))
+            {
+                $escapedName = $assignment.groupDisplayName -replace "'", "''"
+                $group = Get-MgGroup -Filter "DisplayName eq '$escapedName'" -ErrorAction SilentlyContinue
+ 
+                if ($null -eq $group)
+                {
+                    Write-Warning "Skipping assignment: groupDisplayName '{$($assignment.groupDisplayName)}' not found."
+                    $target = $null
+                }
+                elseif ($group.Count -gt 1)
+                {
+                    Write-Warning "Skipping assignment: groupDisplayName '{$($assignment.groupDisplayName)}' is not unique."
                     $target = $null
                 }
             }
-            else {
-                #Skipping assignment if group not found from either groupId or groupDisplayName
+ 
+            # If group found, add its ID
+            if ($null -ne $group)
+            {
                 $target.Add('groupId', $group.Id)
             }
+            elseif ($null -eq $group -and [string]::IsNullOrWhiteSpace($assignment.groupDisplayName))
+            {
+                Write-Warning "Skipping assignment: missing both groupId and groupDisplayName."
+                $target = $null
+            }
         }
-
+ 
+        # Add target if valid
         if ($target)
         {
             $formattedAssignment.Add('target', $target)
         }
-
+ 
+        # Add assignment settings if present
         if ($null -ne $assignment.assignmentSettings)
         {
             $settings = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $assignment.assignmentSettings
@@ -1970,10 +1984,11 @@ function ConvertTo-IntuneMobileAppAssignment
             $formattedAssignment.settings.Add('@odata.type', $formattedAssignment.settings.odataType)
             $formattedAssignment.settings.Remove('odataType') | Out-Null
         }
+ 
         $assignmentResult += $formattedAssignment
     }
-
-    return ,[System.Collections.Hashtable[]]$assignmentResult
+ 
+    return ,$assignmentResult
 }
 
 function Compare-M365DSCIntunePolicyAssignment

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1870,12 +1870,10 @@ function ConvertTo-IntuneMobileAppAssignment
         [Parameter(Mandatory = $true)]
         [AllowNull()]
         $Assignments,
- 
         [Parameter()]
         [System.Boolean]
         $IncludeDeviceFilter = $true
     )
- 
     if ($null -eq $Script:IntuneAssignmentFilters)
     {
         $Script:IntuneAssignmentFilters = Get-MgBetaDeviceManagementAssignmentFilter -All -ErrorAction SilentlyContinue | ForEach-Object {
@@ -1885,18 +1883,15 @@ function ConvertTo-IntuneMobileAppAssignment
             }
         }
     }
- 
     if ($null -eq $Assignments)
     {
         return ,@()
     }
- 
     $assignmentResult = @()
     foreach ($assignment in $Assignments)
     {
         $formattedAssignment = @{}
-        $target = @{"@odata.type" = $assignment.dataType}
- 
+        $target = @{"@odata.type" = $assignment.dataType} 
         # Handle Device Filters
         if ($IncludeDeviceFilter)
         {
@@ -1925,27 +1920,22 @@ function ConvertTo-IntuneMobileAppAssignment
                 }
             }
         }
- 
         # Add intent (required for app assignments)
         $formattedAssignment.Add('intent', $assignment.intent)
- 
         # --- Group resolution logic (refactored) ---
         if ($assignment.dataType -like '*groupAssignmentTarget')
         {
             $group = $null
- 
             # Only check groupId if it's non-empty and looks valid
             if (-not [string]::IsNullOrWhiteSpace($assignment.groupId))
             {
                 $group = Get-MgGroup -GroupId $assignment.groupId -ErrorAction SilentlyContinue
             }
- 
             # If groupId lookup failed, try by display name
             if ($null -eq $group -and -not [string]::IsNullOrWhiteSpace($assignment.groupDisplayName))
             {
                 $escapedName = $assignment.groupDisplayName -replace "'", "''"
                 $group = Get-MgGroup -Filter "DisplayName eq '$escapedName'" -ErrorAction SilentlyContinue
- 
                 if ($null -eq $group)
                 {
                     Write-Warning "Skipping assignment: groupDisplayName '{$($assignment.groupDisplayName)}' not found."
@@ -1957,7 +1947,6 @@ function ConvertTo-IntuneMobileAppAssignment
                     $target = $null
                 }
             }
- 
             # If group found, add its ID
             if ($null -ne $group)
             {
@@ -1969,13 +1958,11 @@ function ConvertTo-IntuneMobileAppAssignment
                 $target = $null
             }
         }
- 
         # Add target if valid
         if ($target)
         {
             $formattedAssignment.Add('target', $target)
         }
- 
         # Add assignment settings if present
         if ($null -ne $assignment.assignmentSettings)
         {
@@ -1984,10 +1971,8 @@ function ConvertTo-IntuneMobileAppAssignment
             $formattedAssignment.settings.Add('@odata.type', $formattedAssignment.settings.odataType)
             $formattedAssignment.settings.Remove('odataType') | Out-Null
         }
- 
         $assignmentResult += $formattedAssignment
     }
- 
     return ,$assignmentResult
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
 This PR fix the issue of the  group assignment , with "DisplayName" property. In the  previous version groupId property was mandatory and not optional . 
If the group you were planning to assign was in the same MOF file, there was no existing identifier(groupid) for the group.
Now the display name is also checked, and if the group is found, it is assigned correctly.


#### This Pull Request (PR) fixes the following issues
<!--
   None
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
