### PR TITLE
Fix DSC type for schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change log for Microsoft365DSC
 
-# Release 1.25.1112.1
+# UNRELEASED
+
+* TeamsMeetingPolicy
+  * Fixed an issue where the schema had an incorrect type assigned.
+    FIXES [#6687](https://github.com/microsoft/Microsoft365DSC/issues/6687)
+
+# 1.25.1112.1
 
 * AADActivityBasedTimeoutPolicy
   * Fixed an issue where the `DisplayName` property was not used for create and update.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingPolicy/MSFT_TeamsMeetingPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingPolicy/MSFT_TeamsMeetingPolicy.schema.mof
@@ -1,4 +1,4 @@
-﻿[ClassVersion("1.0.0.1"), FriendlyName("TeamsMeetingPolicy")]
+﻿[ClassVersion("1.0.0.2"), FriendlyName("TeamsMeetingPolicy")]
 class MSFT_TeamsMeetingPolicy : OMI_BaseResource
 {
     [Key, Description("Identity of the Teams Meeting Policy.")] String Identity;
@@ -92,9 +92,9 @@ class MSFT_TeamsMeetingPolicy : OMI_BaseResource
     [Write, Description("Determines whether you provide support for your users to enable voice isolation in Teams meeting calls."), ValueMap{"Disabled", "Enabled"}, Values{"Disabled", "Enabled"}] String VoiceIsolation;
     [Write, Description("Enables the user to use the voice simulation feature while being AI interpreted. Possible Values: Disabled, Enabled"), ValueMap{"Disabled","Enabled"}, Values{"Disabled","Enabled"}] String VoiceSimulationInInterpreter;
     [Write, Description("Determines the meeting experience and watermark content of an anonymous user."), ValueMap{"JoinWithAudioOnly","WatermarkWithDisplayName"}, Values{"JoinWithAudioOnly","WatermarkWithDisplayName"}] String WatermarkForAnonymousUsers;
-    [Write, Description("Allows the transparency of watermark to be customizable. Must be between 1 and 100 inclusive.")] SInt64 WatermarkForCameraVideoOpacity;
+    [Write, Description("Allows the transparency of watermark to be customizable. Must be between 1 and 100 inclusive.")] SInt32 WatermarkForCameraVideoOpacity;
     [Write, Description("Allows the pattern design of watermark to be customizable."), ValueMap{"Single","Tiled"}, Values{"Single","Tiled"}] String WatermarkForCameraVideoPattern;
-    [Write, Description("Allows the transparency of watermark to be customizable. Must be between 1 and 100 inclusive.")] SInt64 WatermarkForScreenSharingOpacity;
+    [Write, Description("Allows the transparency of watermark to be customizable. Must be between 1 and 100 inclusive.")] SInt32 WatermarkForScreenSharingOpacity;
     [Write, Description("Allows the pattern design of watermark to be customizable."), ValueMap{"Single","Tiled"}, Values{"Single","Tiled"}] String WatermarkForScreenSharingPattern;
     [Write, Description("Determines the background effects that a user can configure in the Teams client. "), ValueMap{"NoFilters", "BlurOnly", "BlurAndDefaultBackgrounds", "AllFilters"}, Values{"NoFilters", "BlurOnly", "BlurAndDefaultBackgrounds", "AllFilters"}] String VideoFiltersMode;
     [Write, Description("Specifies who can attend and register for webinars."), ValueMap{"Everyone", "EveryoneInCompany"}, Values{"Everyone", "EveryoneInCompany"}] String WhoCanRegister;


### PR DESCRIPTION
#### Pull Request (PR) description
This PR changes the type of `SInt64` to `SInt32` to not run into an issue with PowerShell and DSC.

#### This Pull Request (PR) fixes the following issues
- Fixes #6687 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
