### PR TITLE
M365DSCReverse: Properly setup string replacement map entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 * M365DSCIntuneUtil
   * Fixed an issue where a settings array was returned as a single element.
     FIXES [#7055](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7055)
+* M365DSCReverse
+  * Fixed an issue where the string replacement map was being added as
+    configuration data entries with the keys set as values and the values as
+    keys
 * M365DSCUtil
   * Added retry logic for too many requests when invoking batch requests.
 * Dependencies

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -818,8 +818,8 @@ function Start-M365DSCConfigurationExtract
         foreach ($pair in (Get-M365DSCStringReplacementMap).GetEnumerator())
         {
             Add-ConfigurationDataEntry -Node 'NonNodeData' `
-                -Key $pair.Value `
-                -Value $pair.Key `
+                -Key $pair.Key `
+                -Value $pair.Value `
                 -Description "Placeholder for sensitive data - $($pair.Value)"
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description

@FabienTschanz Still enjoying the holidays but while I was looking at improving on how I generate my configuration data file I noticed this problem, looks like the keys and values for the string replacement map entries are being added reversed.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
