### PR TITLE
Gate conditional HKLM check during dll load to Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@
   * Initial release.
 * TeamsTargetingPolicy
   * Initial release.
+* M365DSCDllLoader
+  * Fixed an issue where an attempt was made to read the `HKLM:` drive on non-Windows systems.
+    FIXES [#7157](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7157)
 * M365DSCReverse
   * Added functionality to use wildcards in the `-Components` parameter when exporting.
   * Fixed an issue where the resources to export counter did not match the actual value.

--- a/Modules/Microsoft365DSC/Modules/M365DSCDllLoader.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDllLoader.psm1
@@ -42,19 +42,22 @@ function Initialize-M365DSCDllLoader
 
     try
     {
-        # Validate .NET Framework version (4.7.2 = Release 461808+)
-        $netFrameworkVersion = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full' -ErrorAction Stop
-        $releaseKey = $netFrameworkVersion.Release
-
-        if ($releaseKey -lt 461808)
+        if ($PSVersionTable.PSEdition -eq 'Desktop')
         {
-            $versionString = $netFrameworkVersion.Version
-            $errorMessage = ".NET Framework 4.7.2 or higher is required for Microsoft365DSC C# dll files. Current version: $versionString (Release: $releaseKey). Please install .NET Framework 4.7.2+ from https://dotnet.microsoft.com/download/dotnet-framework"
+            # Validate .NET Framework version (4.7.2 = Release 461808+)
+            $netFrameworkVersion = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full' -ErrorAction Stop
+            $releaseKey = $netFrameworkVersion.Release
 
-            throw $errorMessage
+            if ($releaseKey -lt 461808)
+            {
+                $versionString = $netFrameworkVersion.Version
+                $errorMessage = ".NET Framework 4.7.2 or higher is required for Microsoft365DSC C# dll files on Windows PowerShell. Current version: $versionString (Release: $releaseKey). Please install .NET Framework 4.7.2+ from https://dotnet.microsoft.com/download/dotnet-framework"
+
+                throw $errorMessage
+            }
+
+            Write-Verbose -Message ".NET Framework version check passed (Release: $releaseKey)"
         }
-
-        Write-Verbose -Message ".NET Framework version check passed (Release: $releaseKey)"
 
         # Locate the accelerator DLL
         $moduleRoot = Split-Path -Path $PSScriptRoot -Parent


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where an attempt was made to read the HKLM: drive on non-Windows systems during initializing of the DLL files for Microsoft365DSC.

#### This Pull Request (PR) fixes the following issues
- Fixes #7157 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
