### PR TITLE
Fix attempt of resolving trainable classifiers with null id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
   * Standardized time format of `TokenExpirationDateTime` and excluded it from comparison.
 * IntunePolicySets
   * Updated resource to work with multitenants.
+* SCDLPComplianceRule
+  * Fixed an issue where an attempt was made to resolve trainable classifiers with a null Id.
+    FIXES [#7156](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7156)
 * SCDLPSensitiveInformationType
   * Removed the parameter verbose output to prevent screen cluttering.
     FIXES [#7145](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7145)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
@@ -2108,7 +2108,9 @@ function Add-AdvancedRuleConditionId
             $sensitiveTypesValue = $Condition.Value.Groups.Sensitivetypes
             foreach ($stype in $sensitiveTypesValue)
             {
-                if ($null -eq $stype.Id)
+                # Do not attempt to resolve trainable classifiers that have a classifier type set, e.g. MLModel
+                # See https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7156
+                if ($null -eq $stype.Id -and [System.String]::IsNullOrEmpty($stype.Classifiertype))
                 {
                     $stype.Id = $Script:SensitiveInformationTypes | Where-Object -FilterScript { $_.Name -eq $stype.Name } | Select-Object -ExpandProperty Id
                 }


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where an attempt was made to resolve trainable classifiers that do not have an Id property, which resulted in an error.

#### This Pull Request (PR) fixes the following issues
- Fixes #7156 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
