### PR TITLE
Fix Intune Setting Catalog Custom Policy update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
     FIXES [#6606](https://github.com/microsoft/Microsoft365DSC/issues/6606)
 * M365DSCUtil
   * Added custom post processing to `Test-M365DSCTargetResource`.
+* IntuneSettingCatalogCustomPolicyWindows10
+  * Fixed issue where roleScopeTagIds was sent as null instead of array, causing BadRequest (400) during policy update.  
 * MISC
   * Centralized more resource testing to the testing function.
 * DEPENDENCIES

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogCustomPolicyWindows10/MSFT_IntuneSettingCatalogCustomPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneSettingCatalogCustomPolicyWindows10/MSFT_IntuneSettingCatalogCustomPolicyWindows10.psm1
@@ -904,6 +904,16 @@ function Update-IntuneDeviceConfigurationPolicy
             'settings'          = $Settings
             'roleScopeTagIds'   = $RoleScopeTagIds
         }
+		if (-not $RoleScopeTagIds -or $RoleScopeTagIds.Count -eq 0)
+		{
+			# No tag IDs provided → use the default Intune tag "0"
+			$policy['roleScopeTagIds'] = @("0")
+		}
+		else
+		{
+			# Tag IDs provided → force array type to ensure Graph serialization consistency
+			$policy['roleScopeTagIds'] = @($RoleScopeTagIds)
+		}
         $body = $policy | ConvertTo-Json -Depth 20
         #write-verbose -Message $body
         Invoke-MgGraphRequest -Method PUT -Uri $Uri -Body $body -ErrorAction Stop 4> $null


### PR DESCRIPTION
# Fix(Intune): Handle null or empty roleScopeTagIds in Setting Catalog policy updates

## Summary
This update fixes an issue in the Intune Setting Catalog Custom Policy (Windows10/11) resource where updating an existing policy would fail with:
    BadRequest (400)
during the PUT operation to Microsoft Graph.

The issue occurred because roleScopeTagIds was sometimes sent as null or not formatted as an array, which violates the Graph API schema.

## Problem
When running a configuration that updates an existing Intune Setting Catalog policy, the following error was returned:

    Microsoft.Graph.PowerShell.Authentication.Helpers.HttpResponseException:
    Response status code does not indicate success: BadRequest (Bad Request)

Root cause:
- roleScopeTagIds was sent as $null instead of an array.
- Microsoft Graph rejected invalid payloads when roleScopeTagIds was missing or not correctly structured.

## Fix
Changes made in MSFT_IntuneSettingCatalogCustomPolicyWindows10.psm1:

Ensured that roleScopeTagIds is always a valid array of strings.
If no tags are specified, it defaults to ("0"), the Intune default scope tag.
If tags are provided, it enforces array format with @($RoleScopeTagIds).

```powershell
if (-not $RoleScopeTagIds -or $RoleScopeTagIds.Count -eq 0) {
    $policy['roleScopeTagIds'] = @("0")
} else {
    $policy['roleScopeTagIds'] = @($RoleScopeTagIds)
}
```

This guarantees that the payload sent to Microsoft Graph always matches the expected schema.

Notes:
    roleScopeTagIds must always be an array of strings
    Sending null or non-array values causes Graph validation errors


