### PR TITLE
Fix EXO docs generation for roles and role groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+* M365DSCDocGenerator
+  * Fixed an issue where no distinction between read and update
+    was done for EXO resources.
+    FIXES [#6965](https://github.com/microsoft/Microsoft365DSC/issues/6965)
+
 # 1.26.311.1
 
 * AADAccessReviewDefinition

--- a/Modules/Microsoft365DSC/Modules/M365DSCDocGenerator.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDocGenerator.psm1
@@ -632,13 +632,27 @@ function New-DscMofResourceWikiPage
                     $null = $permissionsContent.AppendLine()
                     $null = $permissionsContent.AppendLine('#### Roles')
                     $null = $permissionsContent.AppendLine()
-                    $null = $permissionsContent.AppendLine("* $($settingsJson.permissions.exchange.requiredroles -join ', ')")
+                    $null = $permissionsContent.AppendLine('* **Read**')
+                    $null = $permissionsContent.AppendLine("* $($settingsJson.permissions.exchange.requiredroles.read -join ', ')")
+                    $null = $permissionsContent.AppendLine('* **Update**')
+                    $null = $permissionsContent.AppendLine("* $($settingsJson.permissions.exchange.requiredroles.update -join ', ')")
                     $null = $permissionsContent.AppendLine()
                     $null = $permissionsContent.AppendLine('#### Role Groups')
                     $null = $permissionsContent.AppendLine()
-                    if ($settingsJson.permissions.exchange.requiredrolegroups.Count -ne 0)
+                    $null = $permissionsContent.AppendLine('* **Read**')
+                    if ($settingsJson.permissions.exchange.requiredrolegroups.read.Count -ne 0)
                     {
-                        $roleGroups = $settingsJson.permissions.exchange.requiredrolegroups -join ', '
+                        $roleGroups = $settingsJson.permissions.exchange.requiredrolegroups.read -join ', '
+                    }
+                    else
+                    {
+                        $roleGroups = 'None'
+                    }
+                    $null = $permissionsContent.AppendLine("* $roleGroups")
+                    $null = $permissionsContent.AppendLine('* **Update**')
+                    if ($settingsJson.permissions.exchange.requiredrolegroups.update.Count -ne 0)
+                    {
+                        $roleGroups = $settingsJson.permissions.exchange.requiredrolegroups.update -join ', '
                     }
                     else
                     {


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where EXO docs were not generated correctly for roles and role groups.

#### This Pull Request (PR) fixes the following issues
- Fixes #6965 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
