### PR TITLE
Fix update of application certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCPermissions
+  * Fixed an issue when updating app certs.
+
 # 1.26.603.1
 
 * AADConditionalAccessPolicy

--- a/Modules/Microsoft365DSC/Modules/M365DSCPermissions.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCPermissions.psm1
@@ -1160,7 +1160,8 @@ function Update-M365DSCAzureAdApplication
                     }
 
                     Write-LogEntry "    Certificate details: $($cerCert.Subject) ($($cerCert.Thumbprint))"
-                    $params = @{
+                    $params = @()
+                    $params += @{
                         type  = 'AsymmetricX509Cert'
                         usage = 'Verify'
                         key   = $cerCert.GetRawCertData()


### PR DESCRIPTION
#### Pull Request (PR) description
Ensures that the body parameters for the certificate update PATCH request are typed as an array to resolve an issue encountered where cert updates fail with:
```
{"error":{"code":"BadRequest","message":"Property keyCredentials in payload has a value that does not match schema.","innerError":{"date":"2026-06-04T08:10:40","request-id":"redacted","client-request-id":"redacted"}}}
```

This is backed up by the PATCH documentation suggesting a "keyCredential **collection**".
https://learn.microsoft.com/en-us/graph/api/application-update?view=graph-rest-1.0&tabs=http

Tested in my own environment.

#### This Pull Request (PR) fixes the following issues
None

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
