### PR TITLE
Add missing permissions and allow VIVA workload export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
     FIXES [#7119](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7119)
 * EXODynamicDistributionGroup
   * Initial release.
+* VivaEngagementRoleMember
+  * Added missing permission `User.ReadBasic.All` to the resource.
+    FIXES [#7133](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7133)
 * M365DSCDocGenerator
   * Fixed an issue where the directory for the generated documentation
     was not found at the intended location.
@@ -16,6 +19,7 @@
   * Updated temporary export save operation to use file stream writer
     to reduce I/O usage.
 * M365DSCExportUtil
+  * Added the `VIVA` workload to the list of supported workloads to export.
   * Fixed an issue where the organization name was not
     replaced with `$OrganizationName` during configuration export.
 * M365DSCReport

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_VivaEngagementRoleMember/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_VivaEngagementRoleMember/settings.json
@@ -11,11 +11,17 @@
         "read": [
           {
             "name": "EngagementRole.Read.All"
+          },
+          {
+            "name": "User.ReadBasic.All"
           }
         ],
         "update": [
           {
             "name": "EngagementRole.ReadWrite.All"
+          },
+          {
+            "name": "User.ReadBasic.All"
           }
         ]
       },
@@ -23,11 +29,17 @@
         "read": [
           {
             "name": "EngagementRole.Read.All"
+          },
+          {
+            "name": "User.ReadBasic.All"
           }
         ],
         "update": [
           {
             "name": "EngagementRole.ReadWrite.All"
+          },
+          {
+            "name": "User.ReadBasic.All"
           }
         ]
       }

--- a/Modules/Microsoft365DSC/Modules/M365DSCExportUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCExportUtil.psm1
@@ -123,7 +123,7 @@ function Export-M365DSCConfiguration
         $ExcludeComponents,
 
         [Parameter(ParameterSetName = 'Export')]
-        [ValidateSet('AAD', 'ADO', 'AZURE', 'COMMERCE', 'DEFENDER', 'EXO', 'FABRIC', 'INTUNE', 'O365', 'OD', 'PLANNER', 'PP', 'SC', 'SENTINEL', 'SH', 'SPO', 'TEAMS')]
+        [ValidateSet('AAD', 'ADO', 'AZURE', 'COMMERCE', 'DEFENDER', 'EXO', 'FABRIC', 'INTUNE', 'O365', 'OD', 'PLANNER', 'PP', 'SC', 'SENTINEL', 'SH', 'SPO', 'TEAMS', 'VIVA')]
         [System.String[]]
         $Workloads,
 

--- a/Tests/QA/Microsoft365DSC.SettingsJson.Tests.ps1
+++ b/Tests/QA/Microsoft365DSC.SettingsJson.Tests.ps1
@@ -65,6 +65,13 @@ Describe -Name 'Successfully validate all used permissions in Settings.json file
             )
         }
 
+        if ($settings.ResourceName -like 'VivaEngagement*')
+        {
+            $allowedPermissions = @(
+                'User.ReadBasic.All'
+            )
+        }
+
         if ($settings.ResourceName -like 'AADAuthenticationMethod*' -or $settings.ResourceName -eq 'AADAuthenticationStrengthPolicy')
         {
             $allowedPermissions = @(


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds the missing permission `User.ReadBasic.All` to the `VivaEngagementRoleMember` resource and the `VIVA` workloads to the list of supported workloads to export.

#### This Pull Request (PR) fixes the following issues
- Fixes #7133

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
