### PR TITLE
Fix GitHub Pages Deployment

### DIFF
--- a/.github/workflows/PublishGitHubPages.yml
+++ b/.github/workflows/PublishGitHubPages.yml
@@ -4,57 +4,70 @@ on:
     branches:
       - Master
       - Dev
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   GenerateResource:
     runs-on: windows-latest
 
-    permissions: write-all
-
-      # Only when run from the main repo
+    # Only run in main repo
     if: github.repository == 'microsoft/Microsoft365DSC'
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Install Modules
-        shell: powershell
+      - uses: actions/checkout@v4
+
+      - name: Import Module & Generate Documentation
+        shell: pwsh
         run: |
           Import-Module -Name "./Modules/Microsoft365DSC"
           Update-M365DSCResourceDocumentationPage -SourcePath ./Modules/Microsoft365DSC
           New-M365DSCCmdletDocumentation
-      - name: Commit files # commit the output folder
-        if: always()
-        shell: pwsh
-        run: |
-          git config --local user.email "nicharl@microsoft.com"
-          git config --local user.name "NikCharlebois"
-          git add D:/a/Microsoft365DSC/Microsoft365DSC/docs/docs/*
-          git pull
-          git commit -m "Updated Resources and Cmdlet documentation pages"
-          git push
-          $SHA = git rev-parse HEAD
-          echo "commitid=$SHA" >> $env:GITHUB_OUTPUT
+
+      - name: Upload documentation as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-generation
+          path: ./docs  # the folder containing the mkdocs.yml and generated docs
 
   deploy:
     needs: GenerateResource
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-      pages: write
-
-    # Only when run from the main repo
+    # Only run in main repo
     if: github.repository == 'microsoft/Microsoft365DSC'
 
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
         with:
-          ref: ${{ needs.GenerateResource.outputs.commitid }}
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
+          python-version: '3.x'
+
       - run: |
           pip install mkdocs-material
           pip install mkdocs-include-dir-to-nav
-      - name: Deploy
+
+      - name: Download generated docs
+        uses: actions/download-artifact@v5
+        with:
+          name: docs-generation
+          path: ./docs
+
+      - name: Build site
         working-directory: ./docs
-        run: mkdocs gh-deploy --force
+        run: mkdocs build --site-dir ../site
+
+      - name: Upload built site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/docs/stylesheets/extra.css
+++ b/docs/docs/stylesheets/extra.css
@@ -1,7 +1,9 @@
 /* Sets the width of the center column a bit wider than default, so tables render better. */
 .md-grid {
-    max-width: 67rem;
+    max-width: initial;
+    margin: 0 15%;
 }
+/* Hides the secondary sidebar, which is not used in this documentation site. */
 .md-sidebar--secondary:not([hidden]) {
-    display:hidden;
+    display: none;
 }


### PR DESCRIPTION
#### Pull Request (PR) description
This PR reworks how the documentation is built, uploaded as an artifact, processed and redeployed to GitHub pages. The previous way using commits does not work anymore because of branch restrictions. 

For this approach to work, the Pages deployment mechanism has to be changed to `GitHub Actions` under Settings > Pages > Sources: 

<img width="812" height="278" alt="image" src="https://github.com/user-attachments/assets/805f34f7-9fae-4927-b20f-fba7ed7ea844" />

Using this approach, I was successfully able to create and update the documentation on my private repository and see all of the updated documentation, including all newly released resources and changes.

Edit: Under Settings > Environments > github-pages, a new branch protection rule must be added that includes the Dev as well as the Master branch. Otherwise, updating the GitHub pages is only allowed from the Default branch (per default), therefore requiring the addition of `Master`.

<img width="818" height="312" alt="image" src="https://github.com/user-attachments/assets/04177de2-4987-4bd1-817b-82511c2fe9bc" />

<img width="575" height="397" alt="image" src="https://github.com/user-attachments/assets/79bbe471-ccaa-48f1-9105-405bf3147043" />


#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
