### PR TITLE
IntuneDeviceConfigurationPlatformScript{MacOS,Windows}: Id parameter should not be mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 * IntuneDeviceConfigurationPlatformScriptMacOS
   * Removed `Id` as being a mandatory parameter
+    FIXES [#7243](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7243)
 * IntuneDeviceConfigurationPlatformScriptWindows
   * Removed `Id` as being a mandatory parameter
+    FIXES [#7243](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7243)
 
 # 1.26.617.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneDeviceConfigurationPlatformScriptMacOS
+  * Removed `Id` as being a mandatory parameter
+* IntuneDeviceConfigurationPlatformScriptWindows
+  * Removed `Id` as being a mandatory parameter
+
 # 1.26.617.1
 
 * AADAdministrativeUnit

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.psm1
@@ -119,10 +119,13 @@ function Get-TargetResource
 
         $getValue = $null
         #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementDeviceShellScript `
-            -DeviceShellScriptId $Id `
-            -ExpandProperty 'assignments' `
-            -ErrorAction SilentlyContinue
+        if (-not [System.String]::IsNullOrEmpty($Id))
+        {
+            $getValue = Get-MgBetaDeviceManagementDeviceShellScript `
+                -DeviceShellScriptId $Id `
+                -ExpandProperty 'assignments' `
+                -ErrorAction SilentlyContinue
+        }
 
         if ($null -eq $getValue)
         {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.psm1
@@ -251,7 +251,7 @@ function Set-TargetResource
         [System.String]
         $ScriptContent,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $Id,
 
@@ -420,7 +420,7 @@ function Test-TargetResource
         [System.String]
         $ScriptContent,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $Id,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.psm1
@@ -44,7 +44,7 @@ function Get-TargetResource
         [System.String]
         $ScriptContent,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $Id,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.schema.mof
@@ -15,14 +15,14 @@ class MSFT_IntuneDeviceConfigurationPlatformScriptMacOS : OMI_BaseResource
 {
     [Write, Description("Does not notify the user a script is being executed")] Boolean BlockExecutionNotifications;
     [Write, Description("Optional description for the device management script.")] String Description;
-    [Required, Description("Name of the device management script.")] String DisplayName;
+    [Key, Description("Name of the device management script.")] String DisplayName;
     [Write, Description("The script file name.")] String FileName;
     [Write, Description("The interval for script to run. If not defined the script will run once")] String ExecutionFrequency;
     [Write, Description("Number of times for the script to be retried if it fails")] UInt32 RetryCount;
     [Write, Description("List of Scope Tag IDs for this PowerShellScript instance.")] String RoleScopeTagIds[];
     [Write, Description("Indicates the type of execution context. Possible values are: system, user."), ValueMap{"system","user"}, Values{"system","user"}] String RunAsAccount;
     [Write, Description("The script content in Base64.")] String ScriptContent;
-    [Key, Description("The unique identifier for an entity. Read-only.")] String Id;
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
     [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
@@ -238,7 +238,7 @@ function Set-TargetResource
         [System.String]
         $ScriptContent,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $Id,
 
@@ -399,7 +399,7 @@ function Test-TargetResource
         [System.String]
         $ScriptContent,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $Id,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
@@ -115,7 +115,10 @@ function Get-TargetResource
 
         $getValue = $null
         #region resource generator code
-        $getValue = Get-MgBetaDeviceManagementScript -DeviceManagementScriptId $Id -ErrorAction SilentlyContinue
+        if (-not [System.String]::IsNullOrEmpty($Id))
+        {
+            $getValue = Get-MgBetaDeviceManagementScript -DeviceManagementScriptId $Id -ErrorAction SilentlyContinue
+        }
 
         if ($null -eq $getValue)
         {

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
@@ -40,7 +40,7 @@ function Get-TargetResource
         [System.String]
         $ScriptContent,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [System.String]
         $Id,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.schema.mof
@@ -14,14 +14,14 @@ class MSFT_DeviceManagementConfigurationPolicyAssignments
 class MSFT_IntuneDeviceConfigurationPlatformScriptWindows : OMI_BaseResource
 {
     [Write, Description("Optional description for the device management script.")] String Description;
-    [Required, Description("Name of the device management script.")] String DisplayName;
+    [Key, Description("Name of the device management script.")] String DisplayName;
     [Write, Description("Indicate whether the script signature needs be checked.")] Boolean EnforceSignatureCheck;
     [Write, Description("The script file name.")] String FileName;
     [Write, Description("List of Scope Tag IDs for this PowerShellScript instance.")] String RoleScopeTagIds[];
     [Write, Description("A value indicating whether the PowerShell script should run as 32-bit")] Boolean RunAs32Bit;
     [Write, Description("Indicates the type of execution context. Possible values are: system, user."), ValueMap{"system","user"}, Values{"system","user"}] String RunAsAccount;
     [Write, Description("The script content in Base64.")] String ScriptContent;
-    [Key, Description("The unique identifier for an entity. Read-only.")] String Id;
+    [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
     [Write, Description("Represents the assignment to the Intune policy."), EmbeddedInstance("MSFT_DeviceManagementConfigurationPolicyAssignments")] String Assignments[];
     [Write, Description("Present ensures the policy exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
     [Write, Description("Credentials of the Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes an issue where both `IntuneDeviceConfigurationPlatformScriptMacOS` and `IntuneDeviceConfigurationPlatformScriptWindows` have the `Id` parameter marked as mandatory, instead only `DisplayName` should be mandatory in this case.

#### This Pull Request (PR) fixes the following issues
- Fixes #7243 

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
