### PR TITLE
AADAdministrativeUnit: Fixed validation of scoped role members' uniqueness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # UNRELEASED
 
+* AADAdministrativeUnit
+  * Fixed validation of scoped role members' uniqueness
 * AADGroup
   * Various timing-related fixes for new group
 * AADEntitlementManagementAccessPackageAssignmentPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
@@ -511,7 +511,7 @@ function Set-TargetResource
                 }
                 if ($roleMember.RoleMemberInfo.Type -eq 'User')
                 {
-                    $roleMemberIdentity = Get-MgUser -Filter "UserPrincipalName eq '$($roleMember.RoleMemberInfo.Identity -replace "'", "''")'" -ErrorAction Stop
+                    [System.Array]$roleMemberIdentity = Get-MgUser -Filter "UserPrincipalName eq '$($roleMember.RoleMemberInfo.Identity -replace "'", "''")'" -ErrorAction Stop
                     if ($null -eq $roleMemberIdentity)
                     {
                         throw "AU {$($DisplayName)}:  Scoped Role User {$($roleMember.RoleMemberInfo.Identity)} for role {$($roleMember.RoleName)} does not exist"
@@ -519,7 +519,7 @@ function Set-TargetResource
                 }
                 elseif ($roleMember.RoleMemberInfo.Type -eq 'Group')
                 {
-                    $roleMemberIdentity = Get-MgGroup -Filter "displayName eq '$($roleMember.RoleMemberInfo.Identity -replace "'", "''")'" -ErrorAction Stop
+                    [System.Array]$roleMemberIdentity = Get-MgGroup -Filter "displayName eq '$($roleMember.RoleMemberInfo.Identity -replace "'", "''")'" -ErrorAction Stop
                     if ($null -eq $roleMemberIdentity)
                     {
                         throw "AU {$($DisplayName)}: Scoped Role Group {$($roleMember.RoleMemberInfo.Identity)} for role {$($roleMember.RoleName)} does not exist"
@@ -531,7 +531,7 @@ function Set-TargetResource
                 }
                 elseif ($roleMember.RoleMemberInfo.Type -eq 'ServicePrincipal')
                 {
-                    $roleMemberIdentity = Get-MgServicePrincipal -Filter "displayName eq '$($roleMember.RoleMemberInfo.Identity -replace "'", "''")'" -ErrorAction Stop
+                    [System.Array]$roleMemberIdentity = Get-MgServicePrincipal -Filter "displayName eq '$($roleMember.RoleMemberInfo.Identity -replace "'", "''")'" -ErrorAction Stop
                     if ($null -eq $roleMemberIdentity)
                     {
                         throw "AU {$($DisplayName)}: Scoped Role ServicePrincipal {$($roleMember.RoleMemberInfo.Identity)} for role {$($roleMember.RoleName)} does not exist"
@@ -541,14 +541,14 @@ function Set-TargetResource
                 {
                     throw "AU {$($DisplayName)}: Invalid ScopedRoleMember.RoleMemberInfo.Type {$($roleMember.RoleMemberInfo.Type)}"
                 }
-                if ($roleMemberIdentity.GetType().BaseType -eq 'System.Array' -and $roleMemberIdentity.Count -gt 1)
+                if ($roleMemberIdentity.Count -gt 1)
                 {
                     throw "AU {$($DisplayName)}: ScopedRoleMember for role {$($roleMember.RoleName)}: $($roleMember.RoleMemberInfo.Type) {$($roleMember.RoleMemberInfo.Identity)} is not unique"
                 }
                 $scopedRoleMemberSpecification += [ordered]@{
                     RoleId         = $roleObject.Id
                     RoleMemberInfo = @{
-                        Id = $roleMemberIdentity.Id
+                        Id = $roleMemberIdentity[0].Id
                     }
                 }
             }

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADAdministrativeUnit/MSFT_AADAdministrativeUnit.psm1
@@ -541,7 +541,7 @@ function Set-TargetResource
                 {
                     throw "AU {$($DisplayName)}: Invalid ScopedRoleMember.RoleMemberInfo.Type {$($roleMember.RoleMemberInfo.Type)}"
                 }
-                if ($roleMemberIdentity.Count -gt 1)
+                if ($roleMemberIdentity.GetType().BaseType -eq 'System.Array' -and $roleMemberIdentity.Count -gt 1)
                 {
                     throw "AU {$($DisplayName)}: ScopedRoleMember for role {$($roleMember.RoleName)}: $($roleMember.RoleMemberInfo.Type) {$($roleMember.RoleMemberInfo.Identity)} is not unique"
                 }


### PR DESCRIPTION
#### Pull Request (PR) description
The resource attempts to invalidate non-unique scoped-role members but fails to discern between arrays and hashtables

#### This Pull Request (PR) fixes the following issues
After introduction of 'the Graph shim' it appears that certain calls return hashtables instead of objects.
When checking for number of instances returned, the variable-type must be taken into account in order to discern arrays from hashtables (a single hash-table with two keys will have Count=2)

#### Task list

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
