### PR TITLE
IntuneEpmElevationSettingsPolicyWindows10: Fix validate set for property DefaultBehaviorValidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
     `DelayedDelicensingEnabledState`, `EndUserMailNotificationForDelayedDelicensingState`
     or `TenantAdminNotificationForDelayedDelicensingState` were null.
     FIXES [#7248](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7248)
+* IntuneEpmElevationSettingsPolicyWindows10
+  * Fixed an issue where property `DefaultBehaviorValidation` didn't have the
+    correct validate set which could result in failing the compilation to MOF
+    FIXES [#7256](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7256)
 * IntuneRoleAssignment
   * Fixed an issue where creating or updating a resource failed if the property
     `ResourceScopes` was omitted.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEpmElevationSettingsPolicyWindows10/MSFT_IntuneEpmElevationSettingsPolicyWindows10.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEpmElevationSettingsPolicyWindows10/MSFT_IntuneEpmElevationSettingsPolicyWindows10.psm1
@@ -34,7 +34,7 @@ function Get-TargetResource
         $DefaultElevationResponse,
 
         [Parameter()]
-        [ValidateSet(0, 1)]
+        [ValidateSet(1, 2)]
         [System.Int32[]]
         $DefaultBehaviorValidation,
 
@@ -242,7 +242,7 @@ function Set-TargetResource
         $DefaultElevationResponse,
 
         [Parameter()]
-        [ValidateSet(0, 1)]
+        [ValidateSet(1, 2)]
         [System.Int32[]]
         $DefaultBehaviorValidation,
 
@@ -431,7 +431,7 @@ function Test-TargetResource
         $DefaultElevationResponse,
 
         [Parameter()]
-        [ValidateSet(0, 1)]
+        [ValidateSet(1, 2)]
         [System.Int32[]]
         $DefaultBehaviorValidation,
 

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEpmElevationSettingsPolicyWindows10/MSFT_IntuneEpmElevationSettingsPolicyWindows10.schema.mof
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneEpmElevationSettingsPolicyWindows10/MSFT_IntuneEpmElevationSettingsPolicyWindows10.schema.mof
@@ -19,7 +19,7 @@ class MSFT_IntuneEpmElevationSettingsPolicyWindows10 : OMI_BaseResource
     [Write, Description("The unique identifier for an entity. Read-only.")] String Id;
     [Write, Description("Endpoint Privilege Management (1: Enabled, 0: Disabled)"), ValueMap{"1", "0"}, Values{"1", "0"}] SInt32 EndpointPrivilegeManagement;
     [Write, Description("Default elevation response - Depends on EndpointPrivilegeManagement (0: DenyAllRequests, 1: RequireUserConfirmation, 2: RequireSupportApproval)"), ValueMap{"0", "1", "2"}, Values{"0", "1", "2"}] SInt32 DefaultElevationResponse;
-    [Write, Description("Validation (0: Business Justification, 1: Windows Authentication)"), ValueMap{"0", "1"}, Values{"0", "1"}] SInt32 DefaultBehaviorValidation[];
+    [Write, Description("Validation (1: Business Justification, 2: Windows Authentication)"), ValueMap{"1", "2"}, Values{"1", "2"}] SInt32 DefaultBehaviorValidation[];
     [Write, Description("(Preview) Automatically detect elevations - Depends on EndpointPrivilegeManagement (0: No, 1: Yes)"), ValueMap{"0", "1"}, Values{"0", "1"}] SInt32 AllowElevationDetection;
     [Write, Description("Send elevation data for reporting - Depends on EndpointPrivilegeManagement (1: Yes, 0: No)"), ValueMap{"1", "0"}, Values{"1", "0"}] SInt32 SendDataToMicrosoft;
     [Write, Description("Reporting scope (1: DiagnosticDataAndManagedElevationsOnly, 2: DiagnosticDataAndAllEndpointElevations, 0: DiagnosticDataOnly)"), ValueMap{"1", "2", "0"}, Values{"1", "2", "0"}] SInt32 ReportingScope;


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes an issue where the validate set for property `DefaultBehaviorValidation` is 0 and 1 instead of 1 and 2.

#### This Pull Request (PR) fixes the following issues
- Fixes #7256

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [X] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
