### PR TITLE
Add report variable substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCExportUtil
+  * Fixed an issue where the organization name was not
+    replaced with `$OrganizationName` during configuration export.
+* M365DSCReport
+  * Added the option to use variable substitution during report generation
+    with `New-M365DSCDeltaReport`. Please refer to the function documentation
+    page for guidance on how to use this new functionality.
+
 # 1.26.506.2
 
 * AADEntitlementManagementConnectedOrganization

--- a/Modules/Microsoft365DSC/Modules/M365DSCExportUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCExportUtil.psm1
@@ -559,15 +559,6 @@ function Get-M365DSCExportContentForResource
         $AllowVariablesInStrings
     )
 
-    if (-not $SkipAuthenticationUpdate)
-    {
-        $withoutAuthentication = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
-            -Results $Results
-        $Results = $withoutAuthentication.Results
-        $NoEscape += $withoutAuthentication.NoEscape
-    }
-    $NoEscape = $NoEscape | Select-Object -Unique
-
     $OrganizationName = ''
     if ($ConnectionMode -like 'ServicePrincipal*' -or `
             $ConnectionMode -eq 'ManagedIdentity')
@@ -582,6 +573,15 @@ function Get-M365DSCExportContentForResource
     {
         $OrganizationName = ''
     }
+
+    if (-not $SkipAuthenticationUpdate)
+    {
+        $withoutAuthentication = Update-M365DSCExportAuthenticationResults -ConnectionMode $ConnectionMode `
+            -Results $Results
+        $Results = $withoutAuthentication.Results
+        $NoEscape += $withoutAuthentication.NoEscape
+    }
+    $NoEscape = $NoEscape | Select-Object -Unique
 
     $primaryKey = ''
     $ModuleFullName = 'MSFT_' + $ResourceName

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -1,6 +1,3 @@
-# Automatically initialize accelerator on module import
-Initialize-M365DSCDllLoader -ErrorAction SilentlyContinue
-
 $Script:ReportCSS = @'
 <style>
     body {
@@ -383,7 +380,6 @@ function New-M365DSCConfigurationToMarkdown
     Write-Output 'Completed generating Markdown report'
 }
 
-
 <#
 .DESCRIPTION
     This function creates a new HTML document from the specified exported configuration
@@ -574,7 +570,6 @@ function New-M365DSCConfigurationToJSON
     $jsonContent = $ParsedContent | ConvertTo-Json -Depth 25
     $jsonContent | Out-File -FilePath $OutputPath
 }
-
 
 <#
 .DESCRIPTION
@@ -1293,11 +1288,28 @@ function Get-M365DSCResourceKey
 .PARAMETER ExcludedResources
     Array that contains the list of resources to exclude.
 
-.EXAMPLE
-    PS> New-M365DSCDeltaReport -Source 'C:\DSC\Source.ps1' -Destination 'C:\DSC\Destination.ps1' -OutputPath 'C:\Dsc\DeltaReport.html'
+.PARAMETER SourceConfigurationDataPath
+    The path to the ConfigurationData.psd1 file that belongs to the source configuration, used for variable substitution in the report.
+
+.PARAMETER DestinationConfigurationDataPath
+    The path to the ConfigurationData.psd1 file that belongs to the destination configuration, used for variable substitution in the report.
+
+.PARAMETER ExcludedSubstitutionProperties
+    Array that contains the list of properties for which variable substitution should be excluded.
+    Authentication properties are always excluded, with additional properties that can be specified through this parameter.
 
 .EXAMPLE
-    PS> New-M365DSCDeltaReport -Source 'C:\DSC\Source.ps1' -Destination 'C:\DSC\Destination.ps1' -OutputPath 'C:\Dsc\DeltaReport.html' -DriftOnly $true
+    PS> New-M365DSCDeltaReport -Source 'C:\DSC\Source.ps1' -Destination 'C:\DSC\Destination.ps1' -OutputPath 'C:\DSC\DeltaReport.html'
+
+.EXAMPLE
+    PS> New-M365DSCDeltaReport -Source 'C:\DSC\Source.ps1' -Destination 'C:\DSC\Destination.ps1' -OutputPath 'C:\DSC\DeltaReport.html' -DriftOnly $true
+
+.EXAMPLE
+    PS> New-M365DSCDeltaReport -Source 'C:\DSC\Source.ps1' -Destination 'C:\DSC\Destination.ps1' -OutputPath 'C:\DSC\DeltaReport.html' -IsBlueprintAssessment $true
+
+.EXAMPLE
+    PS> New-M365DSCDeltaReport -Source 'C:\DSC\Source.ps1' -Destination 'C:\DSC\Destination.ps1' -OutputPath 'C:\DSC\DeltaReport.html' -HeaderFilePath 'C:\DSC\CustomHeader.html' `
+        -SourceConfigurationDataPath 'C:\DSC\SourceConfigData.psd1' -DestinationConfigurationDataPath 'C:\DSC\DestinationConfigData.psd1' -ExcludedSubstitutionProperties @('TenantEnvironment')
 
 .FUNCTIONALITY
     Public
@@ -1346,7 +1358,19 @@ function New-M365DSCDeltaReport
 
         [Parameter()]
         [Array]
-        $ExcludedResources
+        $ExcludedResources,
+
+        [Parameter()]
+        [System.String]
+        $SourceConfigurationDataPath,
+
+        [Parameter()]
+        [System.String]
+        $DestinationConfigurationDataPath,
+
+        [Parameter()]
+        [System.String[]]
+        $ExcludedSubstitutionProperties = @()
     )
 
     # Validate that the latest version of the module is installed.
@@ -1379,6 +1403,7 @@ function New-M365DSCDeltaReport
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
+    Initialize-M365DSCDllLoader -ErrorAction Stop
 
     if ($null -eq (Get-Module -Name 'M365DSCCompare'))
     {
@@ -1411,8 +1436,135 @@ function New-M365DSCDeltaReport
     Write-Verbose -Message 'Obtaining Delta between the source and destination configurations'
     if (-not $Delta)
     {
+        #region ConfigurationData variable substitution
+        $effectiveSource = $Source
+        $effectiveDestination = $Destination
+        $tempSourcePath = $null
+        $tempDestinationPath = $null
+
+        # Build a map of ConfigurationData paths: key = file path, value = config data path
+        $configDataMap = @{}
+        if (-not [System.String]::IsNullOrEmpty($SourceConfigurationDataPath))
+        {
+            $configDataMap[$Source] = $SourceConfigurationDataPath
+        }
+        if (-not [System.String]::IsNullOrEmpty($DestinationConfigurationDataPath))
+        {
+            $configDataMap[$Destination] = $DestinationConfigurationDataPath
+        }
+
+        # Auto-detect ConfigurationData.psd1 when no explicit path was provided
+        foreach ($filePath in @($Source, $Destination))
+        {
+            if (-not $configDataMap.ContainsKey($filePath))
+            {
+                $autoPath = Join-Path -Path (Split-Path -Path $filePath -Parent) -ChildPath 'ConfigurationData.psd1'
+                if (Test-Path -Path $autoPath)
+                {
+                    $configDataMap[$filePath] = $autoPath
+                }
+            }
+        }
+
+        foreach ($filePath in @($Source, $Destination))
+        {
+            if (-not $configDataMap.ContainsKey($filePath))
+            {
+                continue
+            }
+
+            $configDataFile = $configDataMap[$filePath]
+            if (-not (Test-Path -Path $configDataFile))
+            {
+                Write-Warning -Message "ConfigurationData file not found at '$configDataFile'. Skipping variable substitution for '$filePath'."
+                continue
+            }
+
+            Write-Verbose -Message "Importing ConfigurationData from '$configDataFile' for '$filePath'"
+            $configData = Import-PowerShellDataFile -Path $configDataFile
+
+            # Collect all string properties from NonNodeData
+            $substitutions = @{}
+            if ($null -ne $configData.NonNodeData)
+            {
+                $nonNodeEntries = @()
+                if ($configData.NonNodeData -is [System.Array])
+                {
+                    $nonNodeEntries = $configData.NonNodeData
+                }
+                else
+                {
+                    $nonNodeEntries = @($configData.NonNodeData)
+                }
+
+                $ExcludedSubstitutionProperties += @('ApplicationId', 'ApplicationSecret', 'CertificatePath', 'CertificatePassword', 'CertificateThumbprint', 'Credential', 'TenantId', 'TenantGuid')
+                $ExcludedSubstitutionProperties = $ExcludedSubstitutionProperties | Select-Object -Unique
+                foreach ($entry in $nonNodeEntries)
+                {
+                    if ($entry -is [System.Collections.IDictionary])
+                    {
+                        foreach ($key in $entry.Keys)
+                        {
+                            if ($ExcludedSubstitutionProperties -contains $key)
+                            {
+                                Write-Verbose -Message "  Skipping excluded property '$key'"
+                                continue
+                            }
+
+                            $value = $entry[$key]
+                            if ($key -eq 'OrganizationName')
+                            {
+                                $substitutions["`$OrganizationName"] = $value
+                                continue
+                            }
+
+                            if ($value -is [System.String] -and -not [System.String]::IsNullOrEmpty($value))
+                            {
+                                $substitutions["`$ConfigurationData.NonNodeData.$key"] = $value
+                            }
+                        }
+                    }
+                }
+            }
+
+            if ($substitutions.Count -eq 0)
+            {
+                continue
+            }
+
+            $content = [System.IO.File]::ReadAllText($filePath)
+            $hasSubstitutions = $false
+            foreach ($varName in $substitutions.Keys)
+            {
+                if ($content.Contains($varName))
+                {
+                    Write-Verbose -Message "  Replacing $varName with '$($substitutions[$varName])'"
+                    $content = $content.Replace($varName, $substitutions[$varName])
+                    $hasSubstitutions = $true
+                }
+            }
+
+            if ($hasSubstitutions)
+            {
+                $tempPath = [System.IO.Path]::GetTempFileName() + '.ps1'
+                [System.IO.File]::WriteAllText($tempPath, $content)
+
+                if ($filePath -eq $Source)
+                {
+                    $effectiveSource = $tempPath
+                    $tempSourcePath = $tempPath
+                }
+                else
+                {
+                    $effectiveDestination = $tempPath
+                    $tempDestinationPath = $tempPath
+                }
+            }
+        }
+        #endregion
+
         $desiredSplat = @{
-            ConfigurationPath = $Destination
+            ConfigurationPath = $effectiveDestination
             IncludeComments   = $false
             DscResourceInfo   = $Script:DscResourceInfo
         }
@@ -1424,7 +1576,17 @@ function New-M365DSCDeltaReport
 
         # Parse the blueprint file, pass to other comparison functions as object (including comments aka metadata)
         [Array]$desiredConfiguration = Initialize-M365DSCReporting @desiredSplat
-        [Array]$sourceReporting = Initialize-M365DSCReporting -ConfigurationPath $Source
+        [Array]$sourceReporting = Initialize-M365DSCReporting -ConfigurationPath $effectiveSource
+
+        # Clean up temp files if created
+        foreach ($tempPath in @($tempSourcePath, $tempDestinationPath))
+        {
+            if ($null -ne $tempPath -and (Test-Path -Path $tempPath))
+            {
+                Remove-Item -Path $tempPath -Force
+            }
+        }
+
         $Delta = @()
         foreach ($resource in $sourceReporting)
         {

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -1509,7 +1509,7 @@ function New-M365DSCDeltaReport
                         $nonNodeEntries = @($configData.NonNodeData)
                     }
 
-                    $ExcludedSubstitutionProperties += @('ApplicationId', 'ApplicationSecret', 'CertificatePath', 'CertificatePassword', 'CertificateThumbprint', 'Credential', 'TenantId', 'TenantGuid')
+                    $ExcludedSubstitutionProperties += @('ApplicationId', 'ApplicationSecret', 'CertificatePath', 'CertificatePassword', 'CertificateThumbprint', 'Credential', 'ManagedIdentity', 'TenantId', 'TenantGuid')
                     $ExcludedSubstitutionProperties = $ExcludedSubstitutionProperties | Select-Object -Unique
                     foreach ($entry in $nonNodeEntries)
                     {

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -1288,6 +1288,12 @@ function Get-M365DSCResourceKey
 .PARAMETER ExcludedResources
     Array that contains the list of resources to exclude.
 
+.PARAMETER Type
+    The type of report that should be created: HTML or JSON.
+
+.PARAMETER UseVariableSubstitution
+    Switch that indicates whether variable substitution should be used in the report.
+
 .PARAMETER SourceConfigurationDataPath
     The path to the ConfigurationData.psd1 file that belongs to the source configuration, used for variable substitution in the report.
 
@@ -1360,17 +1366,21 @@ function New-M365DSCDeltaReport
         [Array]
         $ExcludedResources,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'VariableSubstitution')]
+        [Switch]
+        $UseVariableSubstitution,
+
+        [Parameter(ParameterSetName = 'VariableSubstitution')]
         [System.String]
         $SourceConfigurationDataPath,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'VariableSubstitution')]
         [System.String]
         $DestinationConfigurationDataPath,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'VariableSubstitution')]
         [System.String[]]
-        $ExcludedSubstitutionProperties = @()
+        $ExcludedSubstitutionProperties
     )
 
     # Validate that the latest version of the module is installed.
@@ -1442,122 +1452,125 @@ function New-M365DSCDeltaReport
         $tempSourcePath = $null
         $tempDestinationPath = $null
 
-        # Build a map of ConfigurationData paths: key = file path, value = config data path
-        $configDataMap = @{}
-        if (-not [System.String]::IsNullOrEmpty($SourceConfigurationDataPath))
+        if ($UseVariableSubstitution)
         {
-            $configDataMap[$Source] = $SourceConfigurationDataPath
-        }
-        if (-not [System.String]::IsNullOrEmpty($DestinationConfigurationDataPath))
-        {
-            $configDataMap[$Destination] = $DestinationConfigurationDataPath
-        }
-
-        # Auto-detect ConfigurationData.psd1 when no explicit path was provided
-        foreach ($filePath in @($Source, $Destination))
-        {
-            if (-not $configDataMap.ContainsKey($filePath))
+            # Build a map of ConfigurationData paths: key = file path, value = config data path
+            $configDataMap = @{}
+            if (-not [System.String]::IsNullOrEmpty($SourceConfigurationDataPath))
             {
-                $autoPath = Join-Path -Path (Split-Path -Path $filePath -Parent) -ChildPath 'ConfigurationData.psd1'
-                if (Test-Path -Path $autoPath)
-                {
-                    $configDataMap[$filePath] = $autoPath
-                }
+                $configDataMap[$Source] = $SourceConfigurationDataPath
             }
-        }
-
-        foreach ($filePath in @($Source, $Destination))
-        {
-            if (-not $configDataMap.ContainsKey($filePath))
+            if (-not [System.String]::IsNullOrEmpty($DestinationConfigurationDataPath))
             {
-                continue
+                $configDataMap[$Destination] = $DestinationConfigurationDataPath
             }
 
-            $configDataFile = $configDataMap[$filePath]
-            if (-not (Test-Path -Path $configDataFile))
+            # Auto-detect ConfigurationData.psd1 when no explicit path was provided
+            foreach ($filePath in @($Source, $Destination))
             {
-                Write-Warning -Message "ConfigurationData file not found at '$configDataFile'. Skipping variable substitution for '$filePath'."
-                continue
-            }
-
-            Write-Verbose -Message "Importing ConfigurationData from '$configDataFile' for '$filePath'"
-            $configData = Import-PowerShellDataFile -Path $configDataFile
-
-            # Collect all string properties from NonNodeData
-            $substitutions = @{}
-            if ($null -ne $configData.NonNodeData)
-            {
-                $nonNodeEntries = @()
-                if ($configData.NonNodeData -is [System.Array])
+                if (-not $configDataMap.ContainsKey($filePath))
                 {
-                    $nonNodeEntries = $configData.NonNodeData
-                }
-                else
-                {
-                    $nonNodeEntries = @($configData.NonNodeData)
-                }
-
-                $ExcludedSubstitutionProperties += @('ApplicationId', 'ApplicationSecret', 'CertificatePath', 'CertificatePassword', 'CertificateThumbprint', 'Credential', 'TenantId', 'TenantGuid')
-                $ExcludedSubstitutionProperties = $ExcludedSubstitutionProperties | Select-Object -Unique
-                foreach ($entry in $nonNodeEntries)
-                {
-                    if ($entry -is [System.Collections.IDictionary])
+                    $autoPath = Join-Path -Path (Split-Path -Path $filePath -Parent) -ChildPath 'ConfigurationData.psd1'
+                    if (Test-Path -Path $autoPath)
                     {
-                        foreach ($key in $entry.Keys)
-                        {
-                            if ($ExcludedSubstitutionProperties -contains $key)
-                            {
-                                Write-Verbose -Message "  Skipping excluded property '$key'"
-                                continue
-                            }
-
-                            $value = $entry[$key]
-                            if ($key -eq 'OrganizationName')
-                            {
-                                $substitutions["`$OrganizationName"] = $value
-                                continue
-                            }
-
-                            if ($value -is [System.String] -and -not [System.String]::IsNullOrEmpty($value))
-                            {
-                                $substitutions["`$ConfigurationData.NonNodeData.$key"] = $value
-                            }
-                        }
+                        $configDataMap[$filePath] = $autoPath
                     }
                 }
             }
 
-            if ($substitutions.Count -eq 0)
+            foreach ($filePath in @($Source, $Destination))
             {
-                continue
-            }
-
-            $content = [System.IO.File]::ReadAllText($filePath)
-            $hasSubstitutions = $false
-            foreach ($varName in $substitutions.Keys)
-            {
-                if ($content.Contains($varName))
+                if (-not $configDataMap.ContainsKey($filePath))
                 {
-                    Write-Verbose -Message "  Replacing $varName with '$($substitutions[$varName])'"
-                    $content = $content.Replace($varName, $substitutions[$varName])
-                    $hasSubstitutions = $true
+                    continue
                 }
-            }
 
-            if ($hasSubstitutions)
-            {
-                $tempPath = [System.IO.Path]::GetTempFileName() + '.ps1'
-                [System.IO.File]::WriteAllText($tempPath, $content)
-
-                if ($filePath -eq $Source)
+                $configDataFile = $configDataMap[$filePath]
+                if (-not (Test-Path -Path $configDataFile))
                 {
-                    $effectiveSource = $tempPath
-                    $tempSourcePath = $tempPath
+                    Write-Warning -Message "ConfigurationData file not found at '$configDataFile'. Skipping variable substitution for '$filePath'."
+                    continue
                 }
-                else
+
+                Write-Verbose -Message "Importing ConfigurationData from '$configDataFile' for '$filePath'"
+                $configData = Import-PowerShellDataFile -Path $configDataFile
+
+                # Collect all string properties from NonNodeData
+                $substitutions = @{}
+                if ($null -ne $configData.NonNodeData)
                 {
-                    $effectiveDestination = $tempPath
-                    $tempDestinationPath = $tempPath
+                    $nonNodeEntries = @()
+                    if ($configData.NonNodeData -is [System.Array])
+                    {
+                        $nonNodeEntries = $configData.NonNodeData
+                    }
+                    else
+                    {
+                        $nonNodeEntries = @($configData.NonNodeData)
+                    }
+
+                    $ExcludedSubstitutionProperties += @('ApplicationId', 'ApplicationSecret', 'CertificatePath', 'CertificatePassword', 'CertificateThumbprint', 'Credential', 'TenantId', 'TenantGuid')
+                    $ExcludedSubstitutionProperties = $ExcludedSubstitutionProperties | Select-Object -Unique
+                    foreach ($entry in $nonNodeEntries)
+                    {
+                        if ($entry -is [System.Collections.IDictionary])
+                        {
+                            foreach ($key in $entry.Keys)
+                            {
+                                if ($ExcludedSubstitutionProperties -contains $key)
+                                {
+                                    Write-Verbose -Message "  Skipping excluded property '$key'"
+                                    continue
+                                }
+
+                                $value = $entry[$key]
+                                if ($key -eq 'OrganizationName')
+                                {
+                                    $substitutions["`$OrganizationName"] = $value
+                                    continue
+                                }
+
+                                if ($value -is [System.String] -and -not [System.String]::IsNullOrEmpty($value))
+                                {
+                                    $substitutions["`$ConfigurationData.NonNodeData.$key"] = $value
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if ($substitutions.Count -eq 0)
+                {
+                    continue
+                }
+
+                $content = [System.IO.File]::ReadAllText($filePath)
+                $hasSubstitutions = $false
+                foreach ($varName in $substitutions.Keys)
+                {
+                    if ($content.Contains($varName))
+                    {
+                        Write-Verbose -Message "  Replacing $varName with '$($substitutions[$varName])'"
+                        $content = $content.Replace($varName, $substitutions[$varName])
+                        $hasSubstitutions = $true
+                    }
+                }
+
+                if ($hasSubstitutions)
+                {
+                    $tempPath = [System.IO.Path]::GetTempFileName() + '.ps1'
+                    [System.IO.File]::WriteAllText($tempPath, $content)
+
+                    if ($filePath -eq $Source)
+                    {
+                        $effectiveSource = $tempPath
+                        $tempSourcePath = $tempPath
+                    }
+                    else
+                    {
+                        $effectiveDestination = $tempPath
+                        $tempDestinationPath = $tempPath
+                    }
                 }
             }
         }

--- a/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReport.psm1
@@ -1551,6 +1551,8 @@ function New-M365DSCDeltaReport
                     if ($content.Contains($varName))
                     {
                         Write-Verbose -Message "  Replacing $varName with '$($substitutions[$varName])'"
+                        $content = $content.Replace('$(' + $varName.TrimStart('`$') + ')', $substitutions[$varName])
+                        $content = $content.Replace('$(' + $varName + ')', $substitutions[$varName])
                         $content = $content.Replace($varName, $substitutions[$varName])
                         $hasSubstitutions = $true
                     }

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -469,6 +469,12 @@ function Start-M365DSCConfigurationExtract
                     -Key 'TenantId' `
                     -Value $TenantId `
                     -Description 'The Id or Name of the tenant to authenticate against'
+
+                $tenantGuid = [System.Guid]::Empty
+                if ([System.Guid]::TryParse($TenantId, [ref]$tenantGuid))
+                {
+                    Set-M365DSCStringReplacementMap -Map @{ $TenantId = '$ConfigurationData.NonNodeData.TenantId' }
+                }
             }
             'CertificateThumbprint'
             {
@@ -528,6 +534,8 @@ function Start-M365DSCConfigurationExtract
                     -Key 'TenantId' `
                     -Value $TenantId `
                     -Description 'The Id or Name of the tenant to authenticate against'
+
+                Set-M365DSCStringReplacementMap -Map @{ $TenantId = '$ConfigurationData.NonNodeData.TenantId' }
             }
             { $_ -in 'Credentials', 'CredentialsWithApplicationId', 'CredentialsWithTenantId' }
             {
@@ -572,6 +580,8 @@ function Start-M365DSCConfigurationExtract
                     -Key 'TenantId' `
                     -Value $TenantId `
                     -Description 'The Id or Name of the tenant to authenticate against'
+
+                Set-M365DSCStringReplacementMap -Map @{ $TenantId = '$ConfigurationData.NonNodeData.TenantId' }
             }
         }
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -971,7 +971,23 @@ function Assert-M365DSCBlueprint
 
         [Parameter()]
         [System.Boolean]
-        $KeepExport = $false
+        $KeepExport = $false,
+
+        [Parameter()]
+        [Switch]
+        $UseVariableSubstitution,
+
+        [Parameter()]
+        [System.String]
+        $SourceConfigurationDataPath,
+
+        [Parameter()]
+        [System.String]
+        $DestinationConfigurationDataPath,
+
+        [Parameter()]
+        [System.String[]]
+        $ExcludedSubstitutionProperties
     )
 
     #Ensure the proper dependencies are installed in the current environment.
@@ -1072,15 +1088,36 @@ function Assert-M365DSCBlueprint
         # Call the New-M365DSCDeltaReport configuration to generate the Delta Report between
         # the BluePrint and the extracted resources;
         $ExportPath = Join-Path -Path $env:Temp -ChildPath $TempExportName
-        New-M365DSCDeltaReport -Source $ExportPath `
-            -Destination $LocalBluePrintPath `
-            -OutputPath $OutputReportPath `
-            -DriftOnly $DriftOnly `
-            -IsBlueprintAssessment:$true `
-            -HeaderFilePath $HeaderFilePath `
-            -Type $Type `
-            -ExcludedProperties $ExcludedProperties `
-            -ExcludedResources $ExcludedResources
+        $deltaReportParams = @{
+            Source                = $ExportPath
+            Destination           = $LocalBluePrintPath
+            OutputPath            = $OutputReportPath
+            DriftOnly             = $DriftOnly
+            IsBlueprintAssessment = $true
+            HeaderFilePath        = $HeaderFilePath
+            Type                  = $Type
+            ExcludedProperties    = $ExcludedProperties
+            ExcludedResources     = $ExcludedResources
+        }
+
+        if ($UseVariableSubstitution)
+        {
+            $deltaReportParams.UseVariableSubstitution = $true
+            if (-not [System.String]::IsNullOrEmpty($SourceConfigurationDataPath))
+            {
+                $deltaReportParams.SourceConfigurationDataPath = $SourceConfigurationDataPath
+            }
+            if (-not [System.String]::IsNullOrEmpty($DestinationConfigurationDataPath))
+            {
+                $deltaReportParams.DestinationConfigurationDataPath = $DestinationConfigurationDataPath
+            }
+            if ($null -ne $ExcludedSubstitutionProperties -and $ExcludedSubstitutionProperties.Count -gt 0)
+            {
+                $deltaReportParams.ExcludedSubstitutionProperties = $ExcludedSubstitutionProperties
+            }
+        }
+
+        New-M365DSCDeltaReport @deltaReportParams
 
         # Clean up the temporary files
         Remove-Item $LocalBluePrintPath -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where the organization name (tenant identifier like tenant1.onmicrosoft.com) was not replaced with `$OrganizationName` and adds the ability to use variable substitution when generating delta reports.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
