### PR TITLE
Add Install-Module fallback parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,10 @@
     FIXES [#6972](https://github.com/microsoft/Microsoft365DSC/issues/6972)
 * TeamsOnlineVoiceMailPolicy
   * [BREAKING CHANGE] Changed the type of `MaximumRecordingLength` from String to Int.
+* M365DSCModuleMgmt
+  * Added the parameter `UsePowerShellGet` to `Update-M365DSCDependencies` as an override
+    fallback if `Install-PSResource` is not available or not working.
+    FIXES [#7003](https://github.com/microsoft/Microsoft365DSC/issues/7003)
 * M365DSCPermissions
   * Removed internal function `Update-M365DSCResourcesSettingsJSON`.
 * M365DSCReport

--- a/Modules/Microsoft365DSC/Modules/M365DSCModuleMgmt.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCModuleMgmt.psm1
@@ -520,6 +520,9 @@ function Uninstall-M365DSCOutdatedDependencies
 .PARAMETER Repository
     Specifies the PowerShell repository name to use for the installation of the dependencies.
 
+.PARAMETER UsePowerShellGet
+    Specifies that Install-Module should be used for the installation of the dependencies instead of Install-PSResource.
+
 .EXAMPLE
     PS> Update-M365DSCDependencies
 
@@ -555,7 +558,11 @@ function Update-M365DSCDependencies
 
         [Parameter()]
         [System.String]
-        $Repository = 'PSGallery'
+        $Repository = 'PSGallery',
+
+        [Parameter()]
+        [switch]
+        $UsePowerShellGet
     )
 
     try
@@ -648,7 +655,7 @@ function Update-M365DSCDependencies
                         }
                         Remove-Module $dependency.ModuleName -Force -ErrorAction SilentlyContinue
 
-                        if ($scopedIsPsResourceGetAvailable)
+                        if ($scopedIsPsResourceGetAvailable -and -not $UsePowerShellGet)
                         {
                             Write-Information -MessageData "Using Install-PSResource to install $($dependency.ModuleName) with version {$($dependency.RequiredVersion)}"
                             Install-PSResource -Name $dependency.ModuleName -Version $dependency.RequiredVersion -Scope $Scope -AcceptLicense -SkipDependencyCheck -TrustRepository -Repository $Repository


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds the `UsePowerShellGet` parameter to `Update-M365DSCDependencies` as a fallback in cases where `Install-PSResource` is not working or cannot be used.

@borgquite Feel free to try it out.

#### This Pull Request (PR) fixes the following issues
- Fixes #7003 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
