### PR TITLE
EXOMessageClassification: Silently continue if resource not found during export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* EXOMessageClassification
+  * Fixed issue where the resource would fail during export if it could not
+    find it by `DisplayName`, and it needed to be created, by silently
+    continuing if that is the case
+    FIXES [#6691](https://github.com/microsoft/Microsoft365DSC/issues/6691)
+
 # Release 1.25.1112.1
 
 * AADActivityBasedTimeoutPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMessageClassification/MSFT_EXOMessageClassification.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMessageClassification/MSFT_EXOMessageClassification.psm1
@@ -112,7 +112,7 @@ function Get-TargetResource
                 if (-not [System.String]::IsNullOrEmpty($DisplayName))
                 {
                     Write-Verbose -Message "Couldn't retrieve Message Classification policy by Id {$($Identity)}. Trying by DisplayName."
-                    $MessageClassification = Get-MessageClassification -Identity $DisplayName
+                    $MessageClassification = Get-MessageClassification -Identity $DisplayName -ErrorAction SilentlyContinue
                 }
                 if ($null -eq $MessageClassification)
                 {


### PR DESCRIPTION
Fixes an issue where the export process would fail if a resource could not be found by `DisplayName`. The change allows the process to continue silently in such cases.

- Fixes #6691