### PR TITLE
AADGroup - improve handling of new groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@
     FIXES [#7102](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7102)
 * AADEntitlementManagementAccessPackageCatalogResource
   * Changed properties `CatalogId` and `OriginId` to their display name equivalent.
-  AADGroup
-  * Include wait after creating new group
-  * Only update existing group
 * AADPIMGroupSetting
   * Changed resource type from `Configuration` to `Data`.
 * AADServicePrincipal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
     FIXES [#7102](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7102)
 * AADEntitlementManagementAccessPackageCatalogResource
   * Changed properties `CatalogId` and `OriginId` to their display name equivalent.
+* AADGroup
+  * Include wait after creating new group
+  * Avoid updating new group
 * AADPIMGroupSetting
   * Changed resource type from `Configuration` to `Data`.
 * AADServicePrincipal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
     FIXES [#7102](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7102)
 * AADEntitlementManagementAccessPackageCatalogResource
   * Changed properties `CatalogId` and `OriginId` to their display name equivalent.
+  AADGroup
+  * Include wait after creating new group
+  * Only update existing group
 * AADPIMGroupSetting
   * Changed resource type from `Configuration` to `Data`.
 * AADServicePrincipal

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -644,8 +644,8 @@ function Set-TargetResource
             {
                 Write-Verbose -Message "Creating Group with Values: $(Convert-M365DscHashtableToString -Hashtable $currentParameters)"
                 $currentGroup = New-MgGroup -BodyParameter $currentParameters
-                Write-Verbose -Message "Created Group $($currentGroup.id), wait for sync to complete"
-                Invoke-M365DSCCommand -ScriptBlock { Get-MgGroup -GroupId $currentGroup.Id -Property Id -ErrorAction Stop } -RetryOnNotFoundError | Out-Null            }
+                Write-Verbose -Message "Created Group $($currentGroup.id)"
+            }
             catch
             {
                 Write-Verbose -Message $_
@@ -660,23 +660,22 @@ function Set-TargetResource
         Write-Verbose -Message "Group {$DisplayName} exists and it should."
         try
         {
-            if ($currentGroup.Ensure -eq 'Present')
+            Write-Verbose -Message "Updating settings by ID for group {$DisplayName}"
+            if ($true -eq $currentParameters.ContainsKey('IsAssignableToRole'))
             {
-                Write-Verbose -Message "Updating settings by ID for group {$DisplayName}"
+                Write-Verbose -Message 'Cannot set IsAssignableToRole once group is created.'
+                $currentParameters.Remove('IsAssignableToRole') | Out-Null
+            }
 
-                if ($true -eq $currentParameters.ContainsKey('IsAssignableToRole'))
-                {
-                    Write-Verbose -Message 'Cannot set IsAssignableToRole once group is created.'
-                    $currentParameters.Remove('IsAssignableToRole') | Out-Null
-                }
-
-                if ($currentParameters.ContainsKey('Id'))
-                {
-                    $currentParameters.Remove('Id') | Out-Null
-                }
-
-                Write-Verbose -Message "Updating existing Group with Values: $(Convert-M365DscHashtableToString -Hashtable $currentParameters)"
-                Update-MgGroup -GroupId $currentGroup.Id -BodyParameter $currentParameters -ErrorAction Stop
+            if ($false -eq $currentParameters.ContainsKey('Id'))
+            {
+                Update-MgGroup -BodyParameter $currentParameters -GroupId $currentGroup.Id | Out-Null
+            }
+            else
+            {
+                $currentParameters.Remove('Id') | Out-Null
+                Write-Verbose -Message "Updating Group with Values: $(Convert-M365DscHashtableToString -Hashtable $currentParameters)"
+                Invoke-M365DSCCommand -ScriptBlock { Update-MgGroup -GroupId $currentGroup.Id -BodyParameter $currentParameters -ErrorAction Stop } -RetryOnNotFoundError | Out-Null
             }
 
             if (($licensesToAdd.Length -gt 0 -or $licensesToRemove.Length -gt 0) -and $PSBoundParameters.ContainsKey('AssignedLicenses'))

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -644,8 +644,8 @@ function Set-TargetResource
             {
                 Write-Verbose -Message "Creating Group with Values: $(Convert-M365DscHashtableToString -Hashtable $currentParameters)"
                 $currentGroup = New-MgGroup -BodyParameter $currentParameters
-                Write-Verbose -Message "Created Group $($currentGroup.id)"
-            }
+                Write-Verbose -Message "Created Group $($currentGroup.id), wait for sync to complete"
+                Invoke-M365DSCCommand -ScriptBlock { Get-MgGroup -GroupId $currentGroup.Id -Property Id -ErrorAction Stop } -RetryOnNotFoundError | Out-Null            }
             catch
             {
                 Write-Verbose -Message $_
@@ -660,22 +660,23 @@ function Set-TargetResource
         Write-Verbose -Message "Group {$DisplayName} exists and it should."
         try
         {
-            Write-Verbose -Message "Updating settings by ID for group {$DisplayName}"
-            if ($true -eq $currentParameters.ContainsKey('IsAssignableToRole'))
+            if ($currentGroup.Ensure -eq 'Present')
             {
-                Write-Verbose -Message 'Cannot set IsAssignableToRole once group is created.'
-                $currentParameters.Remove('IsAssignableToRole') | Out-Null
-            }
+                Write-Verbose -Message "Updating settings by ID for group {$DisplayName}"
 
-            if ($false -eq $currentParameters.ContainsKey('Id'))
-            {
-                Update-MgGroup -BodyParameter $currentParameters -GroupId $currentGroup.Id | Out-Null
-            }
-            else
-            {
-                $currentParameters.Remove('Id') | Out-Null
-                Write-Verbose -Message "Updating Group with Values: $(Convert-M365DscHashtableToString -Hashtable $currentParameters)"
-                Invoke-M365DSCCommand -ScriptBlock { Update-MgGroup -GroupId $currentGroup.Id -BodyParameter $currentParameters -ErrorAction Stop } -RetryOnNotFoundError | Out-Null
+                if ($true -eq $currentParameters.ContainsKey('IsAssignableToRole'))
+                {
+                    Write-Verbose -Message 'Cannot set IsAssignableToRole once group is created.'
+                    $currentParameters.Remove('IsAssignableToRole') | Out-Null
+                }
+
+                if ($currentParameters.ContainsKey('Id'))
+                {
+                    $currentParameters.Remove('Id') | Out-Null
+                }
+
+                Write-Verbose -Message "Updating existing Group with Values: $(Convert-M365DscHashtableToString -Hashtable $currentParameters)"
+                Update-MgGroup -GroupId $currentGroup.Id -BodyParameter $currentParameters -ErrorAction Stop
             }
 
             if (($licensesToAdd.Length -gt 0 -or $licensesToRemove.Length -gt 0) -and $PSBoundParameters.ContainsKey('AssignedLicenses'))

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -645,7 +645,7 @@ function Set-TargetResource
                 Write-Verbose -Message "Creating Group with Values: $(Convert-M365DscHashtableToString -Hashtable $currentParameters)"
                 $currentGroup = New-MgGroup -BodyParameter $currentParameters
                 Write-Verbose -Message "Created Group $($currentGroup.id), wait for sync to complete"
-                Invoke-M365DSCCommand -ScriptBlock { Get-MgGroup -GroupId $currentGroup.Id -Property Id -ErrorAction Stop } -RetryOnNotFoundError | Out-Null            }
+                Invoke-M365DSCCommand -ScriptBlock { Get-MgGroup -GroupId $currentGroup.Id -Property Id -ErrorAction Stop } -RetryOnNotFoundError | Out-Null
             }
             catch
             {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -1400,7 +1400,7 @@ function Get-M365DSCAzureADGroupLicenses
 
     foreach ($assignedLicense in $AssignedLicenses)
     {
-        $skuPartNumber = $Script:SubscribedSkus.Where({ $_.SkuId -eq $assignedLicense.SkuId })
+        $skuPartNumber = $Script:SubscribedSkus | Where-Object -FilterScript { $_.SkuId -eq $assignedLicense.SkuId }
         $disabledPlansValues = @()
         foreach ($plan in $assignedLicense.DisabledPlans)
         {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -644,7 +644,8 @@ function Set-TargetResource
             {
                 Write-Verbose -Message "Creating Group with Values: $(Convert-M365DscHashtableToString -Hashtable $currentParameters)"
                 $currentGroup = New-MgGroup -BodyParameter $currentParameters
-                Write-Verbose -Message "Created Group $($currentGroup.id)"
+                Write-Verbose -Message "Created Group $($currentGroup.id), wait for sync to complete"
+                Invoke-M365DSCCommand -ScriptBlock { Get-MgGroup -GroupId $currentGroup.Id -Property Id -ErrorAction Stop } -RetryOnNotFoundError | Out-Null            }
             }
             catch
             {
@@ -660,22 +661,23 @@ function Set-TargetResource
         Write-Verbose -Message "Group {$DisplayName} exists and it should."
         try
         {
-            Write-Verbose -Message "Updating settings by ID for group {$DisplayName}"
-            if ($true -eq $currentParameters.ContainsKey('IsAssignableToRole'))
+            if ($currentGroup.Ensure -eq 'Present')
             {
-                Write-Verbose -Message 'Cannot set IsAssignableToRole once group is created.'
-                $currentParameters.Remove('IsAssignableToRole') | Out-Null
-            }
+                Write-Verbose -Message "Updating settings by ID for group {$DisplayName}"
 
-            if ($false -eq $currentParameters.ContainsKey('Id'))
-            {
-                Update-MgGroup -BodyParameter $currentParameters -GroupId $currentGroup.Id | Out-Null
-            }
-            else
-            {
-                $currentParameters.Remove('Id') | Out-Null
-                Write-Verbose -Message "Updating Group with Values: $(Convert-M365DscHashtableToString -Hashtable $currentParameters)"
-                Invoke-M365DSCCommand -ScriptBlock { Update-MgGroup -GroupId $currentGroup.Id -BodyParameter $currentParameters -ErrorAction Stop } -RetryOnNotFoundError | Out-Null
+                if ($true -eq $currentParameters.ContainsKey('IsAssignableToRole'))
+                {
+                    Write-Verbose -Message 'Cannot set IsAssignableToRole once group is created.'
+                    $currentParameters.Remove('IsAssignableToRole') | Out-Null
+                }
+
+                if ($currentParameters.ContainsKey('Id'))
+                {
+                    $currentParameters.Remove('Id') | Out-Null
+                }
+
+                Write-Verbose -Message "Updating existing Group with Values: $(Convert-M365DscHashtableToString -Hashtable $currentParameters)"
+                Update-MgGroup -GroupId $currentGroup.Id -BodyParameter $currentParameters -ErrorAction Stop
             }
 
             if (($licensesToAdd.Length -gt 0 -or $licensesToRemove.Length -gt 0) -and $PSBoundParameters.ContainsKey('AssignedLicenses'))


### PR DESCRIPTION
#### Pull Request (PR) description
When creating a new group, a wait is included to ensure that the new group is available from the endpoint you're using. A subsequent and redundant update of a newly created group is also avoided by only updating an existing group

#### This Pull Request (PR) fixes the following issues
When creating new groups, an exception is often thrown because the newly created group hasn't yet replicated to the Graph-endpoint currently used.
As an additional optimization, a subsequent update of the new group is avoided by only updating existing groups.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
