### PR TITLE
Fix compare issue for permission grant policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * AADB2BManagementPolicy
   * Initial release.
+* AADPermissionsGrantPolicy
+  * Fixed an issue when comparing `AADPermissionGrantConditionSet` instances.
+    FIXES [#7062](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7062)
 * TeamsTenantDialPlan
   * Fixed issue so that `NormalizationRules` are always exported as an array even
     when they only contain one entry

--- a/Modules/Microsoft365DSC/ComparisonMetadata.json
+++ b/Modules/Microsoft365DSC/ComparisonMetadata.json
@@ -31,6 +31,10 @@
       "HasCustomComparison": true,
       "Description": "Excludes properties: Password"
     },
+    "AADPermissionGrantPolicy": {
+      "HasCustomComparison": true,
+      "Description": "Uses PostProcessing scriptblock"
+    },
     "AADRoleAssignmentScheduleRequest": {
       "HasCustomComparison": true,
       "Description": "Excludes properties: Action, IsValidationOnly, Justification, TicketInfo; Uses PostProcessing scriptblock"

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADPermissionGrantPolicy/MSFT_AADPermissionGrantPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADPermissionGrantPolicy/MSFT_AADPermissionGrantPolicy.psm1
@@ -1418,4 +1418,4 @@ function Test-ConditionSetsEqual
 
 #endregion
 
-Export-ModuleMember -Function *-TargetResource
+Export-ModuleMember -Function @('*-TargetResource', 'Get-CompareParameters')

--- a/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDRGUtil.psm1
@@ -349,7 +349,7 @@ function Compare-M365DSCComplexObject
         }
     }
 
-    $tuple = [Microsoft365DSC.Compare.ComplexObjectComparer]::Compare($Source, $Target, $PropertyName)
+    $tuple = [Microsoft365DSC.Compare.ComplexObjectComparer]::Compare($Source, $Target, $PropertyName, $null)
     if ($tuple.Item1.Count -gt 0)
     {
         $Global:AllDrifts.DriftInfo += $tuple.Item1

--- a/src/Microsoft365DSC.Compare/ComplexObjectComparer.cs
+++ b/src/Microsoft365DSC.Compare/ComplexObjectComparer.cs
@@ -13,6 +13,8 @@ namespace Microsoft365DSC.Compare
     /// </summary>
     public static class ComplexObjectComparer
     {
+        private static HashSet<string> excludedSet = new(StringComparer.OrdinalIgnoreCase);
+
         /// <summary>
         /// Compares two complex M365DSC objects to detect configuration drift.
         /// </summary>
@@ -23,9 +25,14 @@ namespace Microsoft365DSC.Compare
         public static Tuple<List<Dictionary<string, object>>, bool> Compare(
             object source,
             object target,
-            string propertyName)
+            string propertyName,
+            HashSet<string>? excludedSet)
         {
             var drifts = new List<Dictionary<string, object>>();
+            if (excludedSet is not null)
+            {
+                ComplexObjectComparer.excludedSet = excludedSet;
+            }
             bool result = CompareWithDrifts(source, target, propertyName, drifts);
             return new Tuple<List<Dictionary<string, object>>, bool>(drifts, result);
         }
@@ -59,6 +66,11 @@ namespace Microsoft365DSC.Compare
                 var left = frame.Left;
                 var right = frame.Right;
                 var propName = frame.PropName;
+
+                if (excludedSet.Contains(propName))
+                {
+                    continue;
+                }
 
                 // Both null => identical
                 if (left is null && right is null)
@@ -242,6 +254,11 @@ namespace Microsoft365DSC.Compare
             bool returnResult = true;
             foreach (var key in leftKeys)
             {
+                if (excludedSet.Contains(key))
+                {
+                    continue;
+                }
+
                 // Check if key exists in target
                 if (!HasKey(right, key))
                 {

--- a/src/Microsoft365DSC.Compare/ResourceComparer.cs
+++ b/src/Microsoft365DSC.Compare/ResourceComparer.cs
@@ -23,9 +23,9 @@ namespace Microsoft365DSC.Compare
         // Properties that are always excluded from comparison
         private static readonly HashSet<string> AlwaysExcludedProperties = new(StringComparer.OrdinalIgnoreCase)
         {
-            "Verbose", "Credential", "ApplicationId", "CertificateThumbprint",
-            "CertificatePath", "CertificatePassword", "TenantId",
-            "ApplicationSecret", "ManagedIdentity", "AccessTokens"
+            "Id", "Identity", "Verbose", "Credential", "ApplicationId",
+            "CertificateThumbprint","CertificatePath", "CertificatePassword",
+            "TenantId", "ApplicationSecret", "ManagedIdentity", "AccessTokens"
         };
 
         /// <summary>
@@ -61,12 +61,12 @@ namespace Microsoft365DSC.Compare
             // Transform schema elements from PSObject to their BaseObject if needed for easier access
             var result = new CompareResult();
             var excludedSet = new HashSet<string>(AlwaysExcludedProperties, StringComparer.OrdinalIgnoreCase);
-            if (excludedProperties != null)
+            if (excludedProperties is not null)
             {
                 foreach (string prop in excludedProperties)
                     excludedSet.Add(prop);
             }
-            var includedSet = includedProperties != null
+            var includedSet = includedProperties is not null
                 ? new HashSet<string>(includedProperties, StringComparer.OrdinalIgnoreCase)
                 : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -205,7 +205,7 @@ namespace Microsoft365DSC.Compare
                             RemovePrimaryKeysFromHashtable(currentCopy, primaryKeyNames, includedSet, isIntunePolicyAssignment);
 
                             // Compare as single objects
-                            var compResult = ComplexObjectComparer.Compare(desiredCopy, currentCopy, $"{key}[{idx}]");
+                            var compResult = ComplexObjectComparer.Compare(desiredCopy, currentCopy, $"{key}[{idx}]", excludedSet);
                             if (!compResult.Item2)
                             {
                                 result.TestResult = false;
@@ -226,7 +226,7 @@ namespace Microsoft365DSC.Compare
                     else
                     {
                         // No primary keys: fall back to full array comparison
-                        var compResult = ComplexObjectComparer.Compare(desiredArray, currentArray, key);
+                        var compResult = ComplexObjectComparer.Compare(desiredArray, currentArray, key, excludedSet);
                         if (!compResult.Item2)
                         {
                             result.TestResult = false;
@@ -240,7 +240,7 @@ namespace Microsoft365DSC.Compare
                 else
                 {
                     // Single complex object (not array)
-                    var compResult = ComplexObjectComparer.Compare(normalizedDesired, normalizedCurrent, key);
+                    var compResult = ComplexObjectComparer.Compare(normalizedDesired, normalizedCurrent, key, excludedSet);
                     if (!compResult.Item2)
                     {
                         result.TestResult = false;


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue when comparing `AADPermissionGrantConditionSet` instances when they have differing `Id` properties.

#### This Pull Request (PR) fixes the following issues
- Fixes #7062 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
