### PR TITLE
fix: correct MySite selection filter to prevent array conversion erro…

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSharingSettings/MSFT_SPOSharingSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOSharingSettings/MSFT_SPOSharingSettings.psm1
@@ -176,7 +176,7 @@ function Get-TargetResource
         }
 
         # Local filtering because server side filtering intermittently fails
-        $MySite = Get-PnPTenantSite -Filter "Url -like '-my.sharepoint.'" | Where-Object -FilterScript { $_.Template -notmatch '^RedirectSite#' }
+        $MySite = Get-PnPTenantSite -Filter "Url -like '*.my.sharepoint.com'" | Where-Object { $_.Template -notmatch '^RedirectSite#' } | Select-Object -First 1
 
         if ($null -ne $MySite)
         {
@@ -497,7 +497,7 @@ function Set-TargetResource
     Set-PnPTenant @CurrentParameters | Out-Null
     if ($SetMySharingCapability)
     {
-        $mysite = Get-PnPTenantSite -Filter "Url -like '-my.sharepoint.'" | Where-Object -FilterScript { $_.Template -notmatch '^RedirectSite#' }
+        $mysite = Get-PnPTenantSite -Filter "Url -like '*.my.sharepoint.com'" | Where-Object { $_.Template -notmatch '^RedirectSite#' } | Select-Object -First 1
         Set-PnPTenantSite -Identity $mysite.Url -SharingCapability $MySiteSharingCapability
     }
 }


### PR DESCRIPTION
This PR fixes an issue where Get-PnPTenantSite could return multiple results,
causing a conversion error when used with -Identity.

Changes:
- Updated filter to use '*.my.sharepoint.com' for more precise matching
- Preserved existing Template filtering logic
- Ensured a single object is returned using Select-Object -First 1

This prevents System.Object[] to SPOSitePipeBind conversion errors.

Closes #6991