### PR TITLE
Rollback Graph dependencies to 2.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
   * Added the new function `Get-M365DSCResourceDifferences`, which returns newly
     added or removed resources between different module versions.
     FIXES [#4416](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/4416)
+* DEPENDENCIES
+  * Rolled back the `Microsoft.Graph.*` dependencies to version 2.35.1 to avoid
+    conflict with the `ExchangeOnlineManagement` dependency.
+    FIXES [#7095](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7095)
+    FIXES [#7091](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7091)
 
 # 1.26.422.1
 

--- a/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
+++ b/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
@@ -30,99 +30,99 @@
         },
         @{
             ModuleName      = 'Microsoft.Graph.Applications'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Applications'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Authentication'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.DeviceManagement'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Devices.CorporateManagement'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.DeviceManagement.Administration'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.DeviceManagement.Enrollment'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.NetworkAccess'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Identity.DirectoryManagement'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Identity.DirectoryManagement'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Identity.Governance'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Identity.SignIns'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Identity.SignIns'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Reports'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Search'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Teams'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.DeviceManagement.Administration'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.DirectoryObjects'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Groups'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Beta.Groups'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Planner'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Sites'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Users'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'Microsoft.Graph.Users.Actions'
-            RequiredVersion = '2.36.1'
+            RequiredVersion = '2.35.1'
         },
         @{
             ModuleName      = 'MicrosoftTeams'


### PR DESCRIPTION
#### Pull Request (PR) description
This PR rolls back the Microsoft Graph dependencies to version 2.35.1 due to a conflict with ExchangeOnlineManagement 3.9.2.

#### This Pull Request (PR) fixes the following issues
- Fixes #7095
- Fixes #7091 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
