### PR TITLE
Revert changes to NoEnumerate instead of combined array return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   * Added the new properties `TvosRestriction` and `VisionOSRestriction`.
 * SCDLPComplianceRule
   * Fixed an issue where `ContentContainsSensitiveInformation` was not defined as array.
+* M365DSCUtil
+  * Reverted a change to array return values with `-NoEnumerate`.
+    FIXES [#7105](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7105)
 
 # 1.26.506.1
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -67,13 +67,13 @@ function Get-TargetResource
         $ExcludeRoles,
 
         [Parameter()]
-        [System.String[]]
         [ValidateSet('none', 'internalGuest', 'b2bCollaborationGuest', 'b2bCollaborationMember', 'b2bDirectConnectUser', 'otherExternalUser', 'serviceProvider', 'unknownFutureValue')]
+        [System.String[]]
         $IncludeGuestOrExternalUserTypes,
 
         [Parameter()]
-        [System.String]
         [ValidateSet('', 'all', 'enumerated', 'unknownFutureValue')]
+        [System.String]
         $IncludeExternalTenantsMembershipKind,
 
         [Parameter()]
@@ -81,13 +81,13 @@ function Get-TargetResource
         $IncludeExternalTenantsMembers,
 
         [Parameter()]
-        [System.String[]]
         [ValidateSet('none', 'internalGuest', 'b2bCollaborationGuest', 'b2bCollaborationMember', 'b2bDirectConnectUser', 'otherExternalUser', 'serviceProvider', 'unknownFutureValue')]
+        [System.String[]]
         $ExcludeGuestOrExternalUserTypes,
 
         [Parameter()]
-        [System.String]
         [ValidateSet('', 'all', 'enumerated', 'unknownFutureValue')]
+        [System.String]
         $ExcludeExternalTenantsMembershipKind,
 
         [Parameter()]
@@ -875,13 +875,13 @@ function Set-TargetResource
         $ExcludeRoles,
 
         [Parameter()]
-        [System.String[]]
         [ValidateSet('none', 'internalGuest', 'b2bCollaborationGuest', 'b2bCollaborationMember', 'b2bDirectConnectUser', 'otherExternalUser', 'serviceProvider', 'unknownFutureValue')]
+        [System.String[]]
         $IncludeGuestOrExternalUserTypes,
 
         [Parameter()]
-        [System.String]
         [ValidateSet('', 'all', 'enumerated', 'unknownFutureValue')]
+        [System.String]
         $IncludeExternalTenantsMembershipKind,
 
         [Parameter()]
@@ -889,13 +889,13 @@ function Set-TargetResource
         $IncludeExternalTenantsMembers,
 
         [Parameter()]
-        [System.String[]]
         [ValidateSet('none', 'internalGuest', 'b2bCollaborationGuest', 'b2bCollaborationMember', 'b2bDirectConnectUser', 'otherExternalUser', 'serviceProvider', 'unknownFutureValue')]
+        [System.String[]]
         $ExcludeGuestOrExternalUserTypes,
 
         [Parameter()]
-        [System.String]
         [ValidateSet('', 'all', 'enumerated', 'unknownFutureValue')]
+        [System.String]
         $ExcludeExternalTenantsMembershipKind,
 
         [Parameter()]
@@ -1014,7 +1014,7 @@ function Set-TargetResource
         $PersistentBrowserIsEnabled,
 
         [Parameter()]
-        [nullable[System.Boolean]]
+        [System.Boolean]
         $DisableResilienceDefaultsIsEnabled,
 
         [Parameter()]
@@ -2043,13 +2043,13 @@ function Test-TargetResource
         $ExcludeRoles,
 
         [Parameter()]
-        [System.String[]]
         [ValidateSet('none', 'internalGuest', 'b2bCollaborationGuest', 'b2bCollaborationMember', 'b2bDirectConnectUser', 'otherExternalUser', 'serviceProvider', 'unknownFutureValue')]
+        [System.String[]]
         $IncludeGuestOrExternalUserTypes,
 
         [Parameter()]
-        [System.String]
         [ValidateSet('', 'all', 'enumerated', 'unknownFutureValue')]
+        [System.String]
         $IncludeExternalTenantsMembershipKind,
 
         [Parameter()]
@@ -2057,13 +2057,13 @@ function Test-TargetResource
         $IncludeExternalTenantsMembers,
 
         [Parameter()]
-        [System.String[]]
         [ValidateSet('none', 'internalGuest', 'b2bCollaborationGuest', 'b2bCollaborationMember', 'b2bDirectConnectUser', 'otherExternalUser', 'serviceProvider', 'unknownFutureValue')]
+        [System.String[]]
         $ExcludeGuestOrExternalUserTypes,
 
         [Parameter()]
-        [System.String]
         [ValidateSet('', 'all', 'enumerated', 'unknownFutureValue')]
+        [System.String]
         $ExcludeExternalTenantsMembershipKind,
 
         [Parameter()]

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -143,7 +143,7 @@ function Get-M365DSCArrayFromProperty
         $array += $item
     }
 
-    Write-Output -InputObject $array -NoEnumerate
+    ,$array
 }
 
 <#
@@ -1164,8 +1164,7 @@ function Get-M365DSCResourceDifferences
     if ($installedModules.Count -eq 0)
     {
         Write-Error -Message 'No installed versions of Microsoft365DSC were found.'
-        Write-Output -InputObject @() -NoEnumerate
-        return
+        return ,@()
     }
 
     # Resolve current version


### PR DESCRIPTION
#### Pull Request (PR) description
This PR reverts changes to how arrays are returned. There was a recent change that updated it to use `-NoEnumerate`, but this lead to issues with the LCM.

#### This Pull Request (PR) fixes the following issues
- Fixes #7105 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
