### PR TITLE
VivaEngagementRoleMember: Fix loading required modules for resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
+
 * M365DSCUtil
   * Fixed issue of function ConvertTo-IntuneMobileAppAssignment where groupID property was mantatory for the Assignment.
 * AADFilteringPolicyRule
@@ -13,6 +14,8 @@
 * TeamsMeetingPolicy
   * Added support for new properties.
     FIXES [#6606](https://github.com/microsoft/Microsoft365DSC/issues/6606)
+* VivaEngagementRoleMember
+  * Fixed issue loading the required modules to export this resource
 * M365DSCUtil
   * Added custom post processing to `Test-M365DSCTargetResource`.
 * MISC

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_VivaEngagementRoleMember/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_VivaEngagementRoleMember/settings.json
@@ -34,7 +34,8 @@
     }
   },
   "requiredModules": [
-    "Get-MgGroup"
+    "Microsoft.Graph.Authentication",
+    "Microsoft.Graph.Users"
   ],
   "mode": "Configuration",
   "commands": [


### PR DESCRIPTION
#### Pull Request (PR) description

When trying to use *Export-M365DSCConfiguration* to export the default components it is now failing due to wrongly setup modules in resource *VivaEngagementRoleMember* which makes the whole export error out.

This PR fixes this by defining the correct modules to load in settings.json of the resource.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
- Fixes #6627

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
