### PR TITLE
Fix Intune Health Monitoring Configuration Policy Create and Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10
+  * Fixed an issue with value handling when creating or updating policies.
+    FIXES [#6955](https://github.com/microsoft/Microsoft365DSC/issues/6955)
+* TeamsEmergencyCallingPolicy
+  * Added explicit cast to string for `ExternalLocationLookupMode`.
+
 # 1.26.311.1
 
 * AADAccessReviewDefinition

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10/MSFT_IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10.psm1
@@ -287,36 +287,17 @@ function Set-TargetResource
         Write-Verbose -Message "Creating an Intune Device Configuration Health Monitoring Configuration Policy for Windows10 with DisplayName {$DisplayName}"
         $boundParameters.Remove('Assignments') | Out-Null
 
-        $CreateParameters = ([Hashtable]$boundParameters).Clone()
-        $CreateParameters = Rename-M365DSCCimInstanceParameter -Properties $CreateParameters
-        $CreateParameters.Remove('Id') | Out-Null
+        $createParameters = ([Hashtable]$boundParameters).Clone()
+        $createParameters = Rename-M365DSCCimInstanceParameter -Properties $createParameters
+        $createParameters.Remove('Id') | Out-Null
 
-        $keys = (([Hashtable]$CreateParameters).Clone()).Keys
-        foreach ($key in $keys)
+        if ($createParameters.ContainsKey('configDeviceHealthMonitoringScope'))
         {
-            if ($null -ne $CreateParameters.$key -and $CreateParameters.$key.GetType().Name -like '*cimInstance*')
-            {
-                $CreateParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $CreateParameters.$key
-            }
-        }
-        if ($CreateParameters.ContainsKey('ConfigDeviceHealthMonitoringScope'))
-        {
-            $CreateParameters['configDeviceHealthMonitoringScope'] = ($CreateParameters['ConfigDeviceHealthMonitoringScope'] -join ',')
-            $CreateParameters.Remove('ConfigDeviceHealthMonitoringScope') | Out-Null
-        }
-        if ($CreateParameters.ContainsKey('AllowDeviceHealthMonitoring'))
-        {
-            $CreateParameters['allowDeviceHealthMonitoring'] = $CreateParameters['AllowDeviceHealthMonitoring']
-            $CreateParameters.Remove('AllowDeviceHealthMonitoring') | Out-Null
-        }
-        if ($CreateParameters.ContainsKey('ConfigDeviceHealthMonitoringCustomScope'))
-        {
-            $CreateParameters['configDeviceHealthMonitoringCustomScope'] = $CreateParameters['ConfigDeviceHealthMonitoringCustomScope']
-            $CreateParameters.Remove('ConfigDeviceHealthMonitoringCustomScope') | Out-Null
+            $createParameters['configDeviceHealthMonitoringScope'] = ($createParameters['configDeviceHealthMonitoringScope'] -join ',')
         }
         #region resource generator code
-        $CreateParameters.Add('@odata.type', '#microsoft.graph.windowsHealthMonitoringConfiguration')
-        $policy = New-MgBetaDeviceManagementDeviceConfiguration -BodyParameter $CreateParameters
+        $createParameters.Add('@odata.type', '#microsoft.graph.windowsHealthMonitoringConfiguration')
+        $policy = New-MgBetaDeviceManagementDeviceConfiguration -BodyParameter $createParameters
         $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
 
         if ($policy.id)
@@ -334,37 +315,18 @@ function Set-TargetResource
 
         $UpdateParameters = ([Hashtable]$boundParameters).Clone()
         $UpdateParameters = Rename-M365DSCCimInstanceParameter -Properties $UpdateParameters
-
         $UpdateParameters.Remove('Id') | Out-Null
 
-        $keys = (([Hashtable]$UpdateParameters).Clone()).Keys
-        foreach ($key in $keys)
+        if ($UpdateParameters.ContainsKey('configDeviceHealthMonitoringScope'))
         {
-            if ($null -ne $UpdateParameters.$key -and $UpdateParameters.$key.GetType().Name -like '*cimInstance*')
-            {
-                $UpdateParameters.$key = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $UpdateParameters.$key
-            }
-        }
-        if ($UpdateParameters.ContainsKey('ConfigDeviceHealthMonitoringScope'))
-        {
-            $UpdateParameters['configDeviceHealthMonitoringScope'] = ($UpdateParameters['ConfigDeviceHealthMonitoringScope'] -join ',')
-            $UpdateParameters.Remove('ConfigDeviceHealthMonitoringScope') | Out-Null
-        }
-        if ($UpdateParameters.ContainsKey('AllowDeviceHealthMonitoring'))
-        {
-            $UpdateParameters['allowDeviceHealthMonitoring'] = $UpdateParameters['AllowDeviceHealthMonitoring']
-            $UpdateParameters.Remove('AllowDeviceHealthMonitoring') | Out-Null
-        }
-        if ($UpdateParameters.ContainsKey('ConfigDeviceHealthMonitoringCustomScope'))
-        {
-            $UpdateParameters['configDeviceHealthMonitoringCustomScope'] = $UpdateParameters['ConfigDeviceHealthMonitoringCustomScope']
-            $UpdateParameters.Remove('ConfigDeviceHealthMonitoringCustomScope') | Out-Null
+            $UpdateParameters['configDeviceHealthMonitoringScope'] = ($UpdateParameters['configDeviceHealthMonitoringScope'] -join ',')
         }
         #region resource generator code
         $UpdateParameters.Add('@odata.type', '#microsoft.graph.windowsHealthMonitoringConfiguration')
         Update-MgBetaDeviceManagementDeviceConfiguration  `
             -DeviceConfigurationId $currentInstance.Id `
             -BodyParameter $UpdateParameters
+
         $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
         Update-DeviceConfigurationPolicyAssignment `
             -DeviceConfigurationPolicyId $currentInstance.id `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallingPolicy/MSFT_TeamsEmergencyCallingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsEmergencyCallingPolicy/MSFT_TeamsEmergencyCallingPolicy.psm1
@@ -130,13 +130,19 @@ function Get-TargetResource
             $complexExtendedNotifications += $complexExtendedNotification
         }
 
+        $externalLocationLookupModeValue = $null
+        if ($null -ne $policy.ExternalLocationLookupMode)
+        {
+            $externalLocationLookupModeValue = $policy.ExternalLocationLookupMode.ToString()
+        }
+
         Write-Verbose -Message "Found Teams Emergency Calling Policy {$Identity}"
         $result = @{
             Identity                           = $Identity
             Description                        = $policy.Description
             EnhancedEmergencyServiceDisclaimer = $policy.EnhancedEmergencyServiceDisclaimer
             ExtendedNotifications              = $complexExtendedNotifications
-            ExternalLocationLookupMode         = $policy.ExternalLocationLookupMode
+            ExternalLocationLookupMode         = $externalLocationLookupModeValue
             NotificationDialOutNumber          = $policy.NotificationDialOutNumber
             NotificationGroup                  = $policy.NotificationGroup
             NotificationMode                   = [String]$policy.NotificationMode


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue with creating and updating an `IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10` and adds an explicit cast to the enum that defines the `ExternalLocationLookupMode` in a `TeamsEmergencyCallingPolicy`.

#### This Pull Request (PR) fixes the following issues
- Fixes #6955 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
