### PR TITLE
Fix EXO Data Encryption Policy with AzureKeyIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * AADPermissionsGrantPolicy
   * Fixed an issue when comparing `AADPermissionGrantConditionSet` instances.
     FIXES [#7062](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7062)
+* EXODataEncryptionPolicy
+  * Fixed an issue when comparing `AzureKeyIDs` elements.
+    FIXES [#7069](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7069)
 * TeamsTenantDialPlan
   * Fixed issue so that `NormalizationRules` are always exported as an array even
     when they only contain one entry

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataEncryptionPolicy/MSFT_EXODataEncryptionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataEncryptionPolicy/MSFT_EXODataEncryptionPolicy.psm1
@@ -112,15 +112,9 @@ function Get-TargetResource
 
         Write-Verbose -Message "Found Data encryption policy $($Identity)"
 
-        $azureKeyIdsValue = @()
-        foreach ($azureKeyId in $DataEncryptionPolicy.AzureKeyIDs)
-        {
-            $azureKeyIdsValue += $azureKeyId.ToString()
-        }
-
         $result = @{
             Identity                  = $Identity
-            AzureKeyIDs               = $DataEncryptionPolicy.AzureKeyIDs
+            AzureKeyIDs               = [System.String[]]$DataEncryptionPolicy.AzureKeyIDs
             Description               = $DataEncryptionPolicy.Description
             Enabled                   = $DataEncryptionPolicy.Enabled
             Name                      = $DataEncryptionPolicy.Name

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataEncryptionPolicy/MSFT_EXODataEncryptionPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXODataEncryptionPolicy/MSFT_EXODataEncryptionPolicy.psm1
@@ -11,7 +11,7 @@ function Get-TargetResource
         $Identity,
 
         [Parameter()]
-        [System.Uri[]]
+        [System.String[]]
         $AzureKeyIDs,
 
         [Parameter()]
@@ -112,6 +112,12 @@ function Get-TargetResource
 
         Write-Verbose -Message "Found Data encryption policy $($Identity)"
 
+        $azureKeyIdsValue = @()
+        foreach ($azureKeyId in $DataEncryptionPolicy.AzureKeyIDs)
+        {
+            $azureKeyIdsValue += $azureKeyId.ToString()
+        }
+
         $result = @{
             Identity                  = $Identity
             AzureKeyIDs               = $DataEncryptionPolicy.AzureKeyIDs
@@ -155,7 +161,7 @@ function Set-TargetResource
         $Identity,
 
         [Parameter()]
-        [System.Uri[]]
+        [System.String[]]
         $AzureKeyIDs,
 
         [Parameter()]
@@ -268,7 +274,7 @@ function Test-TargetResource
         $Identity,
 
         [Parameter()]
-        [System.Uri[]]
+        [System.String[]]
         $AzureKeyIDs,
 
         [Parameter()]

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXODataEncryptionPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXODataEncryptionPolicy.Tests.ps1
@@ -40,7 +40,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             Mock -CommandName Get-DataEncryptionPolicy -MockWith {
                 return @{
                     Identity                  = 'Test'
-                    AzureKeyIDs               = '123456789'
+                    AzureKeyIDs               = [System.Collections.ArrayList]::new(@('123456789'))
                     Description               = 'Test Description'
                     Enabled                   = $true
                     Name                      = 'Test Policy'


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes an issue with type management for `AzureKeyIDs` in `EXODataProtectionPolicy`.

#### This Pull Request (PR) fixes the following issues
- Fixes #7069 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
