### PR TITLE
[Fixes #7088] Scheduled type fails to create with empty EntityMappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * M365DSCPermissions
   * Fixed documentation and dependency check issues in `Update-M365DSCAzureADApplication`.
     FIXES [#5694](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/5694)
+* SentinelAlertRule
+  * Fixed an issue where the create failed when sending an empty EntityMapping property.
+    FIXES [#7088](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7088)
 
 # 1.26.422.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SentinelAlertRule/MSFT_SentinelAlertRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SentinelAlertRule/MSFT_SentinelAlertRule.psm1
@@ -579,22 +579,29 @@ function Set-TargetResource
             }
         }
 
-        foreach ($entity in $EntityMappings)
+        if ($null -eq $EntityMappings -or $EntityMappings.Length -eq 0)
         {
-            $entry = @{
-                entityType    = $entity.entityType
-                fieldMappings = @()
-            }
-
-            foreach ($field in $entity.fieldMappings)
+            $instance.properties.Remove('entityMappings') | Out-Null
+        }
+        else
+        {
+            foreach ($entity in $EntityMappings)
             {
-                $entry.fieldMappings += @{
-                    identifier = $field.identifier
-                    columnName = $field.columnName
+                $entry = @{
+                    entityType    = $entity.entityType
+                    fieldMappings = @()
                 }
-            }
 
-            $instance.properties.entityMappings += $entry
+                foreach ($field in $entity.fieldMappings)
+                {
+                    $entry.fieldMappings += @{
+                        identifier = $field.identifier
+                        columnName = $field.columnName
+                    }
+                }
+
+                $instance.properties.entityMappings += $entry
+            }
         }
 
         foreach ($detail in $CustomDetails)


### PR DESCRIPTION
#### Pull Request (PR) description
- PR to fix Scheduled type failing to create with empty EntityMappings
- When a type "Scheduled" SentinelAlertRule is being created without EntityMappings, then the property will be removed before sending to the body / api request

#### This Pull Request (PR) fixes the following issues
- Fixes #7088 

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [X ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
