### PR TITLE
Harden delta report parsing when custom DSC modules are present (#7056)

### DIFF
--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -1892,7 +1892,23 @@ function Initialize-M365DSCReporting
     {
         $params.Add('DscResourceInfo', $DscResourceInfo)
     }
-    $parsedContent = ConvertTo-DSCObject @params
+    try
+    {
+        $parsedContent = ConvertTo-DSCObject @params
+    }
+    catch
+    {
+        if ($PSBoundParameters.ContainsKey('DscResourceInfo'))
+        {
+            Write-Warning -Message "ConvertTo-DSCObject failed while using DscResourceInfo. Retrying without DscResourceInfo. Details: $($_.Exception.Message)"
+            $null = $params.Remove('DscResourceInfo')
+            $parsedContent = ConvertTo-DSCObject @params
+        }
+        else
+        {
+            throw
+        }
+    }
 
     if ($null -eq $parsedContent)
     {


### PR DESCRIPTION
## Summary
Addresses issue #7056 where delta report parsing can fail with custom DSC modules due to parser key lookup failures.

## Change
In `Initialize-M365DSCReporting`:
- Keep the current primary parse path (`ConvertTo-DSCObject` with `DscResourceInfo` when supplied).
- If parsing fails and `DscResourceInfo` was provided, retry parsing once **without** `DscResourceInfo`.
- Emit a warning with the original failure details before fallback.
- Preserve existing behavior for non-fallback scenarios (rethrow when no fallback context exists).

## Why this helps
Custom/non-Microsoft365DSC resources may not map cleanly when constrained by `DscResourceInfo`. Retrying without this hint allows parsing to continue and prevents hard failures in delta report generation for mixed configurations.

## Scope
Single-file, minimal-risk resiliency change:
- `Modules/Microsoft365DSC/Modules/M365DSCReport.psm1`
