### PR TITLE
Change Windows directory path separator to forward slash

### DIFF
--- a/.github/instructions/powershell.instructions.md
+++ b/.github/instructions/powershell.instructions.md
@@ -323,6 +323,8 @@ function Remove-UserAccount {
   - Use `ForEach-Object` instead of `%`
   - Use `Get-ChildItem` instead of `ls` or `dir`
 
+- **Directory Path Separator:** Use forward slashes (/) in directory paths to ensure cross-platform compatibility, even on Windows. For example, use `C:/Users/Username/Documents` instead of `C:\Users\Username\Documents`.
+
 ## Full Example: End-to-End Cmdlet Pattern
 
 ```powershell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
   * Added the new function `Get-M365DSCResourceDifferences`, which returns newly
     added or removed resources between different module versions.
     FIXES [#4416](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/4416)
+* MISC
+  * Changed the directory path separator from backslash (\\) to forward slash (/)
+    to ensure cross-platform compatibility.
+    FIXES [#7097](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7097)
 * DEPENDENCIES
   * Rolled back the `Microsoft.Graph.*` dependencies to version 2.35.1 to avoid
     conflict with the `ExchangeOnlineManagement` dependency.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_M365DSCRuleEvaluation/MSFT_M365DSCRuleEvaluation.psm1
@@ -177,7 +177,7 @@ function Test-TargetResource
     #endregion
 
     $Global:PartialExportFileName = "$((New-Guid).ToString()).partial"
-    $module = Join-Path -Path $PSScriptRoot -ChildPath "..\MSFT_$ResourceTypeName\MSFT_$ResourceTypeName.psm1" -Resolve
+    $module = Join-Path -Path $PSScriptRoot -ChildPath "../MSFT_$ResourceTypeName/MSFT_$ResourceTypeName.psm1" -Resolve
     if ($null -ne $module)
     {
         $params = @{

--- a/Modules/Microsoft365DSC/Modules/M365DSCCheckProperties.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCCheckProperties.psm1
@@ -165,7 +165,7 @@ function Get-PropertyReport
 
                 # Get properties of DSC resource
                 Write-Verbose "Get properties of resource $resourceName"
-                Import-Module $($folderPath + '\' + $resourceName) -Force
+                Import-Module $($folderPath + '/' + $resourceName) -Force
                 $resourceProperties = (Get-Command Set-TargetResource -Module $resourceName).Parameters
 
                 foreach ($property in $resourceProperties.Keys)

--- a/Modules/Microsoft365DSC/Modules/M365DSCCompare.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCCompare.psm1
@@ -54,7 +54,7 @@ function Compare-M365DSCResourceState
     $currentPath = $PSScriptRoot
     if (-not [Microsoft365DSC.Cache.CacheManager]::IsSchemaLoaded)
     {
-        $schemaPath = Join-Path -Path $currentPath -ChildPath '..\SchemaDefinition.json'
+        $schemaPath = Join-Path -Path $currentPath -ChildPath '../SchemaDefinition.json'
         if (-not (Test-Path -Path $schemaPath))
         {
             throw "SchemaDefinition.json not found at expected path: $schemaPath. Ensure that the schema was properly included during module build and that the module is not being run from a non-standard location."

--- a/Modules/Microsoft365DSC/Modules/M365DSCConnection.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCConnection.psm1
@@ -13,7 +13,7 @@ Initialize-M365DSCDllLoader -ErrorAction SilentlyContinue
 function Get-M365DSCComponentsWithMostSecureAuthenticationType
 {
     [CmdletBinding()]
-    [OutputType([System.String[]])]
+        [OutputType([System.Collections.Generic.List[System.Collections.Hashtable]])]
     param
     (
         [Parameter()]
@@ -26,7 +26,7 @@ function Get-M365DSCComponentsWithMostSecureAuthenticationType
         $Resources
     )
 
-    $dscResourcesPath = Join-Path -Path $PSScriptRoot -ChildPath '..\DSCResources'
+    $dscResourcesPath = Join-Path -Path $PSScriptRoot -ChildPath '../DSCResources'
     return [Microsoft365DSC.Connection.ConnectionHelper]::GetComponentsWithMostSecureAuthenticationType(
         $dscResourcesPath,
         $AuthenticationMethod,

--- a/Modules/Microsoft365DSC/Modules/M365DSCDllLoader.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDllLoader.psm1
@@ -77,7 +77,7 @@ function Initialize-M365DSCDllLoader
 
         foreach ($dllName in $dllsToLoad)
         {
-            $dllPath = Join-Path -Path $moduleRoot -ChildPath "Dependencies\Assemblies\$dllName"
+            $dllPath = Join-Path -Path $moduleRoot -ChildPath "Dependencies/Assemblies/$dllName"
             if (-not (Test-Path -Path $dllPath))
             {
                 $errorMessage = "$dllName not found at: $dllPath. Please run Utilities/Build-DllFiles.ps1 to build the dll file."
@@ -100,7 +100,7 @@ function Initialize-M365DSCDllLoader
         $loadedAssemblies = @()
         foreach ($dllName in $dllsToLoad)
         {
-            $dllPath = Join-Path -Path $moduleRoot -ChildPath "Dependencies\Assemblies\$dllName"
+            $dllPath = Join-Path -Path $moduleRoot -ChildPath "Dependencies/Assemblies/$dllName"
             $loadedAssemblies += Add-Type -Path $dllPath -PassThru -ErrorAction Stop
         }
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCDocGenerator.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDocGenerator.psm1
@@ -530,7 +530,7 @@ function New-DscMofResourceWikiPage
         $Force
     )
 
-    $mofSearchPath = Join-Path -Path $SourcePath -ChildPath '\**\*.schema.mof'
+    $mofSearchPath = Join-Path -Path $SourcePath -ChildPath '/**/*.schema.mof'
     $mofSchemaFiles = @(Get-ChildItem -Path $mofSearchPath -Recurse)
 
     Write-Verbose -Message ("Found {0} MOF files in path '{1}'." -f $mofSchemaFiles.Count, $SourcePath)
@@ -864,7 +864,7 @@ function New-DscMofResourceWikiPage
             $null = $output.AppendLine($permissionsContent)
 
             # Adding examples
-            $examplesPath = Join-Path -Path $SourcePath -ChildPath ('..\..\Examples\Resources\{0}' -f $resourceSchema.FriendlyName)
+            $examplesPath = Join-Path -Path $SourcePath -ChildPath ('../../Examples/Resources/{0}' -f $resourceSchema.FriendlyName)
 
             $examplesOutput = Get-ResourceExampleAsMarkdown -Path $examplesPath
 
@@ -952,7 +952,7 @@ function Update-M365DSCResourceDocumentationPage
 
     New-DscMofResourceWikiPage @newDscMofResourceWikiPageParameters
 
-    $resourceDocsRoot = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\docs\docs\resources'
+    $resourceDocsRoot = Join-Path -Path $PSScriptRoot -ChildPath '../../docs/docs/resources'
 
     Write-Output -InputObject '  - Moving generated pages to the Docs folder'
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCLogEngine.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCLogEngine.psm1
@@ -347,8 +347,8 @@ function Export-M365DSCDiagnosticData
     $logPath = Join-Path -Path $tempPath -ChildPath 'DSCLogs'
     $null = New-Item -Path $logPath -ItemType 'Directory'
 
-    $sourceLogPath = Join-Path -Path $env:windir -ChildPath 'System32\Configuration\ConfigurationStatus'
-    $items = Get-ChildItem -Path "$sourceLogPath\*.json" | Where-Object { $_.LastWriteTime -gt $afterDate }
+    $sourceLogPath = Join-Path -Path $env:windir -ChildPath 'System32/Configuration/ConfigurationStatus'
+    $items = Get-ChildItem -Path "$sourceLogPath/*.json" | Where-Object { $_.LastWriteTime -gt $afterDate }
     Copy-Item -Path $items -Destination $logPath -ErrorAction 'SilentlyContinue' #-ErrorVariable $err
 
     if ($Anonymize)

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -155,12 +155,12 @@ function Start-M365DSCConfigurationExtract
                 Write-Warning "$($_.Exception.Message)"
                 Write-Warning "Could not create folder $OutputDSCPath!"
             }
-            $OutputDSCPath = Read-Host 'Please Provide Output Folder for DSC Configuration (Will be Created as Necessary)'
+            $OutputDSCPath = Read-Host 'Please Provide Output Folder for DSC Configuration (will be created as necessary)'
         }
         <## Ensures the path we specify ends with a Slash, in order to make sure the resulting file path is properly structured. #>
-        if (!$OutputDSCPath.EndsWith('\') -and !$OutputDSCPath.EndsWith('/'))
+        if (-not $OutputDSCPath.EndsWith('\') -and -not $OutputDSCPath.EndsWith('/'))
         {
-            $OutputDSCPath += '\'
+            $OutputDSCPath += [System.IO.Path]::DirectorySeparatorChar
         }
         Push-Location -Path $OutputDSCPath
         #endregion
@@ -1098,7 +1098,7 @@ function Get-M365DSCResourcesByWorkloads
         $Mode = 'Default'
     )
 
-    $modules = Get-ChildItem -Path ($PSScriptRoot + '\..\DSCResources\') -Recurse -Filter '*.psm1'
+    $modules = Get-ChildItem -Path ($PSScriptRoot + '/../DSCResources/') -Recurse -Filter '*.psm1'
     $Components = @()
     foreach ($Workload in $Workloads)
     {

--- a/Modules/Microsoft365DSC/Modules/M365DSCSchemaHandler.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCSchemaHandler.psm1
@@ -3,14 +3,14 @@ function New-M365DSCSchemaDefinition
     [CmdletBinding()]
     param ()
 
-    $schemaFiles = Get-ChildItem -Path '.\Modules\Microsoft365DSC\DSCResources\*.schema.mof' -Recurse
+    $schemaFiles = Get-ChildItem -Path './Modules/Microsoft365DSC/DSCResources/*.schema.mof' -Recurse
 
     $classInfoList = @()
     $classesList = @()
 
     foreach ($file in $schemaFiles)
     {
-        $readMePath = "$($file.DirectoryName)\ReadMe.md"
+        $readMePath = "$($file.DirectoryName)/readme.md"
         $readMeContent = Get-Content $readMePath -Raw
         $resourceDescription = $readMeContent.Split('## Description')[1].Trim()
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -472,7 +472,7 @@ function Test-M365DSCTargetResource
     $currentPath = $PSScriptRoot
     if (-not [Microsoft365DSC.Cache.CacheManager]::IsSchemaLoaded)
     {
-        $schemaPath = Join-Path -Path $currentPath -ChildPath '..\SchemaDefinition.json'
+        $schemaPath = Join-Path -Path $currentPath -ChildPath '../SchemaDefinition.json'
         if (-not (Test-Path -Path $schemaPath))
         {
             throw "SchemaDefinition.json not found at expected path: $schemaPath. Ensure that the schema was properly included during module build and that the module is not being run from a non-standard location."
@@ -617,20 +617,20 @@ function Test-CodePage
 }
 
 <#
-.Description
-This function downloads and installs the Dev branch of Microsoft365DSC on the local machine
+.DESCRIPTION
+    This function downloads and installs the Dev branch of Microsoft365DSC on the local machine
 
-.Parameter Scope
-Specifies the scope of the update of the module. The default value is AllUsers(needs to run as elevated user).
+.PARAMETER Scope
+    Specifies the scope of the update of the module. The default value is AllUsers (needs to run as elevated user).
 
-.Example
-Install-M365DSCDevBranch
+.EXAMPLE
+    Install-M365DSCDevBranch
 
-.Example
-Install-M365DSCDevBranch -Scope CurrentUser
+.EXAMPLE
+    Install-M365DSCDevBranch -Scope CurrentUser
 
-.Functionality
-Public
+.FUNCTIONALITY
+    Public
 #>
 function Install-M365DSCDevBranch
 {
@@ -1112,7 +1112,7 @@ function Get-M365DSCAllResources
     [CmdletBinding()]
     param ()
 
-    $allResources = Get-ChildItem -Path ($PSScriptRoot + '\..\DSCResources\') -Recurse -Filter '*.psm1'
+    $allResources = Get-ChildItem -Path ($PSScriptRoot + '/../DSCResources/') -Recurse -Filter '*.psm1'
     $result = @()
     foreach ($resource in $allResources)
     {
@@ -1300,7 +1300,7 @@ function New-M365DSCCmdletDocumentation
 {
     param()
 
-    $cmdletDocsRoot = Join-Path -Path $PSScriptRoot -ChildPath '..\..\..\docs\docs\user-guide\cmdlets'
+    $cmdletDocsRoot = Join-Path -Path $PSScriptRoot -ChildPath '../../../docs/docs/user-guide/cmdlets'
 
     if ((Test-Path -Path $cmdletDocsRoot) -eq $false)
     {
@@ -1544,7 +1544,7 @@ function New-M365DSCMissingResourcesExample
     $location = $PSScriptRoot
 
     $m365Resources = Get-DscResourceV2 -Module 'Microsoft365DSC' | Select-Object -ExpandProperty Name
-    $examplesPath = Join-Path $location -ChildPath '..\..\..\Examples\Resources'
+    $examplesPath = Join-Path $location -ChildPath '../../../Examples/Resources'
     $examples = Get-ChildItem -Path $examplesPath | Where-Object { $_.PsIsContainer } | Select-Object -ExpandProperty Name
 
     [array]$differences = Compare-Object -ReferenceObject $m365Resources -DifferenceObject $examples
@@ -1555,7 +1555,7 @@ function New-M365DSCMissingResourcesExample
     foreach ($difference in $differences)
     {
         Write-Host "[$count/$total] Processing $($difference.InputObject)"
-        $path = Join-Path -Path '.\Examples\Resources' -ChildPath $difference.InputObject
+        $path = Join-Path -Path './Examples/Resources' -ChildPath $difference.InputObject
         switch ($difference.SideIndicator)
         {
             '<='
@@ -1972,7 +1972,7 @@ function Get-M365DSCResourceComparisonMetadata
 
     if ($null -eq $Script:M365DSCComparisonMetadata)
     {
-        $metadataPath = Join-Path -Path $PSScriptRoot -ChildPath '..\ComparisonMetadata.json'
+        $metadataPath = Join-Path -Path $PSScriptRoot -ChildPath '../ComparisonMetadata.json'
         if (Test-Path -Path $metadataPath)
         {
             try
@@ -2056,7 +2056,7 @@ function Get-M365DSCResourceComparisonParameters
 
         if ($null -eq $module)
         {
-            $resourceModulePath = Join-Path -Path $PSScriptRoot -ChildPath "..\DSCResources\$moduleName\$moduleName.psm1"
+            $resourceModulePath = Join-Path -Path $PSScriptRoot -ChildPath "../DSCResources/$moduleName/$moduleName.psm1"
             if (Test-Path -Path $resourceModulePath)
             {
                 $previousValue = $moduleConfig.skipModuleDependencyValidation

--- a/Tests/Integration/M365DSCTestEngine.psm1
+++ b/Tests/Integration/M365DSCTestEngine.psm1
@@ -55,10 +55,10 @@ function New-M365DSCIntegrationTest
 '@
 
     # Fetching examples
-    $exampleFiles = Get-ChildItem -Path ".\Modules\Microsoft365DSC\Examples\Resources\*$Step.ps1" -Recurse
+    $exampleFiles = Get-ChildItem -Path "./Modules/Microsoft365DSC/Examples/Resources/*$Step.ps1" -Recurse
     foreach ($file in $exampleFiles)
     {
-        if ($file.FullName -like "*Modules\Microsoft365DSC\Examples\Resources\$Workload*")
+        if ($file.FullName -like "*Modules/Microsoft365DSC/Examples/Resources/$Workload*")
         {
             # Fetching DSC resources from example file
             $ast = [System.Management.Automation.Language.Parser]::ParseFile($file, [ref]$null, [ref]$null)

--- a/Tests/QA/Microsoft365DSC.Examples.Tests.ps1
+++ b/Tests/QA/Microsoft365DSC.Examples.Tests.ps1
@@ -1,5 +1,5 @@
 ﻿BeforeDiscovery {
-    $examplesPath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Examples'
+    $examplesPath = Join-Path -Path $PSScriptRoot -ChildPath '../../Examples'
 
     # If there are no Examples folder, exit.
     if (-not (Test-Path -Path $examplesPath))
@@ -20,7 +20,7 @@
         }
     }
 
-    $resourcesPath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Modules\Microsoft365DSC\DscResources'
+    $resourcesPath = Join-Path -Path $PSScriptRoot -ChildPath '../../Modules/Microsoft365DSC/DscResources'
 
     # If there are no Examples folder, exit.
     if (-not (Test-Path -Path $resourcesPath))
@@ -201,7 +201,7 @@ Describe -Name 'Successfully compile examples' {
 
 Describe -Name 'Check examples for all resources' {
     BeforeAll {
-        $examplesPath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Examples'
+        $examplesPath = Join-Path -Path $PSScriptRoot -ChildPath '../../Examples'
 
         # If there are no Examples folder, exit.
         if (-not (Test-Path -Path $examplesPath))

--- a/Tests/QA/Microsoft365DSC.ModuleManifest.Tests.ps1
+++ b/Tests/QA/Microsoft365DSC.ModuleManifest.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿Describe -Name 'Checking Module Manifest' {
     BeforeAll {
-        $manifestPath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Modules\Microsoft365DSC\Microsoft365DSC.psd1'
+        $manifestPath = Join-Path -Path $PSScriptRoot -ChildPath '../../Modules/Microsoft365DSC/Microsoft365DSC.psd1'
         $manifest = Import-PowerShellDataFile -Path $manifestPath
     }
 

--- a/Tests/QA/Microsoft365DSC.Resources.Tests.ps1
+++ b/Tests/QA/Microsoft365DSC.Resources.Tests.ps1
@@ -1,5 +1,5 @@
 ﻿BeforeDiscovery {
-    $resourcesPath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Modules\Microsoft365DSC\DSCResources'
+    $resourcesPath = Join-Path -Path $PSScriptRoot -ChildPath '../../Modules/Microsoft365DSC/DSCResources'
     $schemaFiles = Get-ChildItem -Path $resourcesPath -Filter '*.schema.mof' -Recurse | ForEach-Object {
         @{
             ResourceName = $_.Directory.Name

--- a/Tests/QA/Microsoft365DSC.SettingsJson.Tests.ps1
+++ b/Tests/QA/Microsoft365DSC.SettingsJson.Tests.ps1
@@ -1,5 +1,5 @@
 BeforeDiscovery {
-    $resourcesPath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Modules\Microsoft365DSC\DSCResources'
+    $resourcesPath = Join-Path -Path $PSScriptRoot -ChildPath '../../Modules/Microsoft365DSC/DSCResources'
     $settingsFiles = Get-ChildItem -Path $resourcesPath -Filter '*.json' -Recurse | ForEach-Object {
         @{
             ResourceName = $_.Directory.Name
@@ -17,7 +17,7 @@ Describe -Name 'Successfully import Settings.json files' {
 
 Describe -Name 'Successfully validate all used permissions in Settings.json files ' {
     BeforeAll {
-        $permissionsFile = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Tests\QA\Graph.PermissionList.txt'
+        $permissionsFile = Join-Path -Path $PSScriptRoot -ChildPath '../../Tests/QA/Graph.PermissionList.txt'
         $roles = (Get-Content $permissionsFile -Raw).Split(',')
     }
 

--- a/Tests/QA/Microsoft365DSC.TargetResourceParameters.Tests.ps1
+++ b/Tests/QA/Microsoft365DSC.TargetResourceParameters.Tests.ps1
@@ -1,5 +1,5 @@
 BeforeDiscovery {
-    $resourcesPath = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Modules\Microsoft365DSC\DSCResources'
+    $resourcesPath = Join-Path -Path $PSScriptRoot -ChildPath '../../Modules/Microsoft365DSC/DSCResources'
     $schemaFiles = Get-ChildItem -Path $resourcesPath -Filter '*.schema.mof' -Recurse | ForEach-Object {
         $psm1 = Get-ChildItem -Path $_.Directory.FullName -Filter '*.psm1' -File -ErrorAction SilentlyContinue | Select-Object -First 1
         @{

--- a/Tests/TestHarness.psm1
+++ b/Tests/TestHarness.psm1
@@ -17,7 +17,7 @@ function Invoke-TestHarness
 
         [Parameter()]
         [System.String]
-        $ModuleDirectory = (Join-Path -Path $PSScriptRoot -ChildPath '..\Modules\Microsoft365DSC' -Resolve)
+        $ModuleDirectory = (Join-Path -Path $PSScriptRoot -ChildPath '../Modules/Microsoft365DSC' -Resolve)
     )
 
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
@@ -25,7 +25,7 @@ function Invoke-TestHarness
     $MaximumFunctionCount = 32767
     Write-Host -Object 'Running all Microsoft365DSC Unit Tests'
 
-    $repoDir = Join-Path -Path $PSScriptRoot -ChildPath '..\' -Resolve
+    $repoDir = Join-Path -Path $PSScriptRoot -ChildPath '../' -Resolve
 
     $oldModPath = $env:PSModulePath
     $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + $ModuleDirectory
@@ -33,7 +33,7 @@ function Invoke-TestHarness
     $testCoverageFiles = @()
     if ($IgnoreCodeCoverage.IsPresent -eq $false)
     {
-        Get-ChildItem -Path "$repoDir\Modules\Microsoft365DSC\DSCResources\**\*.psm1" -Recurse | ForEach-Object {
+        Get-ChildItem -Path "$repoDir/Modules/Microsoft365DSC/DSCResources/**/*.psm1" -Recurse | ForEach-Object {
             if ($_.FullName -notlike '*\DSCResource.Tests\*')
             {
                 $testCoverageFiles += $_.FullName
@@ -45,18 +45,18 @@ function Invoke-TestHarness
     $testsToRun = @()
 
     # Run Unit Tests
-    $versionsPath = Join-Path -Path $repoDir -ChildPath '\Tests\Unit\Stubs\'
+    $versionsPath = Join-Path -Path $repoDir -ChildPath './Tests/Unit/Stubs/'
     # Import the first stub found so that there is a base module loaded before the tests start
     $firstStub = Join-Path -Path $repoDir `
-        -ChildPath '\Tests\Unit\Stubs\Microsoft365.psm1'
+        -ChildPath './Tests/Unit/Stubs/Microsoft365.psm1'
     Import-Module $firstStub -WarningAction SilentlyContinue
 
     $stubPath = Join-Path -Path $repoDir `
-        -ChildPath '\Tests\Unit\Stubs\Microsoft365.psm1'
+        -ChildPath './Tests/Unit/Stubs/Microsoft365.psm1'
 
     # DSC Common Tests
     $getChildItemParameters = @{
-        Path    = (Join-Path -Path $repoDir -ChildPath '\Tests\Unit')
+        Path    = (Join-Path -Path $repoDir -ChildPath './Tests/Unit')
         Recurse = $true
         Filter  = '*.Tests.ps1'
     }
@@ -66,7 +66,7 @@ function Invoke-TestHarness
 
     # Remove DscResource.Tests unit tests.
     $commonTestFiles = $commonTestFiles | Where-Object -FilterScript {
-        $_.FullName -notmatch 'DSCResource.Tests\\Tests'
+        $_.FullName -notmatch 'DSCResource.Tests[\\/]Tests'
     }
 
     $testsToRun += @( $commonTestFiles.FullName )
@@ -185,14 +185,14 @@ function Invoke-QualityChecksHarness
 
     Write-Host -Object 'Running all Quality Check Tests'
 
-    $repoDir = Join-Path -Path $PSScriptRoot -ChildPath '..\' -Resolve
+    $repoDir = Join-Path -Path $PSScriptRoot -ChildPath '../' -Resolve
 
     $oldModPath = $env:PSModulePath
-    $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + (Join-Path -Path $repoDir -ChildPath 'modules\Microsoft365DSC')
+    $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + (Join-Path -Path $repoDir -ChildPath 'Modules/Microsoft365DSC')
 
     # DSC Common Tests
     $getChildItemParameters = @{
-        Path   = (Join-Path -Path $repoDir -ChildPath '\Tests\QA')
+        Path   = (Join-Path -Path $repoDir -ChildPath './Tests/QA')
         Filter = '*.Tests.ps1'
     }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceManagementEnrollmentAndroidGooglePlay.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneDeviceManagementEnrollmentAndroidGooglePlay.Tests.ps1
@@ -1,9 +1,9 @@
 [CmdletBinding()]
 param()
-$M365DSCTestFolder = Join-Path -Path $PSScriptRoot -ChildPath '..\..\Unit' -Resolve
-$CmdletModule = (Join-Path -Path $M365DSCTestFolder -ChildPath '\Stubs\Microsoft365.psm1' -Resolve)
-$GenericStubPath = (Join-Path -Path $M365DSCTestFolder -ChildPath '\Stubs\Generic.psm1' -Resolve)
-Import-Module -Name (Join-Path -Path $M365DSCTestFolder -ChildPath '\UnitTestHelper.psm1' -Resolve)
+$M365DSCTestFolder = Join-Path -Path $PSScriptRoot -ChildPath '../../Unit' -Resolve
+$CmdletModule = (Join-Path -Path $M365DSCTestFolder -ChildPath 'Stubs/Microsoft365.psm1' -Resolve)
+$GenericStubPath = (Join-Path -Path $M365DSCTestFolder -ChildPath 'Stubs/Generic.psm1' -Resolve)
+Import-Module -Name (Join-Path -Path $M365DSCTestFolder -ChildPath 'UnitTestHelper.psm1' -Resolve)
 
 $CurrentScriptPath = $PSCommandPath.Split('\')
 $CurrentScriptName = $CurrentScriptPath[$CurrentScriptPath.Length -1]

--- a/Tests/Unit/UnitTestHelper.psm1
+++ b/Tests/Unit/UnitTestHelper.psm1
@@ -24,7 +24,7 @@ function New-M365DscUnitTestHelper
         $GenericStubModule
     )
 
-    $repoRoot = Join-Path -Path $PSScriptRoot -ChildPath "../../.." -Resolve
+    $repoRoot = Join-Path -Path $PSScriptRoot -ChildPath "../../" -Resolve
     $moduleRoot = Join-Path -Path $repoRoot -ChildPath "Modules/Microsoft365DSC"
 
     $mainModule = Join-Path -Path $moduleRoot -ChildPath "Microsoft365DSC.psd1"

--- a/Tests/Unit/UnitTestHelper.psm1
+++ b/Tests/Unit/UnitTestHelper.psm1
@@ -1,6 +1,7 @@
 function New-M365DscUnitTestHelper
 {
     [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
     param(
         [Parameter(Mandatory = $true)]
         [String]
@@ -23,8 +24,8 @@ function New-M365DscUnitTestHelper
         $GenericStubModule
     )
 
-    $repoRoot = Join-Path -Path $PSScriptRoot -ChildPath "..\..\" -Resolve
-    $moduleRoot = Join-Path -Path $repoRoot -ChildPath "Modules\Microsoft365DSC"
+    $repoRoot = Join-Path -Path $PSScriptRoot -ChildPath "../../.." -Resolve
+    $moduleRoot = Join-Path -Path $repoRoot -ChildPath "Modules/Microsoft365DSC"
 
     $mainModule = Join-Path -Path $moduleRoot -ChildPath "Microsoft365DSC.psd1"
     Remove-Module -Name "AzureAD" -Force -ErrorAction SilentlyContinue

--- a/Utilities/Build-ComparisonMetadata.ps1
+++ b/Utilities/Build-ComparisonMetadata.ps1
@@ -32,11 +32,11 @@ param
 (
     [Parameter()]
     [System.String]
-    $ResourcesPath = (Join-Path -Path $PSScriptRoot -ChildPath '..\Modules\Microsoft365DSC\DSCResources'),
+    $ResourcesPath = (Join-Path -Path $PSScriptRoot -ChildPath '../Modules/Microsoft365DSC/DSCResources'),
 
     [Parameter()]
     [System.String]
-    $OutputPath = (Join-Path -Path $PSScriptRoot -ChildPath '..\Modules\Microsoft365DSC\ComparisonMetadata.json'),
+    $OutputPath = (Join-Path -Path $PSScriptRoot -ChildPath '../Modules/Microsoft365DSC/ComparisonMetadata.json'),
 
     [Parameter()]
     [switch]

--- a/Utilities/Build-DllFiles.ps1
+++ b/Utilities/Build-DllFiles.ps1
@@ -77,9 +77,9 @@ function Build-Project {
         [switch]$SkipClean
     )
 
-    $projectPath = Join-Path -Path $RepositoryRoot -ChildPath "src\$ProjectName\$ProjectName.csproj"
-    $outputDir = Join-Path -Path $RepositoryRoot -ChildPath "src\$ProjectName\bin\$Configuration\netstandard2.0"
-    $targetDir = Join-Path -Path $RepositoryRoot -ChildPath 'Modules\Microsoft365DSC\Dependencies\Assemblies'
+    $projectPath = Join-Path -Path $RepositoryRoot -ChildPath "src/$ProjectName/$ProjectName.csproj"
+    $outputDir = Join-Path -Path $RepositoryRoot -ChildPath "src/$ProjectName/bin/$Configuration/netstandard2.0"
+    $targetDir = Join-Path -Path $RepositoryRoot -ChildPath 'Modules/Microsoft365DSC/Dependencies/Assemblies'
 
     Write-Host "Building $ProjectName..." -ForegroundColor Cyan
     Write-Host "Repository Root: $RepositoryRoot" -ForegroundColor Gray


### PR DESCRIPTION
#### Pull Request (PR) description
This PR updates the Windows path separator \ to its forward slash equivalent, which is required for cross-platform support.

#### This Pull Request (PR) fixes the following issues
- Fixes #7097

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
