### PR TITLE
Fix Insider Risk policy with non-protected NotificationDetails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@
 * SCDLPSensitiveInformationTypeRulePackage
   * Initial release.
     FIXES [#7144](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7144)
+* SCInsiderRiskPolicy
+  * Fixed an issue where notification values were tried to be set
+    even though the feature was neither configured nor enabled.
+    FIXES [#7162](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7162)
 * SPOTenantCdnPolicy
   * Fixed an issue where property values were not being returned.
 * TeamsAIPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SCInsiderRiskPolicy/MSFT_SCInsiderRiskPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SCInsiderRiskPolicy/MSFT_SCInsiderRiskPolicy.psm1
@@ -2176,7 +2176,13 @@ function Set-TargetResource
         $MDATPTriageStatusValue = $MDATPTriageStatusValue.Substring(0, $MDATPTriageStatusValue.Length - 1)
     }
     $MDATPTriageStatusValue += ']'
-    $featureSettingsValue = "{`"Anonymization`":$($Anonymization.ToString().ToLower()), `"DLPUserRiskSync`":$($DLPUserRiskSync.ToString().ToLower()), `"OptInIRMDataExport`":$($OptInIRMDataExport.ToString().ToLower()), `"RaiseAuditAlert`":$($RaiseAuditAlert.ToString().ToLower()), `"EnableTeam`":$($EnableTeam.ToString().ToLower()), `"InlineAlertPolicyCustomization`":$($InlineAlertPolicyCustomization.ToString().ToLower()), `"NotificationDetails`":`"{\`"Rolegroups\`":$((ConvertTo-Json -InputObject $NotificationDetailsRoleGroups -Compress) -replace '"', '\"'),\`"Recepients\`":[]}`"}"
+
+    $notificationDetailsValue = ''
+    if ($NotificationDetailsEnabled)
+    {
+        $notificationDetailsValue = ", `"NotificationDetails`":`"{\`"Rolegroups\`":$((ConvertTo-Json -InputObject $NotificationDetailsRoleGroups -Compress) -replace '"', '\"'),\`"Recepients\`":[]}`""
+    }
+    $featureSettingsValue = "{`"Anonymization`":$($Anonymization.ToString().ToLower()), `"DLPUserRiskSync`":$($DLPUserRiskSync.ToString().ToLower()), `"OptInIRMDataExport`":$($OptInIRMDataExport.ToString().ToLower()), `"RaiseAuditAlert`":$($RaiseAuditAlert.ToString().ToLower()), `"EnableTeam`":$($EnableTeam.ToString().ToLower()), `"InlineAlertPolicyCustomization`":$($InlineAlertPolicyCustomization.ToString().ToLower())$notificationDetailsValue}"
     $intelligentDetectionValue = "{`"FileVolCutoffLimits`":`"$($FileVolCutoffLimits)`", `"AlertVolume`":`"$($AlertVolume)`", `"MDATPTriageStatus`": `"$($MDATPTriageStatusValue)`"}"
 
     $tenantSettingsValue = "{`"Region`":`"WW`", `"FeatureSettings`":$($featureSettingsValue), " + `


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where an attempt was made to configure notification details in a `SCInsiderRiskPolicy` even if the feature was disabled or not configured, resulting in an error.

#### This Pull Request (PR) fixes the following issues
- Fixes #7162

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
