### PR TITLE
Fixed error in parameter-definition for AADAuthenticationMethodPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
   * Added name resolution for `AppId` and `PermissionIds` in preauthorized applications.
 * AADAuthenticationMethodPolicy
   * [BREAKING CHANGE] Added `IsSingleInstance` parameter.
-    Removed `Ensure`, `DisplayName`, `Description`, `Id` and `PolicyVersion` parameters.
+    Removed `Ensure`, `DisplayName`, `Description`, `Id` and `PolicyVersion`
+  * Fixed error in parameters.
 * AADAuthenticationMethodPolicy*
   * Streamlined group resolution during update operation.
   * Streamlined Target name resolution for all authentication resources.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicy/MSFT_AADAuthenticationMethodPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAuthenticationMethodPolicy/MSFT_AADAuthenticationMethodPolicy.psm1
@@ -425,6 +425,7 @@ function Test-TargetResource
         $SystemCredentialPreferences,
         #endregion
 
+        [Parameter(Mandatory = $true)]
         [ValidateSet('Yes')]
         [System.String]
         $IsSingleInstance,


### PR DESCRIPTION
#### Pull Request (PR) description
The breaking change previously implemented introduced an error in the parameters for Test-TargetResource
This PR fixes that
- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
