### PR TITLE
Feature/fix o365adminauditlogconfig

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365AdminAuditLogConfig/MSFT_O365AdminAuditLogConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365AdminAuditLogConfig/MSFT_O365AdminAuditLogConfig.psm1
@@ -81,7 +81,17 @@ function Get-TargetResource
         }
         else
         {
-            if ($GetResults.UnifiedAuditLogIngestionEnabled)
+            $auditLogValue = $GetResults.UnifiedAuditLogIngestionEnabled
+            if ($auditLogValue -is [bool])
+            {
+                $isEnabled = $auditLogValue
+            }
+            else
+            {
+                $isEnabled = [System.Convert]::ToBoolean($auditLogValue)
+            }
+
+            if ($isEnabled)
             {
                 $UnifiedAuditLogIngestionEnabledReturnValue = 'Enabled'
             }
@@ -336,8 +346,18 @@ function Export-TargetResource
     try
     {
         $O365AdminAuditLogConfig = Get-AdminAuditLogConfig -ErrorAction Stop
+        $auditLogValue = $O365AdminAuditLogConfig.UnifiedAuditLogIngestionEnabled
+        if ($auditLogValue -is [bool])
+        {
+            $isEnabled = $auditLogValue
+        }
+        else
+        {
+            $isEnabled = [System.Convert]::ToBoolean($auditLogValue)
+        }
+
         $value = 'Disabled'
-        if ($O365AdminAuditLogConfig.UnifiedAuditLogIngestionEnabled)
+        if ($isEnabled)
         {
             $value = 'Enabled'
         }

--- a/Test-LapsExport.ps1
+++ b/Test-LapsExport.ps1
@@ -1,0 +1,10 @@
+# Requires Microsoft365DSC module to be installed and basic authentication configured.
+# You will be prompted to authenticate to your Microsoft 365 Tenant.
+
+Write-Host "Exporting AADDeviceRegistrationPolicy configuration..."
+
+# Export the AADDeviceRegistrationPolicy to check if LocalAdminPasswordIsEnabled is captured correctly
+Export-M365DSCConfiguration -Components @("AADDeviceRegistrationPolicy") -Path ".\TenantConfig"
+
+Write-Host "Export completed. Please check the generated configuration in the .\TenantConfig folder."
+Write-Host "Verify if the LocalAdminPasswordIsEnabled property is present and matches the value in your Entra portal."

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.O365AdminAuditLogConfig.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.O365AdminAuditLogConfig.Tests.ps1
@@ -156,7 +156,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
 
                 Mock -CommandName Get-AdminAuditLogConfig -MockWith {
                     return @{
-                        UnifiedAuditLogIngestionEnabled = 'Enabled'
+                        UnifiedAuditLogIngestionEnabled = $true
                     }
                 }
             }


### PR DESCRIPTION
## Description

Fixes mismatch in `O365AdminAuditLogConfig` where `UnifiedAuditLogIngestionEnabled` was exported as "Disabled" while Exchange Online returns `True`.

## Issue Reference
#6952

## Problem
- EXO PowerShell: `UnifiedAuditLogIngestionEnabled = True`
- DSC Export: `"Disabled"`

## Fix
- Corrected mapping:
  - `True` → `"Enabled"`
  - `False` → `"Disabled"`

## Testing
- Verified using App Registration
- Ran `Export-M365DSCConfiguration -Verbose`
- Compared with `Get-AdminAuditLogConfig`

## Permissions
- Exchange.ManageAsApp
- Audit Logs role

## Result
Export output now matches actual EXO configuration.

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
