### PR TITLE
Fix export of O365OrgSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 * IntuneDeviceConfigurationHealthMonitoringConfigurationPolicyWindows10
   * Fixed an issue with value handling when creating or updating policies.
     FIXES [#6955](https://github.com/microsoft/Microsoft365DSC/issues/6955)
+* O365OrgSettings
+  * Fixed an issue where the export was empty.
+    FIXES [#6987](https://github.com/microsoft/Microsoft365DSC/issues/6987)
 * SCLabelPolicy
   * Fixed an issue where setting `AdvancedSettings` failed.
     FIXES [#6973](https://github.com/microsoft/Microsoft365DSC/issues/6973)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
@@ -1094,6 +1094,7 @@ function Export-TargetResource
             AccessTokens          = $AccessTokens
         }
 
+        $Script:exportedInstance = $true
         $Results = Get-TargetResource @Params
         $dscContent = ''
         $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes a regression introduced in an earlier PR #6879 where the fetching of resources was updated to contain either supplied parameters or the `$Script:exportedInstance` variable. Since during the export no parameters are supplied except the required ones and `$Script:exportedInstance` was not set, no properties were actually exported.

#### This Pull Request (PR) fixes the following issues
- Fixes #6987 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
