### PR TITLE
Fix handling of renamed property name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * EXOTransportRule
   * Updated logic to properly handle the Enabled property.
+* IntuneAntivirusPolicyWindows10SettingCatalog
+  * Fixed an issue where the property `TamperProtection` was renamed to
+    `ControlledConfiguration` in the Settings Catalog backend.
 * M365DSCPermissions
   * Fixed an issue where Purview permissions were not in the correct format.
     FIXES [#6822](https://github.com/microsoft/Microsoft365DSC/issues/6822)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * IntuneAntivirusPolicyWindows10SettingCatalog
   * Fixed an issue where the property `TamperProtection` was renamed to
     `ControlledConfiguration` in the Settings Catalog backend.
+    FIXES [#6855](https://github.com/microsoft/Microsoft365DSC/issues/6855)
 * M365DSCPermissions
   * Fixed an issue where Purview permissions were not in the correct format.
     FIXES [#6822](https://github.com/microsoft/Microsoft365DSC/issues/6822)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
@@ -349,6 +349,11 @@ function Get-TargetResource
         $SubmitSamplesConsent,
 
         [Parameter()]
+        [ValidateSet('Onboarding', 'Offboarding', 'ControlledConfig_Onboarding')]
+        [System.String]
+        $ControlledConfiguration,
+
+        [Parameter()]
         [ValidateSet('Onboarding', 'Offboarding')]
         [System.String]
         $TamperProtection,
@@ -913,6 +918,11 @@ function Set-TargetResource
         $SubmitSamplesConsent,
 
         [Parameter()]
+        [ValidateSet('Onboarding', 'Offboarding', 'ControlledConfig_Onboarding')]
+        [System.String]
+        $ControlledConfiguration,
+
+        [Parameter()]
         [ValidateSet('Onboarding', 'Offboarding')]
         [System.String]
         $TamperProtection,
@@ -1005,6 +1015,12 @@ function Set-TargetResource
 
     $currentPolicy = Get-TargetResource @PSBoundParameters
     $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+
+    if ($BoundParameters.ContainsKey('TamperProtection'))
+    {
+        $BoundParameters['ControlledConfiguration'] = $BoundParameters['TamperProtection']
+        $BoundParameters.Remove('TamperProtection')
+    }
 
     if ($BoundParameters.ContainsKey('SevereThreats'))
     {
@@ -1444,6 +1460,11 @@ function Test-TargetResource
         $SubmitSamplesConsent,
 
         [Parameter()]
+        [ValidateSet('Onboarding', 'Offboarding', 'ControlledConfig_Onboarding')]
+        [System.String]
+        $ControlledConfiguration,
+
+        [Parameter()]
         [ValidateSet('Onboarding', 'Offboarding')]
         [System.String]
         $TamperProtection,
@@ -1708,6 +1729,18 @@ function Get-CompareParameters
                         }
                     }
                 }
+            }
+
+            # Map the renaming of TamperProtection to ControlledConfiguration for comparison
+            if ($DesiredValues.ContainsKey('TamperProtection'))
+            {
+                $DesiredValues['ControlledConfiguration'] = $DesiredValues['TamperProtection']
+                $DesiredValues.Remove('TamperProtection')
+            }
+            if ($CurrentValues.ContainsKey('TamperProtection'))
+            {
+                $CurrentValues['ControlledConfiguration'] = $CurrentValues['TamperProtection']
+                $CurrentValues.Remove('TamperProtection')
             }
 
             return [System.Tuple[Hashtable, Hashtable, Hashtable]]::new($DesiredValues, $CurrentValues, $ValuesToCheck)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.schema.mof
@@ -17,7 +17,7 @@ class MSFT_IntuneAntivirusPolicyWindows10SettingCatalog : OMI_BaseResource
     [Write, Description("Identity of the endpoint protection policy for Windows 10.")] String Identity;
     [Write, Description("Description of the endpoint protection policy for Windows 10.")] String Description;
     [Write, Description("List of Scope Tags for this Entity instance.")] String RoleScopeTagIds[];
-    [Write, Description("Tamper protection (Device). (Offboarding, Onboarding)"), ValueMap{"Onboarding","Offboarding","ControlledConfig_Onboarding"}, Values{"Onboarding","Offboarding","ControlledConfig_Onboarding"}] String ControlledConfiguration;
+    [Write, Description("Tamper protection (Device). (Offboarding, Onboarding, ControlledConfig_Onboarding)"), ValueMap{"Onboarding","Offboarding","ControlledConfig_Onboarding"}, Values{"Onboarding","Offboarding","ControlledConfig_Onboarding"}] String ControlledConfiguration;
     [Write, Description("Tamper protection (Device). (Offboarding, Onboarding)"), ValueMap{"Onboarding","Offboarding"}, Values{"Onboarding","Offboarding"}] String TamperProtection;
     [Write, Description("Use this policy setting to specify if to display the Account protection area in Windows Defender Security Center. (0: disable feature. 1: enable feature)"), ValueMap{"0","1"}, Values{"0","1"}] String DisableAccountProtectionUI;
     [Write, Description("Use this policy setting if you want to disable the display of the app and browser protection area in Windows Defender Security Center. (0: disable feature. 1: enable feature)"), ValueMap{"0","1"}, Values{"0","1"}] String DisableAppBrowserUI;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.schema.mof
@@ -10,13 +10,14 @@ class MSFT_DeviceManagementConfigurationPolicyAssignments
     [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
 };
 
-[ClassVersion("1.0.0.2"), FriendlyName("IntuneAntivirusPolicyWindows10SettingCatalog")]
+[ClassVersion("1.0.0.3"), FriendlyName("IntuneAntivirusPolicyWindows10SettingCatalog")]
 class MSFT_IntuneAntivirusPolicyWindows10SettingCatalog : OMI_BaseResource
 {
     [Key, Description("Display name of the endpoint protection policy for Windows 10.")] String DisplayName;
     [Write, Description("Identity of the endpoint protection policy for Windows 10.")] String Identity;
     [Write, Description("Description of the endpoint protection policy for Windows 10.")] String Description;
     [Write, Description("List of Scope Tags for this Entity instance.")] String RoleScopeTagIds[];
+    [Write, Description("Tamper protection (Device). (Offboarding, Onboarding)"), ValueMap{"Onboarding","Offboarding","ControlledConfig_Onboarding"}, Values{"Onboarding","Offboarding","ControlledConfig_Onboarding"}] String ControlledConfiguration;
     [Write, Description("Tamper protection (Device). (Offboarding, Onboarding)"), ValueMap{"Onboarding","Offboarding"}, Values{"Onboarding","Offboarding"}] String TamperProtection;
     [Write, Description("Use this policy setting to specify if to display the Account protection area in Windows Defender Security Center. (0: disable feature. 1: enable feature)"), ValueMap{"0","1"}, Values{"0","1"}] String DisableAccountProtectionUI;
     [Write, Description("Use this policy setting if you want to disable the display of the app and browser protection area in Windows Defender Security Center. (0: disable feature. 1: enable feature)"), ValueMap{"0","1"}, Values{"0","1"}] String DisableAppBrowserUI;


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where the property `TamperProtection` was silently renamed to `ControlledConfiguration` in the Settings Catalog backend for `IntuneAntivirusPolicyWindows10SettingCatalog`.

#### This Pull Request (PR) fixes the following issues
- Fixes #6855 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
