### PR TITLE
Allow module validation skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* MISC
+  * Allow module validation to be skipped when using `ConvertTo-DscObject` internally.
+
 # 1.25.1203.2
+
 * DEPENDENCIES
   * Updated MSCloudLoginAssistant to version 1.1.56.
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCConfigurationHelper.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCConfigurationHelper.psm1
@@ -31,7 +31,10 @@ function Get-M365DSCEvaluationRulesForConfiguration
         $ConnectionMode
     )
 
+    $previousValue = (Get-M365DSCModuleConfiguration).skipModuleDependencyValidation
+    Set-M365DSCModuleConfiguration -Key 'skipModuleDependencyValidation' -Value $true -Persist
     $configurationAsObject = ConvertTo-DSCObject -Path $ConfigurationPath
+    Set-M365DSCModuleConfiguration -Key 'skipModuleDependencyValidation' -Value $previousValue -Persist
 
     $groupCondition = {
         $_.ResourceName

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -2369,6 +2369,8 @@ function Initialize-M365DSCReporting
         Write-Verbose 'Error trying to remove Module Version'
     }
 
+    $previousValue = (Get-M365DSCModuleConfiguration).skipModuleDependencyValidation
+    Set-M365DSCModuleConfiguration -Key 'skipModuleDependencyValidation' -Value $true -Persist
     if ($IncludeComments)
     {
         $parsedContent = ConvertTo-DSCObject -Content $fileContent -IncludeComments:$True
@@ -2377,6 +2379,7 @@ function Initialize-M365DSCReporting
     {
         $parsedContent = ConvertTo-DSCObject -Content $fileContent
     }
+    Set-M365DSCModuleConfiguration -Key 'skipModuleDependencyValidation' -Value $previousValue -Persist
 
     if ($null -eq $parsedContent)
     {

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -39,15 +39,74 @@ if ($null -eq $Script:M365DSCDependencies)
         })
     }
 
-    Write-Verbose -Message "Processing config.json for global required modules"
+    Write-Verbose -Message "Loading current configuration from config.json"
     $Script:M365DSCValidatedDependencies = [System.Collections.Generic.List[System.String]]::new($Script:M365DSCDependencies.Count)
-    $globalRequiredModules = (Get-Content -Path "$PSScriptRoot/../config.json" | ConvertFrom-Json).requiredModules
+    $configAsPsCustomObject = Get-Content -Path "$PSScriptRoot/../config.json" | ConvertFrom-Json
+    $configAsHashtable = @{}
+    foreach ($property in $configAsPsCustomObject.PSObject.Properties)
+    {
+        $configAsHashtable.Add($property.Name, $property.Value)
+    }
+    $Script:CurrentConfiguration = $configAsHashtable
+    $globalRequiredModules = $Script:CurrentConfiguration.requiredModules
     foreach ($entry in $commandToModuleMap.GetEnumerator())
     {
         $sortedFunctions = @($globalRequiredModules.$($entry.Key)) + @($entry.Value) | Sort-Object -Unique
         $Script:M365DSCDependencies[$entry.Key].Commands = $sortedFunctions
     }
     $Script:M365DSCRequiredModules = @($globalRequiredModules.psobject.Properties.Name)
+
+    # Custom settings
+    $skipModuleDependencyValidation = [System.Environment]::GetEnvironmentVariable('M365DSC_SKIP_MODULE_DEPENDENCY_VALIDATION', 'Machine')
+    if (-not [string]::IsNullOrEmpty($skipModuleDependencyValidation))
+    {
+        $Script:CurrentConfiguration.skipModuleDependencyValidation = [System.Convert]::ToBoolean($skipModuleDependencyValidation)
+    }
+}
+
+function Get-M365DSCModuleConfiguration
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param()
+
+    return $Script:CurrentConfiguration.Clone()
+}
+
+function Set-M365DSCModuleConfiguration
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Key,
+
+        [Parameter(Mandatory = $true)]
+        [Object]
+        $Value,
+
+        [Parameter()]
+        [switch]
+        $Persist,
+
+        [Parameter()]
+        [switch]
+        $Clear
+    )
+
+    if ($Key -eq 'skipModuleDependencyValidation')
+    {
+        if ($Persist)
+        {
+            [System.Environment]::SetEnvironmentVariable('M365DSC_SKIP_MODULE_DEPENDENCY_VALIDATION', $Value.ToString(), 'Machine')
+        }
+        elseif ($Clear)
+        {
+            [System.Environment]::('M365DSC_SKIP_MODULE_DEPENDENCY_VALIDATION', [NullString]::Value, 'Machine')
+        }
+    }
+    $Script:CurrentConfiguration."$Key" = $Value
 }
 
 <#
@@ -1933,9 +1992,9 @@ function Confirm-M365DSCModuleDependency
 
     $Global:MaximumFunctionCount = 32767
 
-    if ($Global:IsTestEnvironment)
+    if ($Global:IsTestEnvironment -or (Get-M365DSCModuleConfiguration).skipModuleDependencyValidation)
     {
-        Write-Verbose -Message "Skipping module dependency validation in test environment for module '$ModuleName'."
+        Write-Verbose -Message "Skipping module dependency validation in test environment or because it was requested to be skipped for module '$ModuleName'."
         return
     }
 
@@ -3307,7 +3366,10 @@ function Assert-M365DSCBlueprint
 
         try
         {
+            $previousValue = (Get-M365DSCModuleConfiguration).skipModuleDependencyValidation
+            Set-M365DSCModuleConfiguration -Key 'skipModuleDependencyValidation' -Value $true -Persist
             $parsedBluePrint = ConvertTo-DSCObject -Content $fileContent
+            Set-M365DSCModuleConfiguration -Key 'skipModuleDependencyValidation' -Value $previousValue -Persist
         }
         catch
         {
@@ -5091,7 +5153,10 @@ function Get-M365DSCConfigurationConflict
 
     $results = @()
     Write-Verbose -Message "Converting configuration's content into a PowerShell Object using DSCParser"
+    $previousValue = (Get-M365DSCModuleConfiguration).skipModuleDependencyValidation
+    Set-M365DSCModuleConfiguration -Key 'skipModuleDependencyValidation' -Value $true -Persist
     $parsedContent = ConvertTo-DSCObject -Content $ConfigurationContent
+    Set-M365DSCModuleConfiguration -Key 'skipModuleDependencyValidation' -Value $previousValue -Persist
 
     $resourcesPrimaryIdentities = @()
     if ($Script:IsPowerShellCore)
@@ -5312,8 +5377,11 @@ function Join-M365DSCConfiguration
     $ConfigurationFilePath = Join-Path -Path $ConfigurationPath -ChildPath $ConfigurationFile
     $ConfigurationPath = Join-Path -Path $ConfigurationPath -ChildPath "*"
 
+    $previousValue = (Get-M365DSCModuleConfiguration).skipModuleDependencyValidation
+    Set-M365DSCModuleConfiguration -Key 'skipModuleDependencyValidation' -Value $true -Persist
     $baseConfiguration = ConvertTo-DSCObject -Path $ConfigurationFilePath
     $additionalConfigurations = Get-Item -Path $ConfigurationPath -Filter *.ps1 -Exclude $ConfigurationFile | ForEach-Object { ConvertTo-DSCObject -Path $_.FullName }
+    Set-M365DSCModuleConfiguration -Key 'skipModuleDependencyValidation' -Value $previousValue -Persist
 
     $combinedArray = @($baseConfiguration) + @($additionalConfigurations)
     $combinedConfiguration = ConvertFrom-DSCObject -DSCResources $combinedArray
@@ -5710,6 +5778,7 @@ Export-ModuleMember -Function @(
     'Get-M365DSCAPIEndpoint',
     'Get-M365DSCAuthenticationMode',
     'Get-M365DSCComponentsWithMostSecureAuthenticationType',
+    'Get-M365DSCModuleConfiguration',
     'Get-M365DSCConfigurationConflict',
     'Get-M365DSCConnectedWorkloadList',
     'Get-M365DSCExportContentForResource',
@@ -5734,6 +5803,7 @@ Export-ModuleMember -Function @(
     'Remove-M365DSCAuthenticationParameter',
     'Remove-NullEntriesFromHashtable',
     'Set-M365DSCAllResourcesDictionary',
+    'Set-M365DSCModuleConfiguration',
     'Set-M365DSCStringReplacementMap',
     'Split-M365DSCConfiguration',
     'Sync-M365DSCParameter',

--- a/Modules/Microsoft365DSC/config.json
+++ b/Modules/Microsoft365DSC/config.json
@@ -7,5 +7,6 @@
       "Get-MgBetaRoleManagementDirectoryRoleAssignment",
       "Get-MgBetaRoleManagementDirectoryRoleDefinition"
     ]
-  }
+  },
+  "skipModuleDependencyValidation": false
 }


### PR DESCRIPTION
**Edit: Currently under review. Might not be needed.**

#### Pull Request (PR) description
This PR adds a configuration option to skip the module validation during importing of a resource. This is particularly impactful when no operations from a resource are required, but the resource itself needs to be registered as a CIM resource, e.g. during report generation. Instead of waiting for the resource to load all the modules it depends on, they are simply skipped (because not required).

If the export contains many resources with the same common modules, then the benefit is not really high - But if there are resources with many different modules, then the impact will be much more meaningful. 

In this specific case, persisting the information as an environment variable is necessary in order for the LCM to pick it up because it runs in the SYSTEM context, not in the callers session. However, this requires that the report generation is executed with elevated privileges, which is already a necessity if at least one CIM instance has not been instantiated for the report to be generated.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
