### PR TITLE
Fix Get-TargetResource for AADGroup resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change log for Microsoft365DSC
 
 # UNRELEASED
-
+* AADGroup
+  * Fixed an issue where Get-DscConfiguration would fail.
+    FIXES [#6796](https://github.com/microsoft/Microsoft365DSC/issues/6796)
 * AADAuthenticationMethodPolicy
   * Fixed an issue where empty arrays were not exported.
     FIXES [#6759](https://github.com/microsoft/Microsoft365DSC/issues/6759)
@@ -95,7 +97,7 @@
     FIXES [#6584](https://github.com/microsoft/Microsoft365DSC/issues/6584)
   * Removed verbose output from `Get-TargetResource`.
   * Updated the error behavior to always throw inside `Get-TargetResource`.
-    
+
 # 1.25.1203.2
 
 * DEPENDENCIES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,115 @@
 * AADGroup
   * Fixed an issue where Get-DscConfiguration would fail.
     FIXES [#6796](https://github.com/microsoft/Microsoft365DSC/issues/6796)
+
+# 1.26.211.1
+
+* AADUser
+  * Fixed an export issue where a user was deleted during a long-running job.
+    FIXES [#5703](https://github.com/microsoft/Microsoft365DSC/issues/5703)
+* IntuneRoleAssignment
+  * Fixed an issue where properties were omitted during Set and testing
+    did not work with display names.
+    FIXES [#6881](https://github.com/microsoft/Microsoft365DSC/issues/6881)
+* FabricAdmintenantsettings
+  * Refreshed the property list.
+   FIXES [#6866](https://github.com/microsoft/Microsoft365DSC/issues/6866)
+* O365OrgSettings
+  * Changed how errors are handled to fail instead of returning false drifts.
+   FIXES [#6787](https://github.com/microsoft/Microsoft365DSC/issues/6787)
+* O365SearchAndIntelligenceConfiguration
+  * Expanded try/catch logic to cover all code paths in Get.
+    FIXES [#6788](https://github.com/microsoft/Microsoft365DSC/issues/6788)
+* SPOSearchManagedProperty
+  * Fixed an issue when connecting to the SPO AdminUrl.
+    FIXES [#6787](https://github.com/microsoft/Microsoft365DSC/issues/6787)
+* TeamsDialInConferencingTenantSettings
+  * Fixed an issue where the properties `MigrateServiceNumbersOnCrossForestMove`
+    and `UseUniqueConferenceIds` were not rendered correctly in the
+    documentation
+    FIXES [#6890](https://github.com/microsoft/Microsoft365DSC/issues/6890)
+* M365DSCUtil
+  * Fixed an issue during module update where `Install-PSResource` throws
+    an error if the module was installed in Windows PowerShell but the
+    update attempt was performed in PowerShell 7.
+  * Fixed an issue where `Export-M365DSCConfiguration` would stop
+    exporting resources after an error on Azure DevOps & GitHub.
+    FIXES [#6862](https://github.com/microsoft/Microsoft365DSC/issues/6862)
+* M365DSCPermissions
+  * Fixed an issue when selecting a property for the result.
+    FIXES [#6882](https://github.com/microsoft/Microsoft365DSC/issues/6882)
+* DEPENDENCIES
+  * Updated MSCloudLoginAssistant to version 1.1.58.
+
+# 1.26.128.1
+
+* EXOMailboxFolderPermission
+  * Fixed an issue where `AccessRights` was not exported properly.
+* EXOTransportRule
+  * Updated logic to properly handle the Enabled property.
+* IntuneAntivirusPolicyWindows10SettingCatalog
+  * Fixed an issue where the property `TamperProtection` was renamed to
+    `ControlledConfiguration` in the Settings Catalog backend.
+    FIXES [#6855](https://github.com/microsoft/Microsoft365DSC/issues/6855)
+* IntuneCloudProvisioningPolicyWindows365
+  * Fixed an issue where `ireland` was not a recognized country.
+    FIXES [#6830](https://github.com/microsoft/Microsoft365DSC/issues/6830)
+* IntuneDeviceFeaturesConfigurationPolicyIOS
+  * Fixed an issue where home screen folders were not configurable.
+    FIXES [#6836](https://github.com/microsoft/Microsoft365DSC/issues/6836)
+* O365OrgSettings
+  * Fixed an issue where comparing empty app installation options failed.
+    FIXES [#6812](https://github.com/microsoft/Microsoft365DSC/issues/6812)
+* SCSecurityFilter
+  * Fixed an issue where connecting to the service was not possible.
+    FIXES [#6798](https://github.com/microsoft/Microsoft365DSC/issues/6798)
+* SPOTenantSettings
+  * Fixing the empty array casting for AllowSelectSGsInODBListInTenant,
+    DenySelectSGsInODBListInTenant,DenySelectSecurityGroupsInSPSitesList
+    and AllowSelectSecurityGroupsInSPSitesList in Get-TargetResource.
+* M365DSCPermissions
+  * Fixed an issue where Purview permissions were not in the correct format.
+    FIXES [#6822](https://github.com/microsoft/Microsoft365DSC/issues/6822)
+* DEPENDENCIES
+  * Updated MSCloudLoginAssistant to version 1.1.57.
+* M365DSCUtil
+  * Removed the parameter `SkipModuleReload` from `New-M365DSCConnection`.
+* MISC
+  * Removed the `SkipModuleReload` logic from all resources.
+
+# 1.26.121.1
+
+* AADGroup
+  * Removed caching for the groups role assignments which was causing
+    performance issues in the Get-TargetResource.
+* AADRoleAssignmentScheduleRequest
+  * FIXES [#6810](https://github.com/microsoft/Microsoft365DSC/issues/6810)
+* AADRoleEligibilityScheduleRequest
+  * FIXES [#6810](https://github.com/microsoft/Microsoft365DSC/issues/6810)
+* M365DSCRuleEvaluation
+  * Fixes for an issue where the resource was complaining about the `Name`
+    parameter missing.
+* SPOSiteGroup
+  * Fixed a condition mismatch during export resulting in repeated logins.
+* M365DSCPermissions
+  * Changed the output of `Get-M365DSCCompiledPermissionList` to show the
+    required Read and Update permissions for `Roles` and `RoleGroups`.
+* MISC
+  * Updated the structure of all EXO settings.json files that contain the
+    `Roles` and `RoleGroups` properties.
+* M365DSCUtil
+  * Added the output of the drift event to the screen in Verbose mode.
+    FIXES [#6666](https://github.com/microsoft/Microsoft365DSC/issues/6666)
+  * Added the parameter `-WithStatistics` to `Export-M365DSCConfiguration`.
+  * Fixed an issue where the module is not being updated if installed
+    with `Install-PSResource` because the filter condition was incorrect.
+* DEPENDENCIES
+  * Fixed a case typo in `RequiredVersion` of a dependency.
+    FIXES [#6815](https://github.com/microsoft/Microsoft365DSC/issues/6815)
+  * Updated ReverseDSC to version 2.0.0.31.
+
+# 1.26.114.1
+
 * AADAuthenticationMethodPolicy
   * Fixed an issue where empty arrays were not exported.
     FIXES [#6759](https://github.com/microsoft/Microsoft365DSC/issues/6759)
@@ -12,11 +121,21 @@
     FIXES [#6777](https://github.com/microsoft/Microsoft365DSC/issues/6777)
   * Fixed an issue where updating a policy would fail.
     FIXES [#6782](https://github.com/microsoft/Microsoft365DSC/issues/6782)
+* AADGroup
+  * Prevents retrieving all members of a group in the Get-TargetResource if
+    the parameter is not specified in the configuration.
 * AADNetworkAccessForwardingPolicy
   * Fixed an issue where empty `PolicyRules` would throw an exception during Get.
+* EXODistributionGroup
+  * Fixes performance issue with the retrieval of managers.
+  * Fixes GUID vs UPN evaluation
+    FIXES [#6769](https://github.com/microsoft/Microsoft365DSC/issues/6769)
 * EXOExternalInOutlook
   * Fixed an issue where the export would fail.
     FIXES [#6753](https://github.com/microsoft/Microsoft365DSC/issues/6753)
+* EXOGroupSettings
+  * Fixed performance issue evaluating and setting values due to the full
+    Recipient list being returned.
 * EXOPhishSimOverrideRule
   * Fixed an issue where the export would fail.
     FIXES [#6753](https://github.com/microsoft/Microsoft365DSC/issues/6753)
@@ -37,8 +156,18 @@
 * IntuneDeviceCompliancePolicyAndroidDeviceOwner
   * Fixed an issue where a JSON serialization warning was outputted
     due to the object depth exceeding two levels.
+* IntuneDeviceCompliancePolicyWindows10
+  * Fixed an issue where the complex type mapping was defined incorrectly.
 * IntuneEpmElevationRulesPolicyWindows10
   * Added a throw condition if the reusable certiticate policy setting is not found.
+* IntuneMobileAppsBuiltInStoreApp
+  * Fixed an issue where `AssignmentSettings` was not a valid property.
+* IntuneMobileAppsLobAppiOS
+  * Fixed an issue where `AssignmentSettings` was not a valid property.
+* IntuneMobileAppsLobAppMsiWindows10
+  * Fixed an issue where `Categories` was exported as a String.
+* IntuneMobileAppsMacOSLobApp
+  * Fixed an issue where `AssignmentSettings` was not a valid property.
 * IntuneMobileAppsManagedGooglePlayApp
   * Fixed an issue where `AssignmentSettings` was not a valid property.
     FIXES [#6785](https://github.com/microsoft/Microsoft365DSC/issues/6785)
@@ -48,15 +177,22 @@
     FIXES [#6092](https://github.com/microsoft/Microsoft365DSC/issues/6092)
 * O365OrgSettings
   * Added `CertificatePath` with `CertificatePassword` as an authentication method.
+* SPOSite
+   * Fixed an issue about not correctly passing RestrictedToRegion parameter.
+     FIXES [#6734](https://github.com/microsoft/Microsoft365DSC/issues/6734)
 * PPTenantIsolationSettings
   * Fixed an issue where updating the policy failed because of an unresolved tenant name.
     FIXES [#6778](https://github.com/microsoft/Microsoft365DSC/issues/6778)
+* SCAutoSensitivityLabelRule
+  * Aligned property formating for improved export processing.
 * SCSecurityFilter
   * Added a note that the resource does not support certificate based authentication.
 * TeamsChannel
   * Updated required permissions for read / update.
 * TeamsEmergencyCallRoutingPolicy
   * Updated required permissions for read / update.
+* TeamsMeetingBroadcastConfiguration
+  * Fixed an issue where the `SdnApiToken` property was not compared correctly.
 * TeamsOrgWideAppSettings
   * Added a note that the resource does not support certificate based authentication.
 * TeamsTeam
@@ -78,15 +214,16 @@
     FIXES [#6689](https://github.com/microsoft/Microsoft365DSC/issues/6689)
   * Fixed an issue when attempting to copy non-downloaded `SPOApp` files.
 * M365DSCUtil
-  * Fixed an issue where multiple installed Microsoft365DSC versions
-    will lead to an error during export.
-    FIXES [#6758](https://github.com/microsoft/Microsoft365DSC/issues/6758)
   * Added functionality to change M365DSC configuration during runtime.
   * Added logic to clean up temporary files assertion.
   * Added missing `UseBasicParsing` because of Windows PowerShell hardening.
+  * Fixed an issue where multiple installed Microsoft365DSC versions
+    will lead to an error during export.
+    FIXES [#6758](https://github.com/microsoft/Microsoft365DSC/issues/6758)
   * Fixed an issue where the export would fail if the name of a resource was not
     the same case as the name in Microsoft365DSC.
   * Improved module installation speed for `Update-M365DSCModule`.
+  * Updated the Tenant Guid parsing to not throw but instead use `TryParse`.
 * MISC
   * Applied ordering for CIM instances to minimize Git differences.
   * Fixed a couple of misaligned export messages on the console.
@@ -96,6 +233,7 @@
     FIXES [#6756](https://github.com/microsoft/Microsoft365DSC/issues/6756)
     FIXES [#6584](https://github.com/microsoft/Microsoft365DSC/issues/6584)
   * Removed verbose output from `Get-TargetResource`.
+  * Updated and corrected all EXO and several SC permissions.
   * Updated the error behavior to always throw inside `Get-TargetResource`.
 
 # 1.25.1203.2

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -114,12 +114,11 @@ function Get-TargetResource
         $AccessTokens
     )
 
-    Write-Verbose -Message "Getting configuration of AzureAD Group with DisplayName {$DisplayName}"
-
     try
     {
         if (-not $Script:exportedInstance -or $Script:exportedInstance.DisplayName -ne $DisplayName)
         {
+            Write-Verbose -Message 'Getting configuration of AzureAD Group'
             $null = New-M365DSCConnection -Workload 'MicrosoftGraph' `
                 -InboundParameters $PSBoundParameters
 
@@ -137,12 +136,12 @@ function Get-TargetResource
 
             $nullReturn = $PSBoundParameters
             $nullReturn.Ensure = 'Absent'
-            $nullReturn.Owners = @()
-            $nullReturn.Members = @()
-            $nullReturn.GroupAsMembers = @()
-            $nullReturn.MemberOf = @()
-            $nullReturn.AssignedToRole = @()
-            $nullReturn.AssignedLicenses = @()
+            $nullReturn.Owners = [System.String[]]@()
+            $nullReturn.Members = [System.String[]]@()
+            $nullReturn.GroupAsMembers = [System.String[]]@()
+            $nullReturn.MemberOf = [System.String[]]@()
+            $nullReturn.AssignedToRole = [System.String[]]@()
+            $nullReturn.AssignedLicenses = [CimInstance[]]@()
 
             if ($PSBoundParameters.ContainsKey('Id'))
             {
@@ -223,7 +222,6 @@ function Get-TargetResource
             }
         }
 
-        $MembersValues = $null
         $result = @{}
         if ($Group.MembershipRuleProcessingState -ne 'On')
         {
@@ -283,8 +281,8 @@ function Get-TargetResource
                     }
                 }
             }
-            $result.Add('Members', $MembersValues)
-            $result.Add('GroupAsMembers', $GroupAsMembersValues)
+            $result.Add('Members', [System.String[]]$MembersValues)
+            $result.Add('GroupAsMembers', [System.String[]]$GroupAsMembersValues)
         }
 
         # MemberOf
@@ -341,7 +339,7 @@ function Get-TargetResource
         $assignedLicensesRequest = ($batchResponse | Where-Object -FilterScript { $_.id -eq 'Licenses' }).body
         if ($assignedLicensesRequest.value.Length -gt 0)
         {
-            [Array]$assignedLicensesValues = Get-M365DSCAzureADGroupLicenses -AssignedLicenses $assignedLicensesRequest.value
+            [CimInstance[]]$assignedLicensesValues = Get-M365DSCAzureADGroupLicenses -AssignedLicenses $assignedLicensesRequest.value
         }
 
         # GroupLifecyclePolicies
@@ -352,19 +350,18 @@ function Get-TargetResource
         $policySettings = @{
             DisplayName                         = $Group.DisplayName
             Id                                  = $Group.Id
-            Owners                              = $OwnersValues
-            MemberOf                            = $MemberOfValues
+            Owners                              = [System.String[]]$OwnersValues
+            MemberOf                            = [System.String[]]$MemberOfValues
             Description                         = $Group.Description
-            GroupTypes                          = [System.String[]]$Group.GroupTypes
+            GroupTypes                          = [System.String[]]($Group.GroupTypes)
             MembershipRule                      = $Group.MembershipRule
             MembershipRuleProcessingState       = $Group.MembershipRuleProcessingState
             SecurityEnabled                     = $Group.SecurityEnabled
             MailEnabled                         = $Group.MailEnabled
             IsAssignableToRole                  = $false -or $Group.IsAssignableToRole
-            AssignedToRole                      = $AssignedToRoleValues
+            AssignedToRole                      = [System.String[]]$AssignedToRoleValues
             MailNickname                        = $Group.MailNickname
             Visibility                          = $Group.Visibility
-            AssignedLicenses                    = $assignedLicensesValues
             Ensure                              = 'Present'
             ApplicationId                       = $ApplicationId
             TenantId                            = $TenantId
@@ -372,10 +369,14 @@ function Get-TargetResource
             ApplicationSecret                   = $ApplicationSecret
             Credential                          = $Credential
             ManagedIdentity                     = $ManagedIdentity.IsPresent
-            AccessTokens                        = $AccessTokens
+            AccessTokens                        = [System.String[]]$AccessTokens
         }
 
         $result += $policySettings
+        If ( $assignedLicensesValues )
+        {
+            $result.Add("AssignedLicenses", [CimInstance[]]$assignedLicensesValues)
+        }
         if ($result.MailEnabled)
         {
             $result.Add("GroupLifecyclePolicySelectedEnabled", $isGroupLifecyclePoliciesEnabled)
@@ -391,7 +392,7 @@ function Get-TargetResource
             -TenantId $TenantId `
             -Credential $Credential
 
-        throw
+        throw $_
     }
 }
 
@@ -1407,10 +1408,10 @@ function Get-M365DSCAzureADGroupLicenses
             $disabledPlansValues += $foundItem.ServicePlanName
         }
         $currentLicense = @{
-            DisabledPlans = $disabledPlansValues
+            DisabledPlans = [String[]]$disabledPlansValues
             SkuId         = $skuPartNumber.SkuPartNumber -replace [char]0xFEFF
         }
-        $returnValue += $currentLicense
+        $returnValue += New-CimInstance -ClassName MSFT_AADGroupLicense -Namespace root/Microsoft/Windows/DesiredStateConfiguration -Property $currentLicense -ClientOnly
     }
 
     return $returnValue


### PR DESCRIPTION
#### Pull Request (PR) description
Updates the Get-TargetResource function for AADGroup to return a Schema accurate object that can be processed with the LCM.

#### This Pull Request (PR) fixes the following issues
FIXES [#6796](https://github.com/microsoft/Microsoft365DSC/issues/6796)

#### Task list
- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
