### PR TITLE
Fix Intune EDR Linux/MacOS invalid create-update request (#7055)

### DIFF
--- a/src/Microsoft365DSC.Intune/SettingCatalogPolicySettingBuilder.cs
+++ b/src/Microsoft365DSC.Intune/SettingCatalogPolicySettingBuilder.cs
@@ -504,7 +504,7 @@ namespace Microsoft365DSC.Intune
             var valueResult = SettingValueResolver.Resolve(
                 settingValueType, settingDefinition, allDefinitions, dscParams);
 
-            if (valueResult?.Value is not null)
+            if (valueResult?.Value is not null && !string.IsNullOrEmpty(valueResult.Value.ToString()))
             {
                 choiceSettingValue["value"] = valueResult.Value;
                 // Derive the value @odata.type

--- a/src/Microsoft365DSC.Intune/SettingDefinitionOption.cs
+++ b/src/Microsoft365DSC.Intune/SettingDefinitionOption.cs
@@ -14,6 +14,11 @@ namespace Microsoft365DSC.Intune
         public string ItemId { get; set; }
 
         /// <summary>
+        /// The display name of the option (e.g., "GROUP").
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
         /// The option value object containing the actual value and its OData type.
         /// </summary>
         public OptionValue OptionValue { get; set; }

--- a/src/Microsoft365DSC.Intune/SettingValueResolver.cs
+++ b/src/Microsoft365DSC.Intune/SettingValueResolver.cs
@@ -185,7 +185,8 @@ namespace Microsoft365DSC.Intune
         /// Resolves a ChoiceSetting value by looking up the itemId from the options.
         /// Mirrors the PowerShell logic:
         ///   1. Match by optionValue.value == DSC value
-        ///   2. Fallback: match by itemId == "{definitionId}_{dscValue}"
+        ///   2. Match by option name == DSC value
+        ///   3. Fallback: match by itemId == "{definitionId}_{dscValue}"
         /// </summary>
         private static SettingDSCValueResult ResolveChoiceSettingValue(
             SettingDefinitionInfo settingDefinition,
@@ -198,6 +199,15 @@ namespace Microsoft365DSC.Intune
                 .Where(o => o.OptionValue is not null && string.Equals(o.OptionValue.Value, dscValueStr, StringComparison.OrdinalIgnoreCase))
                 .Select(o => o.ItemId)
                 .FirstOrDefault();
+
+            // Fallback: match by option display name
+            if (string.IsNullOrEmpty(settingValue))
+            {
+                settingValue = settingDefinition.Options
+                    .Where(o => !string.IsNullOrEmpty(o.Name) && string.Equals(o.Name, dscValueStr, StringComparison.OrdinalIgnoreCase))
+                    .Select(o => o.ItemId)
+                    .FirstOrDefault();
+            }
 
             // Fallback: match by itemId pattern
             if (string.IsNullOrEmpty(settingValue))
@@ -238,6 +248,15 @@ namespace Microsoft365DSC.Intune
                     .Where(o => o.OptionValue is not null && string.Equals(o.OptionValue.Value, valueStr, StringComparison.OrdinalIgnoreCase))
                     .Select(o => o.ItemId)
                     .FirstOrDefault();
+
+                // Fallback: match by option display name
+                if (string.IsNullOrEmpty(valueToAdd))
+                {
+                    valueToAdd = settingDefinition.Options
+                        .Where(o => !string.IsNullOrEmpty(o.Name) && string.Equals(o.Name, valueStr, StringComparison.OrdinalIgnoreCase))
+                        .Select(o => o.ItemId)
+                        .FirstOrDefault();
+                }
 
                 // Fallback: match by itemId pattern
                 if (string.IsNullOrEmpty(valueToAdd))

--- a/src/Microsoft365DSC.Intune/SettingsCatalogHelper.cs
+++ b/src/Microsoft365DSC.Intune/SettingsCatalogHelper.cs
@@ -281,7 +281,8 @@ namespace Microsoft365DSC.Intune
 
                 var opt = new SettingDefinitionOption
                 {
-                    ItemId = TryGetProperty(option, "itemId")
+                    ItemId = TryGetProperty(option, "itemId"),
+                    Name = TryGetProperty(option, "name")
                 };
 
                 // Extract optionValue


### PR DESCRIPTION
## Summary
Fixes issue #7055 where `IntuneEndpointDetectionAndResponsePolicyLinux` and `IntuneEndpointDetectionAndResponsePolicyMacOS` could fail create/update with `[] : The request is invalid.`

## Root Cause
Choice setting resolution for tags could fail to map values like `GROUP` to a valid option itemId when metadata provides the value via option `name` rather than only `optionValue.value`.

## Changes
- Add `Name` to `SettingDefinitionOption` and map Graph option `name`.
- Extend choice resolution fallback in `SettingValueResolver`:
  - match by `optionValue.value`
  - then match by option `name`
  - then fallback to itemId pattern
- Avoid serializing empty choice values in `SettingCatalogPolicySettingBuilder`.

## Safety
- Targeted change in shared Intune Settings Catalog resolution path.
- Existing behavior preserved for current `optionValue.value` and itemId matching paths.

## Files
- `src/Microsoft365DSC.Intune/SettingDefinitionOption.cs`
- `src/Microsoft365DSC.Intune/SettingsCatalogHelper.cs`
- `src/Microsoft365DSC.Intune/SettingValueResolver.cs`
- `src/Microsoft365DSC.Intune/SettingCatalogPolicySettingBuilder.cs`
