### PR TITLE
Allow specific time discrepancy for timespans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,10 @@
 * SCSensitivityLabel
   * Fixed an issue where the CIM definition for `MSFT_LabelSetting` did not match.
     FIXES [#7002](https://github.com/microsoft/Microsoft365DSC/issues/7002)
+* SPOBrowserIdleSignout
+  * Updated the timespan comparison to allow a discrepancy of up to 30 seconds
+    for the `SignOutAfter` and `WarnAfter` properties.
+    FIXES [#7031](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7031)
 * TeamsClientConfiguration
   * [BREAKING CHANGE] Added `IsSingleInstance` and removed `Identity` parameter.
 * TeamsFederationConfiguration

--- a/Modules/Microsoft365DSC/ComparisonMetadata.json
+++ b/Modules/Microsoft365DSC/ComparisonMetadata.json
@@ -352,6 +352,10 @@
       "HasCustomComparison": true,
       "Description": "Excludes properties: Path, Publish, Overwrite"
     },
+    "SPOBrowserIdleSignout": {
+      "HasCustomComparison": true,
+      "Description": "Uses PostProcessing scriptblock"
+    },
     "SPOSiteAuditSettings": {
       "HasCustomComparison": true,
       "Description": "Excludes properties: Url"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOBrowserIdleSignout/MSFT_SPOBrowserIdleSignout.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOBrowserIdleSignout/MSFT_SPOBrowserIdleSignout.psm1
@@ -274,8 +274,10 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
+    $compareParameters = Get-CompareParameters
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
+        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
+        @compareParameters
     return $result
 }
 
@@ -394,4 +396,40 @@ function Export-TargetResource
     }
 }
 
-Export-ModuleMember -Function *-TargetResource
+function Get-CompareParameters
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param()
+
+    return @{
+        PostProcessing = {
+            param($DesiredValues, $CurrentValues, $ValuesToCheck, $ignore)
+            if ($null -ne $DesiredValues.SignOutAfter -and $null -ne $CurrentValues.SignOutAfter)
+            {
+                $desiredTimeSpan = [System.TimeSpan]::Parse($DesiredValues.SignOutAfter)
+                $currentTimeSpan = [System.TimeSpan]::Parse($CurrentValues.SignOutAfter)
+                $delta = [System.TimeSpan]::FromSeconds(30)
+                if ([System.TimeSpan]::Compare($desiredTimeSpan, $currentTimeSpan) -ne 0 -and [System.TimeSpan]::Compare(($desiredTimeSpan - $currentTimeSpan).Duration(), $delta) -le 0)
+                {
+                    Write-Verbose -Message "Difference between Desired and Current SignOutAfter is less than or equal to 30 seconds. Desired: $desiredTimeSpan, Current: $currentTimeSpan. Treating as equal."
+                    $ValuesToCheck.Remove('SignOutAfter') | Out-Null
+                }
+            }
+            if ($null -ne $DesiredValues.WarnAfter -and $null -ne $CurrentValues.WarnAfter)
+            {
+                $desiredTimeSpan = [System.TimeSpan]::Parse($DesiredValues.WarnAfter)
+                $currentTimeSpan = [System.TimeSpan]::Parse($CurrentValues.WarnAfter)
+                $delta = [System.TimeSpan]::FromSeconds(30)
+                if ([System.TimeSpan]::Compare($desiredTimeSpan, $currentTimeSpan) -ne 0 -and [System.TimeSpan]::Compare(($desiredTimeSpan - $currentTimeSpan).Duration(), $delta) -le 0)
+                {
+                    Write-Verbose -Message "Difference between Desired and Current WarnAfter is less than or equal to 30 seconds. Desired: $desiredTimeSpan, Current: $currentTimeSpan. Treating as equal."
+                    $ValuesToCheck.Remove('WarnAfter') | Out-Null
+                }
+            }
+            return [System.Tuple[Hashtable, Hashtable, Hashtable]]::new($DesiredValues, $CurrentValues, $ValuesToCheck)
+        }
+    }
+}
+
+Export-ModuleMember -Function @('*-TargetResource', 'Get-CompareParameters')


### PR DESCRIPTION
#### Pull Request (PR) description
This PR allows a time discrepancy of up to 30 seconds for the `SPOBrowserIdleSignout` resource.

#### This Pull Request (PR) fixes the following issues
- Fixes #7031 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
