### PR TITLE
Fix comparison of app installation options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* O365OrgSettings
+  * Fixed an issue where comparing empty app installation options failed.
+    FIXES [#6812](https://github.com/microsoft/Microsoft365DSC/issues/6812)
+
 # 1.26.121.1
 
 * AADGroup

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
@@ -303,8 +303,8 @@ function Get-TargetResource
 
             $results += @{
                 InstallationOptionsUpdateChannel  = $installationOptions.updateChannel
-                InstallationOptionsAppsForWindows = $appsForWindowsValue | Sort-Object
-                InstallationOptionsAppsForMac     = $appsForMacValue | Sort-Object
+                InstallationOptionsAppsForWindows = @($appsForWindowsValue | Sort-Object)
+                InstallationOptionsAppsForMac     = @($appsForMacValue | Sort-Object)
             }
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes a comparison issue for the app installation options in `O365OrgSettings`.

#### This Pull Request (PR) fixes the following issues
- Fixes #6812 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
