### PR TITLE
Remove SkipModuleReload logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * M365DSCPermissions
   * Fixed an issue where Purview permissions were not in the correct format.
     FIXES [#6822](https://github.com/microsoft/Microsoft365DSC/issues/6822)
+* M365DSCUtil
+  * Removed the parameter `SkipModuleReload` from `New-M365DSCConnection`.
+* MISC
+  * Removed the `SkipModuleReload` logic from all resources.
 
 # 1.26.121.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAcceptedDomain/MSFT_EXOAcceptedDomain.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAcceptedDomain/MSFT_EXOAcceptedDomain.psm1
@@ -347,8 +347,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/MSFT_EXOActiveSyncDeviceAccessRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOActiveSyncDeviceAccessRule/MSFT_EXOActiveSyncDeviceAccessRule.psm1
@@ -368,8 +368,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressBookPolicy/MSFT_EXOAddressBookPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressBookPolicy/MSFT_EXOAddressBookPolicy.psm1
@@ -374,8 +374,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressList/MSFT_EXOAddressList.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAddressList/MSFT_EXOAddressList.psm1
@@ -678,8 +678,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishPolicy/MSFT_EXOAntiPhishPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishPolicy/MSFT_EXOAntiPhishPolicy.psm1
@@ -802,8 +802,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishRule/MSFT_EXOAntiPhishRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAntiPhishRule/MSFT_EXOAntiPhishRule.psm1
@@ -473,8 +473,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOApplicationAccessPolicy/MSFT_EXOApplicationAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOApplicationAccessPolicy/MSFT_EXOApplicationAccessPolicy.psm1
@@ -413,8 +413,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/MSFT_EXOArcConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOArcConfig/MSFT_EXOArcConfig.psm1
@@ -294,8 +294,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
@@ -330,8 +330,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAuthenticationPolicy/MSFT_EXOAuthenticationPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAuthenticationPolicy/MSFT_EXOAuthenticationPolicy.psm1
@@ -473,8 +473,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityAddressSpace/MSFT_EXOAvailabilityAddressSpace.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityAddressSpace/MSFT_EXOAvailabilityAddressSpace.psm1
@@ -439,8 +439,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityConfig/MSFT_EXOAvailabilityConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOAvailabilityConfig/MSFT_EXOAvailabilityConfig.psm1
@@ -307,8 +307,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxPlan/MSFT_EXOCASMailboxPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxPlan/MSFT_EXOCASMailboxPlan.psm1
@@ -378,8 +378,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxSettings/MSFT_EXOCASMailboxSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxSettings/MSFT_EXOCASMailboxSettings.psm1
@@ -729,8 +729,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCalendarProcessing/MSFT_EXOCalendarProcessing.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCalendarProcessing/MSFT_EXOCalendarProcessing.psm1
@@ -205,17 +205,8 @@ function Get-TargetResource
 
     Write-Verbose -Message "Getting configuration of Calendar Processing settings for $Identity"
 
-    if ($Global:CurrentModeIsExport)
-    {
-        $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-            -InboundParameters $PSBoundParameters `
-            -SkipModuleReload $true
-    }
-    else
-    {
-        $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-            -InboundParameters $PSBoundParameters
-    }
+    $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
@@ -875,8 +866,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataClassification/MSFT_EXODataClassification.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataClassification/MSFT_EXODataClassification.psm1
@@ -389,8 +389,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataEncryptionPolicy/MSFT_EXODataEncryptionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataEncryptionPolicy/MSFT_EXODataEncryptionPolicy.psm1
@@ -383,8 +383,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/MSFT_EXODistributionGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODistributionGroup/MSFT_EXODistributionGroup.psm1
@@ -1074,8 +1074,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODkimSigningConfig/MSFT_EXODkimSigningConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODkimSigningConfig/MSFT_EXODkimSigningConfig.psm1
@@ -377,8 +377,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODnssecForVerifiedDomain/MSFT_EXODnssecForVerifiedDomain.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODnssecForVerifiedDomain/MSFT_EXODnssecForVerifiedDomain.psm1
@@ -43,17 +43,8 @@ function Get-TargetResource
 
     try
     {
-        if ($Global:CurrentModeIsExport)
-        {
-            $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-                -InboundParameters $PSBoundParameters `
-                -SkipModuleReload $true
-        }
-        else
-        {
-            $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-                -InboundParameters $PSBoundParameters
-        }
+        $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
+            -InboundParameters $PSBoundParameters
 
         #Ensure the proper dependencies are installed in the current environment.
         Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailAddressPolicy/MSFT_EXOEmailAddressPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailAddressPolicy/MSFT_EXOEmailAddressPolicy.psm1
@@ -393,8 +393,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailTenantSettings/MSFT_EXOEmailTenantSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEmailTenantSettings/MSFT_EXOEmailTenantSettings.psm1
@@ -347,7 +347,8 @@ function Export-TargetResource
         $AccessTokens
     )
 
-    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' -InboundParameters $PSBoundParameters -SkipModuleReload $true
+    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGlobalAddressList/MSFT_EXOGlobalAddressList.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGlobalAddressList/MSFT_EXOGlobalAddressList.psm1
@@ -658,8 +658,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGroupSettings/MSFT_EXOGroupSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOGroupSettings/MSFT_EXOGroupSettings.psm1
@@ -1058,8 +1058,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedConnectionFilterPolicy/MSFT_EXOHostedConnectionFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedConnectionFilterPolicy/MSFT_EXOHostedConnectionFilterPolicy.psm1
@@ -396,8 +396,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
@@ -1041,8 +1041,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/MSFT_EXOHostedContentFilterRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterRule/MSFT_EXOHostedContentFilterRule.psm1
@@ -484,6 +484,7 @@ function Export-TargetResource
         [System.String[]]
         $AccessTokens
     )
+
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
 
@@ -497,8 +498,7 @@ function Export-TargetResource
     #endregion
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     try
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterPolicy/MSFT_EXOHostedOutboundSpamFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterPolicy/MSFT_EXOHostedOutboundSpamFilterPolicy.psm1
@@ -436,8 +436,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterRule/MSFT_EXOHostedOutboundSpamFilterRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedOutboundSpamFilterRule/MSFT_EXOHostedOutboundSpamFilterRule.psm1
@@ -479,8 +479,7 @@ function Export-TargetResource
     #endregion
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     try
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIRMConfiguration/MSFT_EXOIRMConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIRMConfiguration/MSFT_EXOIRMConfiguration.psm1
@@ -497,7 +497,8 @@ function Export-TargetResource
         $AccessTokens
     )
 
-    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' -InboundParameters $PSBoundParameters -SkipModuleReload $true
+    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOInboundConnector/MSFT_EXOInboundConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOInboundConnector/MSFT_EXOInboundConnector.psm1
@@ -538,8 +538,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIntraOrganizationConnector/MSFT_EXOIntraOrganizationConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOIntraOrganizationConnector/MSFT_EXOIntraOrganizationConnector.psm1
@@ -370,8 +370,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOJournalRule/MSFT_EXOJournalRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOJournalRule/MSFT_EXOJournalRule.psm1
@@ -378,8 +378,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailContact/MSFT_EXOMailContact.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailContact/MSFT_EXOMailContact.psm1
@@ -777,8 +777,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxAutoReplyConfiguration/MSFT_EXOMailboxAutoReplyConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxAutoReplyConfiguration/MSFT_EXOMailboxAutoReplyConfiguration.psm1
@@ -110,17 +110,8 @@ function Get-TargetResource
 
     try
     {
-        if ($Global:CurrentModeIsExport)
-        {
-            $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-                -InboundParameters $PSBoundParameters `
-                -SkipModuleReload $true
-        }
-        else
-        {
-            $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-                -InboundParameters $PSBoundParameters
-        }
+        $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
+            -InboundParameters $PSBoundParameters
 
         #Ensure the proper dependencies are installed in the current environment.
         Confirm-M365DSCDependencies
@@ -481,8 +472,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxCalendarConfiguration/MSFT_EXOMailboxCalendarConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxCalendarConfiguration/MSFT_EXOMailboxCalendarConfiguration.psm1
@@ -212,17 +212,8 @@ function Get-TargetResource
 
     try
     {
-        if ($Global:CurrentModeIsExport)
-        {
-            $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-                -InboundParameters $PSBoundParameters `
-                -SkipModuleReload $true
-        }
-        else
-        {
-            $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-                -InboundParameters $PSBoundParameters
-        }
+        $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
+            -InboundParameters $PSBoundParameters
 
         #Ensure the proper dependencies are installed in the current environment.
         Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxCalendarFolder/MSFT_EXOMailboxCalendarFolder.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxCalendarFolder/MSFT_EXOMailboxCalendarFolder.psm1
@@ -79,17 +79,8 @@ function Get-TargetResource
 
     try
     {
-        if ($Global:CurrentModeIsExport)
-        {
-            $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-                -InboundParameters $PSBoundParameters `
-                -SkipModuleReload $true
-        }
-        else
-        {
-            $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-                -InboundParameters $PSBoundParameters
-        }
+        $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
+            -InboundParameters $PSBoundParameters
 
         #Ensure the proper dependencies are installed in the current environment.
         Confirm-M365DSCDependencies
@@ -388,8 +379,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxFolderPermission/MSFT_EXOMailboxFolderPermission.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxFolderPermission/MSFT_EXOMailboxFolderPermission.psm1
@@ -56,17 +56,8 @@ function Get-TargetResource
 
     try
     {
-        if ($Global:CurrentModeIsExport)
-        {
-            $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-                -InboundParameters $PSBoundParameters `
-                -SkipModuleReload $true
-        }
-        else
-        {
-            $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-                -InboundParameters $PSBoundParameters
-        }
+        $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
+            -InboundParameters $PSBoundParameters
 
         #Ensure the proper dependencies are installed in the current environment.
         Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPermission/MSFT_EXOMailboxPermission.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPermission/MSFT_EXOMailboxPermission.psm1
@@ -368,8 +368,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPlan/MSFT_EXOMailboxPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxPlan/MSFT_EXOMailboxPlan.psm1
@@ -426,8 +426,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxSettings/MSFT_EXOMailboxSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMailboxSettings/MSFT_EXOMailboxSettings.psm1
@@ -83,17 +83,8 @@ function Get-TargetResource
         if (-not $Script:exportedInstance -or $Script:exportedInstance.UserPrincipalName -ne $DisplayName)
         {
             Write-Verbose -Message "No cached instance found, retrieving from service."
-            if ($Global:CurrentModeIsExport)
-            {
-                $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-                    -InboundParameters $PSBoundParameters `
-                    -SkipModuleReload $true
-            }
-            else
-            {
-                $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
-                    -InboundParameters $PSBoundParameters
-            }
+            $null = New-M365DSCConnection -Workload 'ExchangeOnline' `
+                -InboundParameters $PSBoundParameters
 
             #Ensure the proper dependencies are installed in the current environment.
             Confirm-M365DSCDependencies
@@ -420,8 +411,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterPolicy/MSFT_EXOMalwareFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterPolicy/MSFT_EXOMalwareFilterPolicy.psm1
@@ -543,8 +543,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterRule/MSFT_EXOMalwareFilterRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMalwareFilterRule/MSFT_EXOMalwareFilterRule.psm1
@@ -448,8 +448,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRole/MSFT_EXOManagementRole.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRole/MSFT_EXOManagementRole.psm1
@@ -338,8 +338,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/MSFT_EXOManagementRoleAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleAssignment/MSFT_EXOManagementRoleAssignment.psm1
@@ -519,8 +519,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleEntry/MSFT_EXOManagementRoleEntry.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOManagementRoleEntry/MSFT_EXOManagementRoleEntry.psm1
@@ -361,8 +361,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMessageClassification/MSFT_EXOMessageClassification.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMessageClassification/MSFT_EXOMessageClassification.psm1
@@ -449,7 +449,8 @@ function Export-TargetResource
         $AccessTokens
     )
 
-    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' -InboundParameters $PSBoundParameters -SkipModuleReload $true
+    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMobileDeviceMailboxPolicy/MSFT_EXOMobileDeviceMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOMobileDeviceMailboxPolicy/MSFT_EXOMobileDeviceMailboxPolicy.psm1
@@ -1096,8 +1096,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOMEConfiguration/MSFT_EXOOMEConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOMEConfiguration/MSFT_EXOOMEConfiguration.psm1
@@ -440,7 +440,8 @@ function Export-TargetResource
         $AccessTokens
     )
 
-    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' -InboundParameters $PSBoundParameters -SkipModuleReload $true
+    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOfflineAddressBook/MSFT_EXOOfflineAddressBook.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOfflineAddressBook/MSFT_EXOOfflineAddressBook.psm1
@@ -376,8 +376,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOnPremisesOrganization/MSFT_EXOOnPremisesOrganization.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOnPremisesOrganization/MSFT_EXOOnPremisesOrganization.psm1
@@ -422,8 +422,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationConfig/MSFT_EXOOrganizationConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationConfig/MSFT_EXOOrganizationConfig.psm1
@@ -1797,8 +1797,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationRelationship/MSFT_EXOOrganizationRelationship.psm1
@@ -661,8 +661,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOutboundConnector/MSFT_EXOOutboundConnector.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOutboundConnector/MSFT_EXOOutboundConnector.psm1
@@ -534,8 +534,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOwaMailboxPolicy/MSFT_EXOOwaMailboxPolicy.psm1
@@ -1453,8 +1453,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPartnerApplication/MSFT_EXOPartnerApplication.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPartnerApplication/MSFT_EXOPartnerApplication.psm1
@@ -401,8 +401,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPerimeterConfiguration/MSFT_EXOPerimeterConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPerimeterConfiguration/MSFT_EXOPerimeterConfiguration.psm1
@@ -298,7 +298,8 @@ function Export-TargetResource
         $AccessTokens
     )
 
-    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' -InboundParameters $PSBoundParameters -SkipModuleReload $true
+    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPlace/MSFT_EXOPlace.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPlace/MSFT_EXOPlace.psm1
@@ -591,8 +591,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPolicyTipConfig/MSFT_EXOPolicyTipConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOPolicyTipConfig/MSFT_EXOPolicyTipConfig.psm1
@@ -329,8 +329,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOQuarantinePolicy/MSFT_EXOQuarantinePolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOQuarantinePolicy/MSFT_EXOQuarantinePolicy.psm1
@@ -589,8 +589,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORecipientPermission/MSFT_EXORecipientPermission.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORecipientPermission/MSFT_EXORecipientPermission.psm1
@@ -354,8 +354,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORemoteDomain/MSFT_EXORemoteDomain.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORemoteDomain/MSFT_EXORemoteDomain.psm1
@@ -627,8 +627,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOReportSubmissionPolicy/MSFT_EXOReportSubmissionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOReportSubmissionPolicy/MSFT_EXOReportSubmissionPolicy.psm1
@@ -642,8 +642,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOReportSubmissionRule/MSFT_EXOReportSubmissionRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOReportSubmissionRule/MSFT_EXOReportSubmissionRule.psm1
@@ -347,8 +347,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOResourceConfiguration/MSFT_EXOResourceConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOResourceConfiguration/MSFT_EXOResourceConfiguration.psm1
@@ -298,7 +298,8 @@ function Export-TargetResource
         $AccessTokens
     )
 
-    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' -InboundParameters $PSBoundParameters -SkipModuleReload $true
+    $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleAssignmentPolicy/MSFT_EXORoleAssignmentPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXORoleAssignmentPolicy/MSFT_EXORoleAssignmentPolicy.psm1
@@ -381,8 +381,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentPolicy/MSFT_EXOSafeAttachmentPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentPolicy/MSFT_EXOSafeAttachmentPolicy.psm1
@@ -457,8 +457,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentRule/MSFT_EXOSafeAttachmentRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeAttachmentRule/MSFT_EXOSafeAttachmentRule.psm1
@@ -459,8 +459,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksPolicy/MSFT_EXOSafeLinksPolicy.psm1
@@ -490,8 +490,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksRule/MSFT_EXOSafeLinksRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSafeLinksRule/MSFT_EXOSafeLinksRule.psm1
@@ -460,8 +460,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharedMailbox/MSFT_EXOSharedMailbox.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharedMailbox/MSFT_EXOSharedMailbox.psm1
@@ -482,8 +482,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharingPolicy/MSFT_EXOSharingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOSharingPolicy/MSFT_EXOSharingPolicy.psm1
@@ -362,8 +362,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTeamsProtectionPolicy/MSFT_EXOTeamsProtectionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTeamsProtectionPolicy/MSFT_EXOTeamsProtectionPolicy.psm1
@@ -341,8 +341,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportConfig/MSFT_EXOTransportConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportConfig/MSFT_EXOTransportConfig.psm1
@@ -610,8 +610,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOTransportRule/MSFT_EXOTransportRule.psm1
@@ -2592,8 +2592,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'ExchangeOnline' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload $true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog/MSFT_IntuneAntivirusPolicyWindows10SettingCatalog.psm1
@@ -1576,8 +1576,7 @@ function Export-TargetResource
     )
 
     $ConnectionMode = New-M365DSCConnection -Workload 'MicrosoftGraph' `
-        -InboundParameters $PSBoundParameters `
-        -SkipModuleReload:$true
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceSearch/MSFT_SCComplianceSearch.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCComplianceSearch/MSFT_SCComplianceSearch.psm1
@@ -98,17 +98,9 @@ function Get-TargetResource
     {
         if (-not $Script:exportedInstance -or $Script:exportedInstance.Name -ne $Name)
         {
-            if ($Global:CurrentModeIsExport)
-            {
-                $null = New-M365DSCConnection -Workload 'SecurityComplianceCenter' `
-                    -InboundParameters $PSBoundParameters `
-                    -SkipModuleReload $true
-            }
-            else
-            {
-                $null = New-M365DSCConnection -Workload 'SecurityComplianceCenter' `
-                    -InboundParameters $PSBoundParameters
-            }
+            $null = New-M365DSCConnection -Workload 'SecurityComplianceCenter' `
+                -InboundParameters $PSBoundParameters
+
             #Ensure the proper dependencies are installed in the current environment.
             Confirm-M365DSCDependencies
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCSecurityFilter/MSFT_SCSecurityFilter.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCSecurityFilter/MSFT_SCSecurityFilter.psm1
@@ -82,17 +82,8 @@ function Get-TargetResource
 
     Write-Verbose -Message "Getting configuration of Security Filter for $FilterName"
 
-    if ($Global:CurrentModeIsExport)
-    {
-        $null = New-M365DSCConnection -Workload 'SecurityComplianceCenter' `
-            -InboundParameters $PSBoundParameters `
-            -SkipModuleReload $true
-    }
-    else
-    {
-        $null = New-M365DSCConnection -Workload 'SecurityComplianceCenter' `
-            -InboundParameters $PSBoundParameters
-    }
+    $null = New-M365DSCConnection -Workload 'SecurityComplianceCenter' `
+        -InboundParameters $PSBoundParameters
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2316,11 +2316,7 @@ function New-M365DSCConnection
 
         [Parameter()]
         [System.String]
-        $Url,
-
-        [Parameter()]
-        [System.Boolean]
-        $SkipModuleReload = $false
+        $Url
     )
 
     foreach ($requiredModule in $Script:M365DSCRequiredModules)
@@ -2343,15 +2339,6 @@ function New-M365DSCConnection
 
     Write-Verbose -Message "Attempting connection to {$Workload} with:"
     Write-Verbose -Message "$($InboundParameters | Out-String)"
-
-    if ($SkipModuleReload -eq $true)
-    {
-        $Global:CurrentModeIsExport = $true
-    }
-    else
-    {
-        $Global:CurrentModeIsExport = $false
-    }
 
     #region Telemetry
     $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
@@ -2420,8 +2407,7 @@ function New-M365DSCConnection
                 $Script:M365DSCTelemetryConnectionToGraphParams.Add('Credential', $InboundParameters.Credential)
             }
             Connect-M365Tenant -Workload $Workload `
-                -Credential $InboundParameters.Credential `
-                -SkipModuleReload $Global:CurrentModeIsExport
+                -Credential $InboundParameters.Credential
 
             if (-not $Script:M365ConnectedToWorkloads -contains "$Workload-Credential")
             {
@@ -2458,8 +2444,7 @@ function New-M365DSCConnection
             }
             Connect-M365Tenant -Workload $Workload `
                 -Credential $InboundParameters.Credential `
-                -Url $Url `
-                -SkipModuleReload $Global:CurrentModeIsExport
+                -Url $Url
             if (-not $Script:M365ConnectedToWorkloads -contains "$Workload-Credential")
             {
                 $data.Add('ConnectionMode', 'Credential')
@@ -2504,8 +2489,7 @@ function New-M365DSCConnection
             }
             Connect-M365Tenant -Workload $Workload `
                 -ApplicationId $InboundParameters.ApplicationId `
-                -Credential $InboundParameters.Credential `
-                -SkipModuleReload $Global:CurrentModeIsExport
+                -Credential $InboundParameters.Credential
             if (-not $Script:M365ConnectedToWorkloads -contains "$Workload-CredentialsWithApplicationId")
             {
                 $data.Add('ConnectionMode', 'CredentialsWithApplicationId')
@@ -2545,8 +2529,7 @@ function New-M365DSCConnection
             Connect-M365Tenant -Workload $Workload `
                 -ApplicationId $InboundParameters.ApplicationId `
                 -Credential $InboundParameters.Credential `
-                -Url $Url `
-                -SkipModuleReload $Global:CurrentModeIsExport
+                -Url $Url
             if (-not $Script:M365ConnectedToWorkloads -contains "$Workload-CredentialsWithApplicationId")
             {
                 $data.Add('ConnectionMode', 'CredentialsWithApplicationId')
@@ -2605,8 +2588,7 @@ function New-M365DSCConnection
                 -ApplicationId $InboundParameters.ApplicationId `
                 -TenantId $InboundParameters.TenantId `
                 -CertificatePassword $InboundParameters.CertificatePassword.Password `
-                -CertificatePath $InboundParameters.CertificatePath `
-                -SkipModuleReload $Global:CurrentModeIsExport
+                -CertificatePath $InboundParameters.CertificatePath
 
             if (-not $Script:M365ConnectedToWorkloads -contains "$Workload-ServicePrincipalWithPath")
             {
@@ -2685,8 +2667,7 @@ function New-M365DSCConnection
             Connect-M365Tenant -Workload $Workload `
                 -ApplicationId $InboundParameters.ApplicationId `
                 -TenantId $InboundParameters.TenantId `
-                -ApplicationSecret $InboundParameters.ApplicationSecret `
-                -SkipModuleReload $Global:CurrentModeIsExport
+                -ApplicationSecret $InboundParameters.ApplicationSecret
 
             if (-not $Script:M365ConnectedToWorkloads -contains "$Workload-ServicePrincipalWithSecret")
             {
@@ -2718,8 +2699,7 @@ function New-M365DSCConnection
                 -ApplicationId $InboundParameters.ApplicationId `
                 -TenantId $InboundParameters.TenantId `
                 -ApplicationSecret $InboundParameters.ApplicationSecret `
-                -Url $Url `
-                -SkipModuleReload $Global:CurrentModeIsExport
+                -Url $Url
 
             if (-not $Script:M365ConnectedToWorkloads -contains "$Workload-ServicePrincipalWithSecret")
             {
@@ -2755,7 +2735,6 @@ function New-M365DSCConnection
             -ApplicationId $InboundParameters.ApplicationId `
             -TenantId $InboundParameters.TenantId `
             -CertificateThumbprint $InboundParameters.CertificateThumbprint `
-            -SkipModuleReload $Global:CurrentModeIsExport `
             -Url $Url
         Write-Verbose -Message "Connection initiated."
         if (-not $Script:M365ConnectedToWorkloads -contains "$Workload-ServicePrincipalWithThumbprint")
@@ -2785,8 +2764,7 @@ function New-M365DSCConnection
         Connect-M365Tenant -Workload $Workload `
             -TenantId $InboundParameters.TenantId `
             -Credential $InboundParameters.Credential `
-            -Url $Url `
-            -SkipModuleReload $Global:CurrentModeIsExport
+            -Url $Url
         if (-not $Script:M365ConnectedToWorkloads -contains "$Workload-CredentialsWithTenantId")
         {
             $data.Add('ConnectionMode', 'CredentialsWithTenantId')
@@ -2815,8 +2793,7 @@ function New-M365DSCConnection
         }
         Connect-M365Tenant -Workload $Workload `
             -Identity `
-            -TenantId $InboundParameters.TenantId `
-            -SkipModuleReload $Global:CurrentModeIsExport
+            -TenantId $InboundParameters.TenantId
 
         if (-not $Script:M365ConnectedToWorkloads -contains "$Workload-ManagedIdentity")
         {
@@ -2847,8 +2824,7 @@ function New-M365DSCConnection
         }
         Connect-M365Tenant -Workload $Workload `
             -AccessTokens $InboundParameters.AccessTokens `
-            -TenantId $InboundParameters.TenantId `
-            -SkipModuleReload $Global:CurrentModeIsExport
+            -TenantId $InboundParameters.TenantId
 
         if (-not $Script:M365ConnectedToWorkloads -contains "$Workload-AccessTokens")
         {

--- a/Tests/Unit/Stubs/Generic.psm1
+++ b/Tests/Unit/Stubs/Generic.psm1
@@ -474,10 +474,6 @@ function Connect-M365Tenant
         $CertificatePath,
 
         [Parameter()]
-        [System.Boolean]
-        $SkipModuleReload = $false,
-
-        [Parameter()]
         [Switch]
         $Identity,
 
@@ -512,11 +508,7 @@ function New-M365DSCConnection
 
         [Parameter()]
         [System.String]
-        $Url,
-
-        [Parameter()]
-        [System.Boolean]
-        $SkipModuleReload
+        $Url
     )
 }
 


### PR DESCRIPTION
#### Pull Request (PR) description
With the latest MSCloudLoginAssistant version 1.1.57, the `-SkipModuleReload` parameter can be removed. The internal logic was updated to skip reloading of the module whenever possible.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
