### PR TITLE
Fix export of certificate password

### DIFF
--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEOPProtectionPolicyRule/MSFT_EXOEOPProtectionPolicyRule.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOEOPProtectionPolicyRule/MSFT_EXOEOPProtectionPolicyRule.psm1
@@ -80,7 +80,7 @@ function Get-TargetResource
         $CertificatePath,
 
         [Parameter()]
-        [System.String]
+        [System.Management.Automation.PSCredential]
         $CertificatePassword,
 
         [Parameter()]
@@ -247,7 +247,7 @@ function Set-TargetResource
         $CertificatePath,
 
         [Parameter()]
-        [System.String]
+        [System.Management.Automation.PSCredential]
         $CertificatePassword,
 
         [Parameter()]

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOExternalInOutlook/MSFT_EXOExternalInOutlook.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOExternalInOutlook/MSFT_EXOExternalInOutlook.psm1
@@ -48,7 +48,7 @@ function Get-TargetResource
         $CertificatePath,
 
         [Parameter()]
-        [System.String]
+        [System.Management.Automation.PSCredential]
         $CertificatePassword,
 
         [Parameter()]
@@ -175,7 +175,7 @@ function Set-TargetResource
         $CertificatePath,
 
         [Parameter()]
-        [System.String]
+        [System.Management.Automation.PSCredential]
         $CertificatePassword,
 
         [Parameter()]
@@ -272,7 +272,7 @@ function Test-TargetResource
         $CertificatePath,
 
         [Parameter()]
-        [System.String]
+        [System.Management.Automation.PSCredential]
         $CertificatePassword,
 
         [Parameter()]


### PR DESCRIPTION
#### Pull Request (PR) description
Fix export of certificate password with invalid string type instead of PSCredential.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
