### PR TITLE
Fix Entra Group Export for EXO managed groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+* AADGroup
+  * Fixed an issue where not all manageable Entra groups were exported.
 * AADNamedLocationPolicy
   * Fixed an issue where not all properties were exported.
     FIXES [#6704](https://github.com/microsoft/Microsoft365DSC/issues/6704)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -1288,10 +1288,11 @@ function Export-TargetResource
             $Script:requireGroupMemberFetching = $true
         }
 
+        # Exclude Distribution Groups and mail enabled security groups from Exchange
         [array] $Script:exportedGroups = Get-MgBetaGroup @ExportParameters
         $Script:exportedGroups = $Script:exportedGroups | Where-Object -FilterScript {
-            -not ($_.MailEnabled -and ($null -eq $_.GroupTypes -or $_.GroupTypes.Length -eq 0)) -and `
-                -not ($_.MailEnabled -and $_.SecurityEnabled)
+            -not ($_.MailEnabled -and ($null -eq $_.GroupTypes -or $_.GroupTypes.Count -eq 0)) -and `
+                -not ($_.MailEnabled -and $_.SecurityEnabled -and ($null -eq $_.GroupTypes -or $_.GroupTypes.Count -eq 0))
         } | Sort-Object -Property DisplayName
 
         $i = 1


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes a small condition error when exporting all manageable AAD groups. This resulted in not all M365 AAD groups being exported, that were both M365 and Security enabled.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
