### PR TITLE
IntuneAntivirusPolicyWindows10SettingCatalog: Add missing property ControlledConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * EXOTransportRule
   * Updated logic to properly handle the Enabled property.
+* IntuneAntivirusPolicyWindows10SettingCatalog
+  * Added missing property `ControlledConfiguration`.
 * M365DSCPermissions
   * Fixed an issue where Purview permissions were not in the correct format.
     FIXES [#6822](https://github.com/microsoft/Microsoft365DSC/issues/6822)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Updated logic to properly handle the Enabled property.
 * IntuneAntivirusPolicyWindows10SettingCatalog
   * Added missing property `ControlledConfiguration`.
+    FIXES [#6855](https://github.com/microsoft/Microsoft365DSC/issues/6855)
 * M365DSCPermissions
   * Fixed an issue where Purview permissions were not in the correct format.
     FIXES [#6822](https://github.com/microsoft/Microsoft365DSC/issues/6822)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
@@ -128,6 +128,11 @@ function Get-TargetResource
         $CompanyName,
 
         [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ControlledConfiguration,
+
+        [Parameter()]
         [System.Int32]
         $DaysToRetainCleanedMalware,
 
@@ -692,6 +697,11 @@ function Set-TargetResource
         $CompanyName,
 
         [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ControlledConfiguration,
+
+        [Parameter()]
         [System.Int32]
         $DaysToRetainCleanedMalware,
 
@@ -1221,6 +1231,11 @@ function Test-TargetResource
         [Parameter()]
         [System.String]
         $CompanyName,
+
+        [Parameter()]
+        [ValidateSet('0', '1')]
+        [System.String]
+        $ControlledConfiguration,
 
         [Parameter()]
         [System.Int32]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.schema.mof
@@ -33,6 +33,7 @@ class MSFT_IntuneAntivirusPolicyWindows10SettingCatalog : OMI_BaseResource
     [Write, Description("Enable this policy to display your company name and contact options in the notifications. (0: disable feature. 1: enable feature)"), ValueMap{"0","1"}, Values{"0","1"}] String EnableCustomizedToasts;
     [Write, Description("Enable this policy to have your company name and contact options displayed in a contact card fly out in Windows Defender Security Center. (0: disable feature. 1: enable feature)"), ValueMap{"0","1"}, Values{"0","1"}] String EnableInAppCustomization;
     [Write, Description("The company name that is displayed to the users. CompanyName is required for both EnableCustomizedToasts and EnableInAppCustomization.")] String CompanyName;
+    [Write, Description("This setting can be used to turn on controlled configuration or tamper protection to help protect important security features from unwanted changes and interference. If the setting is configured to Tamper Protection (On), this turns on tamper protection to enforce tamper protected settings to their secure defaults. This includes real-time protection, behavior monitoring, and more. Settings are configured with an MDM solution, such as Intune and is available in Windows 10 Enterprise E5 or equivalent subscriptions. If the setting is configured to Controlled Configuration (On), this turns on controlled configuration, which enforces the configuration coming from Intune exclusively and any non-configured settings to their secure defaults. Controlled configuration is applicable to Antivirus and Endpoint detection and response settings. If the setting is configured to OFF, this turns off Controlled Configuration and Tamper Protection."), ValueMap{"0","1"}, Values{"0","1"}] String ControlledConfiguration;
     [Write, Description("The email address that is displayed to users. The default mail application is used to initiate email actions.")] String Email;
     [Write, Description("The phone number or Skype ID that is displayed to users. Skype is used to initiate the call.")] String Phone;
     [Write, Description("The help portal URL that is displayed to users. The default browser is used to initiate this action.")] String URL;
@@ -100,6 +101,6 @@ class MSFT_IntuneAntivirusPolicyWindows10SettingCatalog : OMI_BaseResource
     [Write, Description("Name of the Azure Active Directory tenant used for authentication. Format contoso.onmicrosoft.com")] String TenantId;
     [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
     [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
-	[Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
     [Write, Description("Access token used for authentication.")] String AccessTokens[];
 };


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds missing property *ControlledConfiguration* to resource *IntuneAntivirusPolicyWindows10SettingCatalog*

#### This Pull Request (PR) fixes the following issues
- Fixes #6855 

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [X] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
