### PR TITLE
AADEntitlementManagementAccessPackageAssignmentPolicy: Add missing sub-property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+* AADEntitlementManagementAccessPackageAssignmentPolicy
+  * Add missing sub-property `IsAgenticExperienceEnabled` to
+    complex object `AccessReviewSettings`
+    FIXES [#6930](https://github.com/microsoft/Microsoft365DSC/issues/6930)
 * EXOTenantAllowBlockListItems
   * Fixed issue where value `Submission` was missing from the validate
     set from `ListSubType` parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * AADEntitlementManagementAccessPackageAssignmentPolicy
   * Add missing sub-property `IsAgenticExperienceEnabled` to
-    complex object `AccessReviewSettings`
+    complex object `AccessReviewSettings` and `ApproverInformationVisibility` to
+    `ApprovalStages[]`
     FIXES [#6930](https://github.com/microsoft/Microsoft365DSC/issues/6930)
 * EXOTenantAllowBlockListItems
   * Fixed issue where value `Submission` was missing from the validate

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.schema.mof
@@ -1,4 +1,4 @@
-[ClassVersion("1.0.0")]
+[ClassVersion("1.0.1")]
 class MSFT_MicrosoftGraphassignmentreviewsettings
 {
     [Write, Description("The default decision to apply if the request is not reviewed within the period specified in durationInDays."), ValueMap{"acceptAccessRecommendation","keepAccess","removeAccess","unknownFutureValue"}, Values{"acceptAccessRecommendation","keepAccess","removeAccess","unknownFutureValue"}] String AccessReviewTimeoutBehavior;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.schema.mof
@@ -4,6 +4,7 @@ class MSFT_MicrosoftGraphassignmentreviewsettings
     [Write, Description("The default decision to apply if the request is not reviewed within the period specified in durationInDays."), ValueMap{"acceptAccessRecommendation","keepAccess","removeAccess","unknownFutureValue"}, Values{"acceptAccessRecommendation","keepAccess","removeAccess","unknownFutureValue"}] String AccessReviewTimeoutBehavior;
     [Write, Description("The number of days within which reviewers should provide input.")] UInt32 DurationInDays;
     [Write, Description("Specifies whether to display recommendations to the reviewer. The default value is true")] Boolean IsAccessRecommendationEnabled;
+    [Write, Description("Specifies whether the agentic experience is enabled for this policy.")] Boolean IsAgenticExperienceEnabled;
     [Write, Description("Specifies whether the reviewer must provide justification for the approval. The default value is true.")] Boolean IsApprovalJustificationRequired;
     [Write, Description("If true, access reviews are required for assignments from this policy.")] Boolean IsEnabled;
     [Write, Description("The interval for recurrence, such as monthly or quarterly.")] String RecurrenceType;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.schema.mof
@@ -65,10 +65,11 @@ class MSFT_MicrosoftGraphapprovalsettings
     [Write, Description("Indicates whether approval is required for a user to extend their assignment.")] Boolean IsApprovalRequiredForExtension;
     [Write, Description("Indicates whether the requestor is required to supply a justification in their request.")] Boolean IsRequestorJustificationRequired;
 };
-[ClassVersion("1.0.0")]
+[ClassVersion("1.0.1")]
 class MSFT_MicrosoftGraphapprovalstage1
 {
     [Write, Description("The number of days that a request can be pending a response before it is automatically denied.")] UInt32 ApprovalStageTimeOutInDays;
+    [Write, Description("Defines whether approver information is visible to the requestor in approval processes within Microsoft Entra entitlement management and related governance scenarios."), ValueMap{"default","notVisible","visible","unknownFutureValue"}, Values{"default","notVisible","visible","unknownFutureValue"}] String ApproverInformationVisibility;
     [Write, Description("Indicates whether the approver is required to provide a justification for approving a request.")] UInt32 EscalationTimeInMinutes;
     [Write, Description("If true, then one or more escalation approvers are configured in this approval stage.")] Boolean IsApproverJustificationRequired;
     [Write, Description("If escalation is required, the time a request can be pending a response from a primary approver.")] Boolean IsEscalationEnabled;

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADEntitlementManagementAccessPackageAssignmentPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADEntitlementManagementAccessPackageAssignmentPolicy.Tests.ps1
@@ -49,6 +49,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     AccessReviewSettings    = @{
                         isEnabled                       = $True
                         isAccessRecommendationEnabled   = $True
+                        isAgenticExperienceEnabled      = $True
                         isApprovalJustificationRequired = $True
                         recurrenceType                  = 'FakeStringValue'
                         reviewerType                    = 'FakeStringValue'
@@ -129,6 +130,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     AccessReviewSettings    = (New-CimInstance -ClassName MSFT_MicrosoftGraphassignmentreviewsettings -Property @{
                             isEnabled                       = $True
                             isAccessRecommendationEnabled   = $True
+                            isAgenticExperienceEnabled      = $True
                             isApprovalJustificationRequired = $True
                             recurrenceType                  = 'FakeStringValue'
                             reviewerType                    = 'FakeStringValue'
@@ -192,6 +194,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     AccessReviewSettings    = (New-CimInstance -ClassName MSFT_MicrosoftGraphassignmentreviewsettings -Property @{
                             isEnabled                       = $True
                             isAccessRecommendationEnabled   = $True
+                            isAgenticExperienceEnabled      = $True
                             isApprovalJustificationRequired = $True
                             recurrenceType                  = 'FakeStringValue'
                             reviewerType                    = 'FakeStringValue'
@@ -254,6 +257,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     AccessReviewSettings    = (New-CimInstance -ClassName MSFT_MicrosoftGraphassignmentreviewsettings -Property @{
                             isEnabled                       = $True
                             isAccessRecommendationEnabled   = $True
+                            isAgenticExperienceEnabled      = $True
                             isApprovalJustificationRequired = $True
                             recurrenceType                  = 'FakeStringValue'
                             reviewerType                    = 'FakeStringValue'
@@ -308,6 +312,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     AccessReviewSettings    = (New-CimInstance -ClassName MSFT_MicrosoftGraphassignmentreviewsettings -Property @{
                             isEnabled                       = $True
                             isAccessRecommendationEnabled   = $True
+                            isAgenticExperienceEnabled      = $True
                             isApprovalJustificationRequired = $True
                             recurrenceType                  = 'FakeStringValue'
                             reviewerType                    = 'FakeStringValue'


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds missing sub-property `IsAgenticExperienceEnabled` to complex object `AccessReviewSettings` on resource `AADEntitlementManagementAccessPackageAssignmentPolicy`

#### This Pull Request (PR) fixes the following issues
- Fixes #6930 

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [X] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [] Examples appropriately added/updated.
- [X] Unit tests added/updated.
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
