### PR TITLE
Fix comparison of AADEntitlementManagementAccessPackageAssignmentPolicy in New-M365DSCDeltaReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   FIXES [#7201](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7201)
 * AADUser
   * Fixes for timing-related new user
+* EXOHostedContentFilterPolicy
+  * Fixes export of AllowedSenderDomains, AllowedSenders, BlockedSenderDomains, BlockedSenders
 * O365OrgSettings
   * Fixes intermittent exception comparing install-options
 * SPOTenantSettings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * AADGroup
   * Various timing-related fixes for new group
+* AADEntitlementManagementAccessPackageAssignmentPolicy
+  * Fixed comparison in New-M365DSCDeltaReport
 * AADTenantAppManagementPolicy
   * Fixed an issue when updating the resource.
   FIXES [#7201](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7201)

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.psm1
@@ -227,6 +227,7 @@ function Get-TargetResource
         {
             foreach ($setting in $formattedRequestorSettings.allowedRequestors)
             {
+                $setting.Remove('description') | Out-Null
                 if (-not $setting.ContainsKey('odataType'))
                 {
                     $setting.Add('odataType', $setting.'@odata.type')

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOHostedContentFilterPolicy/MSFT_EXOHostedContentFilterPolicy.psm1
@@ -297,8 +297,8 @@ function Get-TargetResource
             $HostedContentFilterPolicy = $Script:exportedInstance
         }
 
-        [System.String[]]$AllowedSendersValues = $HostedContentFilterPolicy.AllowedSenders.Sender | Select-Object Address -ExpandProperty Address
-        [System.String[]]$BlockedSendersValues = $HostedContentFilterPolicy.BlockedSenders.Sender | Select-Object Address -ExpandProperty Address
+        [System.String[]]$AllowedSendersValues = $HostedContentFilterPolicy.AllowedSenders
+        [System.String[]]$BlockedSendersValues = $HostedContentFilterPolicy.BlockedSenders
         # Check if the values are null and assign them an empty string array if they are
         if ($null -eq $AllowedSendersValues)
         {
@@ -309,8 +309,8 @@ function Get-TargetResource
             $BlockedSendersValues = @()
         }
 
-        [System.String[]]$AllowedSenderDomains = $HostedContentFilterPolicy.AllowedSenderDomains.Domain
-        [System.String[]]$BlockedSenderDomains = $HostedContentFilterPolicy.BlockedSenderDomains.Domain
+        [System.String[]]$AllowedSenderDomains = $HostedContentFilterPolicy.AllowedSenderDomains
+        [System.String[]]$BlockedSenderDomains = $HostedContentFilterPolicy.BlockedSenderDomains
         # Check if the values are null and assign them an empty string array if they are
         if ($null -eq $AllowedSenderDomains)
         {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOHostedContentFilterPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOHostedContentFilterPolicy.Tests.ps1
@@ -268,26 +268,10 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         EnableRegionBlockList                = $true
                         EnableLanguageBlockList              = $true
                         BulkThreshold                        = 5
-                        AllowedSenders                       = @{
-                            Sender = @(
-                                [PSCustomObject]@{Address = 'test@contoso.com' },
-                                [PSCustomObject]@{Address = 'test@fabrikam.com' }
-                            )
-                        }
-                        AllowedSenderDomains                 = @(
-                            [PSCustomObject]@{Domain = 'contoso.com' },
-                            [PSCustomObject]@{Domain = 'fabrikam.com' }
-                        )
-                        BlockedSenders                       = @{
-                            Sender = @(
-                                [PSCustomObject]@{Address = 'me@privacy.net' },
-                                [PSCustomObject]@{Address = 'thedude@contoso.com' }
-                            )
-                        }
-                        BlockedSenderDomains                 = @(
-                            [PSCustomObject]@{Domain = 'privacy.net' },
-                            [PSCustomObject]@{Domain = 'facebook.com' }
-                        )
+                        AllowedSenders                       = @('test@contoso.com','test@fabrikam.com')
+                        AllowedSenderDomains                 = @('contoso.com', 'fabrikam.com')
+                        BlockedSenders                       = @('me@privacy.net', 'thedude@contoso.com')
+                        BlockedSenderDomains                 = @('privacy.net', 'facebook.com')
                         PhishZapEnabled                      = $true
                         SpamZapEnabled                       = $true
                         InlineSafetyTipsEnabled              = $true


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes the comparison of AADEntitlementManagementAccessPackageAssignmentPolicy in New-M365DSCDeltaReport by removing the redundant description parameter in the formattedRequestorSettings as its already done for EscalationApprovers and PrimaryApprovers 
It also fixes that EXOHostedContentFilterPolicy no longer includes AllowedSenderDomains, AllowedSenders, BlockedSenderDomains, BlockedSenders by removing ".Sender | Select-Object Address -ExpandProperty Address" / ".Domain" since the results are already an Arraylist of type String.


#### This Pull Request (PR) fixes the following issues
Fixes #7210
Fixes #7212

#### Task list


- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
