### PR TITLE
Add support for AllowedValues on Custom Security Attributes

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/MSFT_AADCustomSecurityAttributeDefinition.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/MSFT_AADCustomSecurityAttributeDefinition.psm1
@@ -127,9 +127,18 @@ function Get-TargetResource
             $instance = $Script:exportedInstance
         }
 
+        $complexAllowedValues = @()
+        foreach ($allowedValue in $instance.AllowedValues)
+        {
+            $complexAllowedValues += @{
+                ValueId  = $allowedValue.Id
+                IsActive = $allowedValue.IsActive
+            }
+        }
+
         $results = @{
             Name                    = $instance.Name
-            AllowedValues           = $instance.AllowedValues
+            AllowedValues           = $complexAllowedValues
             AttributeSet            = $instance.AttributeSet
             Id                      = $instance.Id
             Description             = $instance.Description
@@ -258,13 +267,22 @@ function Set-TargetResource
 
     $currentInstance = Get-TargetResource @PSBoundParameters
     $setParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+    $setParameters.Remove('AllowedValues') | Out-Null
 
     # CREATE
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {
         $setParameters.Remove('Id') | Out-Null
         Write-Verbose -Message "Creating new Atribute Definition {$Name}"
-        New-MgBetaDirectoryCustomSecurityAttributeDefinition @SetParameters
+        $attributeDefinition = New-MgBetaDirectoryCustomSecurityAttributeDefinition @SetParameters
+
+        foreach ($allowedValue in $AllowedValues)
+        {
+            New-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue `
+                -CustomSecurityAttributeDefinitionId $attributeDefinition.Id `
+                -Id $allowedValue.ValueId `
+                -IsActive:$allowedValue.IsActive
+        }
     }
     # UPDATE
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
@@ -277,7 +295,33 @@ function Set-TargetResource
         $setParameters.Remove('IsSearchable') | Out-Null
         $setParameters.Remove('Name') | Out-Null
         $setParameters.Remove('Type') | Out-Null
+        if ($setParameters.ContainsKey('UsePreDefinedValuesOnly') -and $setParameters.UsePreDefinedValuesOnly -eq $currentInstance.UsePreDefinedValuesOnly)
+        {
+            $setParameters.Remove('UsePreDefinedValuesOnly') | Out-Null
+        }
         Update-MgBetaDirectoryCustomSecurityAttributeDefinition @SetParameters
+
+        # Allowed values cannot be removed, therefore we only need to add new ones or update existing ones
+        foreach ($allowedValue in $AllowedValues)
+        {
+            $existingAllowedValue = $currentInstance.AllowedValues | Where-Object { $_.Id -eq $allowedValue.ValueId }
+            if ($null -eq $existingAllowedValue)
+            {
+                # Add new allowed value
+                New-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue `
+                    -CustomSecurityAttributeDefinitionId $currentInstance.Id `
+                    -Id $allowedValue.ValueId `
+                    -IsActive:$allowedValue.IsActive
+            }
+            elseif ($existingAllowedValue.IsActive -ne $allowedValue.IsActive)
+            {
+                # Update existing allowed value
+                Update-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue `
+                    -CustomSecurityAttributeDefinitionId $currentInstance.Id `
+                    -AllowedValueId $allowedValue.ValueId `
+                    -IsActive:$allowedValue.IsActive
+            }
+        }
     }
     # REMOVE
     elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
@@ -378,8 +422,34 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
+    $postProcessingScript = {
+        param($DesiredValues, $CurrentValues, $ValuesToCheck, $ignore)
+        # Values cannot be removed from AllowedValues
+        # Therefore, we add the missing values from CurrentValues to DesiredValues for comparison
+        if ($DesiredValues.ContainsKey('AllowedValues'))
+        {
+            foreach ($currentValue in $CurrentValues.AllowedValues)
+            {
+                $matchingValue = $DesiredValues.AllowedValues | Where-Object { $_.ValueId -eq $currentValue.ValueId }
+                if ($null -eq $matchingValue)
+                {
+                    Write-Verbose -Message "Adding missing AllowedValue with ValueId '$($currentValue.ValueId)' from current configuration to desired configuration for comparison."
+                    $DesiredValues.AllowedValues += New-CimInstance -ClassName MSFT_CustomSecurityAttributeAllowedValue -Property @{
+                        IsActive = $currentValue.IsActive
+                        ValueId = $currentValue.ValueId
+                    } -Namespace root/Microsoft/Windows/DesiredStateConfiguration -ClientOnly
+                }
+            }
+
+            $DesiredValues.AllowedValues = [CimInstance[]]$DesiredValues.AllowedValues
+        }
+        return [System.Tuple[Hashtable, Hashtable, Hashtable]]::new($DesiredValues, $CurrentValues, $ValuesToCheck)
+    }
+
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-                                         -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
+                                         -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
+                                         -IncludedProperties @('ValueId', 'IsActive') `
+                                         -PostProcessing $postProcessingScript
     return $result
 }
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/MSFT_AADCustomSecurityAttributeDefinition.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/MSFT_AADCustomSecurityAttributeDefinition.psm1
@@ -15,6 +15,10 @@ function Get-TargetResource
         $AttributeSet,
 
         [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $AllowedValues,
+
+        [Parameter()]
         [System.String]
         $Id,
 
@@ -104,11 +108,13 @@ function Get-TargetResource
             if (-not [System.String]::IsNullOrEmpty($Id))
             {
                 $instance = Get-MgBetaDirectoryCustomSecurityAttributeDefinition -CustomSecurityAttributeDefinitionId $Id `
+                    -ExpandProperty 'allowedValues' `
                     -ErrorAction SilentlyContinue
             }
             if ($null -eq $instance)
             {
                 $instance = Get-MgBetaDirectoryCustomSecurityAttributeDefinition -Filter "Name eq '$($Name -replace "'", "''")'" `
+                    -ExpandProperty 'allowedValues' `
                     -ErrorAction SilentlyContinue
             }
             if ($null -eq $instance)
@@ -123,6 +129,7 @@ function Get-TargetResource
 
         $results = @{
             Name                    = $instance.Name
+            AllowedValues           = $instance.AllowedValues
             AttributeSet            = $instance.AttributeSet
             Id                      = $instance.Id
             Description             = $instance.Description
@@ -167,6 +174,10 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $AttributeSet,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $AllowedValues,
 
         [Parameter()]
         [System.String]
@@ -290,6 +301,10 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $AttributeSet,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $AllowedValues,
 
         [Parameter()]
         [System.String]
@@ -420,7 +435,9 @@ function Export-TargetResource
 
     try
     {
-        [array] $Script:exportedInstances = Get-MgBetaDirectoryCustomSecurityAttributeDefinition -ErrorAction Stop
+        [array] $Script:exportedInstances = Get-MgBetaDirectoryCustomSecurityAttributeDefinition `
+            -ExpandProperty 'allowedValues' `
+            -ErrorAction Stop
 
         $i = 1
         $dscContent = ''
@@ -456,12 +473,28 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
+            if ($null -ne $Results.AllowedValues)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.AllowedValues `
+                    -CIMInstanceName 'CustomSecurityAttributeAllowedValue'
+
+                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
+                {
+                    $Results.AllowedValues = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('AllowedValues') | Out-Null
+                }
+            }
 
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
-                -Credential $Credential
+                -Credential $Credential `
+                -NoEscape @('AllowedValues')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/MSFT_AADCustomSecurityAttributeDefinition.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/MSFT_AADCustomSecurityAttributeDefinition.schema.mof
@@ -1,8 +1,8 @@
 [ClassVersion("1.0.0.0")]
 class MSFT_CustomSecurityAttributeAllowedValue
 {
-    [Key, Description("The id of the allowed value. Must be unique in the set of allowed values.")] String Id;
-    [Write, Description("If the allowed value is active.")] Boolean IsActive;
+    [Key, Description("The id of the allowed value. Must be unique in the set of allowed values.")] String ValueId;
+    [Required, Description("If the allowed value is active.")] Boolean IsActive;
 };
 
 [ClassVersion("1.0.0.2"), FriendlyName("AADCustomSecurityAttributeDefinition")]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/MSFT_AADCustomSecurityAttributeDefinition.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/MSFT_AADCustomSecurityAttributeDefinition.schema.mof
@@ -1,8 +1,16 @@
-[ClassVersion("1.0.0.1"), FriendlyName("AADCustomSecurityAttributeDefinition")]
+[ClassVersion("1.0.0.0")]
+class MSFT_CustomSecurityAttributeAllowedValue
+{
+    [Key, Description("The id of the allowed value. Must be unique in the set of allowed values.")] String Id;
+    [Write, Description("If the allowed value is active.")] Boolean IsActive;
+};
+
+[ClassVersion("1.0.0.2"), FriendlyName("AADCustomSecurityAttributeDefinition")]
 class MSFT_AADCustomSecurityAttributeDefinition : OMI_BaseResource
 {
     [Key, Description("Name of the custom security attribute. Must be unique within an attribute set. Can be up to 32 characters long and include Unicode characters. Can't contain spaces or special characters. Can't be changed later. Case sensitive.")] String Name;
     [Key, Description("Name of the attribute set. Case sensitive.")] String AttributeSet;
+    [Write, Description("The allowed values of the attribute definition."), EmbeddedInstance("MSFT_CustomSecurityAttributeAllowedValue")] String AllowedValues[];
     [Write, Description("Unique identifier of the Attribute Definition.")] String Id;
     [Write, Description("Description of the custom security attribute. Can be up to 128 characters long and include Unicode characters. Can't contain spaces or special characters. Can be changed later. ")] String Description;
     [Write, Description("Indicates whether multiple values can be assigned to the custom security attribute. Can't be changed later. If type is set to Boolean, isCollection can't be set to true.")] Boolean IsCollection;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADCustomSecurityAttributeDefinition/settings.json
@@ -52,7 +52,9 @@
       "cmdlets": [
         "Get-MgBetaDirectoryCustomSecurityAttributeDefinition",
         "New-MgBetaDirectoryCustomSecurityAttributeDefinition",
-        "Update-MgBetaDirectoryCustomSecurityAttributeDefinition"
+        "Update-MgBetaDirectoryCustomSecurityAttributeDefinition",
+        "New-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue",
+        "Update-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue"
       ]
     }
   ]

--- a/Modules/Microsoft365DSC/Examples/Resources/AADCustomSecurityAttributeDefinition/1-Create.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/AADCustomSecurityAttributeDefinition/1-Create.ps1
@@ -24,6 +24,12 @@ Configuration Example
         AADCustomSecurityAttributeDefinition "AADCustomSecurityAttributeDefinition-ShoeSize"
         {
             ApplicationId           = $ApplicationId;
+            AllowedValues           = @(
+                MSFT_CustomSecurityAttributeAllowedValue{
+                    IsActive = $True
+                    ValueId = "AllowedValue1"
+                }
+            );
             AttributeSet            = "TestAttributeSet";
             CertificateThumbprint   = $CertificateThumbprint;
             Ensure                  = "Present";

--- a/Modules/Microsoft365DSC/Examples/Resources/AADCustomSecurityAttributeDefinition/2-Update.ps1
+++ b/Modules/Microsoft365DSC/Examples/Resources/AADCustomSecurityAttributeDefinition/2-Update.ps1
@@ -24,6 +24,12 @@ Configuration Example
         AADCustomSecurityAttributeDefinition "AADCustomSecurityAttributeDefinition-ShoeSize"
         {
             ApplicationId           = $ApplicationId;
+            AllowedValues           = @(
+                MSFT_CustomSecurityAttributeAllowedValue{
+                    IsActive = $True
+                    ValueId = "AllowedValue1"
+                }
+            );
             AttributeSet            = "TestAttributeSet";
             CertificateThumbprint   = $CertificateThumbprint;
             Ensure                  = "Present";

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADCustomSecurityAttributeDefinition.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADCustomSecurityAttributeDefinition.Tests.ps1
@@ -43,6 +43,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
             Mock -CommandName Get-MgBetaDirectoryCustomSecurityAttributeDefinition -MockWith {
                 return @{
+                    AllowedValues           = @(
+                        @{
+                            Id = "Test"
+                            IsActive = $True
+                        }
+                    )
                     AttributeSet            = 'ContosoSet'
                     IsCollection            = $false
                     IsSearchable            = $true
@@ -65,6 +71,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "The instance should exist but it DOES NOT" -Fixture {
             BeforeAll {
                 $testParams = @{
+                    AllowedValues           = [CimInstance[]]@(
+                        New-CimInstance -ClassName 'MSFT_CustomSecurityAttributeAllowedValue' -Property @{
+                            Id = "Test"
+                            IsActive = $True
+                        } -ClientOnly
+                    )
                     ApplicationId           = $ApplicationId;
                     AttributeSet            = "ContosoSet";
                     CertificateThumbprint   = $CertificateThumbprint;
@@ -102,6 +114,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             BeforeAll {
                 $testParams = @{
                     ApplicationId           = $ApplicationId;
+                    AllowedValues           = [CimInstance[]]@(
+                        New-CimInstance -ClassName 'MSFT_CustomSecurityAttributeAllowedValue' -Property @{
+                            Id = "Test"
+                            IsActive = $True
+                        } -ClientOnly
+                    )
                     AttributeSet            = "ContosoSet";
                     CertificateThumbprint   = $CertificateThumbprint;
                     Ensure                  = "Absent";
@@ -133,6 +151,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             BeforeAll {
                 $testParams = @{
                     ApplicationId           = $ApplicationId;
+                    AllowedValues           = [CimInstance[]]@(
+                        New-CimInstance -ClassName 'MSFT_CustomSecurityAttributeAllowedValue' -Property @{
+                            Id = "Test"
+                            IsActive = $True
+                        } -ClientOnly
+                    )
                     AttributeSet            = "ContosoSet";
                     CertificateThumbprint   = $CertificateThumbprint;
                     Ensure                  = "Present";
@@ -157,6 +181,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             BeforeAll {
                 $testParams = @{
                     ApplicationId           = $ApplicationId;
+                    AllowedValues           = [CimInstance[]]@(
+                        New-CimInstance -ClassName 'MSFT_CustomSecurityAttributeAllowedValue' -Property @{
+                            Id = "Test"
+                            IsActive = $True
+                        } -ClientOnly
+                    )
                     AttributeSet            = "ContosoSet";
                     CertificateThumbprint   = $CertificateThumbprint;
                     Ensure                  = "Absent";

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADCustomSecurityAttributeDefinition.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADCustomSecurityAttributeDefinition.Tests.ps1
@@ -36,6 +36,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
 
             Mock -CommandName New-MgBetaDirectoryCustomSecurityAttributeDefinition -MockWith{
+                return @{
+                    Id = "ContosoSet_ShoeSize"
+                }
             }
 
             Mock -CommandName Update-MgBetaDirectoryCustomSecurityAttributeDefinition -MockWith{
@@ -61,6 +64,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 }
             }
 
+            Mock -CommandName New-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue {
+            }
+
+            Mock -CommandName Update-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue {
+            }
+
             # Mock Write-M365DSCHost to hide output during the tests
             Mock -CommandName Write-M365DSCHost -MockWith {
             }
@@ -73,7 +82,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     AllowedValues           = [CimInstance[]]@(
                         New-CimInstance -ClassName 'MSFT_CustomSecurityAttributeAllowedValue' -Property @{
-                            Id = "Test"
+                            ValueId  = "Test"
                             IsActive = $True
                         } -ClientOnly
                     )
@@ -116,7 +125,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ApplicationId           = $ApplicationId;
                     AllowedValues           = [CimInstance[]]@(
                         New-CimInstance -ClassName 'MSFT_CustomSecurityAttributeAllowedValue' -Property @{
-                            Id = "Test"
+                            ValueId  = "Test"
                             IsActive = $True
                         } -ClientOnly
                     )
@@ -153,7 +162,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ApplicationId           = $ApplicationId;
                     AllowedValues           = [CimInstance[]]@(
                         New-CimInstance -ClassName 'MSFT_CustomSecurityAttributeAllowedValue' -Property @{
-                            Id = "Test"
+                            ValueId  = "Test"
                             IsActive = $True
                         } -ClientOnly
                     )
@@ -183,7 +192,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ApplicationId           = $ApplicationId;
                     AllowedValues           = [CimInstance[]]@(
                         New-CimInstance -ClassName 'MSFT_CustomSecurityAttributeAllowedValue' -Property @{
-                            Id = "Test"
+                            ValueId  = "Test"
                             IsActive = $True
                         } -ClientOnly
                     )

--- a/Tests/Unit/Stubs/Microsoft365.psm1
+++ b/Tests/Unit/Stubs/Microsoft365.psm1
@@ -40432,6 +40432,135 @@ function New-MgBetaDirectoryCustomSecurityAttributeDefinition
         $HttpPipelineAppend
     )
 }
+
+function New-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $IsActive,
+
+        [Parameter()]
+        [PSObject]
+        $AdditionalProperties,
+
+        [Parameter()]
+        [System.String]
+        $CustomSecurityAttributeDefinitionId,
+
+        [Parameter()]
+        [PSObject]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [PSObject]
+        $BodyParameter,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
+
+        [Parameter()]
+        [System.String]
+        $ResponseHeadersVariable,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [PSObject]
+        $HttpPipelineAppend
+    )
+}
+
+function Update-MgBetaDirectoryCustomSecurityAttributeDefinitionAllowedValue
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $ProxyUseDefaultCredentials,
+
+        [Parameter()]
+        [System.String]
+        $Id,
+
+        [Parameter()]
+        [System.String]
+        $AllowedValueId,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $IsActive,
+
+        [Parameter()]
+        [PSObject]
+        $AdditionalProperties,
+
+        [Parameter()]
+        [System.String]
+        $CustomSecurityAttributeDefinitionId,
+
+        [Parameter()]
+        [PSObject]
+        $HttpPipelinePrepend,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential,
+
+        [Parameter()]
+        [System.Uri]
+        $Proxy,
+
+        [Parameter()]
+        [PSObject]
+        $BodyParameter,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Confirm,
+
+        [Parameter()]
+        [System.String]
+        $ResponseHeadersVariable,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $Break,
+
+        [Parameter()]
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Parameter()]
+        [PSObject]
+        $HttpPipelineAppend
+    )
+}
+
 function Get-MgBetaDirectoryCustomSecurityAttributeDefinition
 {
     [CmdletBinding()]


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds support for the `AllowedValues` property in the `AADCustomSecurityAttributeDefinition` resource.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
