### PR TITLE
Enable custom site scripts if disabled and reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@
   * Fixed an issue where notification values were tried to be set
     even though the feature was neither configured nor enabled.
     FIXES [#7162](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7162)
+* SPOStorageEntity
+  * Fixed an issue where applying entries to a protected app catalog failed.
+    FIXES [#6895](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/6895)
 * SPOTenantCdnPolicy
   * Fixed an issue where property values were not being returned.
 * TeamsAIPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOStorageEntity/MSFT_SPOStorageEntity.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOStorageEntity/MSFT_SPOStorageEntity.psm1
@@ -257,14 +257,28 @@ function Set-TargetResource
         try
         {
             Write-Verbose -Message "Adding new storage entity $Key"
+            $currentTenantSite = Get-PnPTenantSite -Identity $SiteUrl
+            $resetSecurity = $false
+            if ($currentTenantSite.DenyAddAndCustomizePages -eq 'Enabled')
+            {
+                Set-PnPTenantSite -Identity $SiteUrl -NoScriptSite:$false -ErrorAction Stop
+                $resetSecurity = $true
+            }
             Set-PnPStorageEntity @CurrentParameters
+
+            if ($resetSecurity)
+            {
+                Write-Verbose -Message "Resetting security for $SiteUrl"
+                Set-PnPTenantSite -Identity $SiteUrl -NoScriptSite:$true
+            }
         }
         catch
         {
             if ($_.Exception -like '*Access denied*')
             {
                 throw "It appears that the account doesn't have access to create an SPO Storage " + `
-                    'Entity or that an App Catalog was not created for the specified location'
+                    'Entity or that an App Catalog was not created for the specified location. ' + `
+                    'Additionally, make sure that the site is allowed for custom scripts.'
             }
         }
     }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_SPOStorageEntity/settings.json
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_SPOStorageEntity/settings.json
@@ -68,8 +68,10 @@
       "module": "PnP.PowerShell",
       "cmdlets": [
         "Get-PnPStorageEntity",
+        "Get-PnPTenantSite",
         "Remove-PnPStorageEntity",
-        "Set-PnPStorageEntity"
+        "Set-PnPStorageEntity",
+        "Set-PnPTenantSite"
       ]
     }
   ]

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SPOStorageEntity.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SPOStorageEntity.Tests.ps1
@@ -44,6 +44,16 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 return 'https://contoso-admin.sharepoint.com'
             }
 
+            Mock -CommandName Get-PnPTenantSite -MockWith {
+                return @{
+                    Url = 'https://contoso-admin.sharepoint.com'
+                    DenyAddAndCustomizePages = 'Enabled'
+                }
+            }
+
+            Mock -CommandName Set-PnPTenantSite -MockWith {
+            }
+
             # Mock Write-M365DSCHost to hide output during the tests
             Mock -CommandName Write-M365DSCHost -MockWith {
             }


### PR DESCRIPTION
#### Pull Request (PR) description
This PR configures the `SPOStorageEntity` resource to enable custom scripts on sites if an entity is to be set on that site and it was disabled before.

#### This Pull Request (PR) fixes the following issues
- Fixes #6895 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [x] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
