### PR TITLE
Add Viva Workload to Web Interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 * SentinelAlertRule
   * Fixed an issue where creating a new rule fails due to $null type coercion
     FIXES [#7265](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7265)
+* MISC
+  * Added Viva selector to the web-based GUI.
 
 # 1.26.617.1
 

--- a/generator/src/data/workloads.json
+++ b/generator/src/data/workloads.json
@@ -134,5 +134,13 @@
     "extractionModes": {
       "full": []
     }
+  },
+  {
+    "id": "Viva",
+    "title": "Viva",
+    "iconName": "VivaLogo",
+    "extractionModes": {
+      "full": []
+    }
   }
 ]


### PR DESCRIPTION
#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
-->
Adds the `Viva` workload to the Web Interface menu (https://export.microsoft365dsc.com/). Viva was chosen instead of Viva Engage(ment) in line with the existing `Export` parameter: https://github.com/Microsoft365DSC/Microsoft365DSC/blob/099f798f5eebd8b2de4d93c7a239d31dac1637f5/Modules/Microsoft365DSC/Modules/M365DSCExportUtil.psm1#L151

Happy to rename this to Viva Engage and `VivaEngagement` but my current thought process is I'm considering different Viva solutions to be subsets of Viva in the same way Entitlement Management would be a subset of AzureAD.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->
None

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
