### PR TITLE
Copy M365DSC module files to PowerShell module path

### DIFF
--- a/.github/workflows/Unit Tests.yml
+++ b/.github/workflows/Unit Tests.yml
@@ -77,6 +77,28 @@ jobs:
         shell: pwsh
         run: |
           & ./Utilities/Build-DllFiles.ps1 -Configuration Release
+      - name: Move Module Files to temp directory
+        shell: pwsh
+        run: |
+          $manifest = Test-ModuleManifest -Path './Modules/Microsoft365DSC/Microsoft365DSC.psd1'
+          $version = $manifest.Version
+          $stagingPath = "$env:TEMP\Staging"
+          if (-not (Test-Path -Path $stagingPath))
+          {
+              New-Item -Path $stagingPath -ItemType Directory -Force
+          }
+          $modulePath = "$stagingPath\Microsoft365DSC"
+          if (-not (Test-Path -Path $modulePath))
+          {
+              New-Item -Path $modulePath -ItemType Directory -Force
+          }
+          $modulePath = "$modulePath\$version"
+          if (Test-Path -Path $modulePath)
+          {
+              Remove-Item -Path $modulePath -Recurse -Force
+          }
+          New-Item -Path $modulePath -ItemType Directory -Force
+          Copy-Item -Path './Modules/Microsoft365DSC/*' -Destination $modulePath -Recurse -Force
       - name: Run Test Harness
         shell: pwsh
         run: |
@@ -85,13 +107,13 @@ jobs:
 
           try
           {
-              $results = Invoke-TestHarness -IgnoreCodeCoverage
+              $results = Invoke-TestHarness -IgnoreCodeCoverage -ModuleDirectory "$env:TEMP\Staging"
           }
           catch
           {
               $MaximumFunctionCount = 32767
               Import-Module './Tests/TestHarness.psm1' -Force;
-              $results = Invoke-TestHarness -IgnoreCodeCoverage
+              $results = Invoke-TestHarness -IgnoreCodeCoverage -ModuleDirectory "$env:TEMP\Staging"
           }
           if ($results.FailedCount -gt 0)
           {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
@@ -227,13 +227,13 @@ function Test-TargetResource
         # Generated with Microsoft365DSC version 1.23.906.1
         # For additional information on how to use Microsoft365DSC, please visit https://aka.ms/M365DSC
         param
-    (
+        (
         )
 
         Configuration M365TenantConfig
         {
             param
-    (
+            (
             )
 
             `$OrganizationName = `$ConfigurationData.NonNodeData.OrganizationName

--- a/Tests/TestHarness.psm1
+++ b/Tests/TestHarness.psm1
@@ -13,7 +13,11 @@ function Invoke-TestHarness
 
         [Parameter()]
         [Switch]
-        $IgnoreCodeCoverage
+        $IgnoreCodeCoverage,
+
+        [Parameter()]
+        [System.String]
+        $ModuleDirectory = (Join-Path -Path $PSScriptRoot -ChildPath '..\Modules\Microsoft365DSC' -Resolve)
     )
 
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
@@ -24,7 +28,7 @@ function Invoke-TestHarness
     $repoDir = Join-Path -Path $PSScriptRoot -ChildPath '..\' -Resolve
 
     $oldModPath = $env:PSModulePath
-    $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + (Join-Path -Path $repoDir -ChildPath 'Modules\Microsoft365DSC')
+    $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + $ModuleDirectory
 
     $testCoverageFiles = @()
     if ($IgnoreCodeCoverage.IsPresent -eq $false)

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.M365DSCRuleEvaluation.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.M365DSCRuleEvaluation.Tests.ps1
@@ -38,7 +38,18 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
 
             Mock -CommandName MSFT_AADConditionalAccessPolicy\Export-TargetResource -MockWith {
-                return "AADConditionalAccessPolicy 'FakeItem1'{`r`n    DisplayName='test';State = 'Enabled'`r`n}`r`nAADConditionalAccessPolicy 'FakeItem2'{`r`n    DisplayName='test';State = 'Disabled'`r`n}"
+                return @"
+                AADConditionalAccessPolicy 'FakeItem1'
+                {
+                    DisplayName ='test';
+                    State = 'Enabled';
+                }
+                AADConditionalAccessPolicy 'FakeItem2'
+                {
+                    DisplayName ='test';
+                    State = 'Disabled';
+                }
+"@
             }
 
             Mock -CommandName New-M365DSCConnection -MockWith {


### PR DESCRIPTION
#### Pull Request (PR) description
This PR attempts to fix a pipeline testing issue with `ConvertTo-DscObject` not having the latest module information in the PowerShell module path.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
