### PR TITLE
O365OrgSettings - fix handling of Office on the web SPN in new tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
   * Standardized time format of `TokenExpirationDateTime` and excluded it from comparison.
 * IntunePolicySets
   * Updated resource to work with multitenants.
+* O365OrgSettings
+  * Fixed handling of Office on the Web SPN in new tenants
 * SCDLPComplianceRule
   * Fixed an issue where an attempt was made to resolve trainable classifiers with a null Id.
     FIXES [#7156](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7156)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroup/MSFT_AADGroup.psm1
@@ -665,7 +665,7 @@ function Set-TargetResource
             {
                 Write-Verbose -Message "Updating settings by ID for group {$DisplayName}"
 
-                if ($true -eq $currentParameters.ContainsKey('IsAssignableToRole'))
+                if ($currentParameters.ContainsKey('IsAssignableToRole'))
                 {
                     Write-Verbose -Message 'Cannot set IsAssignableToRole once group is created.'
                     $currentParameters.Remove('IsAssignableToRole') | Out-Null

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
@@ -208,13 +208,15 @@ function Get-TargetResource
         if ($PSBoundParameters.ContainsKey('M365WebEnableUsersToOpenFilesFrom3PStorage') -or `
                 $Script:exportedInstance)
         {
-            $OfficeOnlineId = 'c1f33bc0-bdb4-4248-ba9b-096807ddb43e'
-            $M365WebEnableUsersToOpenFilesFrom3PStorageValue = Get-MgServicePrincipal -Filter "appId eq '$OfficeOnlineId'" -Property 'AccountEnabled' -ErrorAction SilentlyContinue
+            $OfficeOnline3rdPtyStorageAppId = 'c1f33bc0-bdb4-4248-ba9b-096807ddb43e'
+            $M365WebEnableUsersToOpenFilesFrom3PStorageValue = Get-MgServicePrincipal -Filter "appId eq '$OfficeOnline3rdPtyStorageAppId'" -Property 'AccountEnabled' -ErrorAction SilentlyContinue
             if ($null -eq $M365WebEnableUsersToOpenFilesFrom3PStorageValue)
             {
                 Write-Verbose -Message 'Registering the Office on the web Service Principal'
-                New-MgServicePrincipal -AppId $OfficeOnlineId -ErrorAction Stop | Out-Null
-                $M365WebEnableUsersToOpenFilesFrom3PStorageValue = Invoke-M365DSCCommand -ScriptBlock { Get-MgServicePrincipal -Filter "appId eq '$OfficeOnlineId'" -Property 'AccountEnabled' -ErrorAction Stop } -RetryOnNotFoundError
+                New-MgServicePrincipal -AppId $OfficeOnline3rdPtyStorageAppId -ErrorAction Stop | Out-Null
+                $M365WebEnableUsersToOpenFilesFrom3PStorageValue = Invoke-M365DSCCommand -ScriptBlock {
+                    Get-MgServicePrincipal -Filter "appId eq '$OfficeOnline3rdPtyStorageAppId'" -Property 'AccountEnabled' -ErrorAction Stop
+                } -RetryOnNotFoundError
             }
 
             if ($null -ne $M365WebEnableUsersToOpenFilesFrom3PStorageValue)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_O365OrgSettings/MSFT_O365OrgSettings.psm1
@@ -213,8 +213,8 @@ function Get-TargetResource
             if ($null -eq $M365WebEnableUsersToOpenFilesFrom3PStorageValue)
             {
                 Write-Verbose -Message 'Registering the Office on the web Service Principal'
-                New-MgServicePrincipal -AppId 'c1f33bc0-bdb4-4248-ba9b-096807ddb43e' -ErrorAction Stop | Out-Null
-                $M365WebEnableUsersToOpenFilesFrom3PStorageValue = Get-MgServicePrincipal -Filter "appId eq '$OfficeOnlineId'" -Property 'AccountEnabled' -ErrorAction SilentlyContinue
+                New-MgServicePrincipal -AppId $OfficeOnlineId -ErrorAction Stop | Out-Null
+                $M365WebEnableUsersToOpenFilesFrom3PStorageValue = Invoke-M365DSCCommand -ScriptBlock { Get-MgServicePrincipal -Filter "appId eq '$OfficeOnlineId'" -Property 'AccountEnabled' -ErrorAction Stop } -RetryOnNotFoundError
             }
 
             if ($null -ne $M365WebEnableUsersToOpenFilesFrom3PStorageValue)


### PR DESCRIPTION
#### Pull Request (PR) description
Update O365orgSettings to avoid misleading results for new tenants.

#### This Pull Request (PR) fixes the following issues
If the SPN for Office Online 3rd Party Storage is missing, the resource will create it. However, an error occurred when subsequently attempting to read it before allowing time for replication across Graph endpoints.
To make code more intuitive, the variable holding the AppId of the SPN in question has been renamed.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
