### PR TITLE
Fix apply of AdvancedSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,19 @@
 * IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10
   * Fixed an issue with value handling when creating or updating policies.
     FIXES [#6955](https://github.com/microsoft/Microsoft365DSC/issues/6955)
+* SCLabelPolicy
+  * Fixed an issue where setting `AdvancedSettings` failed.
+    FIXES [#6973](https://github.com/microsoft/Microsoft365DSC/issues/6973)
+* SCSensitivityLabel
+  * Fixed an issue where setting `AdvancedSettings` failed.
+    FIXES [#6973](https://github.com/microsoft/Microsoft365DSC/issues/6973)
 * TeamsEmergencyCallingPolicy
   * Added explicit cast to string for `ExternalLocationLookupMode`.
 * M365DSCUtil
   * Removed the internal `Sync-M365DSCParameter` function.
 * MISC
   * Fixed an issue where hardcoded Azure urls were used in multiple resources.
-    FIXES [#6957](https://github.com/microsoft/Microsoft365DSC/issues/6957
+    FIXES [#6957](https://github.com/microsoft/Microsoft365DSC/issues/6957)
 * M365DSCDocGenerator
   * Fixed an issue where no distinction between read and update
     was done for EXO resources.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCLabelPolicy/MSFT_SCLabelPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCLabelPolicy/MSFT_SCLabelPolicy.psm1
@@ -975,7 +975,7 @@ function Convert-CIMToAdvancedSettings
         $AdvancedSettings
     )
 
-    $entry = [ordered]@{}
+    $entry = [PSCustomObject]@{}
     foreach ($obj in $AdvancedSettings)
     {
         $settingsValues = ''
@@ -1006,7 +1006,7 @@ function Convert-CIMToAdvancedSettings
                 $settingsValues += ','
             }
         }
-        $entry[$obj.Key] = $settingsValues.TrimEnd(',')
+        $entry | Add-Member -MemberType NoteProperty -Name $obj.Key -Value $settingsValues.TrimEnd(',') -Force
     }
 
     return $entry

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCSensitivityLabel/MSFT_SCSensitivityLabel.psm1
@@ -1737,7 +1737,7 @@ function Convert-JSONToLocaleSettings
     foreach ($localeSetting in $localeSettings)
     {
         $result = [ordered]@{
-            localeKey = $localeSetting.LocaleKey
+            LocaleKey = $localeSetting.LocaleKey
         }
         foreach ($setting in $localeSetting.Settings)
         {
@@ -1804,7 +1804,7 @@ function Convert-CIMToAdvancedSettings
         $AdvancedSettings
     )
 
-    $entry = [ordered]@{}
+    $entry = [PSCustomObject]@{}
     foreach ($obj in $AdvancedSettings)
     {
         $settingsValues = ''
@@ -1813,7 +1813,7 @@ function Convert-CIMToAdvancedSettings
             $settingsValues += $objVal
             $settingsValues += ','
         }
-        $entry[$obj.Key] = $settingsValues.Substring(0, ($settingsValues.Length - 1))
+        $entry | Add-Member -MemberType NoteProperty -Name $obj.Key -Value $settingsValues.Substring(0, ($settingsValues.Length - 1)) -Force
     }
 
     return $entry


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue with applying `AdvancedSettings`. The PowerShell cmdlets `Set-Label` and `Set-LabelPolicy` expect a PSCustomObject instead of a hashtable for this property.

#### This Pull Request (PR) fixes the following issues
- Fixes #6973 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
