### PR TITLE
Add IntuneAppControlForBusinessPolicyWindows10V2 and fix ExtemptedAppPackages apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   * Deprecated resource.
 * IntuneAppControlForBusinessPolicyWindows10V2
   * Initial release. Supersedes `IntuneAppControlForBusinessPolicyWindows10`.
+    FIXES [#7129](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7129)
+* IntuneAppProtectionPolicyAndroid
+  * Fixed an issue where configuring `ExemptedAppPackages` would fail.
+    FIXES [#7135](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7135)
 * VivaEngagementRoleMember
   * Added missing permission `User.ReadBasic.All` to the resource.
     FIXES [#7133](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
     FIXES [#7119](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7119)
 * EXODynamicDistributionGroup
   * Initial release.
+* IntuneAppControlForBusinessPolicyWindows10
+  * Deprecated resource.
+* IntuneAppControlForBusinessPolicyWindows10V2
+  * Initial release. Supersedes `IntuneAppControlForBusinessPolicyWindows10`.
 * VivaEngagementRoleMember
   * Added missing permission `User.ReadBasic.All` to the resource.
     FIXES [#7133](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7133)

--- a/Examples/Resources/IntuneAppControlForBusinessPolicyWindows10V2/1-Create.ps1
+++ b/Examples/Resources/IntuneAppControlForBusinessPolicyWindows10V2/1-Create.ps1
@@ -1,0 +1,54 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneAppControlForBusinessPolicyWindows10V2 'Example'
+        {
+            ApplicationId                                             = $ApplicationId;
+            Assignments                                               = @(
+                MSFT_DeviceManagementConfigurationPolicyAssignments{
+                    dataType = "#microsoft.graph.exclusionGroupAssignmentTarget"
+                    deviceAndAppManagementAssignmentFilterType = "none"
+                    groupDisplayName = "Exclude"
+                }
+                MSFT_DeviceManagementConfigurationPolicyAssignments{
+                    dataType = "#microsoft.graph.groupAssignmentTarget"
+                    deviceAndAppManagementAssignmentFilterType = "none"
+                    groupDisplayName = "Include"
+                }
+            );
+            CertificateThumbprint                                     = $CertificateThumbprint;
+            ConfigureApplicationControlOptions                        = "1";
+            ConfigureApplicationControlsAuditMode                     = "1";
+            ConfigureApplicationControlsTrustAppsFromManagedInstaller = "1";
+            ConfigureApplicationControlsTrustAppsWithGoodReputation   = "1";
+            Description                                               = "";
+            DisplayName                                               = "Example";
+            Ensure                                                    = "Present";
+            RoleScopeTagIds                                           = @("0");
+            TenantId                                                  = $TenantId;
+        }
+    }
+}

--- a/Examples/Resources/IntuneAppControlForBusinessPolicyWindows10V2/2-Update.ps1
+++ b/Examples/Resources/IntuneAppControlForBusinessPolicyWindows10V2/2-Update.ps1
@@ -1,0 +1,54 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneAppControlForBusinessPolicyWindows10V2 'Example'
+        {
+            ApplicationId                                             = $ApplicationId;
+            Assignments                                               = @(
+                MSFT_DeviceManagementConfigurationPolicyAssignments{
+                    dataType = "#microsoft.graph.exclusionGroupAssignmentTarget"
+                    deviceAndAppManagementAssignmentFilterType = "none"
+                    groupDisplayName = "Exclude"
+                }
+                MSFT_DeviceManagementConfigurationPolicyAssignments{
+                    dataType = "#microsoft.graph.groupAssignmentTarget"
+                    deviceAndAppManagementAssignmentFilterType = "none"
+                    groupDisplayName = "Include"
+                }
+            );
+            CertificateThumbprint                                     = $CertificateThumbprint;
+            ConfigureApplicationControlOptions                        = "0"; # Updated property
+            ConfigureApplicationControlsAuditMode                     = "1";
+            ConfigureApplicationControlsTrustAppsFromManagedInstaller = "1";
+            ConfigureApplicationControlsTrustAppsWithGoodReputation   = "1";
+            Description                                               = "";
+            DisplayName                                               = "Example";
+            Ensure                                                    = "Present";
+            RoleScopeTagIds                                           = @("0");
+            TenantId                                                  = $TenantId;
+        }
+    }
+}

--- a/Examples/Resources/IntuneAppControlForBusinessPolicyWindows10V2/3-Remove.ps1
+++ b/Examples/Resources/IntuneAppControlForBusinessPolicyWindows10V2/3-Remove.ps1
@@ -1,0 +1,36 @@
+<#
+This example is used to test new resources and showcase the usage of new resources being worked on.
+It is not meant to use as a production baseline.
+#>
+
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $ApplicationId,
+
+        [Parameter()]
+        [System.String]
+        $TenantId,
+
+        [Parameter()]
+        [System.String]
+        $CertificateThumbprint
+    )
+
+    Import-DscResource -ModuleName Microsoft365DSC
+
+    node localhost
+    {
+        IntuneAppControlForBusinessPolicyWindows10V2 'Example'
+        {
+            ApplicationId                                             = $ApplicationId;
+            CertificateThumbprint                                     = $CertificateThumbprint;
+            DisplayName                                               = "Example";
+            Ensure                                                    = "Absent";
+            TenantId                                                  = $TenantId;
+        }
+    }
+}

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppControlForBusinessPolicyWindows10V2/MSFT_IntuneAppControlForBusinessPolicyWindows10V2.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppControlForBusinessPolicyWindows10V2/MSFT_IntuneAppControlForBusinessPolicyWindows10V2.psm1
@@ -1,5 +1,3 @@
-Confirm-M365DSCModuleDependency -ModuleName 'MSFT_IntuneAppControlForBusinessPolicyWindows10'
-
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -10,6 +8,10 @@ function Get-TargetResource
         [Parameter()]
         [System.String]
         $Description,
+
+        [Parameter()]
+        [System.Boolean]
+        $DisableEntraGroupPolicyAssignment,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -30,17 +32,22 @@ function Get-TargetResource
 
         [Parameter()]
         [System.String]
-        $Enter_path_of_xml_data,
-
-        [Parameter()]
-        [ValidateSet(1, 2)]
-        [System.Int32[]]
-        $ConfigureApplicationControlSelectAdditionalRulesForTrustingApps,
+        $ConfigureApplicationControlsXMLUpload,
 
         [Parameter()]
         [ValidateSet(0, 1)]
         [System.Int32]
-        $ConfigureApplicationControlEnableAppControlPolicy,
+        $ConfigureApplicationControlsAuditMode,
+
+        [Parameter()]
+        [ValidateSet(0, 1)]
+        [System.Int32]
+        $ConfigureApplicationControlsTrustAppsFromManagedInstaller,
+
+        [Parameter()]
+        [ValidateSet(0, 1)]
+        [System.Int32]
+        $ConfigureApplicationControlsTrustAppsWithGoodReputation,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
@@ -81,9 +88,7 @@ function Get-TargetResource
         $AccessTokens
     )
 
-    Write-Warning -Message 'This resource is deprecated. Please use IntuneAppControlForBusinessPolicyWindows10V2 instead.'
-
-    Write-Verbose -Message "Getting configuration for the Intune App Control For Business Policy for Windows10 with Id {$Id} and Name {$DisplayName}"
+    Write-Verbose -Message "Getting configuration for the Intune App Control For Business Policy for Windows10 V2 with Id {$Id} and Name {$DisplayName}"
 
     try
     {
@@ -112,24 +117,28 @@ function Get-TargetResource
             #region resource generator code
             if (-not [System.String]::IsNullOrEmpty($Id))
             {
-                $getValue = Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id -ErrorAction SilentlyContinue
+                $getValue = Invoke-M365DSCCommand -ScriptBlock {
+                    Get-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $Id  -ErrorAction Stop
+                } -SuppressNotFoundError
             }
 
             if ($null -eq $getValue)
             {
-                Write-Verbose -Message "Could not find an Intune App Control For Business Policy for Windows10 with Id {$Id}"
+                Write-Verbose -Message "Could not find an Intune App Control For Business Policy for Windows10 V2 with Id {$Id}"
 
                 if (-not [System.String]::IsNullOrEmpty($DisplayName))
                 {
-                    $getValue = Get-MgBetaDeviceManagementConfigurationPolicy `
-                        -Filter "Name eq '$($DisplayName -replace "'", "''")'" `
+                    $getValue = Invoke-M365DSCCommand -ScriptBlock {
+                        Get-MgBetaDeviceManagementConfigurationPolicy `
+                            -Filter "Name eq '$($DisplayName -replace "'", "''")'" `
                         -ErrorAction SilentlyContinue
+                    }
                 }
             }
             #endregion
             if ($null -eq $getValue)
             {
-                Write-Verbose -Message "Could not find an Intune App Control For Business Policy for Windows10 with Name {$DisplayName}."
+                Write-Verbose -Message "Could not find an Intune App Control For Business Policy for Windows10 V2 with Name {$DisplayName}."
                 return $nullResult
             }
         }
@@ -138,7 +147,7 @@ function Get-TargetResource
             $getValue = $Script:exportedInstance
         }
         $Id = $getValue.Id
-        Write-Verbose -Message "An Intune App Control For Business Policy for Windows10 with Id {$Id} and Name {$DisplayName} was found"
+        Write-Verbose -Message "An Intune App Control For Business Policy for Windows10 V2 with Id {$Id} and Name {$DisplayName} was found"
 
         # Retrieve policy specific settings
         [array]$settings = Get-MgBetaDeviceManagementConfigurationPolicySetting `
@@ -152,17 +161,17 @@ function Get-TargetResource
 
         $results = @{
             #region resource generator code
-            Description           = $getValue.Description
-            DisplayName           = $getValue.Name
-            RoleScopeTagIds       = $getValue.RoleScopeTagIds
-            Id                    = $getValue.Id
-            Ensure                = 'Present'
-            Credential            = $Credential
-            ApplicationId         = $ApplicationId
-            TenantId              = $TenantId
-            ApplicationSecret     = $ApplicationSecret
-            CertificateThumbprint = $CertificateThumbprint
-            ManagedIdentity       = $ManagedIdentity.IsPresent
+            Description                       = $getValue.Description
+            DisplayName                       = $getValue.Name
+            RoleScopeTagIds                   = $getValue.RoleScopeTagIds
+            Id                                = $getValue.Id
+            Ensure                            = 'Present'
+            Credential                        = $Credential
+            ApplicationId                     = $ApplicationId
+            TenantId                          = $TenantId
+            ApplicationSecret                 = $ApplicationSecret
+            CertificateThumbprint             = $CertificateThumbprint
+            ManagedIdentity                   = $ManagedIdentity.IsPresent
             #endregion
         }
         $results += $policySettings
@@ -199,6 +208,10 @@ function Set-TargetResource
         [System.String]
         $Description,
 
+        [Parameter()]
+        [System.Boolean]
+        $DisableEntraGroupPolicyAssignment,
+
         [Parameter(Mandatory = $true)]
         [System.String]
         $DisplayName,
@@ -218,23 +231,27 @@ function Set-TargetResource
 
         [Parameter()]
         [System.String]
-        $Enter_path_of_xml_data,
-
-        [Parameter()]
-        [ValidateSet(1, 2)]
-        [System.Int32[]]
-        $ConfigureApplicationControlSelectAdditionalRulesForTrustingApps,
+        $ConfigureApplicationControlsXMLUpload,
 
         [Parameter()]
         [ValidateSet(0, 1)]
         [System.Int32]
-        $ConfigureApplicationControlEnableAppControlPolicy,
+        $ConfigureApplicationControlsAuditMode,
+
+        [Parameter()]
+        [ValidateSet(0, 1)]
+        [System.Int32]
+        $ConfigureApplicationControlsTrustAppsFromManagedInstaller,
+
+        [Parameter()]
+        [ValidateSet(0, 1)]
+        [System.Int32]
+        $ConfigureApplicationControlsTrustAppsWithGoodReputation,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $Assignments,
         #endregion
-
         [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
@@ -269,7 +286,7 @@ function Set-TargetResource
         $AccessTokens
     )
 
-    Write-Verbose -Message "Setting configuration of the Intune App Control For Business Policy for Windows10 with Id {$Id} and Name {$DisplayName}"
+    Write-Verbose -Message "Setting configuration of the Intune App Control For Business Policy for Windows10 V2 with Id {$Id} and Name {$DisplayName}"
 
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
@@ -286,27 +303,26 @@ function Set-TargetResource
     $currentInstance = Get-TargetResource @PSBoundParameters
     $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
 
-    $templateReferenceId = '4321b946-b76b-4450-8afd-769c08b16ffc_1'
+    $templateReferenceId = 'd3849ba8-bf95-467c-9640-aa2334eae9e3_1'
     $platforms = 'windows10'
     $technologies = 'mdm'
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {
-        Write-Verbose -Message "Creating an Intune App Control For Business Policy for Windows10 with Name {$DisplayName}"
-        $boundParameters.Remove('Assignments') | Out-Null
+        Write-Verbose -Message "Creating an Intune App Control For Business Policy for Windows10 V2 with Name {$DisplayName}"
+        $boundParameters.Remove("Assignments") | Out-Null
 
         $settings = Get-IntuneSettingCatalogPolicySetting `
             -DSCParams ([System.Collections.Hashtable]$boundParameters) `
             -TemplateId $templateReferenceId
 
         $createParameters = @{
-            Name              = $DisplayName
-            Description       = $Description
-            TemplateReference = @{ templateId = $templateReferenceId }
-            Platforms         = $platforms
-            Technologies      = $technologies
-            Settings          = $settings
-            RoleScopeTagIds   = $RoleScopeTagIds
+            name              = $DisplayName
+            description       = $Description
+            templateReference = @{ templateId = $templateReferenceId }
+            platforms         = $platforms
+            technologies      = $technologies
+            settings          = $settings
         }
 
         #region resource generator code
@@ -324,8 +340,8 @@ function Set-TargetResource
     }
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
     {
-        Write-Verbose -Message "Updating the Intune App Control For Business Policy for Windows10 with Id {$($currentInstance.Id)}"
-        $boundParameters.Remove('Assignments') | Out-Null
+        Write-Verbose -Message "Updating the Intune App Control For Business Policy for Windows10 V2 with Id {$($currentInstance.Id)}"
+        $boundParameters.Remove("Assignments") | Out-Null
 
         $settings = Get-IntuneSettingCatalogPolicySetting `
             -DSCParams ([System.Collections.Hashtable]$boundParameters) `
@@ -352,7 +368,7 @@ function Set-TargetResource
     }
     elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')
     {
-        Write-Verbose -Message "Removing the Intune App Control For Business Policy for Windows10 with Id {$($currentInstance.Id)}"
+        Write-Verbose -Message "Removing the Intune App Control For Business Policy for Windows10 V2 with Id {$($currentInstance.Id)}"
         #region resource generator code
         Remove-MgBetaDeviceManagementConfigurationPolicy -DeviceManagementConfigurationPolicyId $currentInstance.Id
         #endregion
@@ -369,6 +385,10 @@ function Test-TargetResource
         [Parameter()]
         [System.String]
         $Description,
+
+        [Parameter()]
+        [System.Boolean]
+        $DisableEntraGroupPolicyAssignment,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -389,17 +409,22 @@ function Test-TargetResource
 
         [Parameter()]
         [System.String]
-        $Enter_path_of_xml_data,
-
-        [Parameter()]
-        [ValidateSet(1, 2)]
-        [System.Int32[]]
-        $ConfigureApplicationControlSelectAdditionalRulesForTrustingApps,
+        $ConfigureApplicationControlsXMLUpload,
 
         [Parameter()]
         [ValidateSet(0, 1)]
         [System.Int32]
-        $ConfigureApplicationControlEnableAppControlPolicy,
+        $ConfigureApplicationControlsAuditMode,
+
+        [Parameter()]
+        [ValidateSet(0, 1)]
+        [System.Int32]
+        $ConfigureApplicationControlsTrustAppsFromManagedInstaller,
+
+        [Parameter()]
+        [ValidateSet(0, 1)]
+        [System.Int32]
+        $ConfigureApplicationControlsTrustAppsWithGoodReputation,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
@@ -440,8 +465,6 @@ function Test-TargetResource
         $AccessTokens
     )
 
-    Write-Warning -Message 'This resource is deprecated. Please use IntuneAppControlForBusinessPolicyWindows10V2 instead.'
-
     #region Telemetry
     $ResourceName = $MyInvocation.MyCommand.ModuleName.Replace('MSFT_', '')
     $CommandName = $MyInvocation.MyCommand
@@ -451,10 +474,8 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
-    $compareParameters = Get-CompareParameters
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
-        @compareParameters
+                                         -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
     return $result
 }
 
@@ -515,7 +536,7 @@ function Export-TargetResource
     try
     {
         #region resource generator code
-        $policyTemplateID = '4321b946-b76b-4450-8afd-769c08b16ffc_1'
+        $policyTemplateID = 'd3849ba8-bf95-467c-9640-aa2334eae9e3_1'
         $baseFilter = "templateReference/templateId eq '$policyTemplateID'"
         if (-not [System.String]::IsNullOrEmpty($Filter))
         {
@@ -544,11 +565,11 @@ function Export-TargetResource
         foreach ($config in $getValue)
         {
             $displayedKey = $config.Id
-            if (-not [String]::IsNullOrEmpty($config.displayName))
+            if (-not [System.String]::IsNullOrEmpty($config.displayName))
             {
                 $displayedKey = $config.displayName
             }
-            elseif (-not [string]::IsNullOrEmpty($config.name))
+            elseif (-not [System.String]::IsNullOrEmpty($config.name))
             {
                 $displayedKey = $config.name
             }
@@ -568,20 +589,6 @@ function Export-TargetResource
 
             $Script:exportedInstance = $config
             $Results = Get-TargetResource @Params
-            if ($null -ne $Results.ConfigureApplicationControlBuiltInControls)
-            {
-                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
-                    -ComplexObject $Results.ConfigureApplicationControlBuiltInControls `
-                    -CIMInstanceName 'MicrosoftGraphIntuneSettingsCatalogConfigureApplicationControlBuiltInControls'
-                if (-not [String]::IsNullOrWhiteSpace($complexTypeStringResult))
-                {
-                    $Results.ConfigureApplicationControlBuiltInControls = $complexTypeStringResult
-                }
-                else
-                {
-                    $Results.Remove('ConfigureApplicationControlBuiltInControls') | Out-Null
-                }
-            }
 
             if ($Results.Assignments)
             {
@@ -601,7 +608,7 @@ function Export-TargetResource
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
                 -Credential $Credential `
-                -NoEscape @('Assignments', 'ConfigureApplicationControlBuiltInControls')
+                -NoEscape @('Assignments')
             [void]$dscContent.Append($currentDSCBlock)
             Save-M365DSCPartialExport -Content $currentDSCBlock `
                 -FileName $Global:PartialExportFileName
@@ -622,33 +629,4 @@ function Export-TargetResource
     }
 }
 
-function Get-CompareParameters
-{
-    [CmdletBinding()]
-    [OutputType([System.Collections.Hashtable])]
-    param()
-
-    return @{
-        PostProcessing     = {
-            param($DesiredValues, $CurrentValues, $ValuesToCheck, $PostProcessingArgs)
-            $PostProcessingArgs[0] | ForEach-Object {
-                if ($_.Key -notlike '*Variable' -or $_.Key -notin @('Verbose', 'Debug', 'ErrorAction', 'WarningAction', 'InformationAction'))
-                {
-                    if ($null -ne $CurrentValues[$_.Key] -or $null -ne $DesiredValues[$_.Key])
-                    {
-                        $ValuesToCheck[$_.Key] = $null
-                        if (-not $DesiredValues.ContainsKey($_.Key))
-                        {
-                            $DesiredValues.Add($_.Key, $null)
-                        }
-                    }
-                }
-            }
-
-            return [System.Tuple[Hashtable, Hashtable, Hashtable]]::new($DesiredValues, $CurrentValues, $ValuesToCheck)
-        }
-        PostProcessingArgs = $MyInvocation.MyCommand.Parameters.GetEnumerator()
-    }
-}
-
-Export-ModuleMember -Function @('*-TargetResource', 'Get-CompareParameters')
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppControlForBusinessPolicyWindows10V2/MSFT_IntuneAppControlForBusinessPolicyWindows10V2.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppControlForBusinessPolicyWindows10V2/MSFT_IntuneAppControlForBusinessPolicyWindows10V2.psm1
@@ -9,10 +9,6 @@ function Get-TargetResource
         [System.String]
         $Description,
 
-        [Parameter()]
-        [System.Boolean]
-        $DisableEntraGroupPolicyAssignment,
-
         [Parameter(Mandatory = $true)]
         [System.String]
         $DisplayName,
@@ -208,10 +204,6 @@ function Set-TargetResource
         [System.String]
         $Description,
 
-        [Parameter()]
-        [System.Boolean]
-        $DisableEntraGroupPolicyAssignment,
-
         [Parameter(Mandatory = $true)]
         [System.String]
         $DisplayName,
@@ -385,10 +377,6 @@ function Test-TargetResource
         [Parameter()]
         [System.String]
         $Description,
-
-        [Parameter()]
-        [System.Boolean]
-        $DisableEntraGroupPolicyAssignment,
 
         [Parameter(Mandatory = $true)]
         [System.String]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppControlForBusinessPolicyWindows10V2/MSFT_IntuneAppControlForBusinessPolicyWindows10V2.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppControlForBusinessPolicyWindows10V2/MSFT_IntuneAppControlForBusinessPolicyWindows10V2.schema.mof
@@ -1,0 +1,34 @@
+[ClassVersion("1.0.0.3")]
+class MSFT_DeviceManagementConfigurationPolicyAssignments
+{
+    [Required, Description("The type of the target assignment."), ValueMap{"#microsoft.graph.cloudPcManagementGroupAssignmentTarget","#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}, Values{"#microsoft.graph.cloudPcManagementGroupAssignmentTarget","#microsoft.graph.groupAssignmentTarget","#microsoft.graph.allLicensedUsersAssignmentTarget","#microsoft.graph.allDevicesAssignmentTarget","#microsoft.graph.exclusionGroupAssignmentTarget","#microsoft.graph.configurationManagerCollectionAssignmentTarget"}] String dataType;
+    [Write, Description("The type of filter of the target assignment i.e. Exclude or Include. Possible values are:none, include, exclude."), ValueMap{"none","include","exclude"}, Values{"none","include","exclude"}] String deviceAndAppManagementAssignmentFilterType;
+    [Write, Description("The Id of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterId;
+    [Write, Description("The display name of the filter for the target assignment.")] String deviceAndAppManagementAssignmentFilterDisplayName;
+    [Write, Description("The group Id that is the target of the assignment.")] String groupId;
+    [Write, Description("The group Display Name that is the target of the assignment.")] String groupDisplayName;
+    [Write, Description("The collection Id that is the target of the assignment.(ConfigMgr)")] String collectionId;
+};
+
+[ClassVersion("1.0.0.0"), FriendlyName("IntuneAppControlForBusinessPolicyWindows10V2")]
+class MSFT_IntuneAppControlForBusinessPolicyWindows10V2 : OMI_BaseResource
+{
+    [Write, Description("Policy description")] String Description;
+    [Key, Description("Policy name")] String DisplayName;
+    [Write, Description("List of Scope Tags for this Entity instance.")] String RoleScopeTagIds[];
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
+    [Write, Description("Policy creation type (0: XML upload, 1: Built-in controls)"), ValueMap{"0", "1"}, Values{"0", "1"}] SInt32 ConfigureApplicationControlOptions;
+    [Write, Description("XML upload - Depends on ConfigureApplicationControlOptions")] String ConfigureApplicationControlsXMLUpload;
+    [Write, Description("Audit mode - Depends on ConfigureApplicationControlOptions (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] SInt32 ConfigureApplicationControlsAuditMode;
+    [Write, Description("Trust apps from managed installer - Depends on ConfigureApplicationControlOptions (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] SInt32 ConfigureApplicationControlsTrustAppsFromManagedInstaller;
+    [Write, Description("Trust apps with good reputation - Depends on ConfigureApplicationControlOptions (0: Disabled, 1: Enabled)"), ValueMap{"0", "1"}, Values{"0", "1"}] SInt32 ConfigureApplicationControlsTrustAppsWithGoodReputation;
+    [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
+    [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
+    [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
+    [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;
+    [Write, Description("Secret of the Azure Active Directory tenant used for authentication."), EmbeddedInstance("MSFT_Credential")] String ApplicationSecret;
+    [Write, Description("Thumbprint of the Azure Active Directory application's authentication certificate to use for authentication.")] String CertificateThumbprint;
+    [Write, Description("Managed ID being used for authentication.")] Boolean ManagedIdentity;
+    [Write, Description("Access token used for authentication.")] String AccessTokens[];
+};

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppControlForBusinessPolicyWindows10V2/readme.md
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppControlForBusinessPolicyWindows10V2/readme.md
@@ -1,0 +1,5 @@
+# IntuneAppControlForBusinessPolicyWindows10V2
+
+## Description
+
+Intune App Control For Business Policy for Windows10 V2

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppControlForBusinessPolicyWindows10V2/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppControlForBusinessPolicyWindows10V2/settings.json
@@ -1,0 +1,73 @@
+{
+  "resourceName": "IntuneAppControlForBusinessPolicyWindows10V2",
+  "description": "This resource configures an Intune App Control For Business Policy for Windows10 V2.",
+  "permissions": {
+    "graph": {
+      "delegated": {
+        "update": [
+          {
+            "name": "DeviceManagementConfiguration.ReadWrite.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ],
+        "read": [
+          {
+            "name": "DeviceManagementConfiguration.Read.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ]
+      },
+      "application": {
+        "update": [
+          {
+            "name": "DeviceManagementConfiguration.ReadWrite.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ],
+        "read": [
+          {
+            "name": "DeviceManagementConfiguration.Read.All"
+          },
+          {
+            "name": "Group.Read.All"
+          }
+        ]
+      }
+    }
+  },
+  "requiredModules": [
+    "Microsoft.Graph.Authentication",
+    "Microsoft.Graph.Beta.DeviceManagement"
+  ],
+  "supportedEnvironments": [
+    "Global",
+    "USGov"
+  ],
+  "mode": "Configuration",
+  "commands": [
+    {
+      "module": "Microsoft.Graph.Beta.DeviceManagement",
+      "cmdlets": [
+        "Get-MgBetaDeviceManagementAssignmentFilter",
+        "Get-MgBetaDeviceManagementConfigurationPolicy",
+        "Get-MgBetaDeviceManagementConfigurationPolicyAssignment",
+        "Get-MgBetaDeviceManagementConfigurationPolicySetting",
+        "Get-MgBetaDeviceManagementConfigurationPolicyTemplateSettingTemplate",
+        "New-MgBetaDeviceManagementConfigurationPolicy",
+        "Remove-MgBetaDeviceManagementConfigurationPolicy"
+      ]
+    },
+    {
+      "module": "Microsoft.Graph.Groups",
+      "cmdlets": [
+        "Get-MgGroup"
+      ]
+    }
+  ]
+}

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyAndroid/MSFT_IntuneAppProtectionPolicyAndroid.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneAppProtectionPolicyAndroid/MSFT_IntuneAppProtectionPolicyAndroid.psm1
@@ -998,6 +998,7 @@ function Set-TargetResource
             value = $exemptedAppPackage.Split('|')[1]
         }
     }
+    $BoundParameters.ExemptedAppPackages = $myExemptedAppPackages
 
     $durationParameters = @(
         'PeriodOfflineBeforeAccessCheck',

--- a/ResourceGenerator/M365DSCResourceGenerator.psm1
+++ b/ResourceGenerator/M365DSCResourceGenerator.psm1
@@ -680,12 +680,12 @@ $($userDefinitionSettings.MOF -join "`r`n")
             -TemplateId `$templateReferenceId$(if ($containsDeviceAndUserSettings) { " ```r`n            -ContainsDeviceAndUserSettings" })
 
         `$createParameters = @{
-            Name              = `$DisplayName
-            Description       = `$Description
-            TemplateReference = @{ templateId = `$templateReferenceId }
-            Platforms         = `$platforms
-            Technologies      = `$technologies
-            Settings          = `$settings
+            name              = `$DisplayName
+            description       = `$Description
+            templateReference = @{ templateId = `$templateReferenceId }
+            platforms         = `$platforms
+            technologies      = `$technologies
+            settings          = `$settings
         }`r`n
 "@
         }

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAppControlForBusinessPolicyWindows10V2.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAppControlForBusinessPolicyWindows10V2.Tests.ps1
@@ -1,0 +1,444 @@
+[CmdletBinding()]
+param(
+)
+$M365DSCTestFolder = Join-Path -Path $PSScriptRoot `
+                        -ChildPath '..\..\Unit' `
+                        -Resolve
+$CmdletModule = (Join-Path -Path $M365DSCTestFolder `
+            -ChildPath '\Stubs\Microsoft365.psm1' `
+            -Resolve)
+$GenericStubPath = (Join-Path -Path $M365DSCTestFolder `
+    -ChildPath '\Stubs\Generic.psm1' `
+    -Resolve)
+Import-Module -Name (Join-Path -Path $M365DSCTestFolder `
+        -ChildPath '\UnitTestHelper.psm1' `
+        -Resolve)
+
+$Global:DscHelper = New-M365DscUnitTestHelper -StubModule $CmdletModule `
+    -DscResource "IntuneAppControlForBusinessPolicyWindows10V2" -GenericStubModule $GenericStubPath
+Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
+    InModuleScope -ModuleName $Global:DscHelper.ModuleName -ScriptBlock {
+        Invoke-Command -ScriptBlock $Global:DscHelper.InitializeScript -NoNewScope
+        BeforeAll {
+
+            $secpasswd = ConvertTo-SecureString (New-Guid | Out-String) -AsPlainText -Force
+            $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
+
+            Mock -ModuleName M365DSCUtil -CommandName Confirm-M365DSCDependencies -MockWith {
+            }
+
+            Mock -CommandName Get-MSCloudLoginConnectionProfile -MockWith {
+            }
+
+            Mock -CommandName Reset-MSCloudLoginConnectionProfileContext -MockWith {
+            }
+
+            Mock -CommandName Get-PSSession -MockWith {
+            }
+
+            Mock -CommandName Remove-PSSession -MockWith {
+            }
+
+            Mock -CommandName Update-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+            }
+
+            Mock -CommandName New-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+                return @{
+                    Id = '619bd4a4-3b3b-4441-bd6f-3f4c0c444870'
+                }
+            }
+
+            Mock -CommandName Remove-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+            }
+
+            Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+                return @{
+                    Id    = '619bd4a4-3b3b-4441-bd6f-3f4c0c444870'
+                    Description = 'My Test Description'
+                    Name        = 'My Test'
+                    RoleScopeTagIds = @('FakeStringValue')
+                    TemplateReference = @{
+                        TemplateId = 'd3849ba8-bf95-467c-9640-aa2334eae9e3_1'
+                    }
+                }
+            }
+
+            Mock -CommandName New-M365DSCConnection -MockWith {
+                return "Credentials"
+            }
+
+            # Mock Write-M365DSCHost to hide output during the tests
+            Mock -CommandName Write-M365DSCHost -MockWith {
+            }
+            $Script:exportedInstance = $null
+            $Script:ExportMode = $false
+
+            Mock -CommandName Update-IntuneDeviceConfigurationPolicy -MockWith {
+            }
+
+            Mock -CommandName Get-IntuneSettingCatalogPolicySetting -MockWith {
+            }
+
+            Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicySetting -MockWith {
+                return @{
+                    Id                   = 0
+                    SettingDefinitions   = @(
+                        @{
+                            Id = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions'
+                            Name = 'ConfigureApplicationControlOptions'
+                            OffsetUri = '/Policies/{PolicyGuid}/Policy/{0}'
+                            AdditionalProperties = @{
+                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                options = @(
+                                    @{
+                                        itemId = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions_upload_xml_selected'
+                                        name = 'XML upload'
+                                        optionValue = @{
+                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationIntegerSettingValue'
+                                            value = 0
+                                        }
+                                    }
+                                    @{
+                                        itemId = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions_built_in_xml_selected'
+                                        name = 'Built-in controls'
+                                        optionValue = @{
+                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationIntegerSettingValue'
+                                            value = 1
+                                        }
+                                    }
+                                )
+                            }
+                        },
+                        @{
+                            Id = 'device_vendor_msft_policy_config_applicationcontrolv2_auditmode'
+                            Name = 'ConfigureApplicationControlsAuditMode'
+                            OffsetUri = '/Policies/{PolicyGuid}/Policy/{0}'
+                            AdditionalProperties = @{
+                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                options = @(
+                                    @{
+                                        dependentOn = @(
+                                            @{
+                                                dependentOn = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions_built_in_controls_selected'
+                                                parentSettingId = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions'
+                                            }
+                                        )
+                                        itemId = 'device_vendor_msft_policy_config_applicationcontrolv2_auditmode_disabled'
+                                        name = 'Disabled'
+                                        optionValue = @{
+                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationIntegerSettingValue'
+                                            value = 0
+                                        }
+                                    }
+                                    @{
+                                        dependentOn = @(
+                                            @{
+                                                dependentOn = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions_built_in_controls_selected'
+                                                parentSettingId = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions'
+                                            }
+                                        )
+                                        itemId = 'device_vendor_msft_policy_config_applicationcontrolv2_auditmode_enabled'
+                                        name = 'Enabled'
+                                        optionValue = @{
+                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationIntegerSettingValue'
+                                            value = 1
+                                        }
+                                    }
+                                )
+                            }
+                        },
+                        @{
+                            Id = 'device_vendor_msft_policy_config_applicationcontrolv2_trustappsfrommanagedinstaller'
+                            Name = 'ConfigureApplicationControlsTrustAppsFromManagedInstaller'
+                            OffsetUri = '/Policies/{PolicyGuid}/Policy/{0}'
+                            AdditionalProperties = @{
+                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                options = @(
+                                    @{
+                                        dependentOn = @(
+                                            @{
+                                                dependentOn = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions_built_in_controls_selected'
+                                                parentSettingId = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions'
+                                            }
+                                        )
+                                        itemId = 'device_vendor_msft_policy_config_applicationcontrolv2_trustappsfrommanagedinstaller_disabled'
+                                        name = 'Disabled'
+                                        optionValue = @{
+                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationIntegerSettingValue'
+                                            value = 0
+                                        }
+                                    },
+                                    @{
+                                        dependentOn = @(
+                                            @{
+                                                dependentOn = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions_built_in_controls_selected'
+                                                parentSettingId = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions'
+                                            }
+                                        )
+                                        itemId = 'device_vendor_msft_policy_config_applicationcontrolv2_trustappsfrommanagedinstaller_enabled'
+                                        name = 'Enabled'
+                                        optionValue = @{
+                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationIntegerSettingValue'
+                                            value = 1
+                                        }
+                                    }
+                                )
+                            }
+                        },
+                        @{
+                            Id = 'device_vendor_msft_policy_config_applicationcontrolv2_trustappswithgoodreputation'
+                            Name = 'ConfigureApplicationControlsTrustAppsWithGoodReputation'
+                            OffsetUri = '/Policies/{PolicyGuid}/Policy/{0}'
+                            AdditionalProperties = @{
+                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingDefinition'
+                                options = @(
+                                    @{
+                                        dependentOn = @(
+                                            @{
+                                                dependentOn = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions_built_in_controls_selected'
+                                                parentSettingId = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions'
+                                            }
+                                        )
+                                        itemId = 'device_vendor_msft_policy_config_applicationcontrolv2_trustappswithgoodreputation_disabled'
+                                        name = 'Disabled'
+                                        optionValue = @{
+                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationIntegerSettingValue'
+                                            value = 0
+                                        }
+                                    },
+                                    @{
+                                        dependentOn = @(
+                                            @{
+                                                dependentOn = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions_built_in_controls_selected'
+                                                parentSettingId = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions'
+                                            }
+                                        )
+                                        itemId = 'device_vendor_msft_policy_config_applicationcontrolv2_trustappswithgoodreputation_enabled'
+                                        name = 'Enabled'
+                                        optionValue = @{
+                                            '@odata.type' = '#microsoft.graph.deviceManagementConfigurationIntegerSettingValue'
+                                            value = 1
+                                        }
+                                    }
+                                )
+                            }
+                        },
+                        @{
+                            Id = 'device_vendor_msft_policy_config_applicationcontrolv2_xmlupload'
+                            Name = 'ConfigureApplicationControlsXMLUpload'
+                            OffsetUri = '/Policies/{PolicyGuid}/Policy/{0}'
+                            AdditionalProperties = @{
+                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSimpleSettingDefinition'
+                                dependentOn = @(
+                                    @{
+                                        dependentOn = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions_upload_xml_selected'
+                                        parentSettingId = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions'
+                                    }
+                                )
+                            }
+                        },
+                        @{
+                            Id = 'device_vendor_msft_policy_config_applicationcontrolv2_supplementalpolicy_buildoptions_{ruleid}_type_filehashdetails'
+                            Name = 'ApplicationControlV2_SupplementalPolicy_Rule_FileHash'
+                            OffsetUri = '/Policies/{PolicyGuid}/Policy/{0}'
+                            AdditionalProperties = @{
+                                '@odata.type' = '#microsoft.graph.deviceManagementConfigurationSimpleSettingDefinition'
+                                dependentOn = @(
+                                    @{
+                                        dependentOn = 'device_vendor_msft_policy_config_applicationcontrolv2_supplementalpolicy_buildoptions_{ruleid}_type_filehash'
+                                        parentSettingId = 'device_vendor_msft_policy_config_applicationcontrolv2_supplementalpolicy_buildoptions_{ruleid}_type'
+                                    }
+                                )
+                            }
+                        }
+                    )
+                    SettingInstance      = @{
+                        SettingDefinitionId              = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions'
+                        SettingInstanceTemplateReference = @{
+                            SettingInstanceTemplateId = 'abc5b8cd-63a0-4a1c-a34d-da84d9a93f62'
+                        }
+                        AdditionalProperties             = @{
+                            '@odata.type'      = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                            choiceSettingValue = @{
+                                children = @(
+                                    @{
+                                        '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                        choiceSettingValue = @{
+                                            children = @()
+                                            value = 'device_vendor_msft_policy_config_applicationcontrolv2_auditmode_enabled'
+                                        }
+                                        settingDefinitionId = 'device_vendor_msft_policy_config_applicationcontrolv2_auditmode'
+                                    }
+                                    @{
+                                        '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                        settingDefinitionId = 'device_vendor_msft_policy_config_applicationcontrolv2_trustappsfrommanagedinstaller'
+                                        choiceSettingValue = @{
+                                            children = @()
+                                            value = 'device_vendor_msft_policy_config_applicationcontrolv2_trustappsfrommanagedinstaller_enabled'
+                                        }
+                                    }
+                                    @{
+                                        '@odata.type' = '#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance'
+                                        settingDefinitionId = 'device_vendor_msft_policy_config_applicationcontrolv2_trustappswithgoodreputation'
+                                        choiceSettingValue = @{
+                                            children = @()
+                                            value = 'device_vendor_msft_policy_config_applicationcontrolv2_trustappswithgoodreputation_enabled'
+                                        }
+                                    }
+                                )
+                                value = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions_built_in_controls_selected'
+                            }
+                        }
+                    }
+                }
+            }
+
+            Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicyAssignment -MockWith {
+                return @(@{
+                    Id       = '12345-12345-12345-12345-12345'
+                    Source   = 'direct'
+                    SourceId = '12345-12345-12345-12345-12345'
+                    Target   = @{
+                        DeviceAndAppManagementAssignmentFilterType = 'none'
+                        AdditionalProperties                       = @(
+                            @{
+                                '@odata.type' = '#microsoft.graph.configurationManagerCollectionAssignmentTarget'
+                                collectionId  = '26d60dd1-fab6-47bf-8656-358194c1a49d'
+                            }
+                        )
+                    }
+                })
+            }
+        }
+
+        # Test contexts
+        Context -Name "The IntuneAppControlForBusinessPolicyWindows10V2 should exist but it DOES NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Description = "My Test Description"
+                    Id = "FakeStringValue"
+                    DisplayName = "My Test"
+                    ConfigureApplicationControlOptions = "1"
+                    ConfigureApplicationControlsAuditMode = "1"
+                    ConfigureApplicationControlsTrustAppsFromManagedInstaller = "1"
+                    ConfigureApplicationControlsTrustAppsWithGoodReputation = "1"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+
+                Mock -CommandName Get-MgBetaDeviceManagementConfigurationPolicy -MockWith {
+                    return $null
+                }
+            }
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
+            }
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+            It 'Should Create the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName New-MgBetaDeviceManagementConfigurationPolicy -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneAppControlForBusinessPolicyWindows10V2 exists but it SHOULD NOT" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Description = "My Test Description"
+                    Id = "FakeStringValue"
+                    DisplayName = "My Test"
+                    ConfigureApplicationControlOptions = "1"
+                    ConfigureApplicationControlsAuditMode = "1"
+                    ConfigureApplicationControlsTrustAppsFromManagedInstaller = "1"
+                    ConfigureApplicationControlsTrustAppsWithGoodReputation = "1"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Absent"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should Remove the group from the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Remove-MgBetaDeviceManagementConfigurationPolicy -Exactly 1
+            }
+        }
+
+        Context -Name "The IntuneAppControlForBusinessPolicyWindows10V2 Exists and Values are already in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Description = "My Test Description"
+                    Id = "FakeStringValue"
+                    DisplayName = "My Test"
+                    ConfigureApplicationControlOptions = "1"
+                    ConfigureApplicationControlsAuditMode = "1"
+                    ConfigureApplicationControlsTrustAppsFromManagedInstaller = "1"
+                    ConfigureApplicationControlsTrustAppsWithGoodReputation = "1"
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+        }
+
+        Context -Name "The IntuneAppControlForBusinessPolicyWindows10V2 exists and values are NOT in the desired state" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Description = "My Test Description"
+                    Id = "FakeStringValue"
+                    DisplayName = "My Test"
+                    ConfigureApplicationControlOptions = "1"
+                    ConfigureApplicationControlsAuditMode = "1"
+                    ConfigureApplicationControlsTrustAppsFromManagedInstaller = "1"
+                    ConfigureApplicationControlsTrustAppsWithGoodReputation = "0" # Drift
+                    RoleScopeTagIds = @("FakeStringValue")
+                    Ensure = "Present"
+                    Credential = $Credential;
+                }
+            }
+
+            It 'Should return Values from the Get method' {
+                (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should call the Set method' {
+                Set-TargetResource @testParams
+                Should -Invoke -CommandName Update-IntuneDeviceConfigurationPolicy -Exactly 1
+            }
+        }
+
+        Context -Name 'ReverseDSC Tests' -Fixture {
+            BeforeAll {
+                $Global:CurrentModeIsExport = $true
+                $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
+                $testParams = @{
+                    Credential = $Credential
+                }
+            }
+
+            It 'Should Reverse Engineer resource from the Export method' {
+                $result = Export-TargetResource @testParams
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}
+
+Invoke-Command -ScriptBlock $Global:DscHelper.CleanupScript -NoNewScope

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAppControlForBusinessPolicyWindows10V2.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.IntuneAppControlForBusinessPolicyWindows10V2.Tests.ps1
@@ -99,7 +99,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                                         }
                                     }
                                     @{
-                                        itemId = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions_built_in_xml_selected'
+                                        itemId = 'device_vendor_msft_policy_config_applicationcontrolv2_buildoptions_built_in_controls_selected'
                                         name = 'Built-in controls'
                                         optionValue = @{
                                             '@odata.type' = '#microsoft.graph.deviceManagementConfigurationIntegerSettingValue'


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds the new resource `IntuneAppControlForBusinessPolicyWindows10V2`, which supersedes `IntuneAppControlForBusinessPolicyWindows10`. The non-V2 resource configures a setting template that was silently changed by Microsoft by another one with the same template family name, but different id. 

Additionally, it fixes an issue where the `ExtemptedAppPackages` parameter of `IntuneAppProtectionPolicyAndroid` was not re-assigned with the updated parameter value.

#### This Pull Request (PR) fixes the following issues
- Fixes #7135 
- Fixes #7129 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [x] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
