### PR TITLE
Fix invalid properties for ClaimsPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * AADPermissionsGrantPolicy
   * Fixed an issue when comparing `AADPermissionGrantConditionSet` instances.
     FIXES [#7062](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7062)
+* AADServicePrincipal
+  * Fixed an issue where `odataType` and `userType` were missing from the
+    `MSFT_AADServicePrincipalCustomClaimCondition` instances.
 * EXOCASMailboxPlan
   * Fixed an issue where `Identity` was missing in the export.
 * EXODataEncryptionPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.schema.mof
@@ -42,11 +42,12 @@ class MSFT_AADServicePrincipalCustomClaimTransformation
     [Write, Description("The input attribute that provides the source for the transformation. This parameter is required if it's the first or only transformation in the list of transformations to be applied. Subsequent transformations use the output of the prior transformation as input."), EmbeddedInstance("MSFT_AADServicePrincipalTransformationAttribute")] String input;
 };
 
-[ClassVersion("1.0.0.0")]
+[ClassVersion("1.0.0.1")]
 class MSFT_AADServicePrincipalCustomClaimCondition
 {
+    [Write, Description("The type of the entity."), ValueMap{"#microsoft.graph.customClaimCondition"}, Values{"#microsoft.graph.customClaimCondition"}] String odataType;
     [Write, Description("A list of groups (GUIDs) to which the user/application must be a member for this condition to be applied.")] String memberOf[];
-    [Write, Description("The type of user this condition applies to. The possible values are: any, members, allGuests, aadGuests, externalGuests."), ValueMap{"any","members","allGuests","aadGuests","externalGuests"}, Values{"any","members","allGuests","aadGuests","externalGuests"}] String claimConditionUserType;
+    [Write, Description("The type of user this condition applies to. The possible values are: any, members, allGuests, aadGuests, externalGuests."), ValueMap{"any","members","allGuests","aadGuests","externalGuests"}, Values{"any","members","allGuests","aadGuests","externalGuests"}] String userType;
 };
 
 [ClassVersion("1.0.0.0")]


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes invalid properties in the `MSFT_AADServicePrincipalCustomClaimCondition` instance. The property `claimConditionUserType` is going to be renamed to `userType` because I accidentally typed the wrong property name when creating the resource. A property with the name `claimConditionUserType` doesn't exist and won't be exported. Usually, that would be a breaking change, but because it cannot be exported like this and only happened a week ago, it should be acceptable.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
