### PR TITLE
TeamsTenantDialPlan: Always export NormalizationRules as an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* TeamsTenantDialPlan
+  * Fixed issue so that `NormalizationRules` are always exported as an array even
+    when they only contain one entry
+
 # 1.26.408.1
 
 * AADAccessReviewDefinition

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantDialPlan/MSFT_TeamsTenantDialPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsTenantDialPlan/MSFT_TeamsTenantDialPlan.psm1
@@ -597,7 +597,7 @@ function Get-M365DSCNormalizationRules
         $result += $currentRule
     }
 
-    return $result
+    return ,$result
 }
 
 Export-ModuleMember -Function *-TargetResource


### PR DESCRIPTION
#### Pull Request (PR) description

@FabienTschanz Caught this problem when testing your new comparison engine, my compiler always constructs values with data types which are arrays as arrays even when they have a single entry, this was working before but now it reports one of my test policies for `TeamsTenantDialPlan` as a drift since `NormalizationRules` only has one entry, this PR fix it by always exporting this property has an array.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
