### PR TITLE
Fix TeamsOnlineVoicemailPolicy MaximumRecordingLength handling (#7054)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * TeamsTenantDialPlan
   * Fixed issue so that `NormalizationRules` are always exported as an array even
     when they only contain one entry
+* TeamsOnlineVoicemailPolicy
+  * Fixed `MaximumRecordingLength` handling by aligning type to `Int32` and
+    converting values to `TimeSpan` seconds for Teams cmdlets.
+    FIXES [#7054](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7054)
 * M365DSCModuleMgmt
   * Fixed an issue when updating the module from a custom import.
 * M365DSCUtil

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOnlineVoicemailPolicy/MSFT_TeamsOnlineVoicemailPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOnlineVoicemailPolicy/MSFT_TeamsOnlineVoicemailPolicy.psm1
@@ -27,7 +27,7 @@ function Get-TargetResource
         $EnableTranscriptionTranslation,
 
         [Parameter()]
-        [System.String]
+        [System.Int32]
         $MaximumRecordingLength,
 
         [Parameter()]
@@ -184,7 +184,7 @@ function Set-TargetResource
         $EnableTranscriptionTranslation,
 
         [Parameter()]
-        [System.String]
+        [System.Int32]
         $MaximumRecordingLength,
 
         [Parameter()]
@@ -258,9 +258,11 @@ function Set-TargetResource
     $CurrentValues = Get-TargetResource @PSBoundParameters
     $SetParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
 
-    # Convert the MaximumRecordingLength back to a timespan object.
-    $timespan = [TimeSpan]$MaximumRecordingLength
-    $SetParameters.MaximumRecordingLength = $timespan
+    # Convert recording length in seconds to a TimeSpan value expected by Teams cmdlets.
+    if ($PSBoundParameters.ContainsKey('MaximumRecordingLength'))
+    {
+        $SetParameters.MaximumRecordingLength = New-TimeSpan -Seconds $MaximumRecordingLength
+    }
 
     if ($Ensure -eq 'Present' -and $CurrentValues.Ensure -eq 'Absent')
     {
@@ -306,7 +308,7 @@ function Test-TargetResource
         $EnableTranscriptionTranslation,
 
         [Parameter()]
-        [System.String]
+        [System.Int32]
         $MaximumRecordingLength,
 
         [Parameter()]

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsOnlineVoicemailPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsOnlineVoicemailPolicy.Tests.ps1
@@ -96,6 +96,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             It 'Should create the policy in the Set method' {
                 Set-TargetResource @testParams
                 Should -Invoke -CommandName New-CsOnlineVoicemailPolicy -Exactly 1
+                Should -Invoke -CommandName New-CsOnlineVoicemailPolicy -Exactly 1 -ParameterFilter {
+                    $MaximumRecordingLength -eq [TimeSpan]::FromSeconds(600)
+                }
             }
         }
 
@@ -126,6 +129,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 Set-TargetResource @testParams
                 Should -Invoke -CommandName Set-CsOnlineVoicemailPolicy -Exactly 1
                 Should -Invoke -CommandName New-CsOnlineVoicemailPolicy -Exactly 0
+                Should -Invoke -CommandName Set-CsOnlineVoicemailPolicy -Exactly 1 -ParameterFilter {
+                    $MaximumRecordingLength -eq [TimeSpan]::FromSeconds(300)
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
Fixes issue #7054 where `MaximumRecordingLength` in `TeamsOnlineVoicemailPolicy` was changed in schema to `SInt32` but implementation still treated it as string and converted incorrectly.

## Root Cause
- Resource parameters in `MSFT_TeamsOnlineVoicemailPolicy.psm1` still declared `MaximumRecordingLength` as `System.String`.
- Set logic used `[TimeSpan]$MaximumRecordingLength`, which interprets integer values incorrectly for this scenario.

## Fix
- Align `MaximumRecordingLength` parameter type to `System.Int32` in Get/Set/Test.
- Convert seconds explicitly using `New-TimeSpan -Seconds $MaximumRecordingLength` before calling Teams cmdlets.
- Only perform conversion when the parameter is provided.
- Add unit-test assertions to verify `New-CsOnlineVoicemailPolicy` and `Set-CsOnlineVoicemailPolicy` receive the expected `TimeSpan` values.

## Files
- `Modules/Microsoft365DSC/DSCResources/MSFT_TeamsOnlineVoicemailPolicy/MSFT_TeamsOnlineVoicemailPolicy.psm1`
- `Tests/Unit/Microsoft365DSC/Microsoft365DSC.TeamsOnlineVoicemailPolicy.Tests.ps1`
