### PR TITLE
AADGroup - Fix Members retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
     FIXES [#6777](https://github.com/microsoft/Microsoft365DSC/issues/6777)
   * Fixed an issue where updating a policy would fail.
     FIXES [#6782](https://github.com/microsoft/Microsoft365DSC/issues/6782)
+* AADGroup
+  * Prevents retrieving all members of a group in the Get-TargetResource if
+    the parameter is not specified in the configuration.
 * AADNetworkAccessForwardingPolicy
   * Fixed an issue where empty `PolicyRules` would throw an exception during Get.
 * EXOExternalInOutlook
@@ -95,7 +98,7 @@
     FIXES [#6584](https://github.com/microsoft/Microsoft365DSC/issues/6584)
   * Removed verbose output from `Get-TargetResource`.
   * Updated the error behavior to always throw inside `Get-TargetResource`.
-    
+
 # 1.25.1203.2
 
 * DEPENDENCIES

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -225,7 +225,8 @@ function Get-TargetResource
 
         $MembersValues = $null
         $result = @{}
-        if ($Group.MembershipRuleProcessingState -ne 'On')
+        # If the Members parameter is not specified, do not attempt to retrieve them as part of the Get-TargetResource.
+        if ($Group.MembershipRuleProcessingState -ne 'On' -and $Members -ne $null -and $Members.Count -gt 0)
         {
             # Members
             $MembersValues = [System.Collections.Generic.List[System.String]]::new()
@@ -1302,6 +1303,7 @@ function Export-TargetResource
                 ApplicationSecret     = $ApplicationSecret
                 DisplayName           = $group.DisplayName
                 MailNickName          = $group.MailNickName
+                Members               = @('toextract')
                 SecurityEnabled       = $true
                 MailEnabled           = $true
                 Id                    = $group.Id

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AzureBillingAccountScheduledAction/MSFT_AzureBillingAccountScheduledAction.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AzureBillingAccountScheduledAction/MSFT_AzureBillingAccountScheduledAction.psm1
@@ -116,8 +116,8 @@ function Get-TargetResource
                 daysOfWeek   = [Array]($instance.properties.schedule.daysOfWeek)
                 weeksofMonth = [Array]($instance.properties.schedule.weeksofMonth)
                 dayOfMonth   = $instance.properties.schedule.dayOfMonth
-                startDate    = $instance.properties.schedule.startDate.ToString('yyy-MM-ddTHH:mm:ssZ')
-                endDate      = $instance.properties.schedule.endDate.ToString('yyy-MM-ddTHH:mm:ssZ')
+                startDate    = $instance.properties.schedule.startDate.ToString('yyyy-MM-ddTHH:mm:ssZ')
+                endDate      = $instance.properties.schedule.endDate.ToString('yyyy-MM-ddTHH:mm:ssZ')
             }
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description
* Prevents retrieving all members of a group in the Get-TargetResource if the parameter is not specified in the configuration.

#### This Pull Request (PR) fixes the following issues
* N/A