### PR TITLE
Fix DisplayName not being used for Activity Based Timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # UNRELEASED
 
+* AADActivityBasedTimeoutPolicy
+  * Fixed an issue where the `DisplayName` property was not used for create and update.
+    FIXES [#6680](https://github.com/microsoft/Microsoft365DSC/issues/6680)
+
+# UNRELEASED
+
 * AADApplication
   * Added support for `TokenLifetimePolicies`.
   * Fixing issue where Set-TargetResource threw an error trying to recreate

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADActivityBasedTimeoutPolicy/MSFT_AADActivityBasedTimeoutPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADActivityBasedTimeoutPolicy/MSFT_AADActivityBasedTimeoutPolicy.psm1
@@ -263,7 +263,7 @@ function Set-TargetResource
                 definition            = @(
                     "$json"
                 )
-                displayName           = 'displayName-value'
+                displayName           = $DisplayName
                 isOrganizationDefault = $true
             }
 
@@ -307,7 +307,7 @@ function Set-TargetResource
                 definition            = @(
                     "$json"
                 )
-                displayName           = 'displayName-value'
+                displayName           = $DisplayName
                 isOrganizationDefault = $true
             }
 


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where the `DisplayName` property was not used when creating or updating an `AADActivityBasedTimeoutPolicy`.

#### This Pull Request (PR) fixes the following issues
- Fixes #6680 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
