### PR TITLE
Fix Intune Assignment comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,14 @@
 * IntuneSettingCatalogCustomPolicyWindows10
   * Fixed an issue where simple settings with whitespaces were not exported correctly.
     FIXES [#7207](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7207)
+* IntuneWindowsAutopilotDeploymentProfileAzureADJoined
+  * Fixed an issue where updating assignments could include assignments through Policy Sets.
 * SPOSharingSettings
   * Improved host site look from O(n) to O(1) with fallback logic.
+* IntunePolicyAssignmentComparer
+  * Fixed an issue where comparing assignments would skip assignments
+    if the `groupId` property was omitted.
+    FIXES [#7254](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7254)
 * M365DSCExportUtil
   * **PREVIEW**: Added the parameter `-IncludeDependencies` to `Export-M365DSCConfiguration`
     to automatically export resources that are referenced by other resources.

--- a/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined.psm1
+++ b/Modules/Microsoft365DSC/DSCResources/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined/MSFT_IntuneWindowsAutopilotDeploymentProfileAzureADJoined.psm1
@@ -439,6 +439,7 @@ function Set-TargetResource
         #region new Intune assignment management
         $currentAssignments = @()
         $currentAssignments += Get-MgBetaDeviceManagementWindowsAutopilotDeploymentProfileAssignment -WindowsAutopilotDeploymentProfileId $currentInstance.id
+        $currentAssignments = $currentAssignments | Where-Object -FilterScript { $_.source -eq 'direct' }
 
         $intuneAssignments = @()
         if ($null -ne $Assignments -and $Assignments.Count -gt 0)

--- a/src/Microsoft365DSC.Compare/IntunePolicyAssignmentComparer.cs
+++ b/src/Microsoft365DSC.Compare/IntunePolicyAssignmentComparer.cs
@@ -82,7 +82,7 @@ namespace Microsoft365DSC.Compare
                     }
 
                     // If not found by groupId, try by groupDisplayName
-                    if (!testResult)
+                    if (!testResult || (testResult && assignmentTarget is null))
                     {
                         var assignmentGroupDisplayName = GetPropertyValue<string>(assignment, "groupDisplayName");
                         assignmentTarget = FindAssignmentTarget(target, "groupDisplayName", assignmentGroupDisplayName);
@@ -152,7 +152,7 @@ namespace Microsoft365DSC.Compare
                     {
                         drifts.Add(new Dictionary<string, object>
                         {
-                            { "PropertyName", $"Assignments[{i}].DataType" },
+                            { "PropertyName", $"Assignments[{i}].dataType" },
                             { "CurrentValue", dataType },
                             { "DesiredValue", null }
                         });


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where Intune assignments were not correctly compared if the `groupId` property was omitted.

#### This Pull Request (PR) fixes the following issues
- Fixes #7254 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
