### PR TITLE
Breaking Change - Fix Access Review Definition ScopeValue Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+* AADAccessReviewDefinition
+  * [BREAKING CHANGE] Fixed the type definition of the `ScopeValue` property.
 * EXOTransportRule
   * Updated logic to properly handle the Enabled property.
 * M365DSCPermissions

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAccessReviewDefinition/MSFT_AADAccessReviewDefinition.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAccessReviewDefinition/MSFT_AADAccessReviewDefinition.psm1
@@ -148,6 +148,7 @@ function Get-TargetResource
             $myPrincipalScopes.Add('Query', $currentPrincipalScopes.query)
             $myPrincipalScopes.Add('QueryRoot', $currentPrincipalScopes.queryRoot)
             $myPrincipalScopes.Add('QueryType', $currentPrincipalScopes.queryType)
+            $myPrincipalScopes.Add('ScopeType', $currentPrincipalScopes.scopeType)
             if ($null -ne $currentPrincipalScopes.'@odata.type')
             {
                 $myPrincipalScopes.Add('odataType', $currentPrincipalScopes.'@odata.type'.ToString())
@@ -165,6 +166,9 @@ function Get-TargetResource
             $myResourceScopes.Add('Query', $currentResourceScopes.query)
             $myResourceScopes.Add('QueryRoot', $currentResourceScopes.queryRoot)
             $myResourceScopes.Add('QueryType', $currentResourceScopes.queryType)
+            $myResourceScopes.Add('DisplayName', $currentResourceScopes.displayName)
+            $myResourceScopes.Add('ResourceScopeId', $currentResourceScopes.resourceId)
+            $myResourceScopes.Add('ScopeType', $currentResourceScopes.scopeType)
             if ($null -ne $currentResourceScopes.'@odata.type')
             {
                 $myResourceScopes.Add('odataType', $currentResourceScopes.'@odata.type'.ToString())
@@ -175,7 +179,6 @@ function Get-TargetResource
             }
         }
         $complexScope.Add('ResourceScopes', $complexResourceScopes)
-
 
         if ($null -ne $getValue.Scope.AdditionalProperties.'@odata.type')
         {
@@ -366,6 +369,7 @@ function Get-TargetResource
                 }
                 $myFallbackReviewer = [ordered]@{}
                 $myFallbackReviewer.Add('DisplayName', $currentQuery.body.displayName)
+                $myFallbackReviewer.Add('ScopeType', $currentFallbackReviewer.AdditionalProperties.scopeType)
                 $myFallbackReviewer.Add('Type', $reviewerType)
                 $complexFallbackReviewers += $myFallbackReviewer
             }
@@ -374,12 +378,8 @@ function Get-TargetResource
         $complexReviewers = @()
         $allQueries = $getValue.Reviewers.Query
         $batchRequests = @()
-        foreach ($query in $allQueries)
+        foreach ($query in $($allQueries | Where-Object { $_ -notlike "*manager*" -and -not [System.String]::IsNullOrEmpty($_) }))
         {
-            if ($query -like "*manager*")
-            {
-                continue
-            }
             $batchRequests += @{
                 id     = $query
                 method = 'GET'
@@ -416,6 +416,7 @@ function Get-TargetResource
             }
             $myReviewer = [ordered]@{}
             $myReviewer.Add('DisplayName', $currentQuery.body.displayName)
+            $myReviewer.Add('ScopeType', $currentReviewer.AdditionalProperties.scopeType)
             $myReviewer.Add('Type', $reviewerType)
             $complexReviewers += $myReviewer
         }
@@ -606,7 +607,7 @@ function Set-TargetResource
         $batchRequests = @()
         foreach ($currentReviewer in $Reviewers)
         {
-            if ($currentReviewer.Type -eq 'Manager')
+            if ($currentReviewer.Type -eq 'Manager' -or $currentReviewer.ScopeType -in @('Manager', 'ResourceOwner'))
             {
                 continue
             }
@@ -699,6 +700,14 @@ function Set-TargetResource
         $createParameters = Rename-M365DSCCimInstanceParameter -Properties $createParameters
         $createParameters.Remove('Id') | Out-Null
 
+        foreach ($scope in $createParameters.ScopeValue.ResourceScopes)
+        {
+            if ($scope.ContainsKey('ResourceScopeId'))
+            {
+                $scope.Add('ResourceId', $scope.ResourceScopeId)
+                $scope.Remove('ResourceScopeId') | Out-Null
+            }
+        }
         $createParameters.Add('Scope', $createParameters.ScopeValue)
         $createParameters.Remove('ScopeValue') | Out-Null
 
@@ -752,6 +761,14 @@ function Set-TargetResource
 
         $createParameters.Remove('Id') | Out-Null
 
+        foreach ($scope in $createParameters.ScopeValue.ResourceScopes)
+        {
+            if ($scope.ContainsKey('ResourceScopeId'))
+            {
+                $scope.Add('ResourceId', $scope.ResourceScopeId)
+                $scope.Remove('ResourceScopeId') | Out-Null
+            }
+        }
         $createParameters.Add('Scope', $createParameters.ScopeValue)
         $createParameters.Remove('ScopeValue') | Out-Null
 
@@ -809,6 +826,14 @@ function Set-TargetResource
 
         $updateParameters.Remove('Id') | Out-Null
 
+        foreach ($scope in $updateParameters.ScopeValue.ResourceScopes)
+        {
+            if ($scope.ContainsKey('ResourceScopeId'))
+            {
+                $scope.Add('ResourceId', $scope.ResourceScopeId)
+                $scope.Remove('ResourceScopeId') | Out-Null
+            }
+        }
         $updateParameters.Add('Scope', $updateParameters.ScopeValue)
         $updateParameters.Remove('ScopeValue') | Out-Null
 
@@ -1049,12 +1074,12 @@ function Export-TargetResource
                     }
                     @{
                         Name            = 'PrincipalScopes'
-                        CimInstanceName = 'MicrosoftGraphAccessReviewScope'
+                        CimInstanceName = 'MicrosoftGraphAccessReviewPrincipalScope'
                         IsRequired      = $False
                     }
                     @{
                         Name            = 'ResourceScopes'
-                        CimInstanceName = 'MicrosoftGraphAccessReviewScope'
+                        CimInstanceName = 'MicrosoftGraphAccessReviewResourceScope'
                         IsRequired      = $False
                     }
                 )

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAccessReviewDefinition/MSFT_AADAccessReviewDefinition.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAccessReviewDefinition/MSFT_AADAccessReviewDefinition.schema.mof
@@ -1,11 +1,28 @@
 [ClassVersion("1.0.0")]
-class MSFT_MicrosoftGraphAccessReviewScope
+class MSFT_MicrosoftGraphAccessReviewPrincipalScope
 {
     [Write, Description("The query representing what will be reviewed in an access review.")] String Query;
     [Write, Description("In the scenario where reviewers need to be specified dynamically, this property is used to indicate the relative source of the query. This property is only required if a relative query is specified. For example, ./manager.")] String QueryRoot;
     [Write, Description("Indicates the type of query. Types include MicrosoftGraph and ARM.")] String QueryType;
-    [Write, Description("Defines the scopes of the principals for which access to resources are reviewed in the access review."), EmbeddedInstance("MSFT_MicrosoftGraphAccessReviewScope")] String PrincipalScopes[];
-    [Write, Description("Defines the scopes of the resources for which access is reviewed."), EmbeddedInstance("MSFT_MicrosoftGraphAccessReviewScope")] String ResourceScopes[];
+    [Write, Description("The type of the entity."), ValueMap{"#microsoft.graph.accessReviewPrincipalScope","#microsoft.graph.accessReviewQueryScope"}, Values{"#microsoft.graph.accessReviewPrincipalScope","#microsoft.graph.accessReviewQueryScope"}] String odataType;
+    [Write, Description("The type of users to include in the review. The possible values are: allUsers, guestUsers, inactiveUsers, inactiveGuestUsers."), ValueMap{"allUsers","guestUsers","inactiveUsers","inactiveGuestUsers"}, Values{"allUsers","guestUsers","inactiveUsers","inactiveGuestUsers"}] String scopeType;
+};
+[ClassVersion("1.0.0")]
+class MSFT_MicrosoftGraphAccessReviewResourceScope
+{
+    [Write, Description("The query representing what will be reviewed in an access review.")] String Query;
+    [Write, Description("In the scenario where reviewers need to be specified dynamically, this property is used to indicate the relative source of the query. This property is only required if a relative query is specified. For example, ./manager.")] String QueryRoot;
+    [Write, Description("Indicates the type of query. Types include MicrosoftGraph and ARM.")] String QueryType;
+    [Write, Description("The type of the entity."), ValueMap{"#microsoft.graph.accessReviewResourceScope"}, Values{"#microsoft.graph.accessReviewResourceScope"}] String odataType;
+    [Write, Description("The display name of the resource.")] String displayName;
+    [Write, Description("The identifier of the resource.")] String resourceScopeId;
+    [Write, Description("The type of users to include in the review. The possible values are: group, catalog, servicePrincipal, directoryRole, accessPackageAssignmentPolicy."), ValueMap{"group","catalog","servicePrincipal","directoryRole","accessPackageAssignmentPolicy"}, Values{"group","catalog","servicePrincipal","directoryRole","accessPackageAssignmentPolicy"}] String scopeType;
+};
+[ClassVersion("1.0.1")]
+class MSFT_MicrosoftGraphAccessReviewScope
+{
+    [Write, Description("Defines the scopes of the principals for which access to resources are reviewed in the access review."), EmbeddedInstance("MSFT_MicrosoftGraphAccessReviewPrincipalScope")] String PrincipalScopes[];
+    [Write, Description("Defines the scopes of the resources for which access is reviewed."), EmbeddedInstance("MSFT_MicrosoftGraphAccessReviewResourceScope")] String ResourceScopes[];
     [Write, Description("The type of the entity."), ValueMap{"#microsoft.graph.accessReviewQueryScope","#microsoft.graph.accessReviewReviewerScope","#microsoft.graph.principalResourceMembershipsScope","#microsoft.graph.accessReviewInactiveUsersQueryScope"}, Values{"#microsoft.graph.accessReviewQueryScope","#microsoft.graph.accessReviewReviewerScope","#microsoft.graph.principalResourceMembershipsScope","#microsoft.graph.accessReviewInactiveUsersQueryScope"}] String odataType;
 };
 [ClassVersion("1.0.0")]
@@ -74,11 +91,12 @@ class MSFT_MicrosoftGraphAccessReviewStageSettings
     [Required, Description("Indicates whether showing recommendations to reviewers is enabled. Required. NOTE: The value of this property overrides the corresponding setting on the accessReviewScheduleDefinition object.")] Boolean RecommendationsEnabled;
     [Write, Description("Unique identifier of the accessReviewStageSettings. The stageId is used in dependsOn property to indicate the stage relationship. Required.")] String StageId;
 };
-[ClassVersion("1.0.0")]
+[ClassVersion("1.0.1")]
 class MSFT_AADAccessReviewDefinitionReviewer
 {
     [Write, Description("Indicates the display name of the current reviewer, either of a group or of a user.")] String DisplayName;
     [Write, Description("Indicates the type of reviewer. Possible values: Manager, Owner, User, Group"), ValueMap{"Manager", "Owner", "User", "Group"}, Values{"Manager", "Owner", "User", "Group"}] String Type;
+    [Write, Description("Indicates the type of reviewer. Possible values: User, Group, Self, Manager, Sponsor, ResourceOwner, ManagerOrSponsor"), ValueMap{"User", "Group", "Self", "Manager", "Sponsor", "ResourceOwner", "ManagerOrSponsor"}, Values{"User", "Group", "Self", "Manager", "Sponsor", "ResourceOwner", "ManagerOrSponsor"}] String ScopeType;
 };
 
 [ClassVersion("1.0.0.0"), FriendlyName("AADAccessReviewDefinition")]


### PR DESCRIPTION
#### Pull Request (PR) description
This PR updates the format for the permission and resource scopes of the `AADAccessReviewDefinition` resource. 
Usually, this could be considered a breaking change because it changes the structure of the object, but there was no possible way to create such an Access Review Definition in the GUI. The only way to create it now is through a feature that's still in preview, called Catalog Reviews - Multi Resource.

<img width="386" height="247" alt="image" src="https://github.com/user-attachments/assets/bd4acb54-1b81-49f5-903a-64f3b35d78aa" />

Because this is only preview for now and was not previously part of the experience, I believe this is justified to be changed. My test policies were not affected by this change and still contained the same definitions as before.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
