### PR TITLE
Fix Intune AssignmentSettings property for more resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@
   * Updated required permissions for read / update.
 * TeamsEmergencyCallRoutingPolicy
   * Updated required permissions for read / update.
+* TeamsMeetingBroadcastConfiguration
+  * Fixed an issue where the `SdnApiToken` property was not compared correctly.
 * TeamsOrgWideAppSettings
   * Added a note that the resource does not support certificate based authentication.
 * TeamsTeam

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@
     due to the object depth exceeding two levels.
 * IntuneEpmElevationRulesPolicyWindows10
   * Added a throw condition if the reusable certiticate policy setting is not found.
+* IntuneMobileAppsBuiltInStoreApp
+  * Fixed an issue where `AssignmentSettings` was not a valid property.
+* IntuneMobileAppsLobAppiOS
+  * Fixed an issue where `AssignmentSettings` was not a valid property.
+* IntuneMobileAppsLobAppMsiWindows10
+  * Fixed an issue where `Categories` was exported as a String.
+* IntuneMobileAppsMacOSLobApp
+  * Fixed an issue where `AssignmentSettings` was not a valid property.
 * IntuneMobileAppsManagedGooglePlayApp
   * Fixed an issue where `AssignmentSettings` was not a valid property.
     FIXES [#6785](https://github.com/microsoft/Microsoft365DSC/issues/6785)
@@ -95,7 +103,7 @@
     FIXES [#6584](https://github.com/microsoft/Microsoft365DSC/issues/6584)
   * Removed verbose output from `Get-TargetResource`.
   * Updated the error behavior to always throw inside `Get-TargetResource`.
-    
+
 # 1.25.1203.2
 
 * DEPENDENCIES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 * IntuneDeviceCompliancePolicyAndroidDeviceOwner
   * Fixed an issue where a JSON serialization warning was outputted
     due to the object depth exceeding two levels.
+* IntuneDeviceCompliancePolicyWindows10
+  * Fixed an issue where the complex type mapping was defined incorrectly.
 * IntuneEpmElevationRulesPolicyWindows10
   * Added a throw condition if the reusable certiticate policy setting is not found.
 * IntuneMobileAppsBuiltInStoreApp
@@ -84,15 +86,16 @@
     FIXES [#6689](https://github.com/microsoft/Microsoft365DSC/issues/6689)
   * Fixed an issue when attempting to copy non-downloaded `SPOApp` files.
 * M365DSCUtil
-  * Fixed an issue where multiple installed Microsoft365DSC versions
-    will lead to an error during export.
-    FIXES [#6758](https://github.com/microsoft/Microsoft365DSC/issues/6758)
   * Added functionality to change M365DSC configuration during runtime.
   * Added logic to clean up temporary files assertion.
   * Added missing `UseBasicParsing` because of Windows PowerShell hardening.
+  * Fixed an issue where multiple installed Microsoft365DSC versions
+    will lead to an error during export.
+    FIXES [#6758](https://github.com/microsoft/Microsoft365DSC/issues/6758)
   * Fixed an issue where the export would fail if the name of a resource was not
     the same case as the name in Microsoft365DSC.
   * Improved module installation speed for `Update-M365DSCModule`.
+  * Updated the Tenant Guid parsing to not throw but instead use `TryParse`.
 * MISC
   * Applied ordering for CIM instances to minimize Git differences.
   * Fixed a couple of misaligned export messages on the console.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@
 * PPTenantIsolationSettings
   * Fixed an issue where updating the policy failed because of an unresolved tenant name.
     FIXES [#6778](https://github.com/microsoft/Microsoft365DSC/issues/6778)
+* SCAutoSensitivityLabelRule
+  * Aligned property formating for improved export processing.
 * SCSecurityFilter
   * Added a note that the resource does not support certificate based authentication.
 * TeamsChannel

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyWindows10/MSFT_IntuneDeviceCompliancePolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceCompliancePolicyWindows10/MSFT_IntuneDeviceCompliancePolicyWindows10.psm1
@@ -1068,7 +1068,7 @@ function Export-TargetResource
                     @{
                         Name            = 'Assignments'
                         CimInstanceName = 'MSFT_DeviceManagementConfigurationPolicyAssignments'
-                            sRequired      = $False
+                        IsRequired      = $False
                     }
                 )
                 $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.psm1
@@ -276,6 +276,17 @@ function Get-TargetResource
         {
             $assignmentResult += ConvertFrom-IntuneMobileAppAssignment -Assignments $assignmentsValues -IncludeDeviceFilter $true
         }
+        foreach ($assignment in $assignmentResult)
+        {
+            if ($null -ne $assignment.assignmentSettings -and $null -ne $assignment.assignmentSettings.vpnConfigurationId)
+            {
+                $vpnConfiguration = Get-MgBetaDeviceManagementDeviceConfiguration -DeviceConfigurationId $assignment.assignmentSettings.vpnConfigurationId -Property "DisplayName" -ErrorAction SilentlyContinue
+                if ($null -ne $vpnConfiguration)
+                {
+                    $assignment.assignmentSettings.vpnConfigurationId = $vpnConfiguration.DisplayName
+                }
+            }
+        }
         $results.Add('Assignments', $assignmentResult)
 
         return $results
@@ -454,6 +465,25 @@ function Set-TargetResource
     #endregion
 
     $currentInstance = Get-TargetResource @PSBoundParameters
+
+    foreach ($assignment in $Assignments)
+    {
+        if ($null -ne $assignment.assignmentSettings -and -not [System.String]::IsNullOrEmpty($assignment.assignmentSettings.vpnConfigurationId))
+        {
+            $guid = [System.Guid]::Empty
+            if (-not [System.Guid]::TryParse($assignment.assignmentSettings.vpnConfigurationId, [ref]$guid))
+            {
+                $vpnConfiguration = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "displayName eq '$($assignment.assignmentSettings.vpnConfigurationId)'" | Where-Object -FilterScript {
+                    $_.AdditionalProperties.'@odata.type' -like "#microsoft.graph.*VpnConfiguration"
+                }
+                if ($null -eq $vpnConfiguration)
+                {
+                    throw "Could not find a VPN Configuration Policy with DisplayName '$($assignment.assignmentSettings.vpnConfigurationId)'."
+                }
+                $assignment.assignmentSettings.vpnConfigurationId = $vpnConfiguration.Id
+            }
+        }
+    }
 
     $boundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
     $boundParameters.Remove('Categories') | Out-Null
@@ -873,7 +903,17 @@ function Export-TargetResource
 
             if ($Results.Assignments)
             {
-                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementMobileAppAssignment
+                $complexMapping = @(
+                    @{
+                        Name = 'AssignmentSettings'
+                        CIMInstanceName = 'DeviceManagementBuiltInStoreAppAssignmentSettings'
+                        IsRequired = $false
+                    }
+                )
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.Assignments `
+                    -CIMInstanceName DeviceManagementBuiltInStoreAppAssignment `
+                    -ComplexTypeMapping $complexMapping
                 if ($complexTypeStringResult)
                 {
                     $Results.Assignments = $complexTypeStringResult

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/MSFT_IntuneMobileAppsBuiltInStoreApp.schema.mof
@@ -10,6 +10,27 @@ class MSFT_DeviceManagementMobileAppAssignment
     [Write, Description("Possible values for the install intent chosen by the admin."), ValueMap{"available", "required", "uninstall", "availableWithoutEnrollment"}, Values{"available", "required", "uninstall", "availableWithoutEnrollment"}] String intent;
 };
 
+[ClassVersion("1.0.0.3")]
+class MSFT_DeviceManagementMobileAppAssignmentSettings
+{
+    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementBuiltInStoreAppAssignmentSettings : MSFT_DeviceManagementMobileAppAssignmentSettings
+{
+    [Write, Description("Display name or Id of the VPN configuration profile associated with this policy.")] String vpnConfigurationId;
+    [Write, Description("When TRUE, indicates that the app should be uninstalled when the device is removed from Intune. When FALSE, indicates that the app will not be uninstalled when the device is removed from Intune. By default, property is set to null which internally is treated as TRUE.")] Boolean uninstallOnDeviceRemoval;
+    [Write, Description("When TRUE, indicates that the app can be uninstalled by the user. When FALSE, indicates that the app cannot be uninstalled by the user. By default, this property is set to null which internally is treated as TRUE.")] Boolean isRemovable;
+    [Write, Description("When TRUE, indicates that the app should not be backed up to iCloud. When FALSE, indicates that the app may be backed up to iCloud. By default, this property is set to null which internally is treated as FALSE.")] Boolean preventManagedAppBackup;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementBuiltInStoreAppAssignment : MSFT_DeviceManagementMobileAppAssignment
+{
+    [Write, Description("The settings of the assignment."), EmbeddedInstance("MSFT_DeviceManagementBuiltInStoreAppAssignmentSettings")] String assignmentSettings;
+};
+
 [ClassVersion("1.0.0")]
 class MSFT_MicrosoftGraphIosDeviceType
 {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsBuiltInStoreApp/settings.json
@@ -62,7 +62,8 @@
     {
       "module": "Microsoft.Graph.Beta.DeviceManagement",
       "cmdlets": [
-        "Get-MgBetaDeviceManagementAssignmentFilter"
+        "Get-MgBetaDeviceManagementAssignmentFilter",
+        "Get-MgBetaDeviceManagementDeviceConfiguration"
       ]
     },
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsLobAppMsiWindows10/MSFT_IntuneMobileAppsLobAppMsiWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsLobAppMsiWindows10/MSFT_IntuneMobileAppsLobAppMsiWindows10.psm1
@@ -747,7 +747,7 @@ function Export-TargetResource
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
                 -Credential $Credential `
-                -NoEscape @('Assignments', 'MinimumSupportedOperatingSystem', 'LargeIcon')
+                -NoEscape @('Assignments', 'Categories', 'MinimumSupportedOperatingSystem', 'LargeIcon')
             $dscContent += $currentDSCBlock
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsLobAppWindows10/MSFT_IntuneMobileAppsLobAppWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsLobAppWindows10/MSFT_IntuneMobileAppsLobAppWindows10.schema.mof
@@ -13,7 +13,7 @@ class MSFT_DeviceManagementMobileAppAssignment
 [ClassVersion("1.0.0.3")]
 class MSFT_DeviceManagementMobileAppAssignmentSettings
 {
-    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
+    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
 };
 
 [ClassVersion("1.0.0.0")]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsLobAppiOS/MSFT_IntuneMobileAppsLobAppiOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsLobAppiOS/MSFT_IntuneMobileAppsLobAppiOS.psm1
@@ -262,6 +262,17 @@ function Get-TargetResource
         {
             $assignmentResult += ConvertFrom-IntuneMobileAppAssignment -Assignments $assignmentsValues -IncludeDeviceFilter $true
         }
+        foreach ($assignment in $assignmentResult)
+        {
+            if ($null -ne $assignment.assignmentSettings -and $null -ne $assignment.assignmentSettings.vpnConfigurationId)
+            {
+                $vpnConfiguration = Get-MgBetaDeviceManagementDeviceConfiguration -DeviceConfigurationId $assignment.assignmentSettings.vpnConfigurationId -Property "DisplayName" -ErrorAction SilentlyContinue
+                if ($null -ne $vpnConfiguration)
+                {
+                    $assignment.assignmentSettings.vpnConfigurationId = $vpnConfiguration.DisplayName
+                }
+            }
+        }
         $results.Add('Assignments', $assignmentResult)
 
         return $results
@@ -414,6 +425,25 @@ function Set-TargetResource
     #endregion
 
     $currentInstance = Get-TargetResource @PSBoundParameters
+
+    foreach ($assignment in $Assignments)
+    {
+        if ($null -ne $assignment.assignmentSettings -and -not [System.String]::IsNullOrEmpty($assignment.assignmentSettings.vpnConfigurationId))
+        {
+            $guid = [System.Guid]::Empty
+            if (-not [System.Guid]::TryParse($assignment.assignmentSettings.vpnConfigurationId, [ref]$guid))
+            {
+                $vpnConfiguration = Get-MgBetaDeviceManagementDeviceConfiguration -All -Filter "displayName eq '$($assignment.assignmentSettings.vpnConfigurationId)'" | Where-Object -FilterScript {
+                    $_.AdditionalProperties.'@odata.type' -like "#microsoft.graph.*VpnConfiguration"
+                }
+                if ($null -eq $vpnConfiguration)
+                {
+                    throw "Could not find a VPN Configuration Policy with DisplayName '$($assignment.assignmentSettings.vpnConfigurationId)'."
+                }
+                $assignment.assignmentSettings.vpnConfigurationId = $vpnConfiguration.Id
+            }
+        }
+    }
 
     $boundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
     $boundParameters.Remove('Categories') | Out-Null
@@ -788,7 +818,17 @@ function Export-TargetResource
 
             if ($Results.Assignments)
             {
-                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments -CIMInstanceName DeviceManagementMobileAppAssignment
+                $complexMapping = @(
+                    @{
+                        Name = 'AssignmentSettings'
+                        CIMInstanceName = 'DeviceManagementLobAppiOSAssignmentSettings'
+                        IsRequired = $false
+                    }
+                )
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.Assignments `
+                    -CIMInstanceName DeviceManagementLobAppiOSAssignment `
+                    -ComplexTypeMapping $complexMapping
                 if ($complexTypeStringResult)
                 {
                     $Results.Assignments = $complexTypeStringResult

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsLobAppiOS/MSFT_IntuneMobileAppsLobAppiOS.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsLobAppiOS/MSFT_IntuneMobileAppsLobAppiOS.schema.mof
@@ -10,6 +10,27 @@ class MSFT_DeviceManagementMobileAppAssignment
     [Write, Description("Possible values for the install intent chosen by the admin."), ValueMap{"available", "required", "uninstall", "availableWithoutEnrollment"}, Values{"available", "required", "uninstall", "availableWithoutEnrollment"}] String intent;
 };
 
+[ClassVersion("1.0.0.3")]
+class MSFT_DeviceManagementMobileAppAssignmentSettings
+{
+    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementLobAppiOSAssignmentSettings : MSFT_DeviceManagementMobileAppAssignmentSettings
+{
+    [Write, Description("Display name or Id of the VPN configuration profile associated with this policy.")] String vpnConfigurationId;
+    [Write, Description("When TRUE, indicates that the app should be uninstalled when the device is removed from Intune. When FALSE, indicates that the app will not be uninstalled when the device is removed from Intune. By default, property is set to null which internally is treated as TRUE.")] Boolean uninstallOnDeviceRemoval;
+    [Write, Description("When TRUE, indicates that the app can be uninstalled by the user. When FALSE, indicates that the app cannot be uninstalled by the user. By default, this property is set to null which internally is treated as TRUE.")] Boolean isRemovable;
+    [Write, Description("When TRUE, indicates that the app should not be backed up to iCloud. When FALSE, indicates that the app may be backed up to iCloud. By default, this property is set to null which internally is treated as FALSE.")] Boolean preventManagedAppBackup;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementLobAppiOSAssignment : MSFT_DeviceManagementMobileAppAssignment
+{
+    [Write, Description("The settings of the assignment."), EmbeddedInstance("MSFT_DeviceManagementLobAppiOSAssignmentSettings")] String assignmentSettings;
+};
+
 [ClassVersion("1.0.0")]
 class MSFT_MicrosoftGraphIosDeviceType
 {
@@ -69,7 +90,6 @@ class MSFT_IntuneMobileAppsLobAppiOS : OMI_BaseResource
     [Write, Description("The privacy statement Url.")] String PrivacyInformationUrl;
     [Write, Description("The publisher of the app.")] String Publisher;
     [Write, Description("List of scope tag ids for this mobile app.")] String RoleScopeTagIds[];
-
     [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementMobileAppAssignment")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsLobAppiOS/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsLobAppiOS/settings.json
@@ -61,7 +61,8 @@
     {
       "module": "Microsoft.Graph.Beta.DeviceManagement",
       "cmdlets": [
-        "Get-MgBetaDeviceManagementAssignmentFilter"
+        "Get-MgBetaDeviceManagementAssignmentFilter",
+        "Get-MgBetaDeviceManagementDeviceConfiguration"
       ]
     },
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.psm1
@@ -798,22 +798,27 @@ function Export-TargetResource
                 }
             }
 
-            if ($null -ne $Results.Assignments)
+            if ($Results.Assignments)
             {
-                if ($Results.Assignments)
-                {
-                    $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
-                        -ComplexObject $Results.Assignments `
-                        -CIMInstanceName DeviceManagementMobileAppAssignment
+                $complexMapping = @(
+                    @{
+                        Name = 'AssignmentSettings'
+                        CIMInstanceName = 'DeviceManagementMacOSLobAppAssignmentSettings'
+                        IsRequired = $false
+                    }
+                )
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.Assignments `
+                    -CIMInstanceName DeviceManagementMacOSLobAppAssignment `
+                    -ComplexTypeMapping $complexMapping
 
-                    if ($complexTypeStringResult)
-                    {
-                        $Results.Assignments = $complexTypeStringResult
-                    }
-                    else
-                    {
-                        $Results.Remove('Assignments') | Out-Null
-                    }
+                if ($complexTypeStringResult)
+                {
+                    $Results.Assignments = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('Assignments') | Out-Null
                 }
             }
             #endregion complex types

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMacOSLobApp/MSFT_IntuneMobileAppsMacOSLobApp.schema.mof
@@ -10,6 +10,24 @@ class MSFT_DeviceManagementMobileAppAssignment
     [Write, Description("Possible values for the install intent chosen by the admin."), ValueMap{"available", "required", "uninstall", "availableWithoutEnrollment"}, Values{"available", "required", "uninstall", "availableWithoutEnrollment"}] String intent;
 };
 
+[ClassVersion("1.0.0.3")]
+class MSFT_DeviceManagementMobileAppAssignmentSettings
+{
+    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementMacOSLobAppAssignmentSettings : MSFT_DeviceManagementMobileAppAssignmentSettings
+{
+    [Write, Description("When TRUE, indicates that the app should be uninstalled when the device is removed from Intune. When FALSE, indicates that the app will not be uninstalled when the device is removed from Intune.")] Boolean uninstallOnDeviceRemoval;
+};
+
+[ClassVersion("1.0.0.0")]
+class MSFT_DeviceManagementMacOSLobAppAssignment : MSFT_DeviceManagementMobileAppAssignment
+{
+    [Write, Description("The settings of the assignment."), EmbeddedInstance("MSFT_DeviceManagementMacOSLobAppAssignmentSettings")] String assignmentSettings;
+};
+
 [ClassVersion("1.0.0")]
 class MSFT_DeviceManagementMinimumOperatingSystem
 {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsManagedGooglePlayApp/MSFT_IntuneMobileAppsManagedGooglePlayApp.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsManagedGooglePlayApp/MSFT_IntuneMobileAppsManagedGooglePlayApp.psm1
@@ -499,7 +499,8 @@ function Export-TargetResource
                         IsRequired = $false
                     }
                 )
-                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString -ComplexObject $Results.Assignments `
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.Assignments `
                     -CIMInstanceName DeviceManagementManagedGooglePlayMobileAppAssignment `
                     -ComplexTypeMapping $complexMapping
                 if ($complexTypeStringResult)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsManagedGooglePlayApp/MSFT_IntuneMobileAppsManagedGooglePlayApp.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsManagedGooglePlayApp/MSFT_IntuneMobileAppsManagedGooglePlayApp.schema.mof
@@ -13,7 +13,7 @@ class MSFT_DeviceManagementMobileAppAssignment
 [ClassVersion("1.0.0.3")]
 class MSFT_DeviceManagementMobileAppAssignmentSettings
 {
-    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
+    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
 };
 
 [ClassVersion("1.0.0.0")]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsManagedGooglePlayApp/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsManagedGooglePlayApp/settings.json
@@ -43,6 +43,7 @@
   },
   "requiredModules": [
     "Microsoft.Graph.Authentication",
+    "Microsoft.Graph.Beta.DeviceManagement",
     "Microsoft.Graph.Beta.Devices.CorporateManagement",
     "Microsoft.Graph.Groups"
   ],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMicrosoftStoreAppWindows10/MSFT_IntuneMobileAppsMicrosoftStoreAppWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsMicrosoftStoreAppWindows10/MSFT_IntuneMobileAppsMicrosoftStoreAppWindows10.schema.mof
@@ -29,7 +29,7 @@ class MSFT_DeviceManagementWinGetMobileAppAssignmentSettingsInstallTimeSettings
 [ClassVersion("1.0.0.3")]
 class MSFT_DeviceManagementMobileAppAssignmentSettings
 {
-    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
+    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
 };
 
 [ClassVersion("1.0.0.0")]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsStoreApp/MSFT_IntuneMobileAppsStoreApp.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsStoreApp/MSFT_IntuneMobileAppsStoreApp.schema.mof
@@ -13,7 +13,7 @@ class MSFT_DeviceManagementMobileAppAssignment
 [ClassVersion("1.0.0.3")]
 class MSFT_DeviceManagementMobileAppAssignmentSettings
 {
-    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
+    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
 };
 
 [ClassVersion("1.0.0.0")]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/MSFT_IntuneMobileAppsWin32AppWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneMobileAppsWin32AppWindows10/MSFT_IntuneMobileAppsWin32AppWindows10.schema.mof
@@ -35,7 +35,7 @@ class MSFT_DeviceManagementWin32MobileAppAssignmentSettingsInstallTimeSettings
 [ClassVersion("1.0.0.3")]
 class MSFT_DeviceManagementMobileAppAssignmentSettings
 {
-    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
+    [Required, Description("The odata type of the assignment type."), ValueMap{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}, Values{"#microsoft.graph.androidManagedStoreAppAssignmentSettings", "#microsoft.graph.iosLobAppAssignmentSettings", "#microsoft.graph.iosStoreAppAssignmentSettings", "#microsoft.graph.macOsLobAppAssignmentSettings", "#microsoft.graph.win32LobAppAssignmentSettings", "#microsoft.graph.winGetAppAssignmentSettings", "#microsoft.graph.windowsUniversalAppXAppAssignmentSettings"}] String odataType;
 };
 
 [ClassVersion("1.0.0.0")]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCAutoSensitivityLabelRule/MSFT_SCAutoSensitivityLabelRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCAutoSensitivityLabelRule/MSFT_SCAutoSensitivityLabelRule.psm1
@@ -1159,6 +1159,10 @@ function Export-TargetResource
                         $group.SensitiveInformation = [array]$group.sensitivetypes
                         $group.Remove('sensitivetypes') | Out-Null
                     }
+                    $Results.ContentContainsSensitiveInformation = @{
+                        Groups = [array]$Results.ContentContainsSensitiveInformation.groups
+                        Operator = $Results.ContentContainsSensitiveInformation.operator
+                    }
                 }
                 else
                 {
@@ -1221,6 +1225,10 @@ function Export-TargetResource
                         }
                         $group.SensitiveInformation = [array]$group.sensitivetypes
                         $group.Remove('sensitivetypes') | Out-Null
+                    }
+                    $Results.ExceptIfContentContainsSensitiveInformation = @{
+                        Groups = [array]$Results.ExceptIfContentContainsSensitiveInformation.groups
+                        Operator = $Results.ExceptIfContentContainsSensitiveInformation.operator
                     }
                 }
                 else

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingBroadcastConfiguration/MSFT_TeamsMeetingBroadcastConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsMeetingBroadcastConfiguration/MSFT_TeamsMeetingBroadcastConfiguration.psm1
@@ -378,9 +378,9 @@ function Get-CompareParameters
     return @{
         PostProcessing = {
             param($DesiredValues, $CurrentValues, $ValuesToCheck, $ignore)
-            if ($CurrentValues.SdnApiToken -eq '**********')
+            if ($DesiredValues.SdnApiToken -eq '**********' -or $CurrentValues.SdnApiToken -eq '**********')
             {
-                $CurrentValues.Remove('SdnApiToken') | Out-Null
+                $ValuesToCheck.Remove('SdnApiToken') | Out-Null
             }
             return [System.Tuple[Hashtable, Hashtable, Hashtable]]::new($DesiredValues, $CurrentValues, $ValuesToCheck)
         }

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2281,31 +2281,21 @@ function New-M365DSCConnection
 
             if ($null -ne $_.TenantId)
             {
-                $invalid = $false
-                try
-                {
-                    [System.Guid]::Parse($_.TenantId) | Out-Null
-                    $invalid = $true
-                }
-                catch
-                {
-                    $invalid = $false
-                }
-                if ($invalid)
+                $parseGuid = [System.Guid]::Empty
+                $isValid = [System.Guid]::TryParse($_.TenantId, [ref]$parseGuid)
+                if ($isValid)
                 {
                     throw "Please provide the tenant name (e.g., contoso.onmicrosoft.com) for TenantId instead of its GUID."
                 }
+
+                $isValid = $_.TenantId -match ".onmicrosoft."
+                if ($isValid)
+                {
+                    return $true
+                }
                 else
                 {
-                    $invalid = $_.TenantId -notmatch ".onmicrosoft."
-                    if (-not $invalid)
-                    {
-                        return $true
-                    }
-                    else
-                    {
-                        Write-Warning -Message "We recommend providing the tenant name in format <tenant>.onmicrosoft.* for TenantId."
-                    }
+                    Write-Warning -Message "We recommend providing the tenant name in format <tenant>.onmicrosoft.* for TenantId."
                 }
             }
             return $true


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes issues where multiple `AssignmentSettings` properties were not correctly exported and modelled as DSC resource properties. It also includes fixes for Guid parsing, property aligning during export, missing module in settings files and the comparison of the `SdnApiToken` in reports.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
