### PR TITLE
Refactor EXO roles and rolegroups with output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCPermissions
+  * Changed the output of `Get-M365DSCCompiledPermissionList` to show the
+    required Read and Update permissions for `Roles` and `RoleGroups`.
+* MISC
+  * Updated the structure of all EXO settings.json files that contain the
+    `Roles` and `RoleGroups` properties.
+
 # 1.26.114.1
 
 * AADAuthenticationMethodPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOATPBuiltInProtectionRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOATPBuiltInProtectionRule/settings.json
@@ -21,16 +21,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAcceptedDomain/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAcceptedDomain/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Remote and Accepted Domains",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Remote and Accepted Domains"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Client Access",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Organization Client Access"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncMailboxPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncMailboxPolicy/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Recipient Policies",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Recipient Policies"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressBookPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressBookPolicy/settings.json
@@ -25,13 +25,20 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Address Lists",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Address Lists"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": []
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressList/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressList/settings.json
@@ -21,10 +21,18 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Address Lists"
-      ],
-      "requiredrolegroups": []
+      "requiredroles": {
+        "read": [
+          "Address Lists"
+        ],
+        "update": [
+          "Address Lists"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [],
+        "update": []
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishPolicy/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishRule/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOApplicationAccessPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOApplicationAccessPolicy/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Configuration",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Organization Configuration"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Tenant AllowBlockList Manager",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Security Operator",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Tenant AllowBlockList Manager"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Security Operator"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpProtectionPolicyRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpProtectionPolicyRule/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAuthenticationPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAuthenticationPolicy/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Configuration",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Organization Configuration"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAuthenticationPolicyAssignment/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAuthenticationPolicyAssignment/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Configuration",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Organization Configuration"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityAddressSpace/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityAddressSpace/settings.json
@@ -25,12 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Tips"
-      ],
-      "requiredrolegroups": [
-        "Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "Mail Tips"
+        ],
+        "update": [
+          "Mail Tips"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityConfig/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityConfig/settings.json
@@ -25,12 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Federated Sharing"
-      ],
-      "requiredrolegroups": [
-        "Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "Federated Sharing"
+        ],
+        "update": [
+          "Federated Sharing"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxPlan/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxPlan/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipients",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxSettings/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Client Access",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Organization Client Access"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCalendarProcessing/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCalendarProcessing/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "User Options",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Help Desk",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataAtRestEncryptionPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataAtRestEncryptionPolicy/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Compliance Admin",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Compliance Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Compliance Admin"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Compliance Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataAtRestEncryptionPolicyAssignment/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataAtRestEncryptionPolicyAssignment/settings.json
@@ -25,12 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Compliance Admin"
-      ],
-      "requiredrolegroups": [
-        "Compliance Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "Compliance Admin"
+        ],
+        "update": [
+          "Compliance Admin"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "Compliance Management"
+        ],
+        "update": [
+          "Compliance Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataClassification/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataClassification/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Data Loss Prevention",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Compliance Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Data Loss Prevention"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Compliance Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataEncryptionPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataEncryptionPolicy/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Recipient Policies",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Recipient Policies"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/settings.json
@@ -23,14 +23,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Distribution Groups",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Distribution Groups"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODkimSigningConfig/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODkimSigningConfig/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODnssecForVerifiedDomain/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODnssecForVerifiedDomain/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Security Admin",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Security Administrator",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Security Admin"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Security Administrator"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEOPProtectionPolicyRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEOPProtectionPolicyRule/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailAddressPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailAddressPolicy/settings.json
@@ -25,12 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "E-Mail Address Policies"
-      ],
-      "requiredrolegroups": [
-        "Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "E-Mail Address Policies"
+        ],
+        "update": [
+          "E-Mail Address Policies"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "Recipient Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailTenantSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailTenantSettings/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOExternalInOutlook/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOExternalInOutlook/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Configuration",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Organization Configuration"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOFocusedInbox/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOFocusedInbox/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipients",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGlobalAddressList/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGlobalAddressList/settings.json
@@ -25,10 +25,18 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Address Lists"
-      ],
-      "requiredrolegroups": []
+      "requiredroles": {
+        "read": [
+          "Address Lists"
+        ],
+        "update": [
+          "Address Lists"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [],
+        "update": []
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGroupSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGroupSettings/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipients",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedConnectionFilterPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedConnectionFilterPolicy/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterPolicy/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterRule/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIRMConfiguration/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIRMConfiguration/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Information Rights Management",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Compliance Management",
-        "Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Information Rights Management"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Compliance Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOInboundConnector/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOInboundConnector/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Remote and Accepted Domains",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Remote and Accepted Domains"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIntraOrganizationConnector/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIntraOrganizationConnector/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Federated Sharing",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Federated Sharing"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOJournalRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOJournalRule/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Journaling",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "Records Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Journaling"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailContact/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailContact/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipient Creation",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipient Creation"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxAuditBypassAssociation/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxAuditBypassAssociation/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Audit Logs",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Records Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Audit Logs"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Records Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxAutoReplyConfiguration/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxAutoReplyConfiguration/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipients",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxCalendarConfiguration/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxCalendarConfiguration/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipients",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxCalendarFolder/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxCalendarFolder/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipients",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxFolderPermission/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxFolderPermission/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipients",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxIRMAccess/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxIRMAccess/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "View-Only Recipients",
-        "Mail Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPermission/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPermission/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipients",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPlan/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPlan/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipients",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxSettings/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxSettings/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipients",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterPolicy/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterRule/settings.json
@@ -25,15 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Transport Hygiene",
-        "Security Admin",
-        "View-Only Configuration",
-        "Security Reader"
-      ],
-      "requiredrolegroups": [
-        "Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRole/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRole/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Role Management",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Role Management"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Role Management",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Role Management"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleEntry/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleEntry/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Role Management",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Role Management"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementScope/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementScope/settings.json
@@ -25,13 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Role Management"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Role Management"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMessageClassification/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMessageClassification/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Transport Rules",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Records Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Rules"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Records Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMigration/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMigration/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Migration",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Migration"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMigrationEndpoint/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMigrationEndpoint/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Migration",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Migration"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMobileDeviceMailboxPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMobileDeviceMailboxPolicy/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Recipient Policies",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Recipient Policies"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOMEConfiguration/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOMEConfiguration/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Information Rights Management",
-        "Security Reader",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Compliance Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Information Rights Management"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Compliance Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOfflineAddressBook/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOfflineAddressBook/settings.json
@@ -25,12 +25,18 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Address Lists"
-      ],
-      "requiredrolegroups": [
-        "Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "Address Lists"
+        ],
+        "update": [
+          "Address Lists"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [],
+        "update": []
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOnPremisesOrganization/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOnPremisesOrganization/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Remote and Accepted Domains",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Remote and Accepted Domains"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationConfig/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationConfig/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Configuration",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Organization Configuration"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Federated Sharing",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Federated Sharing"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOutboundConnector/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOutboundConnector/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Remote and Accepted Domains",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Remote and Accepted Domains"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Recipient Policies",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Recipient Policies"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPartnerApplication/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPartnerApplication/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Client Access",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Organization Client Access"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPerimeterConfiguration/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPerimeterConfiguration/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Configuration",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Organization Configuration"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPhishSimOverrideRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPhishSimOverrideRule/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Configuration",
-        "Security Reader",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Organization Configuration"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPlace/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPlace/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "TenantPlacesManagement",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Places Administrator",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "TenantPlacesManagement"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Places Administrator"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPolicyTipConfig/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPolicyTipConfig/settings.json
@@ -25,15 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Data Loss Prevention",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Compliance Management",
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Data Loss Prevention"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Compliance Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOQuarantinePolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOQuarantinePolicy/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORecipientPermission/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORecipientPermission/settings.json
@@ -25,12 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "Mail Recipients"
+        ],
+        "update": [
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "Recipient Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORemoteDomain/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORemoteDomain/settings.json
@@ -25,13 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Remote and Accepted Domains",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Remote and Accepted Domains"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOReportSubmissionPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOReportSubmissionPolicy/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOReportSubmissionRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOReportSubmissionRule/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOResourceConfiguration/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOResourceConfiguration/settings.json
@@ -25,12 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "Organization Configuration"
+        ],
+        "update": [
+          "Organization Configuration"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicy/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Retention Management",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Records Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Retention Management"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Records Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicyTag/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORetentionPolicyTag/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Retention Management",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Records Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Retention Management"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Records Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleAssignmentPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleAssignmentPolicy/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Role Management",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Role Management"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleGroup/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleGroup/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Role Management",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Role Management"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentPolicy/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentRule/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksRule/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSecOpsOverrideRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSecOpsOverrideRule/settings.json
@@ -3,7 +3,7 @@
   "description": "Use this resource to manage phish sim override rules.",
   "roles": {
     "read": [
-      "Exchange Admin"
+      "Global Reader"
     ],
     "update": [
       "Exchange Admin"
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Configuration",
-        "Security Reader",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Organization Configuration"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOServicePrincipal/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOServicePrincipal/settings.json
@@ -3,7 +3,7 @@
   "description": "Use this resource to to view information about service principals, create service principals, to remove service principals, to change service principals in your cloud-based organization.",
   "roles": {
     "read": [
-      "Exchange Admin"
+      "Global Reader"
     ],
     "update": [
       "Exchange Admin"
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Role Management",
-        "Security Reader",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Role Management"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharedMailbox/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharedMailbox/settings.json
@@ -25,15 +25,23 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Mail Recipient Creation",
-        "Mail Recipients",
-        "View-Only Recipients"
-      ],
-      "requiredrolegroups": [
-        "Recipient Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Recipients"
+        ],
+        "update": [
+          "Mail Recipient Creation",
+          "Mail Recipients"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Recipient Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharingPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharingPolicy/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Federated Sharing",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Federated Sharing"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSmtpDaneInbound/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSmtpDaneInbound/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Admin",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Security Administrator",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Security Admin"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Security Administrator"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSweepRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSweepRule/settings.json
@@ -3,7 +3,7 @@
   "description": "Use this resource to create Sweep rules in mailboxes. Sweep rules run at regular intervals to help keep your Inbox clean.",
   "roles": {
     "read": [
-      "Exchange Admin"
+      "Global Reader"
     ],
     "update": [
       "Exchange Admin"
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "User Options",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "User Options"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTeamsProtectionPolicy/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTeamsProtectionPolicy/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Hygiene",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Hygiene Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Hygiene"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Hygiene Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTenantAllowBlockListItems/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTenantAllowBlockListItems/settings.json
@@ -3,7 +3,7 @@
   "description": "This resource configures the tenant allow/block list (TABL) entries",
   "roles": {
     "read": [
-      "Exchange Admin"
+      "Global Reader"
     ],
     "update": [
       "Exchange Admin"
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Tenant AllowBlockList Manager",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Security Operator",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Tenant AllowBlockList Manager"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Security Operator"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTenantAllowBlockListSpoofItems/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTenantAllowBlockListSpoofItems/settings.json
@@ -3,7 +3,7 @@
   "description": "Configures blocked spoofed items in Exchange Online.",
   "roles": {
     "read": [
-      "Exchange Admin"
+      "Global Reader"
     ],
     "update": [
       "Exchange Admin"
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Tenant AllowBlockList Manager",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Security Operator",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Tenant AllowBlockList Manager"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Security Operator"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportConfig/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportConfig/settings.json
@@ -25,14 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Organization Transport Settings",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Organization Management",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Organization Transport Settings"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Organization Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/settings.json
@@ -25,16 +25,22 @@
       }
     },
     "exchange": {
-      "requiredroles": [
-        "Security Reader",
-        "Transport Rules",
-        "View-Only Configuration"
-      ],
-      "requiredrolegroups": [
-        "Records Management",
-        "Security Reader",
-        "View-Only Organization Management"
-      ]
+      "requiredroles": {
+        "read": [
+          "View-Only Configuration"
+        ],
+        "update": [
+          "Transport Rules"
+        ]
+      },
+      "requiredrolegroups": {
+        "read": [
+          "View-Only Organization Management"
+        ],
+        "update": [
+          "Records Management"
+        ]
+      }
     }
   },
   "requiredModules": [],

--- a/Modules/Microsoft365DSC/Modules/M365DSCPermissions.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCPermissions.psm1
@@ -85,8 +85,14 @@ function Get-M365DSCCompiledPermissionList
                 }
             }
         )
-        RequiredRoles       = @()
-        RequiredRoleGroups  = @()
+        RequiredRoles       = @{
+            Read = @()
+            Update = @()
+        }
+        RequiredRoleGroups  = @{
+            Read = @()
+            Update = @()
+        }
     }
 
     $total = $ResourceNameList.Count
@@ -195,30 +201,54 @@ function Get-M365DSCCompiledPermissionList
             {
                 Write-Verbose -Message '  Retrieving Exchange permissions'
                 # Required Role
-                foreach ($requiredRole in $resourceSettings.permissions.exchange.requiredroles)
+                foreach ($requiredRole in $resourceSettings.permissions.exchange.requiredroles.read)
                 {
-                    if (-not $results.RequiredRoles.Contains($requiredRole))
+                    if (-not $results.RequiredRoles.Read.Contains($requiredRole))
                     {
-                        Write-Verbose -Message "    Found new Required Role {$($requiredRole)}"
-                        $results.RequiredRoles += $requiredRole
+                        Write-Verbose -Message "    Found new Read Required Role {$($requiredRole)}"
+                        $results.RequiredRoles.Read += $requiredRole
                     }
                     else
                     {
-                        Write-Verbose -Message "    Required Role {$($requiredRole)} was already added"
+                        Write-Verbose -Message "    Required Read Role {$($requiredRole)} was already added"
+                    }
+                }
+                foreach ($requiredRole in $resourceSettings.permissions.exchange.requiredroles.update)
+                {
+                    if (-not $results.RequiredRoles.Update.Contains($requiredRole))
+                    {
+                        Write-Verbose -Message "    Found new Update Required Role {$($requiredRole)}"
+                        $results.RequiredRoles.Update += $requiredRole
+                    }
+                    else
+                    {
+                        Write-Verbose -Message "    Required Update Role {$($requiredRole)} was already added"
                     }
                 }
 
                 # Required RoleGroups
-                foreach ($requiredRoleGroup in $resourceSettings.permissions.exchange.requiredrolegroups)
+                foreach ($requiredRoleGroup in $resourceSettings.permissions.exchange.requiredrolegroups.read)
                 {
-                    if (-not $results.RequiredRoleGroups.Contains($requiredRoleGroup))
+                    if (-not $results.RequiredRoleGroups.Read.Contains($requiredRoleGroup))
                     {
-                        Write-Verbose -Message "    Found new Required Role Group {$($requiredRoleGroup)}"
-                        $results.RequiredRoleGroups += $requiredRoleGroup
+                        Write-Verbose -Message "    Found new Read Required Role Group {$($requiredRoleGroup)}"
+                        $results.RequiredRoleGroups.Read += $requiredRoleGroup
                     }
                     else
                     {
-                        Write-Verbose -Message "    Required Role Group {$($requiredRoleGroup)} was already added"
+                        Write-Verbose -Message "    Required Read Role Group {$($requiredRoleGroup)} was already added"
+                    }
+                }
+                foreach ($requiredRoleGroup in $resourceSettings.permissions.exchange.requiredrolegroups.update)
+                {
+                    if (-not $results.RequiredRoleGroups.Update.Contains($requiredRoleGroup))
+                    {
+                        Write-Verbose -Message "    Found new Update Required Role Group {$($requiredRoleGroup)}"
+                        $results.RequiredRoleGroups.Update += $requiredRoleGroup
+                    }
+                    else
+                    {
+                        Write-Verbose -Message "    Required Update Role Group {$($requiredRoleGroup)} was already added"
                     }
                 }
 
@@ -363,10 +393,14 @@ function Get-M365DSCCompiledPermissionList
         $results = @{
             AdministrativeRoles = $results.AdministrativeRoles.$AccessType
             Permissions = $resultsByType
-            RequiredRoles = $results.RequiredRoles
+            RequiredRoles = $results.RequiredRoles | Select-Object -ExpandProperty $AccessType
+            RequiredRoleGroups = $results.RequiredRoleGroups | Select-Object -ExpandProperty $AccessType
         }
     }
 
+    $results.AdministrativeRoles = $results.AdministrativeRoles | Sort-Object -Unique
+    $results.RequiredRoleGroups = $results.RequiredRoleGroups | Sort-Object -Unique
+    $results.RequiredRoles = $results.RequiredRoles | Sort-Object -Unique
     return $results
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
This is the second refactoring of the EXO settings.json files in a short time, I know. Now, it includes the required Roles and RoleGroups according to the requirement for Read and Update and it can be used with `Get-M365DSCCompiledPermissionList` to exactly show the required roles / rolegroups.

This might be breaking because the output of `Get-M365DSCCompiledPermissionList` changes now. Previously, it included the roles and rolegroups as a string array, but now it's possible that it contains an array of objects with the two properties `Read` and `Update` to reflect which role / rolegroup is required for what access type, very similar to what we already for the Graph permissions.

In my opinion, the impact is not that big to make it breaking, but if there is something automated around this cmdlet, then it might break their automation.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
