### PR TITLE
Fix intune health monitoring camel case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
     FIXES [#6606](https://github.com/microsoft/Microsoft365DSC/issues/6606)
 * M365DSCUtil
   * Added custom post processing to `Test-M365DSCTargetResource`.
+* IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10
+  * Fixed a breaking issue where the resource failed with `ModelValidationFailure` due to property casing mismatch after Microsoft Graph SDK v2.10+. Updated to use camelCase property names to align with current Graph schema.  
 * MISC
   * Centralized more resource testing to the testing function.
 * DEPENDENCIES

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10.psm1
@@ -300,6 +300,18 @@ function Set-TargetResource
             }
         }
         $CreateParameters.ConfigDeviceHealthMonitoringScope = [String[]]$CreateParameters.ConfigDeviceHealthMonitoringScope -join ','
+		if ($CreateParameters.ContainsKey('ConfigDeviceHealthMonitoringScope')) {
+			$CreateParameters['configDeviceHealthMonitoringScope'] = ($CreateParameters['ConfigDeviceHealthMonitoringScope'] -join ',')
+			$CreateParameters.Remove('ConfigDeviceHealthMonitoringScope') | Out-Null
+		}
+		if ($CreateParameters.ContainsKey('AllowDeviceHealthMonitoring')) {
+			$CreateParameters['allowDeviceHealthMonitoring'] = $CreateParameters['AllowDeviceHealthMonitoring']
+			$CreateParameters.Remove('AllowDeviceHealthMonitoring') | Out-Null
+		}
+		if ($CreateParameters.ContainsKey('ConfigDeviceHealthMonitoringCustomScope')) {
+			$CreateParameters['configDeviceHealthMonitoringCustomScope'] = $CreateParameters['ConfigDeviceHealthMonitoringCustomScope']
+			$CreateParameters.Remove('ConfigDeviceHealthMonitoringCustomScope') | Out-Null
+		}
         #region resource generator code
         $CreateParameters.Add('@odata.type', '#microsoft.graph.windowsHealthMonitoringConfiguration')
         $policy = New-MgBetaDeviceManagementDeviceConfiguration -BodyParameter $CreateParameters
@@ -332,6 +344,18 @@ function Set-TargetResource
             }
         }
         $UpdateParameters.ConfigDeviceHealthMonitoringScope = [String[]]$UpdateParameters.ConfigDeviceHealthMonitoringScope -join ','
+		if ($UpdateParameters.ContainsKey('ConfigDeviceHealthMonitoringScope')) {
+			$UpdateParameters['configDeviceHealthMonitoringScope'] = ($UpdateParameters['ConfigDeviceHealthMonitoringScope'] -join ',')
+			$UpdateParameters.Remove('ConfigDeviceHealthMonitoringScope') | Out-Null
+		}
+		if ($UpdateParameters.ContainsKey('AllowDeviceHealthMonitoring')) {
+			$UpdateParameters['allowDeviceHealthMonitoring'] = $UpdateParameters['AllowDeviceHealthMonitoring']
+			$UpdateParameters.Remove('AllowDeviceHealthMonitoring') | Out-Null
+		}
+		if ($UpdateParameters.ContainsKey('ConfigDeviceHealthMonitoringCustomScope')) {
+			$UpdateParameters['configDeviceHealthMonitoringCustomScope'] = $UpdateParameters['ConfigDeviceHealthMonitoringCustomScope']
+			$UpdateParameters.Remove('ConfigDeviceHealthMonitoringCustomScope') | Out-Null
+		}
         #region resource generator code
         $UpdateParameters.Add('@odata.type', '#microsoft.graph.windowsHealthMonitoringConfiguration')
         Update-MgBetaDeviceManagementDeviceConfiguration  `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10.psm1
@@ -299,7 +299,6 @@ function Set-TargetResource
                 $CreateParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $CreateParameters.$key
             }
         }
-        $CreateParameters.ConfigDeviceHealthMonitoringScope = [String[]]$CreateParameters.ConfigDeviceHealthMonitoringScope -join ','
 		if ($CreateParameters.ContainsKey('ConfigDeviceHealthMonitoringScope')) {
 			$CreateParameters['configDeviceHealthMonitoringScope'] = ($CreateParameters['ConfigDeviceHealthMonitoringScope'] -join ',')
 			$CreateParameters.Remove('ConfigDeviceHealthMonitoringScope') | Out-Null
@@ -343,7 +342,6 @@ function Set-TargetResource
                 $UpdateParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $UpdateParameters.$key
             }
         }
-        $UpdateParameters.ConfigDeviceHealthMonitoringScope = [String[]]$UpdateParameters.ConfigDeviceHealthMonitoringScope -join ','
 		if ($UpdateParameters.ContainsKey('ConfigDeviceHealthMonitoringScope')) {
 			$UpdateParameters['configDeviceHealthMonitoringScope'] = ($UpdateParameters['ConfigDeviceHealthMonitoringScope'] -join ',')
 			$UpdateParameters.Remove('ConfigDeviceHealthMonitoringScope') | Out-Null


### PR DESCRIPTION
### Summary
Fixes a breaking issue in `MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10` where the resource failed with a `ModelValidationFailure` after updating to Microsoft Graph SDK v2.28.0.
```
[ModelValidationFailure] : The property 'ConfigDeviceHealthMonitoringScope' does not exist on type 'microsoft.management.services.api.windowsHealthMonitoringConfiguration'. Make sure to only use property names that are defined by the type.
At C:\agent_work_temp<GUID>.ps1:4 char:1

Start-DSCConfiguration -path '.' -Wait -Force -Verbose -ErrorAction S ...

  + CategoryInfo          : InvalidOperation: ({ Headers = , b...Configuration }:) [], CimException
  + FullyQualifiedErrorId : ModelValidationFailure,Microsoft.Graph.Beta.PowerShell.Cmdlets.NewMgBetaDeviceManagementDeviceConfiguration_Create
  + PSComputerName        : localhost
```
### Root Cause
Microsoft Graph now enforces strict property name validation and requires camelCase property names:
- `allowDeviceHealthMonitoring`
- `configDeviceHealthMonitoringScope`
- `configDeviceHealthMonitoringCustomScope`

The module was still using PascalCase equivalents, causing Graph to reject the payload.

### Fix
Added normalization logic in both the Create and Update paths to rename the outgoing hashtable keys before sending the request to Graph.

### Validation
Tested successfully with:
- Microsoft365DSC v1.25.1015.1  
- Microsoft.Graph.Beta.DeviceManagement v2.28.0+  
Confirmed creation and update of Intune Health Monitoring policies now succeed.

### Changelog
Added entry under `UNRELEASED`:
> * IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10  
>   * Fixed a breaking issue where the resource failed with `ModelValidationFailure` due to property casing mismatch after Microsoft Graph SDK v2.10+. Updated to use camelCase property names to align with Graph schema.

### Impact
- No breaking changes for users.
- Restores compatibility with latest Graph SDK.
