### PR TITLE
Add Pwsh warning message in Windows PowerShell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@
   * Updated `ReverseDSC` to version 2.0.0.34.
 * MISC
   * Added CIM information about required properties to all resources where applicable.
+  * Added message about requiring PowerShell 7 starting Octoboer 2026.
   * Improved filtering for Intune configuration policies during Export.
   * Improved the accuracy of the comparison engine.
   * Refactored module structure to improve maintainability.

--- a/Modules/Microsoft365DSC/Microsoft365DSC.psd1
+++ b/Modules/Microsoft365DSC/Microsoft365DSC.psd1
@@ -57,6 +57,7 @@
   # Script files (.ps1) that are run in the caller's environment prior to importing this module.
   ScriptsToProcess = @(
     'Import-M365DSCDllLoaderModule.ps1',
+    'Show-PwshWarning.ps1',
     'Update-MaximumFunctionCount.ps1'
   )
 

--- a/Modules/Microsoft365DSC/Show-PwshWarning.ps1
+++ b/Modules/Microsoft365DSC/Show-PwshWarning.ps1
@@ -1,0 +1,8 @@
+if ($PSVersionTable.PSEdition -eq 'Core')
+{
+    return
+}
+
+Write-Warning -Message 'Starting October 2026, PowerShell 7 will be required to be installed when using Microsoft365DSC.'
+Write-Warning -Message 'It is recommended to start planning for this new requirement and ensure that PowerShell 7 is installed and configured properly on your systems.'
+Write-Warning -Message 'Please note: Windows PowerShell 5.1 will continue to work, but some features will require PowerShell 7 to function properly.'


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds a warning message when Microsoft365DSC is run in Windows PowerShell that it will require PowerShell 7 starting October 2026.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
