### PR TITLE
fix certificate handling in AADOrganizationCertificateBasedAuthConfig…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     in `ServicePrincipalFilterRule`.
 * AADFilteringPolicyRule
   * Fixed an issue where an incorrect number of instances to export was shown.
+* AADOrganizationCertificateBasedAuthConfiguration
+  * Fixed an issue where the `Certificate` property was incorrectly converted using `ToBase64String` when the Graph SDK already returns it as a Base64 string. FIXES [#7193](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7193)
 * AzureRoleDefinition
   * Initial Release
     FIXES [#7077](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7077)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADOrganizationCertificateBasedAuthConfiguration/MSFT_AADOrganizationCertificateBasedAuthConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADOrganizationCertificateBasedAuthConfiguration/MSFT_AADOrganizationCertificateBasedAuthConfiguration.psm1
@@ -104,7 +104,15 @@ function Get-TargetResource
         foreach ($currentCertificateAuthorities in $getValue.certificateAuthorities)
         {
             $myCertificateAuthorities = [ordered]@{}
-            $myCertificateAuthorities.Add('Certificate', [System.Convert]::ToBase64String($currentCertificateAuthorities.certificate))
+            if ($currentCertificateAuthorities.certificate -is [System.Byte[]])
+            {
+            $certValue = [System.Convert]::ToBase64String($currentCertificateAuthorities.certificate)
+            }
+            else
+            {
+            $certValue = $currentCertificateAuthorities.certificate
+            }
+            $myCertificateAuthorities.Add('Certificate', $certValue)
             $myCertificateAuthorities.Add('CertificateRevocationListUrl', $currentCertificateAuthorities.certificateRevocationListUrl)
             $myCertificateAuthorities.Add('DeltaCertificateRevocationListUrl', $currentCertificateAuthorities.deltaCertificateRevocationListUrl)
             $myCertificateAuthorities.Add('IsRootAuthority', $currentCertificateAuthorities.isRootAuthority)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADOrganizationCertificateBasedAuthConfiguration/MSFT_AADOrganizationCertificateBasedAuthConfiguration.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADOrganizationCertificateBasedAuthConfiguration/MSFT_AADOrganizationCertificateBasedAuthConfiguration.psm1
@@ -104,15 +104,7 @@ function Get-TargetResource
         foreach ($currentCertificateAuthorities in $getValue.certificateAuthorities)
         {
             $myCertificateAuthorities = [ordered]@{}
-            if ($currentCertificateAuthorities.certificate -is [System.Byte[]])
-            {
-            $certValue = [System.Convert]::ToBase64String($currentCertificateAuthorities.certificate)
-            }
-            else
-            {
-            $certValue = $currentCertificateAuthorities.certificate
-            }
-            $myCertificateAuthorities.Add('Certificate', $certValue)
+            $myCertificateAuthorities.Add('Certificate', $currentCertificateAuthorities.certificate)
             $myCertificateAuthorities.Add('CertificateRevocationListUrl', $currentCertificateAuthorities.certificateRevocationListUrl)
             $myCertificateAuthorities.Add('DeltaCertificateRevocationListUrl', $currentCertificateAuthorities.deltaCertificateRevocationListUrl)
             $myCertificateAuthorities.Add('IsRootAuthority', $currentCertificateAuthorities.isRootAuthority)

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADOrganizationCertificateBasedAuthConfiguration.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADOrganizationCertificateBasedAuthConfiguration.Tests.ps1
@@ -46,7 +46,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             IsRootAuthority = $True
                             CertificateRevocationListUrl = "FakeStringValue"
                             Issuer = "FakeStringValue"
-                            Certificate = [byte[]] @(84, 101, 115, 116) # "Test"
+                            Certificate = "VGVzdA==" # "Test"
                         }
                     )
                     Id = "FakeStringValue"


### PR DESCRIPTION
Hey, found the exact cause and fixed it.
The problem is in Get-TargetResource in MSFT_AADOrganizationCertificateBasedAuthConfiguration.psm1. There's a single line that calls [System.Convert]::ToBase64String() on the certificate property coming back from Graph which worked fine before because Graph used to return it as a raw byte[]. At some point (looks like around https://github.com/Microsoft365DSC/Microsoft365DSC/commit/0f9b96629fa4969575ef107d87f148925546236f) the SDK started returning it already as a Base64 string, so calling ToBase64String() on a string blows up trying to treat each character as a byte. That's exactly the "Input string was not in a correct format" error you're seeing.

The fix is a type check before the conversion:

if ($currentCertificateAuthorities.certificate -is [System.Byte[]])
{
$certValue = [System.Convert]::ToBase64String($currentCertificateAuthorities.certificate)
}
else
{
$certValue = $currentCertificateAuthorities.certificate
}
$myCertificateAuthorities.Add('Certificate', $certValue)

No other functions need touching Test-TargetResource and Export-TargetResource both go through Get-TargetResource so they're fixed automatically. Set-TargetResource goes the other direction (FromBase64String) so that was never broken.