### PR TITLE
Move full comparison to C# with normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,8 @@
   * Fixed an issue where comparing instances of `EXOTenantAllowBlockListItems` would
     use the wrong resource keys.
     FIXES [#6981](https://github.com/microsoft/Microsoft365DSC/issues/6981)
+  * Fixed an issue where incorrect resources were compared against each other if
+    the resource contains more than three key properties in `New-M365DSCDeltaReport`.
   * Removed the deprecated function `Compare-M365DSCConfigurations`.
     Use `New-M365DSCDeltaReport` as a replacement.
 * M365DSCStubsUtility
@@ -164,6 +166,7 @@
 * MISC
   * Added CIM information about required properties to all resources where applicable.
   * Improved filtering for Intune configuration policies during Export.
+  * Improved the accuracy of the comparison engine.
   * Refactored module structure to improve maintainability.
   * Removed duplicate complex hashtable conversions.
   * Updated documentation for different group types for AADGroup, EXOGroupSettings

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.psm1
@@ -293,7 +293,7 @@ function Get-TargetResource
         #endregion
 
         #region Format Questions
-        $formattedQuestions = Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $getValue.Questions
+        [array]$formattedQuestions = Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $getValue.Questions
         foreach ($question in $formattedQuestions)
         {
             if (-not $question.ContainsKey('odataType'))

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsNamingPolicy/MSFT_AADGroupsNamingPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsNamingPolicy/MSFT_AADGroupsNamingPolicy.psm1
@@ -89,7 +89,7 @@ function Get-TargetResource
             $customBlockedWordsListValue = @()
             if (-not [System.String]::IsNullOrEmpty($valueBlockedWords.Value))
             {
-                foreach ($word in $valueBlockedWords.Value.Split(','))
+                foreach ($word in $valueBlockedWords.Value.Split(',') | Where-Object -FilterScript { -not [System.String]::IsNullOrEmpty($_) })
                 {
                     $customBlockedWordsListValue += $word
                 }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAndroidManagedStoreAppConfiguration/MSFT_IntuneAndroidManagedStoreAppConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAndroidManagedStoreAppConfiguration/MSFT_IntuneAndroidManagedStoreAppConfiguration.psm1
@@ -40,7 +40,8 @@ function Get-TargetResource
         $appSupportsOemConfig,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
+        [ValidateSet('default', 'androidWorkProfile', 'androidDeviceOwner')]
+        [System.String]
         $profileApplicability,
 
         [Parameter()]
@@ -239,7 +240,8 @@ function Set-TargetResource
         $appSupportsOemConfig,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
+        [ValidateSet('default', 'androidWorkProfile', 'androidDeviceOwner')]
+        [System.String]
         $profileApplicability,
 
         [Parameter()]
@@ -411,7 +413,8 @@ function Test-TargetResource
         $appSupportsOemConfig,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
+        [ValidateSet('default', 'androidWorkProfile', 'androidDeviceOwner')]
+        [System.String]
         $profileApplicability,
 
         [Parameter()]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCPolicyConfig/MSFT_SCPolicyConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCPolicyConfig/MSFT_SCPolicyConfig.psm1
@@ -60,7 +60,7 @@ function Get-TargetResource
         $DLPRemovableMediaGroups,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
+        [Microsoft.Management.Infrastructure.CimInstance]
         $EvidenceStoreSettings,
 
         [Parameter()]
@@ -638,7 +638,7 @@ function Set-TargetResource
         $DLPRemovableMediaGroups,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
+        [Microsoft.Management.Infrastructure.CimInstance]
         $EvidenceStoreSettings,
 
         [Parameter()]
@@ -1167,7 +1167,7 @@ function Test-TargetResource
         $DLPRemovableMediaGroups,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance[]]
+        [Microsoft.Management.Infrastructure.CimInstance]
         $EvidenceStoreSettings,
 
         [Parameter()]

--- a/Modules/Microsoft365DSC/Modules/M365DSCCompare.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCCompare.psm1
@@ -1,12 +1,12 @@
 <#
 .SYNOPSIS
     This module contains the comparison logic for M365DSC.
+    Delegates to the C# ResourceComparer for all type normalization,
+    primary-key alignment, and drift detection.
 #>
 
-$Script:IsPowerShellCore = $PSVersionTable.PSEdition -eq 'Core'
-
-# Automatically initialize accelerator on module import
 Initialize-M365DSCDllLoader -ErrorAction SilentlyContinue
+$Script:IsPowerShellCore = $PSVersionTable.PSEdition -eq 'Core'
 
 function Compare-M365DSCResourceState
 {
@@ -50,35 +50,17 @@ function Compare-M365DSCResourceState
     }
     $Global:PotentialDrifts = @()
 
-    # Retrieve the primary keys of the given resource and remove them from the list of values to check.
+    # Load the schema once via the C# CacheManager (avoids boxing on every call).
     $currentPath = $PSScriptRoot
-    if ($null -eq $Script:M365DSCSchema)
+    if (-not [Microsoft365DSC.Cache.CacheManager]::IsSchemaLoaded)
     {
         $schemaPath = Join-Path -Path $currentPath -ChildPath '..\SchemaDefinition.json'
-        $schemaJSON = Get-Content $schemaPath -Raw
-        if ($Script:IsPowerShellCore)
-        {
-            $Script:M365DSCSchema = ConvertFrom-Json $schemaJSON -AsHashtable
-        }
-        else
-        {
-            $Script:M365DSCSchema = ConvertFrom-Json $schemaJSON
-        }
-
-        $Script:ResourceDefinitionCache = @{}
-        foreach ($schemaEntry in $Script:M365DSCSchema)
-        {
-            $Script:ResourceDefinitionCache[$schemaEntry.ClassName] = $schemaEntry
-        }
+        [Microsoft365DSC.Cache.CacheManager]::LoadSchema($schemaPath)
     }
-    $resourceDefinition = $Script:ResourceDefinitionCache["MSFT_$ResourceName"]
 
-    # Create a cache for resource property lookups to improve performance
-    $Script:ResourcePropertyCache = @{}
-
+    # Apply custom post-processing callback if specified.
+    # PostProcessing is a PowerShell Func delegate, so it must be called here (before entering C#).
     $ValuesToCheck = $DesiredValues.Clone()
-
-    # Apply custom post-processing to CurrentValues and ValuesToCheck if specified
     if ($null -ne $PostProcessing)
     {
         Write-Verbose -Message "Applying custom post-processing to CurrentValues and ValuesToCheck for resource $ResourceName"
@@ -102,224 +84,33 @@ function Compare-M365DSCResourceState
         }
     }
 
-    $null = $ValuesToCheck.Remove('Id')
-    $null = $ValuesToCheck.Remove('Identity')
-
-    # Remove the key parameters from the comparison
-    # Remove PSCredential object from the list of properties to be evaluated
-    $resourceParameters = $resourceDefinition.Parameters
-    foreach ($resourceParameter in $resourceParameters)
-    {
-        if ($resourceParameter.CIMType -eq 'PSCredential' -or $resourceParameter.Option -eq 'Key')
-        {
-            $null = $ValuesToCheck.Remove($resourceParameter.Name)
-        }
-    }
-
-    # Remove the ExcludedProperties from the list of properties to be evaluated
-    foreach ($property in $ExcludedProperties)
-    {
-        $null = $ValuesToCheck.Remove($property)
-    }
-
-    # Add the IncludedProperties to the list of properties to be evaluated
-    foreach ($property in $IncludedProperties)
-    {
-        if ($DesiredValues.ContainsKey($property))
-        {
-            $ValuesToCheck.$property = $DesiredValues.$property
-        }
-    }
-
-    $testTargetResource = $true
-    $skipEvaluation = $false
-    if ($DesiredValues.Ensure -eq 'Present' -and $CurrentValues.Ensure -eq 'Absent')
-    {
-        Write-Verbose -Message "The resource $ResourceName with $finalString was not found in the tenant."
-        $Global:AllDrifts.DriftInfo += @{
-            PropertyName = 'Ensure'
-            CurrentValue = 'Absent'
-            DesiredValue = 'Present'
-        }
-        $testTargetResource = $false
-        $ExcludedProperties += 'Ensure'
-    }
-    elseif ($DesiredValues.Ensure -eq 'Absent' -and $CurrentValues.Ensure -eq 'Present')
-    {
-        Write-Verbose -Message "The resource $ResourceName with $finalString should not exist in the tenant."
-        $Global:AllDrifts.DriftInfo += @{
-            PropertyName = 'Ensure'
-            CurrentValue = 'Present'
-            DesiredValue = 'Absent'
-        }
-        $testTargetResource = $false
-        $ExcludedProperties += 'Ensure'
-    }
-    elseif ($DesiredValues.Ensure -eq 'Absent' -and $CurrentValues.Ensure -eq 'Absent')
-    {
-        Write-Verbose -Message "The resource $ResourceName with $finalString does not exist in the tenant as desired."
-        $skipEvaluation = $true
-    }
-
-    $testResult = $true
-    if (-not $skipEvaluation)
-    {
-        # Compare Cim instances
-        # Create property lookup hashtable for this resource type if not already cached
-        if (-not $Script:ResourcePropertyCache.ContainsKey($ResourceName))
-        {
-            $propertyLookup = @{}
-            foreach ($prop in $resourceParameters)
-            {
-                $propertyLookup[$prop.Name] = $prop
-            }
-            $Script:ResourcePropertyCache[$ResourceName] = $propertyLookup
-        }
-        $resourcePropertyLookup = $Script:ResourcePropertyCache[$ResourceName]
-
-        $desiredKeys = $DesiredValues.Clone().Keys
-        foreach ($key in $desiredKeys)
-        {
-            $source = $DesiredValues.$key
-            $target = $CurrentValues.$key
-            $parameterDefinition = $resourcePropertyLookup[$key]
-            if ($null -ne $source -and ($source.GetType().Name -like '*CimInstance*' -or $parameterDefinition.CIMType -like 'MSFT_*'))
-            {
-                Write-Verbose -Message "Comparing complex object property $key of resource $ResourceName"
-                $CIMName = $parameterDefinition.CIMType.Replace('[]', '')
-                $CIMDefinition = [Microsoft365DSC.Utilities.Utilities]::FilterCimClassesByName($Script:M365DSCSchema, $CIMName)
-                # Can potentially be a single PSObject, therefore not using Where()
-                [array]$CIMPrimaryKeys = @()
-                $requiredParameters = $CIMDefinition.Parameters | Where-Object Option -EQ 'Required'
-                if ($requiredParameters.Count -gt 0)
-                {
-                    $CIMPrimaryKeys += $requiredParameters
-                }
-
-                $targetObjects = @{}
-                if ($source.GetType().Name -in @('CimInstance[]', 'Object[]'))
-                {
-                    $targetObjects = @()
-                }
-
-                $isIntunePolicyAssignment = $false
-                if (($CIMName -like "*Intune*PolicyAssignments" -or $CIMName -like "*DeviceManagementConfigurationPolicyAssignments") -and $CIMName -ne "MSFT_IntuneDeviceRemediationPolicyAssignments")
-                {
-                    $isIntunePolicyAssignment = $true
-                    if (($source.Count -gt 0 -and $source[0].dataType -notin @("#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget")) -or `
-                        ($target.Count -gt 0 -and $target[0].dataType -notin @("#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget")))
-                    {
-                        $CIMPrimaryKeys += @{
-                            Name = 'groupDisplayName'
-                        }
-                    }
-                }
-
-                # Filter all target objects that match the primary keys of the source object(s)
-                $noPrimaryKeyRemoval = $false
-                if ($source -is [array] -and $source.Count -gt 0)
-                {
-                    $target = $target | Where-Object -FilterScript {
-                        $match = $true
-                        foreach ($primaryKey in $CIMPrimaryKeys.Name)
-                        {
-                            # Because $source can be an array, we need to check if the
-                            # primary key value exists in any of the source objects
-                            # Address is a reserved property / method overload in Arrays
-                            if ($primaryKey -eq 'Address' -and $source.GetType().Name -like "*CimInstance*")
-                            {
-                                $sourceValue = $source.CimInstanceProperties.Where({ $_.Name -eq $primaryKey }).Value | Select-Object -Unique
-                            }
-                            else
-                            {
-                                $sourceValue = $source.$primaryKey | Select-Object -Unique
-                            }
-                            if ($sourceValue -is [array] -and $sourceValue.Count -gt 1)
-                            {
-                                Write-Verbose "Multiple values found for primary key $primaryKey in source object. Skipping primary key removal for this property."
-                                $noPrimaryKeyRemoval = $true
-                            }
-                            if ($null -ne $_.$primaryKey -and $_.$primaryKey -notin @($sourceValue))
-                            {
-                                $match = $false
-                            }
-                        }
-                        return $match
-                    }
-                }
-
-                # For cases where $nullreturn is returned from a resource, the properties may
-                # contain or be CimInstances that need to be converted to hashtables first for comparison
-                if (($null -ne $target -and $target.GetType().Name -like 'CimInstance*') -or `
-                    ($target -is [array] -and $target.Count -gt 0 -and $target[0].GetType().Name -like 'CimInstance*'))
-                {
-                    $target = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $target
-                }
-                foreach ($targetObject in $target)
-                {
-                    foreach ($primaryKey in $CIMPrimaryKeys.Name)
-                    {
-                        if ($isIntunePolicyAssignment -and $primaryKey -eq 'dataType')
-                        {
-                            continue
-                        }
-
-                        if ($primaryKey -notin $IncludedProperties -and -not $noPrimaryKeyRemoval)
-                        {
-                            $targetObject.Remove($primaryKey) | Out-Null
-                        }
-                    }
-
-                    if ($targetObjects -is [array])
-                    {
-                        $targetObjects += $targetObject
-                    }
-                    else
-                    {
-                        $targetObjects = $targetObject
-                    }
-                }
-
-                $testResult = Compare-M365DSCComplexObject `
-                    -Source ($source) `
-                    -Target ($targetObjects) `
-                    -PropertyName $key
-
-                if (-not $testResult)
-                {
-                    Write-Verbose "TestResult returned False for $source"
-                    $testTargetResource = $false
-                }
-
-                $DesiredValues.Remove($key) | Out-Null
-                $ValuesToCheck.Remove($key) | Out-Null
-            }
-        }
-    }
-
     Write-Verbose -Message "Current Values: $(Convert-M365DscHashtableToString -Hashtable $CurrentValues)"
-    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $ValuesToCheck)"
+    Write-Verbose -Message "Target Values: $(Convert-M365DscHashtableToString -Hashtable $DesiredValues)"
 
-    $testResult2 = $true
-    if (-not $skipEvaluation)
-    {
-        $testResult2 = Test-M365DSCParameterState -CurrentValues $CurrentValues `
-            -Source $ResourceName `
-            -DesiredValues $DesiredValues `
-            -ValuesToCheck $ValuesToCheck.Keys `
-            -NoEventMessage `
-            -NoDriftReset `
-            -ExcludedProperties $ExcludedProperties
-    }
+    # Delegate the entire comparison to C#.
+    # ResourceComparer handles: schema lookup, key/credential exclusion, Ensure handling,
+    # CimInstance/PSObject normalization (via ObjectNormalizer), primary-key alignment,
+    # complex object comparison, and simple property comparison.
+    $compareResult = [Microsoft365DSC.Compare.ResourceComparer]::Compare(
+        $DesiredValues,
+        $CurrentValues,
+        $ValuesToCheck,
+        [Microsoft365DSC.Cache.CacheManager]::Schema,
+        $ResourceName,
+        $ExcludedProperties,
+        $IncludedProperties
+    )
 
-    if ($testResult -and -not $testResult2)
+    # Populate the global drift state from the C# result for downstream consumers
+    # (event logging, telemetry, drift reporting).
+    $testTargetResource = $compareResult.TestResult
+    foreach ($drift in $compareResult.DriftInfo)
     {
-        $testResult = $false
-    }
-
-    if (-not $testResult)
-    {
-        $testTargetResource = $false
+        $Global:AllDrifts.DriftInfo += @{
+            PropertyName = $drift['PropertyName']
+            CurrentValue = $drift['CurrentValue']
+            DesiredValue = $drift['DesiredValue']
+        }
     }
 
     return $testTargetResource

--- a/Modules/Microsoft365DSC/Modules/M365DSCCompare.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCCompare.psm1
@@ -55,7 +55,8 @@ function Compare-M365DSCResourceState
     if (-not [Microsoft365DSC.Cache.CacheManager]::IsSchemaLoaded)
     {
         $schemaPath = Join-Path -Path $currentPath -ChildPath '..\SchemaDefinition.json'
-        [Microsoft365DSC.Cache.CacheManager]::LoadSchema($schemaPath)
+        $schemaContent = [System.IO.File]::ReadAllText($schemaPath) | ConvertFrom-Json
+        [Microsoft365DSC.Cache.CacheManager]::LoadSchema($schemaContent)
     }
 
     # Apply custom post-processing callback if specified.

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -1,4 +1,3 @@
-# Automatically initialize accelerator on module import
 Initialize-M365DSCDllLoader -ErrorAction SilentlyContinue
 
 function Get-StringFirstCharacterToUpper
@@ -484,22 +483,6 @@ function Convert-M365DSCDRGComplexTypeToHashtable
         return @{}
     }
 
-    if ($ComplexObject.GetType().Fullname -like '*[[\]]')
-    {
-        $results = @()
-        foreach ($item in $ComplexObject)
-        {
-            $hash = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $item
-            $results += $hash
-        }
-
-        #Write-Verbose -Message ("Convert-M365DSCDRGComplexTypeToHashtable >>> results: "+(convertTo-JSON $results -Depth 20))
-        # PowerShell returns all non-captured stream output, not just the argument of the return statement.
-        #An empty array is mangled into $null in the process.
-        #However, an array can be preserved on return by prepending it with the array construction operator (,)
-        return ,[System.Collections.Hashtable[]]$results
-    }
-
     if ($SingleLevel)
     {
         $returnObject = @{}
@@ -517,34 +500,5 @@ function Convert-M365DSCDRGComplexTypeToHashtable
         return $returnObject
     }
 
-    $hashComplexObject = Get-M365DSCDRGComplexTypeToHashtable -ComplexObject $ComplexObject
-
-    if ($null -ne $hashComplexObject)
-    {
-
-        $results = $hashComplexObject.Clone()
-
-        if ($SingleLevel)
-        {
-            return $results
-        }
-
-        $keys = $hashComplexObject.Keys | Where-Object -FilterScript { $_ -ne 'PSComputerName' }
-        foreach ($key in $keys)
-        {
-            if ($hashComplexObject[$key] -and $hashComplexObject[$key].GetType().Fullname -like '*CimInstance*')
-            {
-                $results[$key] = Convert-M365DSCDRGComplexTypeToHashtable -ComplexObject $hashComplexObject[$key]
-            }
-            else
-            {
-                $propertyName = $key[0].ToString().ToLower() + $key.Substring(1, $key.Length - 1)
-                $propertyValue = $results[$key]
-                $results.Remove($key) | Out-Null
-                $results.Add($propertyName, $propertyValue)
-            }
-        }
-    }
-
-    return $results
+    return [Microsoft365DSC.Converter.ObjectNormalizer]::Normalize($ComplexObject)
 }

--- a/Modules/Microsoft365DSC/Modules/M365DSCDllLoader.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDllLoader.psm1
@@ -67,6 +67,7 @@ function Initialize-M365DSCDllLoader
         # Locate the accelerator DLL
         $moduleRoot = Split-Path -Path $PSScriptRoot -Parent
         $dllsToLoad = @(
+            'Microsoft365DSC.Cache.dll'
             'Microsoft365DSC.Compare.dll'
             'Microsoft365DSC.Connection.dll'
             'Microsoft365DSC.Converter.dll'

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -1440,6 +1440,12 @@ function New-M365DSCDeltaReport
                 [array]$destinationResource = $destinationResource.Where({ $_.($key[1]) -eq $resource.($key[1]) })
                 $sourceKeyValue = $resource.($key[0]), $resource.($key[1]) -join '\'
             }
+            # Filter on the third key
+            if ($key.Count -gt 2)
+            {
+                [array]$destinationResource = $destinationResource.Where({ $_.($key[2]) -eq $resource.($key[2]) })
+                $sourceKeyValue = $resource.($key[0]), $resource.($key[1]), $resource.($key[2]) -join '\'
+            }
             if ($null -eq $destinationResource -or $destinationResource.Count -eq 0)
             {
                 $Delta += @{
@@ -1550,6 +1556,12 @@ function New-M365DSCDeltaReport
             {
                 [array]$sourceResource = $sourceResource.Where({ $_.($key[1]) -eq $resource.($key[1]) })
                 $destinationKeyValue = $resource.($key[0]), $resource.($key[1]) -join '\'
+            }
+            # Filter on the third key
+            if ($key.Count -gt 2)
+            {
+                [array]$sourceResource = $sourceResource.Where({ $_.($key[2]) -eq $resource.($key[2]) })
+                $destinationKeyValue = $resource.($key[0]), $resource.($key[1]), $resource.($key[2]) -join '\'
             }
 
             if ($null -eq $sourceResource -or $sourceResource.Count -eq 0)

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -470,13 +470,12 @@ function Test-M365DSCTargetResource
 
     # Retrieve the primary keys of the given resource and remove them from the list of values to check.
     $currentPath = $PSScriptRoot
-    if ($null -eq $Script:M365DSCSchema)
+    if (-not [Microsoft365DSC.Cache.CacheManager]::IsSchemaLoaded)
     {
         $schemaPath = Join-Path -Path $currentPath -ChildPath '..\SchemaDefinition.json'
-        $schemaJSON = Get-Content $schemaPath -Raw
-        $Script:M365DSCSchema = ConvertFrom-Json $schemaJSON
+        [Microsoft365DSC.Cache.CacheManager]::LoadSchema($schemaPath)
     }
-    $resourceDefinition = $Script:M365DSCSchema | Where-Object -FilterScript { $_.ClassName -eq "MSFT_$ResourceName" }
+    $resourceDefinition = [Microsoft365DSC.Utilities.Utilities]::FilterLoadedCimClassesByName("MSFT_$ResourceName")
     $resourceKeys = $resourceDefinition.Parameters | Where-Object -FilterScript { $_.Option -eq 'Key' }
 
     $keyStrings = @()
@@ -1865,7 +1864,7 @@ function Get-M365DSCResourceComparisonMetadata
         {
             try
             {
-                $metadataContent = Get-Content -Path $metadataPath -Raw | ConvertFrom-Json
+                $metadataContent = [System.IO.File]::ReadAllText($metadataPath) | ConvertFrom-Json
                 $Script:M365DSCComparisonMetadata = @{}
                 foreach ($resource in $metadataContent.Resources.PSObject.Properties)
                 {

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -473,7 +473,8 @@ function Test-M365DSCTargetResource
     if (-not [Microsoft365DSC.Cache.CacheManager]::IsSchemaLoaded)
     {
         $schemaPath = Join-Path -Path $currentPath -ChildPath '..\SchemaDefinition.json'
-        [Microsoft365DSC.Cache.CacheManager]::LoadSchema($schemaPath)
+        $schemaContent = [System.IO.File]::ReadAllText($schemaPath) | ConvertFrom-Json
+        [Microsoft365DSC.Cache.CacheManager]::LoadSchema($schemaContent)
     }
     $resourceDefinition = [Microsoft365DSC.Utilities.Utilities]::FilterLoadedCimClassesByName("MSFT_$ResourceName")
     $resourceKeys = $resourceDefinition.Parameters | Where-Object -FilterScript { $_.Option -eq 'Key' }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADVerifiedIdAuthority.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADVerifiedIdAuthority.Tests.ps1
@@ -46,6 +46,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                 linkedDomainUrls = @("FakeStringValue")
                                 did = "did:FakeStringValue"
                             }
+                            keyVaultMetadata = @{
+                                subscriptionId = "FakeStringValue"
+                                resourceGroup = "FakeStringValue"
+                                resourceName = "FakeStringValue"
+                                resourceUrl = "FakeStringValue"
+                            }
                         }
                     )
                 }
@@ -63,7 +69,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
             Mock -CommandName Write-Warning -MockWith {
             }
-            $Script:exportedInstances =$null
+            $Script:exportedInstances = $null
             $Script:ExportMode = $false
         }
         # Test contexts

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAntivirusPolicyMacOS.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAntivirusPolicyMacOS.Tests.ps1
@@ -671,7 +671,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         } -ClientOnly)
                         (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
                             Exclusions_item_name = 'Test'
-                            ThreatTypeSettings_item_key = 'excludedFileName'
+                            Exclusions_item_type = 'excludedFileName'
                         } -ClientOnly)
                     );
                     Id = "12345-12345-12345-12345-12345"
@@ -722,7 +722,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         } -ClientOnly)
                         (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
                             Exclusions_item_name = 'Test'
-                            ThreatTypeSettings_item_key = 'excludedFileName'
+                            Exclusions_item_type = 'excludedFileName'
                         } -ClientOnly)
                     );
                     Id = "12345-12345-12345-12345-12345"
@@ -765,7 +765,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         } -ClientOnly)
                         (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogExclusions -Property @{
                             Exclusions_item_name = 'Test'
-                            ThreatTypeSettings_item_key = 'excludedFileName'
+                            Exclusions_item_type = 'excludedFileName'
                         } -ClientOnly)
                     );
                     Id = "12345-12345-12345-12345-12345"

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneCloudProvisioningPolicyWindows365.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneCloudProvisioningPolicyWindows365.Tests.ps1
@@ -55,7 +55,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             id = "12345-12345-12345-12345-12345"
                             target = @{
                                 '@odata.type' = '#microsoft.graph.cloudPcManagementGroupAssignmentTarget'
-                                groupId = "26d60dd1-fab6-47bf-8656-358194c1a49d"
+                                groupId = "42a638ec-2bf2-47a8-8f5f-176ce2124b7b"
                             }
                         }
                     )

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneSecurityBaselineDefenderForEndpoint.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneSecurityBaselineDefenderForEndpoint.Tests.ps1
@@ -411,7 +411,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     DisplayName = "My Test"
                     RoleScopeTagIds = @("FakeStringValue")
                     userSettings = (New-CimInstance -ClassName MSFT_MicrosoftGraphIntuneSettingsCatalogUserSettings_IntuneSecurityBaselineDefenderForEndpoint -Property @{
-                        DisableSafetyFilterOverrideForAppRepUnknown = 0
+                        DisableSafetyFilterOverrideForAppRepUnknown = 0 # Drift
                     } -ClientOnly)
                     Ensure = "Present"
                     Credential = $Credential;

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneWindowsInformationProtectionPolicyWindows10MdmEnrolled.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneWindowsInformationProtectionPolicyWindows10MdmEnrolled.Tests.ps1
@@ -194,7 +194,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     EnterpriseIPRanges                     = @(
                         (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsInformationProtectionIPRangeCollection -Property @{
                             DisplayName = 'FakeStringValue'
-                            Ranges      = [CIMInstance[]]@(New-CimInstance -ClassName MSFT_MicrosoftGraphipRange -Property @{
+                            Ranges      = [CimInstance[]]@(New-CimInstance -ClassName MSFT_MicrosoftGraphipRange -Property @{
                                     CidrAddress  = 'FakeStringValue'
                                     UpperAddress = 'FakeStringValue'
                                     LowerAddress = 'FakeStringValue'
@@ -316,7 +316,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     EnterpriseIPRanges                     = @(
                         (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsInformationProtectionIPRangeCollection -Property @{
                             DisplayName = 'FakeStringValue'
-                            Ranges      = (New-CimInstance -ClassName MSFT_MicrosoftGraphipRange -Property @{
+                            Ranges      = [CimInstance[]]@(New-CimInstance -ClassName MSFT_MicrosoftGraphipRange -Property @{
                                     CidrAddress  = 'FakeStringValue'
                                     UpperAddress = 'FakeStringValue'
                                     LowerAddress = 'FakeStringValue'
@@ -436,7 +436,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     EnterpriseIPRanges                     = @(
                         (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsInformationProtectionIPRangeCollection -Property @{
                             DisplayName = 'FakeStringValue'
-                            Ranges      = (New-CimInstance -ClassName MSFT_MicrosoftGraphipRange -Property @{
+                            Ranges      = [CimInstance[]]@(New-CimInstance -ClassName MSFT_MicrosoftGraphipRange -Property @{
                                     CidrAddress  = 'FakeStringValue'
                                     UpperAddress = 'FakeStringValue'
                                     LowerAddress = 'FakeStringValue'
@@ -548,7 +548,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     EnterpriseIPRanges                     = @(
                         (New-CimInstance -ClassName MSFT_MicrosoftGraphwindowsInformationProtectionIPRangeCollection -Property @{
                             DisplayName = 'FakeStringValue'
-                            Ranges      = (New-CimInstance -ClassName MSFT_MicrosoftGraphipRange -Property @{
+                            Ranges      = [CimInstance[]]@(New-CimInstance -ClassName MSFT_MicrosoftGraphipRange -Property @{
                                     CidrAddress  = 'FakeStringValue'
                                     UpperAddress = 'FakeStringValue'
                                     LowerAddress = 'FakeStringValue'

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.PPDLPPolicyConnectorConfigurations.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.PPDLPPolicyConnectorConfigurations.Tests.ps1
@@ -47,7 +47,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     ConnectorActionConfigurations =
                         (New-CimInstance -ClassName 'MSFT_PPDLPPolicyConnectorConfigurationsAction' -Property @{
-                            actionRules = (New-CimInstance -ClassName 'MSFT_PPDLPPolicyConnectorConfigurationsActionRules' -Property @{
+                            actionRules = [CimInstance[]]@(New-CimInstance -ClassName 'MSFT_PPDLPPolicyConnectorConfigurationsActionRules' -Property @{
                                     actionId = 'CreateInvitation'
                                     behavior = 'Block'
                                 } -ClientOnly)
@@ -134,7 +134,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     ConnectorActionConfigurations =
                         (New-CimInstance -ClassName 'MSFT_PPDLPPolicyConnectorConfigurationsAction' -Property @{
-                            actionRules = (New-CimInstance -ClassName 'MSFT_PPDLPPolicyConnectorConfigurationsActionRules' -Property @{
+                            actionRules = [CimInstance[]]@(New-CimInstance -ClassName 'MSFT_PPDLPPolicyConnectorConfigurationsActionRules' -Property @{
                                     actionId = 'CreateInvitation'
                                     behavior = 'Block'
                                 } -ClientOnly)
@@ -211,7 +211,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $testParams = @{
                     ConnectorActionConfigurations =
                         (New-CimInstance -ClassName 'MSFT_PPDLPPolicyConnectorConfigurationsAction' -Property @{
-                            actionRules = (New-CimInstance -ClassName 'MSFT_PPDLPPolicyConnectorConfigurationsActionRules' -Property @{
+                            actionRules = [CimInstance[]]@(New-CimInstance -ClassName 'MSFT_PPDLPPolicyConnectorConfigurationsActionRules' -Property @{
                                     actionId = 'CreateInvitation'
                                     behavior = 'Block'
                                 } -ClientOnly)

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCPolicyConfig.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCPolicyConfig.Tests.ps1
@@ -163,7 +163,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     SiteGroups                              = @(
                         (New-CimInstance -ClassName MSFT_PolicyConfigDLPSiteGroups -Property @{
                             Name      = 'Whatever'
-                            Addresses = (New-CimInstance -ClassName MSFT_PolicyConfigSiteGroupAddress -Property @{
+                            Addresses = [CimInstance[]]@(New-CimInstance -ClassName MSFT_PolicyConfigSiteGroupAddress -Property @{
                                     MatchType    = 'UrlMatch'
                                     Url          = 'Karakette.com'
                                     AddressLower = ''

--- a/Utilities/Build-DllFiles.ps1
+++ b/Utilities/Build-DllFiles.ps1
@@ -136,8 +136,8 @@ function Build-Project {
 
     $filesToCopy = @(
         "$projectName.dll"
-        "$projectName.pdb"  # Include PDB for debugging
-        "$projectName.xml"  # Include XML documentation
+        "$projectName.pdb" # Include PDB for debugging
+        "$projectName.xml" # Include XML documentation
     )
 
     foreach ($fileName in $filesToCopy) {

--- a/src/Microsoft365DSC.Cache/CacheManager.cs
+++ b/src/Microsoft365DSC.Cache/CacheManager.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
-using System.Text.Json;
+using System.Management.Automation;
 
 namespace Microsoft365DSC.Cache
 {
@@ -52,21 +51,19 @@ namespace Microsoft365DSC.Cache
         /// the result. Subsequent calls are no-ops unless <paramref name="force"/>
         /// is <c>true</c>.
         /// </summary>
-        /// <param name="filePath">Absolute path to SchemaDefinition.json.</param>
+        /// <param name="schema">List of schema objects to cache.</param>
         /// <param name="force">When <c>true</c>, reloads even if already cached.</param>
-        public static void LoadSchema(string filePath, bool force = false)
+        public static void LoadSchema(List<object> schema, bool force = false)
         {
-            if (string.IsNullOrEmpty(filePath))
-                throw new ArgumentNullException(nameof(filePath));
+            List<object> newSchema = [];
+            foreach (object entry in schema)
+            {
+                newSchema.Add(ConvertObjectToHashtable(entry));
+            }
 
             lock (SchemaLock)
             {
-                if (_schema != null && !force)
-                    return;
-
-                string json = File.ReadAllText(filePath);
-                using JsonDocument doc = JsonDocument.Parse(json);
-                _schema = ConvertJsonArray(doc.RootElement);
+                _schema = newSchema;
             }
         }
 
@@ -82,63 +79,43 @@ namespace Microsoft365DSC.Cache
             }
         }
 
-        #region JSON to Hashtable conversion
+        private static object ConvertObjectToHashtable(object entry)
+        {
+            Hashtable result = new(StringComparer.OrdinalIgnoreCase);
 
-        /// <summary>
-        /// Converts a <see cref="JsonElement"/> array into a <see cref="List{Object}"/>
-        /// of Hashtables, preserving the structure expected by ResourceComparer's
-        /// GetProperty / GetStringProperty helpers.
-        /// </summary>
-        private static List<object> ConvertJsonArray(JsonElement element)
+            if (entry is PSObject psObject)
+            {
+                foreach (var prop in psObject.Properties)
+                {
+                    result[prop.Name] = ConvertObjectToHashtable(prop.Value);
+                }
+            }
+            else if (entry is IDictionary dict)
+            {
+                foreach (DictionaryEntry kvp in dict)
+                {
+                    result[kvp.Key.ToString()] = ConvertObjectToHashtable(kvp.Value);
+                }
+            }
+            else if (entry is IEnumerable enumerable && entry is not string)
+            {
+                return ConvertEnumerableToHashtableArray(enumerable);
+            }
+            else
+            {
+                return entry;
+            }
+            return result;
+        }
+
+        private static object[] ConvertEnumerableToHashtableArray(IEnumerable enumerable)
         {
             var list = new List<object>();
-            foreach (JsonElement item in element.EnumerateArray())
+            foreach (object item in enumerable)
             {
-                list.Add(ConvertJsonElement(item));
+                list.Add(ConvertObjectToHashtable(item));
             }
-            return list;
+            return list.ToArray();
         }
-
-        private static object ConvertJsonElement(JsonElement element)
-        {
-            switch (element.ValueKind)
-            {
-                case JsonValueKind.Object:
-                    var table = new Hashtable(StringComparer.OrdinalIgnoreCase);
-                    foreach (JsonProperty prop in element.EnumerateObject())
-                    {
-                        table[prop.Name] = ConvertJsonElement(prop.Value);
-                    }
-                    return table;
-
-                case JsonValueKind.Array:
-                    var items = new List<object>();
-                    foreach (JsonElement child in element.EnumerateArray())
-                    {
-                        items.Add(ConvertJsonElement(child));
-                    }
-                    return items;
-
-                case JsonValueKind.String:
-                    return element.GetString();
-
-                case JsonValueKind.Number:
-                    if (element.TryGetInt64(out long longVal))
-                        return longVal;
-                    return element.GetDouble();
-
-                case JsonValueKind.True:
-                    return true;
-
-                case JsonValueKind.False:
-                    return false;
-
-                case JsonValueKind.Null:
-                default:
-                    return null;
-            }
-        }
-
-        #endregion
     }
 }

--- a/src/Microsoft365DSC.Cache/CacheManager.cs
+++ b/src/Microsoft365DSC.Cache/CacheManager.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace Microsoft365DSC.Cache
+{
+    /// <summary>
+    /// Provides a centralized, thread-safe cache for expensive data structures
+    /// shared across PowerShell and C# layers. Loading data here avoids repeated
+    /// deserialization and the boxing overhead that occurs when passing rich
+    /// objects from PowerShell to C#.
+    /// </summary>
+    public static class CacheManager
+    {
+        private static readonly object SchemaLock = new();
+        private static List<object> _schema;
+
+        /// <summary>
+        /// Gets a value indicating whether the M365DSC schema has been loaded.
+        /// </summary>
+        public static bool IsSchemaLoaded
+        {
+            get
+            {
+                lock (SchemaLock)
+                {
+                    return _schema != null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the cached schema as an <see cref="IEnumerable{Object}"/> of Hashtables.
+        /// Returns <c>null</c> if the schema has not been loaded yet.
+        /// </summary>
+        public static IEnumerable<object> Schema
+        {
+            get
+            {
+                lock (SchemaLock)
+                {
+                    return _schema;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Loads the SchemaDefinition.json file from <paramref name="filePath"/>,
+        /// deserializes it into a list of <see cref="Hashtable"/> trees, and caches
+        /// the result. Subsequent calls are no-ops unless <paramref name="force"/>
+        /// is <c>true</c>.
+        /// </summary>
+        /// <param name="filePath">Absolute path to SchemaDefinition.json.</param>
+        /// <param name="force">When <c>true</c>, reloads even if already cached.</param>
+        public static void LoadSchema(string filePath, bool force = false)
+        {
+            if (string.IsNullOrEmpty(filePath))
+                throw new ArgumentNullException(nameof(filePath));
+
+            lock (SchemaLock)
+            {
+                if (_schema != null && !force)
+                    return;
+
+                string json = File.ReadAllText(filePath);
+                using JsonDocument doc = JsonDocument.Parse(json);
+                _schema = ConvertJsonArray(doc.RootElement);
+            }
+        }
+
+        /// <summary>
+        /// Clears the cached schema, allowing it to be reloaded on next access.
+        /// Primarily useful for testing.
+        /// </summary>
+        public static void ClearSchema()
+        {
+            lock (SchemaLock)
+            {
+                _schema = null;
+            }
+        }
+
+        #region JSON to Hashtable conversion
+
+        /// <summary>
+        /// Converts a <see cref="JsonElement"/> array into a <see cref="List{Object}"/>
+        /// of Hashtables, preserving the structure expected by ResourceComparer's
+        /// GetProperty / GetStringProperty helpers.
+        /// </summary>
+        private static List<object> ConvertJsonArray(JsonElement element)
+        {
+            var list = new List<object>();
+            foreach (JsonElement item in element.EnumerateArray())
+            {
+                list.Add(ConvertJsonElement(item));
+            }
+            return list;
+        }
+
+        private static object ConvertJsonElement(JsonElement element)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    var table = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                    foreach (JsonProperty prop in element.EnumerateObject())
+                    {
+                        table[prop.Name] = ConvertJsonElement(prop.Value);
+                    }
+                    return table;
+
+                case JsonValueKind.Array:
+                    var items = new List<object>();
+                    foreach (JsonElement child in element.EnumerateArray())
+                    {
+                        items.Add(ConvertJsonElement(child));
+                    }
+                    return items;
+
+                case JsonValueKind.String:
+                    return element.GetString();
+
+                case JsonValueKind.Number:
+                    if (element.TryGetInt64(out long longVal))
+                        return longVal;
+                    return element.GetDouble();
+
+                case JsonValueKind.True:
+                    return true;
+
+                case JsonValueKind.False:
+                    return false;
+
+                case JsonValueKind.Null:
+                default:
+                    return null;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/Microsoft365DSC.Cache/Microsoft365DSC.Cache.csproj
+++ b/src/Microsoft365DSC.Cache/Microsoft365DSC.Cache.csproj
@@ -16,7 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
+    <PackageReference Include="System.Management" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft365DSC.Cache/Microsoft365DSC.Cache.csproj
+++ b/src/Microsoft365DSC.Cache/Microsoft365DSC.Cache.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Microsoft365DSC.Cache</AssemblyName>
+    <RootNamespace>Microsoft365DSC.Cache</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Authors>Microsoft365DSC Team</Authors>
+    <Company>Microsoft365DSC</Company>
+    <Product>Microsoft365DSC Cache</Product>
+    <Description>Performance-optimized C# Cache for Microsoft365DSC configuration operations</Description>
+    <Copyright>Copyright © Microsoft365DSC</Copyright>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="10.0.5" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft365DSC.Compare/IntunePolicyAssignmentComparer.cs
+++ b/src/Microsoft365DSC.Compare/IntunePolicyAssignmentComparer.cs
@@ -25,7 +25,7 @@ namespace Microsoft365DSC.Compare
             }
 
             bool testResult = source.Length == target.Length;
-            
+
             if (!testResult)
             {
                 drifts.Add(new Dictionary<string, object>
@@ -54,13 +54,13 @@ namespace Microsoft365DSC.Compare
                 }
 
                 // Check if dataType ends with 'AssignmentTarget'
-                if (dataType.EndsWith("AssignmentTarget", StringComparison.OrdinalIgnoreCase))
+                if (dataType!.EndsWith("AssignmentTarget", StringComparison.OrdinalIgnoreCase))
                 {
                     var assignmentGroupId = GetPropertyValue<string>(assignment, "groupId");
                     var assignmentIntent = GetPropertyValue<string>(assignment, "intent");
-                    
+
                     // Find matching assignment target by dataType and groupId
-                    Hashtable assignmentTarget = FindAssignmentTarget(target, dataType, assignmentGroupId);
+                    Hashtable? assignmentTarget = FindAssignmentTarget(target, dataType, assignmentGroupId);
                     testResult = assignmentTarget is not null;
 
                     // Check for mobile app assignments with intent
@@ -99,9 +99,9 @@ namespace Microsoft365DSC.Compare
                     {
                         var assignmentCollectionId = GetPropertyValue<string>(assignment, "collectionId");
                         var targetCollectionId = GetPropertyValue<string>(assignmentTarget, "collectionId");
-                        
+
                         testResult = string.Equals(assignmentCollectionId, targetCollectionId, StringComparison.OrdinalIgnoreCase);
-                        
+
                         if (!testResult)
                         {
                             drifts.Add(new Dictionary<string, object>
@@ -119,20 +119,21 @@ namespace Microsoft365DSC.Compare
                     bool found = false;
                     foreach (var targetItem in target)
                     {
-                        if (targetItem is null) continue;
-                        
+                        if (targetItem is null)
+                            continue;
+
                         var targetHash = ComplexObjectConverter.ToHashtable(targetItem);
                         var targetDataType = GetPropertyValue<string>(targetHash, "dataType");
-                        
+
                         if (string.Equals(dataType, targetDataType, StringComparison.OrdinalIgnoreCase))
                         {
                             found = true;
                             break;
                         }
                     }
-                    
+
                     testResult = found;
-                    
+
                     if (!testResult)
                     {
                         drifts.Add(new Dictionary<string, object>
@@ -164,11 +165,11 @@ namespace Microsoft365DSC.Compare
             var assignmentFilterId = GetPropertyValue<string>(assignment, "deviceAndAppManagementAssignmentFilterId");
             var targetFilterId = GetPropertyValue<string>(assignmentTarget, "deviceAndAppManagementAssignmentFilterId");
 
-            bool isFilterTypeSpecified = 
+            bool isFilterTypeSpecified =
                 (!string.IsNullOrEmpty(assignmentFilterType) && !assignmentFilterType!.Equals("none", StringComparison.OrdinalIgnoreCase)) ||
                 (!string.IsNullOrEmpty(targetFilterType) && !targetFilterType!.Equals("none", StringComparison.OrdinalIgnoreCase));
 
-            bool isFilterIdSpecified = 
+            bool isFilterIdSpecified =
                 (!string.IsNullOrEmpty(assignmentFilterId) && !assignmentFilterId!.Equals("00000000-0000-0000-0000-000000000000", StringComparison.OrdinalIgnoreCase)) ||
                 (!string.IsNullOrEmpty(targetFilterId) && !targetFilterId!.Equals("00000000-0000-0000-0000-000000000000", StringComparison.OrdinalIgnoreCase));
 
@@ -254,7 +255,7 @@ namespace Microsoft365DSC.Compare
         /// <summary>
         /// Gets a typed property value from a hashtable with null safety.
         /// </summary>
-        private static T? GetPropertyValue<T>(Hashtable hashtable, string key)
+        private static T? GetPropertyValue<T>(Hashtable? hashtable, string key)
         {
             if (hashtable is null || !hashtable.ContainsKey(key))
             {

--- a/src/Microsoft365DSC.Compare/ResourceComparer.cs
+++ b/src/Microsoft365DSC.Compare/ResourceComparer.cs
@@ -1,0 +1,734 @@
+using Microsoft365DSC.Converter;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+
+namespace Microsoft365DSC.Compare
+{
+    /// <summary>
+    /// High-level resource comparison entry point.
+    /// Normalizes both sides to Hashtable trees, resolves schema metadata,
+    /// aligns complex arrays by primary keys, then delegates to
+    /// ComplexObjectComparer and SimpleObjectComparer for the actual diff.
+    ///
+    /// This class replaces the complex PowerShell orchestration loop that
+    /// previously lived in Compare-M365DSCResourceState, eliminating
+    /// CimInstance type checks, the Address property workaround, and the
+    /// two-phase complex-then-simple split.
+    /// </summary>
+    public static class ResourceComparer
+    {
+        // Properties that are always excluded from comparison
+        private static readonly HashSet<string> AlwaysExcludedProperties = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Verbose", "Credential", "ApplicationId", "CertificateThumbprint",
+            "CertificatePath", "CertificatePassword", "TenantId",
+            "ApplicationSecret", "ManagedIdentity", "AccessTokens"
+        };
+
+        /// <summary>
+        /// Compares desired vs current values for a single DSC resource.
+        /// Both sides are normalized to Hashtable trees before comparison.
+        /// </summary>
+        /// <param name="desiredValues">Desired state hashtable (from PSBoundParameters)</param>
+        /// <param name="currentValues">Current state hashtable (from Get-TargetResource)</param>
+        /// <param name="schema">The full schema array (deserialized SchemaDefinition.json)</param>
+        /// <param name="resourceName">Resource name without MSFT_ prefix (e.g. "AADUser")</param>
+        /// <param name="excludedProperties">Properties to skip during comparison</param>
+        /// <param name="includedProperties">Properties to force-include even if otherwise skipped</param>
+        /// <returns>A CompareResult with test result, drift info, and value snapshots</returns>
+        public static CompareResult Compare(
+            Hashtable desiredValues,
+            Hashtable currentValues,
+            Hashtable valuesToCheck,
+            IEnumerable<object> schema,
+            string resourceName,
+            string[]? excludedProperties = null,
+            string[]? includedProperties = null)
+        {
+            if (desiredValues is null)
+                throw new ArgumentNullException(nameof(desiredValues));
+            if (desiredValues is null)
+                throw new ArgumentNullException(nameof(currentValues));
+            if (desiredValues is null)
+                throw new ArgumentNullException(nameof(schema));
+            if (string.IsNullOrEmpty(resourceName))
+                throw new ArgumentNullException(nameof(resourceName));
+
+            // Transform schema elements from PSObject to their BaseObject if needed for easier access
+            var result = new CompareResult();
+            var excludedSet = new HashSet<string>(AlwaysExcludedProperties, StringComparer.OrdinalIgnoreCase);
+            if (excludedProperties != null)
+            {
+                foreach (string prop in excludedProperties)
+                    excludedSet.Add(prop);
+            }
+            var includedSet = includedProperties != null
+                ? new HashSet<string>(includedProperties, StringComparer.OrdinalIgnoreCase)
+                : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            // Look up the resource definition from the schema
+            string fullClassName = "MSFT_" + resourceName;
+            var resourceDef = FindSchemaEntry(schema, fullClassName) ?? throw new InvalidOperationException($"Resource definition not found in schema for '{fullClassName}'.");
+
+            // Build a dictionary of parameter definitions for this resource
+            var parameterDefs = BuildParameterLookup(resourceDef);
+
+            // Build a schema lookup for nested CIM type resolution
+            var schemaLookup = BuildSchemaLookup(schema);
+
+            // Determine which keys to compare: start from desired, remove keys/credentials/excluded, add included
+            var keysToCompare = BuildKeysToCompare(valuesToCheck, parameterDefs, excludedSet, includedSet);
+
+            // Handle Ensure early: if both sides agree on Absent, skip everything
+            bool skipEvaluation = false;
+            string? desiredEnsure = GetStringValue(desiredValues, "Ensure");
+            string? currentEnsure = GetStringValue(currentValues, "Ensure");
+
+            if (string.Equals(desiredEnsure ?? "Present", "Present", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(currentEnsure, "Absent", StringComparison.OrdinalIgnoreCase))
+            {
+                result.AddDrift("Ensure", "Absent", "Present");
+                result.TestResult = false;
+                excludedSet.Add("Ensure");
+                keysToCompare.Remove("Ensure");
+            }
+            else if (string.Equals(desiredEnsure ?? "Present", "Absent", StringComparison.OrdinalIgnoreCase) &&
+                     string.Equals(currentEnsure, "Present", StringComparison.OrdinalIgnoreCase))
+            {
+                result.AddDrift("Ensure", "Present", "Absent");
+                result.TestResult = false;
+                excludedSet.Add("Ensure");
+                keysToCompare.Remove("Ensure");
+            }
+            else if (string.Equals(desiredEnsure ?? "Present", "Absent", StringComparison.OrdinalIgnoreCase) &&
+                     string.Equals(currentEnsure, "Absent", StringComparison.OrdinalIgnoreCase))
+            {
+                skipEvaluation = true;
+            }
+
+            if (skipEvaluation)
+                return result;
+
+            // Separate keys into complex (MSFT_* CIM types) and simple
+            List<string> complexKeys = [];
+            List<string> simpleKeys = [];
+
+            foreach (string key in keysToCompare)
+            {
+                if (excludedSet.Contains(key))
+                    continue;
+
+                if (parameterDefs.TryGetValue(key, out var paramDef))
+                {
+                    string? cimType = GetStringProperty(paramDef, "CIMType");
+                    if (!string.IsNullOrEmpty(cimType) && cimType!.IndexOf("MSFT_", StringComparison.OrdinalIgnoreCase) > -1)
+                    {
+                        complexKeys.Add(key);
+                        continue;
+                    }
+                }
+
+                // Also check if the actual value is a complex object (CimInstance, Hashtable with nested structure from CIM)
+                object? desiredVal = desiredValues.ContainsKey(key) ? desiredValues[key] : null;
+                if (desiredVal is not null && IsComplexValue(desiredVal))
+                {
+                    complexKeys.Add(key);
+                    continue;
+                }
+
+                simpleKeys.Add(key);
+            }
+
+            // --- Complex property comparison ---
+            foreach (string key in complexKeys)
+            {
+                object? desiredRaw = desiredValues.ContainsKey(key) ? desiredValues[key] : null;
+                object? currentRaw = currentValues.ContainsKey(key) ? currentValues[key] : null;
+
+                if (desiredRaw is null)
+                    continue;
+
+                // Normalize both sides to uniform Hashtable/object[] trees
+                object? normalizedDesired = ObjectNormalizer.Normalize(desiredRaw);
+                object? normalizedCurrent = ObjectNormalizer.Normalize(currentRaw);
+
+                // For array properties: align target items by primary keys before comparison
+                if (normalizedDesired is object[] desiredArray)
+                {
+                    object[] currentArray = normalizedCurrent as object[] ?? [];
+
+                    // Resolve CIM primary keys from schema
+                    string? cimType = GetStringProperty(
+                        parameterDefs.TryGetValue(key, out object? value) ? value : null, "CIMType");
+                    string cimName = cimType?.Replace("[]", "") ?? string.Empty;
+
+                    var primaryKeyNames = GetPrimaryKeys(cimName, schemaLookup);
+                    bool isIntunePolicyAssignment = IsIntunePolicyAssignmentType(cimName);
+
+                    // For Intune policy assignments that have group-specific targets,
+                    // add groupDisplayName as an alignment key
+                    if (isIntunePolicyAssignment)
+                    {
+                        bool hasGroupTargets = HasGroupTargets(desiredArray) || HasGroupTargets(currentArray);
+                        if (hasGroupTargets && !primaryKeyNames.Contains("groupDisplayName", StringComparer.OrdinalIgnoreCase))
+                        {
+                            primaryKeyNames.Add("groupDisplayName");
+                        }
+                    }
+
+                    // Align: filter current array to only items whose primary keys match any desired item
+                    object[] alignedCurrent = AlignArrayByPrimaryKeys(desiredArray, currentArray, primaryKeyNames);
+
+                    // Remove primary keys from target items before comparison (unless force-included)
+                    // to avoid false positives when primary keys differ in casing etc.
+                    if (!isIntunePolicyAssignment || primaryKeyNames.Count > 0)
+                    {
+                        bool noPrimaryKeyRemoval = ShouldSkipPrimaryKeyRemoval(desiredArray, primaryKeyNames);
+                        if (!noPrimaryKeyRemoval)
+                        {
+                            RemovePrimaryKeysFromTargets(alignedCurrent, primaryKeyNames, includedSet, isIntunePolicyAssignment);
+                        }
+                    }
+
+                    // Delegate to ComplexObjectComparer
+                    var compResult = ComplexObjectComparer.Compare(desiredArray, alignedCurrent, key);
+                    if (!compResult.Item2)
+                    {
+                        result.TestResult = false;
+                        foreach (var drift in compResult.Item1)
+                        {
+                            result.DriftInfo.Add(ConvertDriftDict(drift));
+                        }
+                    }
+                }
+                else
+                {
+                    // Single complex object (not array)
+                    var compResult = ComplexObjectComparer.Compare(normalizedDesired, normalizedCurrent, key);
+                    if (!compResult.Item2)
+                    {
+                        result.TestResult = false;
+                        foreach (var drift in compResult.Item1)
+                        {
+                            result.DriftInfo.Add(ConvertDriftDict(drift));
+                        }
+                    }
+                }
+            }
+
+            // --- Simple property comparison ---
+            // Build filtered desired/current for simple comparison
+            Hashtable simpleDesired = new(StringComparer.OrdinalIgnoreCase);
+            foreach (string key in simpleKeys)
+            {
+                if (desiredValues.ContainsKey(key))
+                    simpleDesired[key] = desiredValues[key];
+            }
+
+            if (simpleKeys.Count > 0)
+            {
+                var simpleResult = SimpleObjectComparer.Compare(
+                    currentValues,
+                    simpleDesired,
+                    simpleKeys.ToArray(),
+                    null,
+                    true,  // noEventMessage: true because we handle drift reporting ourselves
+                    true,  // noDriftReset: true because we own the drift state
+                    excludedProperties != null ? [.. excludedProperties] : null);
+
+                bool simpleTestResult = (bool)simpleResult["TestResult"];
+                if (!simpleTestResult)
+                {
+                    result.TestResult = false;
+
+                    // Extract drift info from SimpleObjectComparer result
+                    if (simpleResult["DriftObject"] is Hashtable driftObject)
+                    {
+                        if (driftObject["DriftInfo"] is List<Hashtable> driftInfoList)
+                        {
+                            foreach (Hashtable drift in driftInfoList)
+                            {
+                                result.DriftInfo.Add(drift);
+                            }
+                        }
+                    }
+                }
+
+                // Copy drifted parameter event strings for telemetry
+                if (simpleResult["DriftedParameters"] is Hashtable driftedParams)
+                {
+                    foreach (DictionaryEntry entry in driftedParams)
+                    {
+                        result.DriftedParameters[entry.Key] = entry.Value;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        #region Schema helpers
+
+        /// <summary>
+        /// Finds a schema entry by ClassName from the schema collection.
+        /// Handles both PSObject (Windows PowerShell) and Hashtable (PowerShell Core) representations.
+        /// </summary>
+        private static object? FindSchemaEntry(IEnumerable<object> schema, string className)
+        {
+            foreach (object entry in schema)
+            {
+                string? name = GetStringProperty(entry, "ClassName");
+                if (string.Equals(name, className, StringComparison.OrdinalIgnoreCase))
+                    return entry;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Builds a lookup dictionary mapping ClassName to schema entry for fast nested type resolution.
+        /// </summary>
+        private static Dictionary<string, object> BuildSchemaLookup(IEnumerable<object> schema)
+        {
+            var lookup = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            foreach (object entry in schema)
+            {
+                string? name = GetStringProperty(entry, "ClassName");
+                if (!string.IsNullOrEmpty(name) && !lookup.ContainsKey(name!))
+                    lookup[name!] = entry;
+            }
+            return lookup;
+        }
+
+        /// <summary>
+        /// Builds a case-insensitive dictionary of parameter name to parameter definition object.
+        /// </summary>
+        private static Dictionary<string, object> BuildParameterLookup(object resourceDef)
+        {
+            var result = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            object parameters = GetProperty(resourceDef, "Parameters");
+            if (parameters is null)
+                return result;
+
+            IEnumerable<object> paramList = parameters is IEnumerable<object> list
+                ? list
+                : (parameters is IEnumerable enumerable ? enumerable.Cast<object>() : []);
+
+            foreach (object param in paramList)
+            {
+                string? name = GetStringProperty(param, "Name");
+                if (!string.IsNullOrEmpty(name))
+                    result[name!] = param;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Determines which keys from desired values should be compared,
+        /// excluding Key parameters, PSCredential types, Id/Identity, and explicitly excluded properties.
+        /// </summary>
+        private static HashSet<string> BuildKeysToCompare(
+            Hashtable desiredValues,
+            Dictionary<string, object> parameterDefs,
+            HashSet<string> excludedSet,
+            HashSet<string> includedSet)
+        {
+            var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (string key in desiredValues.Keys.Cast<string>())
+            {
+                // Always skip Id and Identity (they are lookup fields, not config)
+                if (string.Equals(key, "Id", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(key, "Identity", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // Skip if explicitly excluded
+                if (excludedSet.Contains(key))
+                    continue;
+
+                // Skip Key parameters and PSCredential types (from schema)
+                if (parameterDefs.TryGetValue(key, out var paramDef))
+                {
+                    string? option = GetStringProperty(paramDef, "Option");
+                    string? cimType = GetStringProperty(paramDef, "CIMType");
+
+                    if (string.Equals(option, "Key", StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    if (string.Equals(cimType, "PSCredential", StringComparison.OrdinalIgnoreCase))
+                        continue;
+                }
+
+                keys.Add(key);
+            }
+
+            // Force-include any explicitly requested properties
+            foreach (string prop in includedSet)
+            {
+                if (desiredValues.ContainsKey(prop))
+                    keys.Add(prop);
+            }
+
+            return keys;
+        }
+
+        /// <summary>
+        /// Gets the primary key names (Required parameters) for a CIM class from the schema.
+        /// </summary>
+        private static List<string> GetPrimaryKeys(string cimClassName, Dictionary<string, object> schemaLookup)
+        {
+            var primaryKeys = new List<string>();
+            if (string.IsNullOrEmpty(cimClassName) || !schemaLookup.TryGetValue(cimClassName, out object cimDef))
+                return primaryKeys;
+
+            object parameters = GetProperty(cimDef, "Parameters");
+            if (parameters is null)
+                return primaryKeys;
+
+            IEnumerable<object> paramList = parameters is IEnumerable<object> list
+                ? list
+                : (parameters is IEnumerable enumerable ? enumerable.Cast<object>() : Enumerable.Empty<object>());
+
+            foreach (object param in paramList)
+            {
+                string? option = GetStringProperty(param, "Option");
+                if (string.Equals(option, "Required", StringComparison.OrdinalIgnoreCase))
+                {
+                    string? name = GetStringProperty(param, "Name");
+                    if (!string.IsNullOrEmpty(name))
+                        primaryKeys.Add(name!);
+                }
+            }
+
+            return primaryKeys;
+        }
+
+        #endregion
+
+        #region Array alignment
+
+        /// <summary>
+        /// Filters the current array to only include items whose primary key values
+        /// match any of the desired items' primary key values.
+        /// This is the C# equivalent of the PowerShell Where-Object block that previously
+        /// suffered from the Address property workaround. Since we work with normalized
+        /// Hashtables here, we simply do case-insensitive dictionary lookups.
+        /// </summary>
+        private static object[] AlignArrayByPrimaryKeys(
+            object[] desired,
+            object[] current,
+            List<string> primaryKeyNames)
+        {
+            if (primaryKeyNames.Count == 0 || desired.Length == 0)
+                return current;
+
+            // Collect all primary key values from desiredarray per key name
+            var desiredKeyValues = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+            foreach (string pk in primaryKeyNames)
+            {
+                var values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (object item in desired)
+                {
+                    string val = GetHashtableStringValue(item as Hashtable, pk);
+                    if (val != null)
+                        values.Add(val);
+                }
+                desiredKeyValues[pk] = values;
+            }
+
+            var aligned = new List<object>();
+            foreach (object currentItem in current)
+            {
+                if (currentItem is not Hashtable currentHash)
+                    continue;
+
+                bool match = true;
+                foreach (string pk in primaryKeyNames)
+                {
+                    string currentVal = GetHashtableStringValue(currentHash, pk);
+                    if (currentVal != null && desiredKeyValues.TryGetValue(pk, out var allowedValues))
+                    {
+                        if (!allowedValues.Contains(currentVal))
+                        {
+                            match = false;
+                            break;
+                        }
+                    }
+                }
+
+                if (match)
+                    aligned.Add(currentItem);
+            }
+
+            return aligned.ToArray();
+        }
+
+        /// <summary>
+        /// Removes primary key entries from each target Hashtable so they do not
+        /// cause false-positive drifts. Skips removal for explicitly included properties
+        /// and for the dataType key on Intune policy assignments.
+        /// </summary>
+        private static void RemovePrimaryKeysFromTargets(
+            object[] targets,
+            List<string> primaryKeyNames,
+            HashSet<string> includedSet,
+            bool isIntunePolicyAssignment)
+        {
+            foreach (object item in targets)
+            {
+                if (item is not Hashtable hash)
+                    continue;
+
+                foreach (string pk in primaryKeyNames)
+                {
+                    // Keep dataType on Intune assignments (needed by IntunePolicyAssignmentComparer)
+                    if (isIntunePolicyAssignment &&
+                        string.Equals(pk, "dataType", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    // Keep if explicitly included
+                    if (includedSet.Contains(pk))
+                        continue;
+
+                    hash.Remove(pk);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks if we should skip primary key removal.
+        /// This happens when a primary key has multiple distinct values across source items
+        /// (meaning it is not truly a "primary key" for matching but rather a data field).
+        /// </summary>
+        private static bool ShouldSkipPrimaryKeyRemoval(object[] desired, List<string> primaryKeyNames)
+        {
+            foreach (string pk in primaryKeyNames)
+            {
+                var values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (object item in desired)
+                {
+                    string val = GetHashtableStringValue(item as Hashtable, pk);
+                    if (val != null)
+                        values.Add(val);
+                }
+                if (values.Count > 1)
+                    return true;
+            }
+            return false;
+        }
+
+        #endregion
+
+        #region Intune helpers
+
+        /// <summary>
+        /// Determines if a CIM class name represents an Intune policy assignment type.
+        /// </summary>
+        private static bool IsIntunePolicyAssignmentType(string cimName)
+        {
+            if (string.IsNullOrEmpty(cimName))
+                return false;
+
+            // Exclude the special case that should not be treated as Intune assignment
+            if (string.Equals(cimName, "MSFT_IntuneDeviceRemediationPolicyAssignments", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            bool matchesIntune = cimName.IndexOf("Intune", StringComparison.OrdinalIgnoreCase) > -1 &&
+                                 cimName.EndsWith("PolicyAssignments", StringComparison.OrdinalIgnoreCase);
+            bool matchesDevMgmt = cimName.IndexOf("DeviceManagementConfigurationPolicyAssignments", StringComparison.OrdinalIgnoreCase) > -1;
+
+            return matchesIntune || matchesDevMgmt;
+        }
+
+        /// <summary>
+        /// Checks if any item in the array has a dataType that is group-specific
+        /// (not allLicensedUsers or allDevices).
+        /// </summary>
+        private static bool HasGroupTargets(object[] items)
+        {
+            if (items is null || items.Length == 0)
+                return false;
+
+            if (items[0] is not Hashtable first)
+                return false;
+
+            string dataType = GetHashtableStringValue(first, "dataType");
+            if (string.IsNullOrEmpty(dataType))
+                return false;
+
+            return !string.Equals(dataType, "#microsoft.graph.allLicensedUsersAssignmentTarget", StringComparison.OrdinalIgnoreCase) &&
+                   !string.Equals(dataType, "#microsoft.graph.allDevicesAssignmentTarget", StringComparison.OrdinalIgnoreCase);
+        }
+
+        #endregion
+
+        #region Property access helpers
+
+        /// <summary>
+        /// Gets a string property from an object that could be a PSObject, Hashtable, or other type.
+        /// Handles both Windows PowerShell (PSObject) and PowerShell Core (Hashtable) schema representations.
+        /// </summary>
+        private static string? GetStringProperty(object? obj, string propertyName)
+        {
+            if (obj is null)
+                return null;
+
+            if (obj is Hashtable hash)
+                return hash.ContainsKey(propertyName) ? hash[propertyName]?.ToString() : null;
+
+            if (obj is IDictionary dict)
+                return dict.Contains(propertyName) ? dict[propertyName]?.ToString() : null;
+
+            if (obj is PSObject psObj)
+            {
+                var prop = psObj.Properties[propertyName];
+                return prop?.Value?.ToString();
+            }
+
+            // Try dynamic access as last resort
+            try
+            {
+                var type = obj.GetType();
+                var propInfo = type.GetProperty(propertyName);
+                return propInfo?.GetValue(obj)?.ToString();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets a property value from an object (supports Hashtable, IDictionary, PSObject).
+        /// </summary>
+        private static object? GetProperty(object obj, string propertyName)
+        {
+            if (obj is null)
+                return null;
+
+            if (obj is Hashtable hash)
+                return hash.ContainsKey(propertyName) ? hash[propertyName] : null;
+
+            if (obj is IDictionary dict)
+                return dict.Contains(propertyName) ? dict[propertyName] : null;
+
+            if (obj is PSObject psObj)
+            {
+                var prop = psObj.Properties[propertyName];
+                return prop?.Value;
+            }
+
+            try
+            {
+                var type = obj.GetType();
+                var propInfo = type.GetProperty(propertyName);
+                return propInfo?.GetValue(obj);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets a string value from a hashtable by key with null safety.
+        /// </summary>
+        private static string? GetHashtableStringValue(Hashtable hash, string key)
+        {
+            if (hash is null || !hash.ContainsKey(key))
+                return null;
+            return hash[key]?.ToString();
+        }
+
+        /// <summary>
+        /// Gets a string from a Hashtable, defaulting to null if not present.
+        /// </summary>
+        private static string? GetStringValue(Hashtable hash, string key)
+        {
+            if (hash is null || !hash.ContainsKey(key))
+                return null;
+            return hash[key]?.ToString();
+        }
+
+        /// <summary>
+        /// Checks whether a value is a complex type that needs ComplexObjectComparer
+        /// rather than SimpleObjectComparer.
+        /// </summary>
+        private static bool IsComplexValue(object value)
+        {
+            if (value is null)
+                return false;
+
+            if (value is PSObject psObj)
+                value = psObj.BaseObject;
+
+            // CimInstance or CimInstance[]
+            string typeName = value.GetType().Name;
+            if (typeName.IndexOf("CimInstance", StringComparison.OrdinalIgnoreCase) > -1)
+                return true;
+
+            // Array of hashtables (already normalized complex objects)
+            if (value is Array array && array.Length > 0)
+            {
+                object first = array.GetValue(0);
+                if (first is PSObject firstPs)
+                    first = firstPs.BaseObject;
+                if (first is Hashtable || first is IDictionary)
+                    return true;
+                if (first != null && first.GetType().Name.IndexOf("CimInstance", StringComparison.OrdinalIgnoreCase) > -1)
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Converts a Dictionary&lt;string, object&gt; drift entry to a Hashtable for PowerShell consumption.
+        /// </summary>
+        private static Hashtable ConvertDriftDict(Dictionary<string, object> drift)
+        {
+            var ht = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            foreach (var kvp in drift)
+                ht[kvp.Key] = kvp.Value;
+            return ht;
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// Result object for ResourceComparer.Compare.
+    /// Contains the test result (true = no drift), drift info entries,
+    /// and drifted parameter event strings for telemetry.
+    /// </summary>
+    public class CompareResult
+    {
+        /// <summary>
+        /// True if no drift was detected; false otherwise.
+        /// </summary>
+        public bool TestResult { get; set; } = true;
+
+        /// <summary>
+        /// List of drift entries. Each entry has PropertyName, CurrentValue, DesiredValue.
+        /// </summary>
+        public List<Hashtable> DriftInfo { get; } = [];
+
+        /// <summary>
+        /// Drifted parameter event strings for telemetry (key = param name, value = XML snippet).
+        /// </summary>
+        public Hashtable DriftedParameters { get; } = new Hashtable(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Adds a drift entry.
+        /// </summary>
+        public void AddDrift(string propertyName, object currentValue, object desiredValue)
+        {
+            DriftInfo.Add(new Hashtable(StringComparer.OrdinalIgnoreCase)
+            {
+                { "PropertyName", propertyName },
+                { "CurrentValue", currentValue },
+                { "DesiredValue", desiredValue }
+            });
+        }
+    }
+}

--- a/src/Microsoft365DSC.Converter/ComplexObjectConverter.cs
+++ b/src/Microsoft365DSC.Converter/ComplexObjectConverter.cs
@@ -32,6 +32,29 @@ namespace Microsoft365DSC.Converter
             if (complexObject is PSObject psObject && psObject.BaseObject is not null)
                 complexObject = psObject.BaseObject;
 
+            if (complexObject is PSObject psObject2)
+            {
+                var result = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                foreach (PSPropertyInfo prop in psObject2.Properties)
+                {
+                    // Skip computed properties; only take NoteProperty and Property
+                    if (prop.MemberType != PSMemberTypes.NoteProperty &&
+                        prop.MemberType != PSMemberTypes.Property)
+                        continue;
+
+                    try
+                    {
+                        result[prop.Name] = ToHashtable(prop.Value);
+                    }
+                    catch
+                    {
+                        // Some properties may throw on access (ParameterizedProperty etc.)
+                        // Skip them silently
+                    }
+                }
+                return result;
+            }
+
             if (complexObject is Hashtable hashtable)
                 return hashtable;
 
@@ -56,27 +79,7 @@ namespace Microsoft365DSC.Converter
             }
             else if (complexObject.GetType().FullName.Contains("Microsoft.Graph."))
             {
-                var graphResult = new Hashtable(StringComparer.OrdinalIgnoreCase);
-                var type = complexObject.GetType();
-                PropertyInfo[] properties;
-                lock (_cacheLock)
-                {
-                    if (!_propertyCache.TryGetValue(type.FullName!, out properties))
-                    {
-                        // Exclude "EntityItem" property because it is a ParameterizedProperty and is not required
-                        properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                            .Where(property => !property.Name.Equals("EntityItem")).ToArray();
-                        _propertyCache[type.FullName!] = properties;
-                    }
-                }
-
-                foreach (var property in properties)
-                {
-                    var value = property.GetValue(complexObject);
-                    graphResult[property.Name] = GetValueFromObject(value);
-                }
-
-                return graphResult;
+                return GetValueFromGraphObject(complexObject);
             }
 
             return new Hashtable(StringComparer.OrdinalIgnoreCase);
@@ -143,7 +146,7 @@ namespace Microsoft365DSC.Converter
 
             // Check for CIM instance types
             // Because .Contains with a StringComparison is not available, we use IndexOf
-            if (typeName.IndexOf("CimInstance", StringComparison.OrdinalIgnoreCase) >= 0)
+            if (typeName.IndexOf("CimInstance", StringComparison.OrdinalIgnoreCase) > -1)
             {
                 return true;
             }
@@ -198,6 +201,45 @@ namespace Microsoft365DSC.Converter
                 return value;
             }
         }
+
+        /// <summary>
+        /// Creates a hashtable representation of the public and selected non-public properties of the specified complex
+        /// object.
+        /// </summary>
+        /// <remarks>Properties named "EntityItem" are excluded from the result. Non-public properties
+        /// containing "AdditionalProperties" in their name are also included. The method uses a cache to improve
+        /// performance when processing objects of the same type.</remarks>
+        /// <param name="complexObject">The object whose properties are to be extracted and represented in the resulting hashtable. Cannot be null.</param>
+        /// <returns>A hashtable containing the names and values of the object's properties. Property names are used as keys, and
+        /// their corresponding values are recursively processed. The hashtable is case-insensitive with respect to
+        /// keys.</returns>
+        private static Hashtable GetValueFromGraphObject(object complexObject)
+        {
+            var type = complexObject.GetType();
+            PropertyInfo[] properties;
+            lock (_cacheLock)
+            {
+                if (!_propertyCache.TryGetValue(type.FullName!, out properties))
+                {
+                    // Exclude "EntityItem" property because it is a ParameterizedProperty and is not required
+                    properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                        .Where(property => !property.Name.Equals("EntityItem")).ToArray();
+                    var additionalProperties = type.GetProperties(BindingFlags.NonPublic | BindingFlags.Instance)
+                        .Where(property => property.Name.Contains("AdditionalProperties")).ToArray();
+                    _propertyCache[type.FullName!] = properties.Concat(additionalProperties).ToArray();
+                }
+            }
+
+            var graphResult = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            foreach (var property in properties)
+            {
+                var value = property.GetValue(complexObject);
+                graphResult[property.Name] = GetValueFromObject(value);
+            }
+
+            return graphResult;
+        }
+
 
         /// <summary>
         /// Clears the property reflection cache (primarily for testing purposes).

--- a/src/Microsoft365DSC.Converter/ObjectNormalizer.cs
+++ b/src/Microsoft365DSC.Converter/ObjectNormalizer.cs
@@ -1,0 +1,123 @@
+using Microsoft.Management.Infrastructure;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Management.Automation;
+
+namespace Microsoft365DSC.Converter
+{
+    /// <summary>
+    /// Recursively converts any object (CimInstance, PSObject, IDictionary, Graph SDK types,
+    /// arrays of any of these) into a uniform Hashtable tree with case-insensitive key lookup.
+    /// After normalization every node is either a Hashtable, a primitive/string, or an
+    /// object[] of those. This eliminates all CimInstance/PSObject type-specific handling
+    /// from the comparison pipeline.
+    /// </summary>
+    public static class ObjectNormalizer
+    {
+        /// <summary>
+        /// Normalizes an arbitrary object into the primitives, Array or Hashtable tree.
+        /// - null stays null
+        /// - Primitives, strings, DateTime, Guid stay as-is
+        /// - Arrays become object[] where each element is normalized
+        /// - CimInstance / PSObject / IDictionary / Graph SDK objects become
+        ///   Hashtable (case-insensitive) with recursively normalized values
+        /// </summary>
+        public static object? Normalize(object? obj)
+        {
+            if (obj is null)
+                return null;
+
+            // Unwrap PSObject wrapper to get at the real object
+            if (obj is PSObject psObject)
+            {
+                // PSObject can wrap null
+                if (psObject.BaseObject is null || psObject.BaseObject is PSCustomObject)
+                {
+                    return Normalize(psObject);
+                }
+                obj = psObject.BaseObject;
+            }
+
+            // Primitives and well-known leaf types: return directly
+            if (IsLeafType(obj))
+                return obj;
+
+            // Arrays (including CimInstance[], object[], string[]): normalize each element
+            if (obj is Array array)
+                return NormalizeArray(array);
+                
+            if (obj is IDictionary or CimInstance)
+                return ComplexObjectConverter.ToHashtable(obj);
+
+            // IEnumerable but not primitive/array/dictionary: treat as array
+            // (covers List<T>, Collection<T>, etc.)
+            if (obj is IEnumerable enumerable && obj is not string)
+                return NormalizeEnumerable(enumerable);
+
+            // Truly unknown leaf: return as-is (ToString will be used downstream)
+            return obj;
+        }
+
+        /// <summary>
+        /// Returns true if the object is a leaf type that should not be decomposed further.
+        /// </summary>
+        private static bool IsLeafType(object obj)
+        {
+            if (obj is null)
+                return true;
+
+            Type type = obj.GetType();
+
+            // All .NET primitive types (bool, int, long, double, etc.)
+            if (type.IsPrimitive)
+                return true;
+
+            // Common non-primitive leaf types
+            if (type == typeof(string) ||
+                type == typeof(DateTime) ||
+                type == typeof(DateTimeOffset) ||
+                type == typeof(decimal) ||
+                type == typeof(Guid) ||
+                type == typeof(TimeSpan))
+                return true;
+
+            // Enum values are leaf types
+            if (type.IsEnum)
+                return true;
+
+            // SwitchParameter from PowerShell
+            if (type == typeof(SwitchParameter))
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Normalizes an array. Returns object[] with each element normalized.
+        /// </summary>
+        private static object[] NormalizeArray(Array source)
+        {
+            var result = new object[source.Length];
+            for (int i = 0; i < source.Length; i++)
+            {
+                result[i] = Normalize(source.GetValue(i));
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Normalizes an IEnumerable (non-array, non-string, non-dictionary)
+        /// by materializing to a list and converting to object[].
+        /// </summary>
+        private static object[] NormalizeEnumerable(IEnumerable source)
+        {
+            var items = new List<object>();
+            foreach (object item in source)
+            {
+                items.Add(Normalize(item));
+            }
+            return items.ToArray();
+        }
+    }
+}

--- a/src/Microsoft365DSC.Converter/SimpleObjectConverter.cs
+++ b/src/Microsoft365DSC.Converter/SimpleObjectConverter.cs
@@ -34,7 +34,7 @@ namespace Microsoft365DSC.Converter
             else if (valueType == typeof(string))
             {
                 var stringValue = (string)value;
-                
+
                 // Handle special @odata.type key
                 if (key.Equals("@odata.type", StringComparison.OrdinalIgnoreCase))
                 {
@@ -61,10 +61,10 @@ namespace Microsoft365DSC.Converter
             {
                 var items = enumerable.Cast<object>().Where(item => item is not null).ToList();
                 _ = returnValue.Append($"{space}{key} = @(");
-                
+
                 string whitespace = string.Empty;
                 string newline = string.Empty;
-                
+
                 if (items.Count > 1)
                 {
                     _ = returnValue.Append("\r\n");
@@ -77,7 +77,7 @@ namespace Microsoft365DSC.Converter
                     if (item is null) continue;
 
                     var itemType = item.GetType();
-                    
+
                     if (itemType == typeof(string))
                     {
                         var itemString = ((string)item)

--- a/src/Microsoft365DSC.Intune/SettingsCatalogHelper.cs
+++ b/src/Microsoft365DSC.Intune/SettingsCatalogHelper.cs
@@ -153,7 +153,7 @@ namespace Microsoft365DSC.Intune
             return TryGetPropertyRaw(obj, propertyName)?.ToString();
         }
 
-        private static object TryGetPropertyRaw(object obj, string propertyName)
+        private static object? TryGetPropertyRaw(object obj, string propertyName)
         {
             if (obj is null) return null;
 
@@ -168,7 +168,7 @@ namespace Microsoft365DSC.Intune
             return prop?.GetValue(obj);
         }
 
-        private static IEnumerable TryGetPropertyAsEnumerable(object obj, string propertyName)
+        private static IEnumerable? TryGetPropertyAsEnumerable(object obj, string propertyName)
         {
             if (obj is null) return null;
 
@@ -201,7 +201,7 @@ namespace Microsoft365DSC.Intune
         /// more maintainable - adding a new simplification rule requires only one line instead of a new
         /// switch case block.
         /// </summary>
-        private static readonly List<(string ExactMatch, string Prefix, string Suffix, string Search, string Replace)> NameSimplificationRules =
+        private static readonly List<(string? ExactMatch, string? Prefix, string? Suffix, string? Search, string Replace)> NameSimplificationRules =
             [
                 // Exact match: 'com.apple.managedclient.preferences_enforcementLevel' -> 'enforcementLevel'
                 ("com.apple.managedclient.preferences_enforcementLevel", null, null, null, "enforcementLevel"),

--- a/src/Microsoft365DSC.Utilities/Microsoft365DSC.Utilities.csproj
+++ b/src/Microsoft365DSC.Utilities/Microsoft365DSC.Utilities.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="System.Management" Version="10.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft365DSC.Cache\Microsoft365DSC.Cache.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft365DSC.Utilities/Utilities.cs
+++ b/src/Microsoft365DSC.Utilities/Utilities.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft365DSC.Cache;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -54,15 +55,34 @@ namespace Microsoft365DSC.Utilities
             return results;
         }
 
+        public static object? FilterLoadedCimClassesByName(string className)
+        {
+            if (CacheManager.IsSchemaLoaded)
+            {
+                return FilterCimClassesByName(CacheManager.Schema, className);
+            }
+            return null;
+        }
+
         public static object? FilterCimClassesByName(IEnumerable<object> schemaObjects, string className)
         {
-            foreach (PSObject entry in schemaObjects.Cast<PSObject>())
+            foreach (object obj in schemaObjects)
             {
-                dynamic dyn = entry as dynamic;
-                string name = dyn.ClassName;
-                if (name == className)
+                if (obj is PSObject psObject)
                 {
-                    return entry;
+                    dynamic dyn = psObject as dynamic;
+                    string name = dyn.ClassName;
+                    if (name == className)
+                    {
+                        return psObject;
+                    }
+                }
+                else if (obj is IDictionary hashtable)
+                {
+                    if (hashtable["ClassName"]?.ToString() == className)
+                    {
+                        return hashtable;
+                    }
                 }
             }
             return null;

--- a/src/Microsoft365DSC.sln
+++ b/src/Microsoft365DSC.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft365DSC.Connection"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft365DSC.Intune", "Microsoft365DSC.Intune\Microsoft365DSC.Intune.csproj", "{438CE330-0E88-4DA3-B32E-1EBBC562E8D3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft365DSC.Cache", "Microsoft365DSC.Cache\Microsoft365DSC.Cache.csproj", "{B72F417B-88D1-4B40-B8F6-2EFC88095ABB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{438CE330-0E88-4DA3-B32E-1EBBC562E8D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{438CE330-0E88-4DA3-B32E-1EBBC562E8D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{438CE330-0E88-4DA3-B32E-1EBBC562E8D3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B72F417B-88D1-4B40-B8F6-2EFC88095ABB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B72F417B-88D1-4B40-B8F6-2EFC88095ABB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B72F417B-88D1-4B40-B8F6-2EFC88095ABB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B72F417B-88D1-4B40-B8F6-2EFC88095ABB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
#### Pull Request (PR) description
This PR introduces a common `Normalizer` method which converts all complex objects to a normalized Hashtable, array or primitive value type. Any CimInstance, List or Dictionary type gets converted into basic types for a streamlined and easier comparison. 

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
