### PR TITLE
Add verbose event message, fix issues and new parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * M365DSCUtil
   * Added the output of the drift event to the screen in Verbose mode.
     FIXES [#6666](https://github.com/microsoft/Microsoft365DSC/issues/6666)
+  * Added the parameter `-WithStatistics` to `Export-M365DSCConfiguration`.
   * Fixed an issue where the module is not being updated if installed
     with `Install-PSResource` because the filter condition was incorrect.
 * DEPENDENCIES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@
   * Updated the structure of all EXO settings.json files that contain the
     `Roles` and `RoleGroups` properties.
 * M365DSCUtil
+  * Added the output of the drift event to the screen in Verbose mode.
+    FIXES [#6666](https://github.com/microsoft/Microsoft365DSC/issues/6666)
   * Fixed an issue where the module is not being updated if installed
     with `Install-PSResource` because the filter condition was incorrect.
 * DEPENDENCIES
-* Updated ReverseDSC to version 2.0.0.31.
+  * Fixed a case typo in `RequiredVersion` of a dependency.
+    FIXES [#6815](https://github.com/microsoft/Microsoft365DSC/issues/6815)
+  * Updated ReverseDSC to version 2.0.0.31.
 
 # 1.26.114.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+* SPOSiteGroup
+  * Fixed a condition mismatch during export resulting in repeated logins.
 * M365DSCPermissions
   * Changed the output of `Get-M365DSCCompiledPermissionList` to show the
     required Read and Update permissions for `Roles` and `RoleGroups`.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteGroup/MSFT_SPOSiteGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSiteGroup/MSFT_SPOSiteGroup.psm1
@@ -68,7 +68,7 @@ function Get-TargetResource
 
     try
     {
-        if (-not $Script:exportedInstance -or $Script:exportedInstance.Url -ne $Url)
+        if (-not $Script:exportedInstance -or $Script:exportedInstance.Title -ne $Identity)
         {
             $null = New-M365DSCConnection -Workload 'PNP' `
                 -InboundParameters $PSBoundParameters

--- a/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
+++ b/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
@@ -34,7 +34,7 @@
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Applications'
-            Requiredversion = '2.28.0'
+            RequiredVersion = '2.28.0'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Authentication'

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -102,7 +102,11 @@ function Start-M365DSCConfigurationExtract
 
         [Parameter()]
         [System.Collections.Generic.Dictionary[System.String, System.Object]]
-        $ResourceSettings
+        $ResourceSettings,
+
+        [Parameter()]
+        [Switch]
+        $WithStatistics
     )
 
     # Start by checking to see if a new version of the tool is available in the PowerShell Gallery
@@ -687,8 +691,10 @@ function Start-M365DSCConfigurationExtract
         $partialExportName = $Global:PartialExportFileName
         $resourcesPath = $resourcesPath | Sort-Object $_.Name
         $synchronizedHashtable = [System.Collections.Hashtable]::Synchronized(@{
-            ResourceCounter = 1
-            ResourcesResult = @{}
+            ResourceCounter     = 1
+            ResourcesResult     = @{}
+            SuccessfulResources = 0
+            FailedResources     = 0
         })
         $resourceDictionary = Get-M365DSCAllResourcesDictionary
         $exportScriptBlock = {
@@ -798,10 +804,12 @@ function Start-M365DSCConfigurationExtract
                     $exportOutput = Export-TargetResource @parameters
                     $exportString.Append($exportOutput) | Out-Null
                     ($using:synchronizedHashtable).ResourcesResult.Add($resourceName, $exportString.ToString())
+                    ($using:synchronizedHashtable).SuccessfulResources++
                 }
                 catch
                 {
                     Write-M365DSCHost -Message "$($Global:M365DSCEmojiRedX)`r`n    An error occurred while exporting resource {$resourceName}: $($_.Exception.Message)" -ForegroundColor Red -CommitWrite
+                    ($using:synchronizedHashtable).FailedResources++
                     if ($ErrorActionPreference -eq 'Stop')
                     {
                         throw $_
@@ -883,7 +891,7 @@ function Start-M365DSCConfigurationExtract
                 $credsContent = ''
                 foreach ($credEntry in $Global:CredsRepo)
                 {
-                    if (!$credEntry.ToLower().StartsWith('builtin'))
+                    if (-not $credEntry.ToLower().StartsWith('builtin'))
                     {
                         if (!$AzureAutomation)
                         {
@@ -916,6 +924,16 @@ function Start-M365DSCConfigurationExtract
         Write-M365DSCHost -Message '} for {' -DeferWrite
         Write-M365DSCHost -Message "$($Global:M365DSCExportResourceInstancesCount) instances" -DeferWrite -ForegroundColor Magenta
         Write-M365DSCHost -Message '}' -CommitWrite
+        Write-M365DSCHost -Message "Successful exports: {$($synchronizedHashtable.SuccessfulResources)}"
+        Write-M365DSCHost -Message "Failed exports: {$($synchronizedHashtable.FailedResources)}"
+        if ($($synchronizedHashtable.FailedResources) -eq 0)
+        {
+            Write-M365DSCHost -Message "$($Global:M365DSCEmojiGreenCheckmark) Export completed successfully." -ForegroundColor Green
+        }
+        else
+        {
+            Write-M365DSCHost -Message "$($Global:M365DSCEmojiRedX) Export completed with errors." -ForegroundColor Red
+        }
         #endregion
 
         $sessions = Get-PSSession | Where-Object -FilterScript { $_.Name -like 'SfBPowerShellSessionViaTeamsModule_*' -or `
@@ -1075,6 +1093,15 @@ function Start-M365DSCConfigurationExtract
         }
 
         Pop-Location
+        if ($WithStatistics)
+        {
+            @{
+                ExportDurationInSeconds = $timeTaken.TotalSeconds
+                ExportedResourceCount   = $synchronizedHashtable.SuccessfulResources
+                FailedResourceCount     = $synchronizedHashtable.FailedResources
+                TotalResourceCount      = $synchronizedHashtable.SuccessfulResources + $synchronizedHashtable.FailedResources
+            }
+        }
     }
     catch
     {

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1326,7 +1326,8 @@ function Test-M365DSCTargetResource
                                       -ResourceName $ResourceName `
                                       -TenantName $TenantName `
                                       -CurrentValues $CurrentValues `
-                                      -DesiredValues $DesiredValues
+                                      -DesiredValues $DesiredValues `
+                                      -Verbose:$Verbose
     }
 
     Write-Verbose -Message "Test-M365DSCTargetResource returned $testTargetResource" -Verbose:$Verbose

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -1483,6 +1483,9 @@ Specifies that the configuration needs to be validated for conflicts or issues a
 .PARAMETER TokenReplacement
     Specifies the hashtable to use for token replacement. Key is the value to replace, and the value is the variable to use for replacement without the '$' sign.
 
+.PARAMETER WithStatistics
+    Specifies that statistics about the export should be shown after completion.
+
 .Example
 Export-M365DSCConfiguration -Components @("AADApplication", "AADConditionalAccessPolicy", "AADGroupsSettings") -Credential $Credential
 
@@ -1608,7 +1611,11 @@ function Export-M365DSCConfiguration
 
         [Parameter(ParameterSetName = 'Export')]
         [System.Collections.Hashtable]
-        $TokenReplacement
+        $TokenReplacement,
+
+        [Parameter(ParameterSetName = 'Export')]
+        [Switch]
+        $WithStatistics
     )
 
     $currentStartDateTime = [System.DateTime]::Now
@@ -1764,7 +1771,8 @@ function Export-M365DSCConfiguration
             -Validate:$Validate `
             -Parallel:$Parallel `
             -ResourceSettings $Script:M365DSCResourceSettings `
-            -ErrorAction $ErrorActionPreference
+            -ErrorAction $ErrorActionPreference `
+            -WithStatistics:$WithStatistics
     }
     elseif ($null -ne $Components)
     {
@@ -1787,7 +1795,8 @@ function Export-M365DSCConfiguration
             -Validate:$Validate `
             -Parallel:$Parallel `
             -ResourceSettings $Script:M365DSCResourceSettings `
-            -ErrorAction $ErrorActionPreference
+            -ErrorAction $ErrorActionPreference `
+            -WithStatistics:$WithStatistics
     }
     elseif ($null -ne $Mode)
     {
@@ -1811,7 +1820,8 @@ function Export-M365DSCConfiguration
             -Validate:$Validate `
             -Parallel:$Parallel `
             -ResourceSettings $Script:M365DSCResourceSettings `
-            -ErrorAction $ErrorActionPreference
+            -ErrorAction $ErrorActionPreference `
+            -WithStatistics:$WithStatistics
     }
 
     # Clear the exported resource instances' names Global variable


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes a typo in the `RequiredVersion` of a dependency and adds the drift event to the console output if `-Verbose` is specified. 

It also includes a fix for the very slow export of `SPOSiteGroup` as well as a new parameter `-WithStatistics` for `Export-M365DSCConfiguration`. The parameter outputs diagnostics information about the export with the following information: 

- Time taken
- Failed resources
- Successful resources
- Total resources

Be aware that "resource" in this context means the resource itself, not an instance of the resource. If one instance of a resource fails and the catch block of the export is not hit, it will not register as a failed resource.

@SNikalaichyk It looks like the following now if you specify `-Verbose` for e.g. `Test-DscConfiguration`. I guess this should suffice now?

<img width="1681" height="1064" alt="image" src="https://github.com/user-attachments/assets/23671c8b-a87e-49b3-9391-0e17f8293c91" />


#### This Pull Request (PR) fixes the following issues
- Fixes #6666 
- Fixes #6815 

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
