### PR TITLE
Fix missing array definition for property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     FIXES [#7103](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7103)
 * IntuneDeviceEnrollmentPlatformRestriction
   * Added the new properties `TvosRestriction` and `VisionOSRestriction`.
+* SCDLPComplianceRule
+  * Fixed an issue where `ContentContainsSensitiveInformation` was not defined as array.
 
 # 1.26.506.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
@@ -37,11 +37,11 @@ function Get-TargetResource
         $AdvancedRule,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
         $ContentContainsSensitiveInformation,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
         $ExceptIfContentContainsSensitiveInformation,
 
         [Parameter()]
@@ -565,11 +565,11 @@ function Set-TargetResource
         $AdvancedRule,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
         $ContentContainsSensitiveInformation,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
         $ExceptIfContentContainsSensitiveInformation,
 
         [Parameter()]
@@ -1040,11 +1040,11 @@ function Test-TargetResource
         $AdvancedRule,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
         $ContentContainsSensitiveInformation,
 
         [Parameter()]
-        [Microsoft.Management.Infrastructure.CimInstance]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
         $ExceptIfContentContainsSensitiveInformation,
 
         [Parameter()]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.schema.mof
@@ -35,7 +35,7 @@ class MSFT_SCDLPContainsSensitiveInformation
     [Write, Description("Operator"),ValueMap{"And","Or"}, Values{"And","Or"}] String Operator;
 };
 
-[ClassVersion("1.0.0.1"), FriendlyName("SCDLPComplianceRule")]
+[ClassVersion("1.0.0.2"), FriendlyName("SCDLPComplianceRule")]
 class MSFT_SCDLPComplianceRule : OMI_BaseResource
 {
     [Key, Description("Name of the Rule.")] String Name;
@@ -45,8 +45,8 @@ class MSFT_SCDLPComplianceRule : OMI_BaseResource
     [Write, Description("The BlockAccessScope parameter specifies the scope of the block access action."), ValueMap{"All", "PerUser","None"}, Values{"All", "PerUser","None"}] String BlockAccessScope;
     [Write, Description("The Comment parameter specifies an optional comment. If you specify a value that contains spaces, enclose the value in quotation marks.")] String Comment;
     [Write, Description("The AdvancedRule parameter uses complex rule syntax that supports multiple AND, OR, and NOT operators and nested groups")] String AdvancedRule;
-    [Write, Description("The ContentContainsSensitiveInformation parameter specifies a condition for the rule that's based on a sensitive information type match in content. The rule is applied to content that contains the specified sensitive information type."), EmbeddedInstance("MSFT_SCDLPContainsSensitiveInformation")] String ContentContainsSensitiveInformation;
-    [Write, Description("The ExceptIfContentContainsSensitiveInformation parameter specifies an exception for the rule that's based on a sensitive information type match in content. The rule isn't applied to content that contains the specified sensitive information type."), EmbeddedInstance("MSFT_SCDLPContainsSensitiveInformation")] String ExceptIfContentContainsSensitiveInformation;
+    [Write, Description("The ContentContainsSensitiveInformation parameter specifies a condition for the rule that's based on a sensitive information type match in content. The rule is applied to content that contains the specified sensitive information type."), EmbeddedInstance("MSFT_SCDLPContainsSensitiveInformation")] String ContentContainsSensitiveInformation[];
+    [Write, Description("The ExceptIfContentContainsSensitiveInformation parameter specifies an exception for the rule that's based on a sensitive information type match in content. The rule isn't applied to content that contains the specified sensitive information type."), EmbeddedInstance("MSFT_SCDLPContainsSensitiveInformation")] String ExceptIfContentContainsSensitiveInformation[];
     [Write, Description("The ContentPropertyContainsWords parameter specifies a condition for the DLP rule that's based on a property match in content. The rule is applied to content that contains the specified property.")] String ContentPropertyContainsWords[];
     [Write, Description("The Disabled parameter specifies whether the DLP rule is disabled.")] Boolean Disabled;
     [Write, Description("The Quarantine parameter specifies an action that quarantines messages. Valid values are: $true: The message is delivered to the hosted quarantine. $false: The message is not quarantined.")] Boolean Quarantine;

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCDLPComplianceRule.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCDLPComplianceRule.Tests.ps1
@@ -112,7 +112,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Policy                              = 'MyParentPolicy'
                     Comment                             = ''
                     AdvancedRule                        = "`"{\r\n  \`"Version\`": \`"1.0\`",\r\n  \`"Condition\`": {\r\n    \`"Operator\`": \`"And\`",\r\n    \`"SubConditions\`": [\r\n      {\r\n        \`"ConditionName\`": \`"ContentContainsSensitiveInformation\`",\r\n        \`"Value\`": [\r\n          {\r\n            \`"Groups\`": [\r\n              {\r\n                \`"Name\`": \`"Default\`",\r\n                \`"Operator\`": \`"Or\`",\r\n                \`"Sensitivetypes\`": [\r\n                  {\r\n                    \`"Name\`": \`"SCSEDM001-SCHEMA-CUSTOMERDATA\`",\r\n                    \`"Id\`": null,\r\n                    \`"Mincount\`": 5,\r\n                    \`"Maxcount\`": 9,\r\n                    \`"Confidencelevel\`": \`"High\`",\r\n                    \`"Minconfidence\`": 85,\r\n                    \`"Maxconfidence\`": 100\r\n                  }\r\n                ]\r\n              }\r\n            ],\r\n            \`"Operator\`": \`"And\`"\r\n          }\r\n        ]\r\n      }\r\n    ]\r\n  }\r\n}`"";
-                    ContentContainsSensitiveInformation = New-CimInstance -ClassName MSFT_SCDLPContainsSensitiveInformation -Property @{
+                    ContentContainsSensitiveInformation = [CIMInstance[]]@(New-CimInstance -ClassName MSFT_SCDLPContainsSensitiveInformation -Property @{
                         Operator = 'And'
                         Groups   = [CIMInstance[]]@(
                             New-CimInstance -ClassName MSFT_SCDLPContainsSensitiveInformationGroup -Property @{
@@ -140,7 +140,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                 )
                             } -ClientOnly
                         )
-                    } -ClientOnly
+                    } -ClientOnly)
                     BlockAccess                         = $False
                     Name                                = 'TestPolicy'
                     Credential                          = $Credential
@@ -169,8 +169,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Ensure                              = 'Present'
                     Policy                              = 'MyParentPolicy'
                     Comment                             = 'New comment'
-                    ContentContainsSensitiveInformation = (New-CimInstance -ClassName MSFT_SCDLPContainsSensitiveInformation -Property @{
-                            SensitiveInformation = (New-CimInstance -ClassName  MSFT_SCDLPSensitiveInformation -Property @{
+                    ContentContainsSensitiveInformation = [CimInstance[]]@(New-CimInstance -ClassName MSFT_SCDLPContainsSensitiveInformation -Property @{
+                            SensitiveInformation = [CIMInstance[]]@(New-CimInstance -ClassName  MSFT_SCDLPSensitiveInformation -Property @{
                                     name           = 'ABA Routing Number'
                                     id             = 'cb353f78-2b72-4c3c-8827-92ebe4f69fdf'
                                     maxconfidence  = '100'


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes a missing array definition for the two properties `ContentContainsSensitiveInformation` and `ExceptIfContentContainsSensitiveInformation` of the `SCDLPComplianceRule` resource.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
