### PR TITLE
Fix Intune Settings Catalog policy creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
     when they only contain one entry
 * M365DSCModuleMgmt
   * Fixed an issue when updating the module from a custom import.
+* M365DSCIntuneUtil
+  * Fixed an issue where a settings array was returned as a single element.
+    FIXES [#7055](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7055)
 * M365DSCUtil
   * Added retry logic for too many requests when invoking batch requests.
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
@@ -268,7 +268,7 @@ function Set-TargetResource
 
     $templateReferenceId = '3514388a-d4d1-4aa8-bd64-c317776008f5_1'
     $platforms = 'linux'
-    $technologies = 'mdm,microsoftSense'
+    $technologies = 'microsoftSense'
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux/MSFT_IntuneEndpointDetectionAndResponsePolicyLinux.psm1
@@ -268,7 +268,7 @@ function Set-TargetResource
 
     $templateReferenceId = '3514388a-d4d1-4aa8-bd64-c317776008f5_1'
     $platforms = 'linux'
-    $technologies = 'microsoftSense'
+    $technologies = 'mdm,microsoftSense'
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS/MSFT_IntuneEndpointDetectionAndResponsePolicyMacOS.psm1
@@ -268,7 +268,7 @@ function Set-TargetResource
 
     $templateReferenceId = 'a6ff37f6-c841-4264-9249-1ecf793d94ef_1'
     $platforms = 'macOS'
-    $technologies = 'microsoftSense'
+    $technologies = 'mdm,microsoftSense'
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {

--- a/Modules/Microsoft365DSC/Modules/M365DSCIntuneUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCIntuneUtil.psm1
@@ -953,7 +953,7 @@ function Get-IntuneSettingCatalogPolicySetting
             -All
     }
 
-    return [Microsoft365DSC.Intune.SettingCatalogPolicySettingBuilder]::Build(
+    return ,[Microsoft365DSC.Intune.SettingCatalogPolicySettingBuilder]::Build(
         [System.Collections.Generic.List[object]]@($SettingTemplates),
         $DSCParams,
         $ContainsDeviceAndUserSettings.IsPresent)

--- a/src/Microsoft365DSC.Intune/SettingInstanceTemplateInfo.cs
+++ b/src/Microsoft365DSC.Intune/SettingInstanceTemplateInfo.cs
@@ -129,6 +129,13 @@ namespace Microsoft365DSC.Intune
                 ? GetAdditionalPropertyRaw(template, valueTemplateKey)
                 : SettingDefinitionMapper.TryGetPropertyRaw(template, valueTemplateKey);
 
+            // Collection types (GroupSettingCollection, SimpleSettingCollection, ChoiceSettingCollection)
+            // return an array of value templates. Unwrap to the first element which defines the repeating structure.
+            if (valueTemplateRaw is IEnumerable<object> valueTemplateCollection)
+            {
+                valueTemplateRaw = valueTemplateCollection.FirstOrDefault();
+            }
+
             if (valueTemplateRaw is not null)
             {
                 // Extract @odata.type from value template and transform ValueTemplate->Value
@@ -146,7 +153,7 @@ namespace Microsoft365DSC.Intune
                     {
                         info.ValueTemplateId = templateIdStr;
                     }
-                    else if (templateIdRaw is IEnumerable && !(templateIdRaw is string))
+                    else if (templateIdRaw is IEnumerable && templateIdRaw is not string)
                     {
                         // Array of template IDs (e.g., ThreatTypeSettings in IntuneAntivirusPolicyLinux)
                         // The IDs are from child settings, not from the parent - set null


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue when creation Settings Catalog policies in Intune. The `Settings` array might get reduced to a single element, resulting in an error.

#### This Pull Request (PR) fixes the following issues
- Fixes #7055

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
