### PR TITLE
Fix Intune Role Assignment apply and EXO Org Config Processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* IntuneRoleAssignment
+  * Fixed an issue where creating or updating a resource failed if the property
+    `ResourceScopes` was omitted.
+    FIXES [#7247](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7247)
+
 # 1.26.617.1
 
 * AADAdministrativeUnit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # UNRELEASED
 
+* EXOOrganizationConfig
+  * Fixed an issue where processing would fail if any of the properties
+    `DelayedDelicensingEnabledState`, `EndUserMailNotificationForDelayedDelicensingState`
+    or `TenantAdminNotificationForDelayedDelicensingState` were null.
+    FIXES [#7248](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7248)
 * IntuneRoleAssignment
   * Fixed an issue where creating or updating a resource failed if the property
     `ResourceScopes` was omitted.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationConfig/MSFT_EXOOrganizationConfig.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_EXOOrganizationConfig/MSFT_EXOOrganizationConfig.psm1
@@ -530,39 +530,48 @@ function Get-TargetResource
         }
 
         # DelayedDelicensingEnabledState
-        $DelayedDelicensingEnabledStateParsed = $configSettings.DelayedDelicensingEnabledState.ToString().Split(';')[0].Replace('Enabled: ', '')
-        $DelayedDelicensingEnabledStateValue = $false
-        if ($DelayedDelicensingEnabledStateParsed -eq 'True')
+        if ($null -ne $configSettings.DelayedDelicensingEnabledState)
         {
-            $DelayedDelicensingEnabledStateValue = $true
-        }
-        else
-        {
+            $DelayedDelicensingEnabledStateParsed = $configSettings.DelayedDelicensingEnabledState.ToString().Split(';')[0].Replace('Enabled: ', '')
             $DelayedDelicensingEnabledStateValue = $false
+            if ($DelayedDelicensingEnabledStateParsed -eq 'True')
+            {
+                $DelayedDelicensingEnabledStateValue = $true
+            }
+            else
+            {
+                $DelayedDelicensingEnabledStateValue = $false
+            }
         }
 
         # EndUserMailNotificationForDelayedDelicensingEnabled
-        $EndUserMailNotificationForDelayedDelicensingEnabledParsed = $configSettings.EndUserMailNotificationForDelayedDelicensingState.ToString().Split(';')[0].Replace('Enabled: ', '')
-        $EndUserMailNotificationForDelayedDelicensingEnabledValue = $false
-        if ($EndUserMailNotificationForDelayedDelicensingEnabledParsed -eq 'True')
+        if ($null -ne $configSettings.EndUserMailNotificationForDelayedDelicensingState)
         {
-            $EndUserMailNotificationForDelayedDelicensingEnabledValue = $true
-        }
-        else
-        {
+            $EndUserMailNotificationForDelayedDelicensingEnabledParsed = $configSettings.EndUserMailNotificationForDelayedDelicensingState.ToString().Split(';')[0].Replace('Enabled: ', '')
             $EndUserMailNotificationForDelayedDelicensingEnabledValue = $false
+            if ($EndUserMailNotificationForDelayedDelicensingEnabledParsed -eq 'True')
+            {
+                $EndUserMailNotificationForDelayedDelicensingEnabledValue = $true
+            }
+            else
+            {
+                $EndUserMailNotificationForDelayedDelicensingEnabledValue = $false
+            }
         }
 
         # TenantAdminNotificationForDelayedDelicensingEnabled
-        $TenantAdminNotificationForDelayedDelicensingEnabledParsed = $configSettings.TenantAdminNotificationForDelayedDelicensingState.ToString().Split(';')[0].Replace('Enabled: ', '')
-        $TenantAdminNotificationForDelayedDelicensingEnabledValue = $false
-        if ($TenantAdminNotificationForDelayedDelicensingEnabledParsed -eq 'True')
+        if ($null -ne $configSettings.TenantAdminNotificationForDelayedDelicensingState)
         {
-            $TenantAdminNotificationForDelayedDelicensingEnabledValue = $true
-        }
-        else
-        {
+            $TenantAdminNotificationForDelayedDelicensingEnabledParsed = $configSettings.TenantAdminNotificationForDelayedDelicensingState.ToString().Split(';')[0].Replace('Enabled: ', '')
             $TenantAdminNotificationForDelayedDelicensingEnabledValue = $false
+            if ($TenantAdminNotificationForDelayedDelicensingEnabledParsed -eq 'True')
+            {
+                $TenantAdminNotificationForDelayedDelicensingEnabledValue = $true
+            }
+            else
+            {
+                $TenantAdminNotificationForDelayedDelicensingEnabledValue = $false
+            }
         }
 
         $results = @{

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS/MSFT_IntuneDeviceConfigurationPlatformScriptMacOS.psm1
@@ -317,25 +317,25 @@ function Set-TargetResource
     #endregion
 
     $currentInstance = Get-TargetResource @PSBoundParameters
-    $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
-    if ($BoundParameters.ContainsKey('ExecutionFrequency'))
+    $boundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+    $boundParameters = Rename-M365DSCCimInstanceParameter -Properties $boundParameters
+    if ($boundParameters.ContainsKey('ExecutionFrequency'))
     {
-        $BoundParameters['ExecutionFrequency'] = [System.Xml.XmlConvert]::ToString([System.TimeSpan]::Parse($BoundParameters['ExecutionFrequency']))
+        $boundParameters['executionFrequency'] = [System.Xml.XmlConvert]::ToString([System.TimeSpan]::Parse($boundParameters['ExecutionFrequency']))
     }
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {
         Write-Verbose -Message "Creating an Intune Device Configuration Platform Script MacOS with DisplayName {$DisplayName}"
-        $BoundParameters.Remove('Assignments') | Out-Null
+        $boundParameters.Remove('Assignments') | Out-Null
 
-        $CreateParameters = ([Hashtable]$BoundParameters).Clone()
-        $CreateParameters = Rename-M365DSCCimInstanceParameter -Properties $CreateParameters
-        $CreateParameters.ScriptContent = [System.Convert]::FromBase64String($ScriptContent)
-        $CreateParameters.Remove('Id') | Out-Null
+        $createParameters = ([Hashtable]$boundParameters).Clone()
+        $createParameters.scriptContent = [System.Convert]::FromBase64String($createParameters.scriptContent)
+        $createParameters.Remove('Id') | Out-Null
 
         #region resource generator code
-        $CreateParameters.Add('@odata.type', '#microsoft.graph.DeviceShellScript')
-        $policy = New-MgBetaDeviceManagementDeviceShellScript -BodyParameter $CreateParameters
+        $createParameters.Add('@odata.type', '#microsoft.graph.DeviceShellScript')
+        $policy = New-MgBetaDeviceManagementDeviceShellScript -BodyParameter $createParameters
         $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
 
         if ($policy.Id)
@@ -350,18 +350,17 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
     {
         Write-Verbose -Message "Updating the Intune Device Configuration Platform Script MacOS with Id {$($currentInstance.Id)}"
-        $BoundParameters.Remove('Assignments') | Out-Null
+        $boundParameters.Remove('Assignments') | Out-Null
 
-        $UpdateParameters = ([Hashtable]$BoundParameters).Clone()
-        $UpdateParameters = Rename-M365DSCCimInstanceParameter -Properties $UpdateParameters
-        $UpdateParameters.ScriptContent = [System.Convert]::FromBase64String($ScriptContent)
-        $UpdateParameters.Remove('Id') | Out-Null
+        $updateParameters = ([Hashtable]$boundParameters).Clone()
+        $updateParameters.scriptContent = [System.Convert]::FromBase64String($updateParameters.scriptContent)
+        $updateParameters.Remove('Id') | Out-Null
 
         #region resource generator code
-        $UpdateParameters.Add('@odata.type', '#microsoft.graph.DeviceShellScript')
+        $updateParameters.Add('@odata.type', '#microsoft.graph.DeviceShellScript')
         Update-MgBetaDeviceManagementDeviceShellScript `
             -DeviceShellScriptId $currentInstance.Id `
-            -BodyParameter $UpdateParameters
+            -BodyParameter $updateParameters
         $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
         Update-DeviceConfigurationPolicyAssignment `
             -DeviceConfigurationPolicyId $currentInstance.id `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneDeviceConfigurationPlatformScriptWindows/MSFT_IntuneDeviceConfigurationPlatformScriptWindows.psm1
@@ -304,21 +304,21 @@ function Set-TargetResource
     #endregion
 
     $currentInstance = Get-TargetResource @PSBoundParameters
-    $BoundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+    $boundParameters = Remove-M365DSCAuthenticationParameter -BoundParameters $PSBoundParameters
+    $boundParameters = Rename-M365DSCCimInstanceParameter -Properties $boundParameters
 
     if ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Absent')
     {
         Write-Verbose -Message "Creating an Intune Device Configuration Platform Script Windows with DisplayName {$DisplayName}"
-        $BoundParameters.Remove('Assignments') | Out-Null
+        $boundParameters.Remove('Assignments') | Out-Null
 
-        $CreateParameters = ([Hashtable]$BoundParameters).Clone()
-        $CreateParameters = Rename-M365DSCCimInstanceParameter -Properties $CreateParameters
-        $CreateParameters.ScriptContent = [System.Convert]::FromBase64String($CreateParameters.ScriptContent)
-        $CreateParameters.Remove('Id') | Out-Null
+        $createParameters = ([Hashtable]$boundParameters).Clone()
+        $createParameters.scriptContent = [System.Convert]::FromBase64String($createParameters.scriptContent)
+        $createParameters.Remove('Id') | Out-Null
 
         #region resource generator code
-        $CreateParameters.Add('@odata.type', '#microsoft.graph.DeviceManagementScript')
-        $policy = New-MgBetaDeviceManagementScript -BodyParameter $CreateParameters
+        $createParameters.Add('@odata.type', '#microsoft.graph.DeviceManagementScript')
+        $policy = New-MgBetaDeviceManagementScript -BodyParameter $createParameters
         $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
 
         if ($policy.Id)
@@ -333,18 +333,17 @@ function Set-TargetResource
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
     {
         Write-Verbose -Message "Updating the Intune Device Configuration Platform Script Windows with Id {$($currentInstance.Id)}"
-        $BoundParameters.Remove('Assignments') | Out-Null
+        $boundParameters.Remove('Assignments') | Out-Null
 
-        $UpdateParameters = ([Hashtable]$BoundParameters).Clone()
-        $UpdateParameters = Rename-M365DSCCimInstanceParameter -Properties $UpdateParameters
-        $UpdateParameters.ScriptContent = [System.Convert]::FromBase64String($UpdateParameters.ScriptContent)
-        $UpdateParameters.Remove('Id') | Out-Null
+        $updateParameters = ([Hashtable]$boundParameters).Clone()
+        $updateParameters.scriptContent = [System.Convert]::FromBase64String($updateParameters.scriptContent)
+        $updateParameters.Remove('Id') | Out-Null
 
         #region resource generator code
-        $UpdateParameters.Add('@odata.type', '#microsoft.graph.DeviceManagementScript')
+        $updateParameters.Add('@odata.type', '#microsoft.graph.DeviceManagementScript')
         Update-MgBetaDeviceManagementScript `
             -DeviceManagementScriptId $currentInstance.Id `
-            -BodyParameter $UpdateParameters
+            -BodyParameter $updateParameters
         $assignmentsHash = ConvertTo-IntunePolicyAssignment -IncludeDeviceFilter:$true -Assignments $Assignments
         Update-DeviceConfigurationPolicyAssignment `
             -DeviceConfigurationPolicyId $currentInstance.id `

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleAssignment/MSFT_IntuneRoleAssignment.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneRoleAssignment/MSFT_IntuneRoleAssignment.psm1
@@ -403,34 +403,42 @@ function Set-TargetResource
     {
         Write-Verbose -Message "Creating an Intune Role Assignment with DisplayName {$DisplayName}"
 
-        $CreateParameters = @{
+        $createParameters = @{
             description                 = $Description
             displayName                 = $DisplayName
-            resourceScopes              = $resourceScopesValue
             scopeType                   = $scopeTypeValue
             members                     = $membersValue
             '@odata.type'               = '#microsoft.graph.deviceAndAppManagementRoleAssignment'
             'roleDefinition@odata.bind' = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/roleDefinitions('$RoleDefinition')"
         }
 
-        $null = New-MgBetaDeviceManagementRoleAssignment -BodyParameter $CreateParameters
+        if ($null -ne $resourceScopesValue)
+        {
+            $createParameters['resourceScopes'] = $resourceScopesValue
+        }
+
+        $null = New-MgBetaDeviceManagementRoleAssignment -BodyParameter $createParameters
     }
     elseif ($Ensure -eq 'Present' -and $currentInstance.Ensure -eq 'Present')
     {
         Write-Verbose -Message "Updating the Intune Role Assignment with Id {$($currentInstance.Id)} and DisplayName {$DisplayName}"
 
-        $UpdateParameters = @{
+        $updateParameters = @{
             description                 = $Description
             displayName                 = $DisplayName
-            resourceScopes              = $resourceScopesValue
             scopeType                   = $scopeTypeValue
             members                     = $membersValue
             '@odata.type'               = '#microsoft.graph.deviceAndAppManagementRoleAssignment'
             'roleDefinition@odata.bind' = "$((Get-MSCloudLoginConnectionProfile -Workload MicrosoftGraph).ResourceUrl)beta/deviceManagement/roleDefinitions('$RoleDefinition')"
         }
 
+        if ($null -ne $resourceScopesValue)
+        {
+            $updateParameters['resourceScopes'] = $resourceScopesValue
+        }
+
         $null = Update-MgBetaDeviceManagementRoleAssignment `
-            -BodyParameter $UpdateParameters `
+            -BodyParameter $updateParameters `
             -DeviceAndAppManagementRoleAssignmentId $currentInstance.Id
     }
     elseif ($Ensure -eq 'Absent' -and $currentInstance.Ensure -eq 'Present')


### PR DESCRIPTION
#### Pull Request (PR) description
This issue fixes an issue when applying `IntuneRoleAssignment` and when some properties of `EXOOrganizationConfig` have a null value when returned from the cmdlet.

#### This Pull Request (PR) fixes the following issues
- Fixes #7247 
- Fixes #7248 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
