### PR TITLE
Fix export of Identity in EXO CAS Mailbox Plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * AADPermissionsGrantPolicy
   * Fixed an issue when comparing `AADPermissionGrantConditionSet` instances.
     FIXES [#7062](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7062)
+* EXOCASMailboxPlan
+  * Fixed an issue where `Identity` was missing in the export.
 * TeamsTenantDialPlan
   * Fixed issue so that `NormalizationRules` are always exported as an array even
     when they only contain one entry

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxPlan/MSFT_EXOCASMailboxPlan.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOCASMailboxPlan/MSFT_EXOCASMailboxPlan.psm1
@@ -125,7 +125,7 @@ function Get-TargetResource
 
         $result = @{
             Ensure                = 'Present'
-            Identity              = $currentInstance.Identity
+            Identity              = $CASMailboxPlan.Identity
             DisplayName           = $CASMailboxPlan.DisplayName
             ActiveSyncEnabled     = $CASMailboxPlan.ActiveSyncEnabled
             ImapEnabled           = $CASMailboxPlan.ImapEnabled


### PR DESCRIPTION
#### Pull Request (PR) description
Fix export of Identity in EXO CAS Mailbox Plan. It was missing because a non-existing variable was used.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
