### PR TITLE
AADGroupsSettings: Fix error introduced by recent update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Fixed validation of scoped role members' uniqueness
 * AADGroup
   * Various timing-related fixes for new group
+* AADGroupsSettings
+  * Fixed issue with handling of existing DirectorySetting-object during update
 * AADEntitlementManagementAccessPackageAssignmentPolicy
   * Fixed comparison in New-M365DSCDeltaReport
 * AADServicePrincipal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   * Various timing-related fixes for new group
 * AADEntitlementManagementAccessPackageAssignmentPolicy
   * Fixed comparison in New-M365DSCDeltaReport
+* AADGroupsSettings
+  * Fixed error introduced by prevous correction when creating GroupsSettings in a new tenant
 * AADTenantAppManagementPolicy
   * Fixed an issue when updating the resource.
   FIXES [#7201](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7201)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
   * Various timing-related fixes for new group
 * AADEntitlementManagementAccessPackageAssignmentPolicy
   * Fixed comparison in New-M365DSCDeltaReport
-* AADGroupsSettings
-  * Fixed error introduced by prevous correction when creating GroupsSettings in a new tenant
 * AADTenantAppManagementPolicy
   * Fixed an issue when updating the resource.
   FIXES [#7201](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7201)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@
   * Fixed comparison in New-M365DSCDeltaReport
 * AADGroupsSettings
   * Fixed error introduced by prevous correction when creating GroupsSettings in a new tenant
+* AADServicePrincipal
+  * Fixed and issue where Custom SecurityAttributes were not handled properly.
+  * FIXES [#7192](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7192)
 * AADTenantAppManagementPolicy
   * Fixed an issue when updating the resource.
-  FIXES [#7201](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7201)
+  * FIXES [#7201](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7201)
 * AADUser
   * Fixes for timing-related new user
 * EXOHostedContentFilterPolicy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,9 @@
   * Fixed comparison in New-M365DSCDeltaReport
 * AADGroupsSettings
   * Fixed error introduced by prevous correction when creating GroupsSettings in a new tenant
-* AADServicePrincipal
-  * Fixed and issue where Custom SecurityAttributes were not handled properly.
-  * FIXES [#7192](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7192)
 * AADTenantAppManagementPolicy
   * Fixed an issue when updating the resource.
-  * FIXES [#7201](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7201)
+  FIXES [#7201](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7201)
 * AADUser
   * Fixes for timing-related new user
 * EXOHostedContentFilterPolicy

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsSettings/MSFT_AADGroupsSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsSettings/MSFT_AADGroupsSettings.psm1
@@ -293,11 +293,10 @@ function Set-TargetResource
         $Policy = New-MgBetaDirectorySetting -TemplateId '62375ab9-6b52-47ed-826b-58e47e0e304b' | Out-Null
         $needToUpdate = $true
     }
-    elseif ($currentPolicy.Ensure -eq 'Present')
-    {
-        $Policy = Get-MgBetaDirectorySetting -All | Where-Object -FilterScript { $_.DisplayName -eq 'Group.Unified' }
-    }
 
+    $Policy = Invoke-M365DSCCommand -ScriptBlock {
+        Get-MgBetaDirectorySetting -DirectorySettingId $Policy.id
+    } -RetryOnNotFoundError
     if (($Ensure -eq 'Present' -and $currentPolicy.Ensure -eq 'Present') -or $needToUpdate)
     {
         $groupObject = $null
@@ -367,10 +366,7 @@ function Set-TargetResource
             values = $newValues
         }
         Write-Verbose -Message "Updating Policy's Values with $($body | ConvertTo-Json -Depth 10)"
-        Invoke-M365DSCCommand -ScriptBlock  {
-            Update-MgBetaDirectorySetting -DirectorySettingId $Policy.id -BodyParameter $body
-        } -RetryOnNotFoundError
-
+        Update-MgBetaDirectorySetting -DirectorySettingId $Policy.id -BodyParameter $body
     }
     elseif ($Ensure -eq 'Absent' -and $currentPolicy.Ensure -eq 'Present')
     {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsSettings/MSFT_AADGroupsSettings.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_AADGroupsSettings/MSFT_AADGroupsSettings.psm1
@@ -293,10 +293,11 @@ function Set-TargetResource
         $Policy = New-MgBetaDirectorySetting -TemplateId '62375ab9-6b52-47ed-826b-58e47e0e304b' | Out-Null
         $needToUpdate = $true
     }
+    elseif ($currentPolicy.Ensure -eq 'Present')
+    {
+        $Policy = Get-MgBetaDirectorySetting -All | Where-Object -FilterScript { $_.DisplayName -eq 'Group.Unified' }
+    }
 
-    $Policy = Invoke-M365DSCCommand -ScriptBlock {
-        Get-MgBetaDirectorySetting -DirectorySettingId $Policy.id
-    } -RetryOnNotFoundError
     if (($Ensure -eq 'Present' -and $currentPolicy.Ensure -eq 'Present') -or $needToUpdate)
     {
         $groupObject = $null
@@ -366,7 +367,10 @@ function Set-TargetResource
             values = $newValues
         }
         Write-Verbose -Message "Updating Policy's Values with $($body | ConvertTo-Json -Depth 10)"
-        Update-MgBetaDirectorySetting -DirectorySettingId $Policy.id -BodyParameter $body
+        Invoke-M365DSCCommand -ScriptBlock  {
+            Update-MgBetaDirectorySetting -DirectorySettingId $Policy.id -BodyParameter $body
+        } -RetryOnNotFoundError
+
     }
     elseif ($Ensure -eq 'Absent' -and $currentPolicy.Ensure -eq 'Present')
     {


### PR DESCRIPTION
#### Pull Request (PR) description
AADGroupsSettings updated - when the DirectorySettings object doesn't exist in a new tenant, the resource throws an exception because the policy-id is blank. This is now fixed by using the policy-id of a newly created directorysetting object *or* use the policy-id of an existing directorysetting object.
There's a conflict caused by updates to the changelog which I've attempted to include in this PR

#### This Pull Request (PR) fixes the following issues
None

#### Task list

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
