### PR TITLE
Fix telemetry connection to Graph for non-public clouds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
     FIXES [#7207](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7207)
 * IntuneWindowsAutopilotDeploymentProfileAzureADJoined
   * Fixed an issue where updating assignments could include assignments through Policy Sets.
+* M365DSCTelemetryEngine
+  * Fixed an issue where connection setup to Microsoft Graph would fail for
+    non-public clouds.
+    FIXES [#7255](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7255)
 * SPOSharingSettings
   * Improved host site look from O(n) to O(1) with fallback logic.
 * IntunePolicyAssignmentComparer

--- a/Modules/Microsoft365DSC/Modules/M365DSCConnection.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCConnection.psm1
@@ -126,7 +126,7 @@ function New-M365DSCConnection
     Write-Verbose -Message "$($InboundParameters | Out-String)"
 
     #region Telemetry
-    $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
+    $data = [System.Collections.Generic.Dictionary[[System.String], [System.Object]]]::new()
     $data.Add('Source', 'M365DSCUtil')
     $data.Add('Workload', $Workload)
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCTelemetryEngine.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCTelemetryEngine.psm1
@@ -105,13 +105,19 @@ function Add-M365DSCTelemetryEvent
         $Type,
 
         [Parameter()]
-        [System.Collections.Generic.Dictionary[[System.String], [System.String]]]
+        [System.Collections.Generic.Dictionary[[System.String], [System.Object]]]
         $Data,
 
         [Parameter()]
         [System.Collections.Generic.Dictionary[[System.String], [System.Double]]]
         $Metrics
     )
+
+    $dataNew = [System.Collections.Generic.Dictionary[[System.String], [System.String]]]::new()
+    foreach ($key in $Data.Keys)
+    {
+        $dataNew.Add($key, $Data[$key])
+    }
 
     if ($null -eq $Script:TelemetryEnabled -or $Script:TelemetryEnabled -eq $true)
     {
@@ -139,9 +145,9 @@ function Add-M365DSCTelemetryEvent
                 {
                     $Script:M365DSCExecutionContextId = $hostId
                 }
-                $Data.Add('ResourceInstancesCount', $Script:M365DSCCountResourceInstance)
-                $Data.Add('M365DSCExecutionContextId', $hostId)
-                $Data.Add('M365DSCOperationTotalTime', $Script:M365DSCOperationTimeTaken.TotalSeconds)
+                $dataNew.Add('ResourceInstancesCount', $Script:M365DSCCountResourceInstance)
+                $dataNew.Add('M365DSCExecutionContextId', $hostId)
+                $dataNew.Add('M365DSCOperationTotalTime', $Script:M365DSCOperationTimeTaken.TotalSeconds)
             }
             catch
             {
@@ -151,7 +157,13 @@ function Add-M365DSCTelemetryEvent
 
         try
         {
-            if ($null -ne $Data.ConnectionMode -and $Data.ConnectionMode.StartsWith('Credential'))
+            $telemetryParameters = Get-M365DSCTelemetryConnectionParameter
+            if ($null -eq $telemetryParameters -or $telemetryParameters.Count -eq 0)
+            {
+                New-M365DSCConnection -Workload 'MicrosoftGraph' -InboundParameters $Data.PSBoundParameters
+            }
+
+            if ($null -ne $dataNew.ConnectionMode -and $dataNew.ConnectionMode.StartsWith('Credential'))
             {
                 if ($null -eq $Script:M365DSCCurrentRoles -or $Script:M365DSCCurrentRoles.Length -eq 0)
                 {
@@ -175,15 +187,15 @@ function Add-M365DSCTelemetryEvent
                                 $Script:M365DSCCurrentRoles += $assignment.RoleDefinition.DisplayName + '|' + $assignment.DirectoryScopeId
                             }
                         }
-                        $Data.Add('M365DSCCurrentRoles', $Script:M365DSCCurrentRoles -join ',')
+                        $dataNew.Add('M365DSCCurrentRoles', $Script:M365DSCCurrentRoles -join ',')
                     }
                 }
                 else
                 {
-                    $Data.Add('M365DSCCurrentRoles', $Script:M365DSCCurrentRoles -join ',')
+                    $dataNew.Add('M365DSCCurrentRoles', $Script:M365DSCCurrentRoles -join ',')
                 }
             }
-            elseif ($null -ne $Data.ConnectionMode -and $Data.ConnectionMode.StartsWith('ServicePrincipal'))
+            elseif ($null -ne $dataNew.ConnectionMode -and $dataNew.ConnectionMode.StartsWith('ServicePrincipal'))
             {
                 if ($null -eq $Script:M365DSCCurrentRoles -or $Script:M365DSCCurrentRoles.Length -eq 0)
                 {
@@ -208,7 +220,7 @@ function Add-M365DSCTelemetryEvent
                                         $Script:M365DSCCurrentRoles += $assignment.RoleDefinition.DisplayName + '|' + $assignment.DirectoryScopeId
                                     }
                                 }
-                                $Data.Add('M365DSCCurrentRoles', $Script:M365DSCCurrentRoles -join ',')
+                                $dataNew.Add('M365DSCCurrentRoles', $Script:M365DSCCurrentRoles -join ',')
                             }
                         }
                     }
@@ -219,7 +231,7 @@ function Add-M365DSCTelemetryEvent
                 }
                 else
                 {
-                    $Data.Add('M365DSCCurrentRoles', $Script:M365DSCCurrentRoles -join ',')
+                    $dataNew.Add('M365DSCCurrentRoles', $Script:M365DSCCurrentRoles -join ',')
                 }
             }
         }
@@ -237,159 +249,159 @@ function Add-M365DSCTelemetryEvent
 
             if ($null -ne $ProjectName)
             {
-                $Data.Add('ProjectName', $ProjectName)
+                $dataNew.Add('ProjectName', $ProjectName)
             }
 
-            if (-not $Data.ContainsKey('Tenant'))
+            if (-not $dataNew.ContainsKey('Tenant'))
             {
-                if (-not [System.String]::IsNullOrEmpty($Data.Principal))
+                if (-not [System.String]::IsNullOrEmpty($dataNew.Principal))
                 {
-                    if ($Data.Principal -like '*@*.*')
+                    if ($dataNew.Principal -like '*@*.*')
                     {
-                        $principalValue = $Data.Principal.Split('@')[1]
-                        $Data.Add('Tenant', $principalValue)
+                        $principalValue = $dataNew.Principal.Split('@')[1]
+                        $dataNew.Add('Tenant', $principalValue)
                     }
                 }
-                elseif (-not [System.String]::IsNullOrEmpty($Data.TenantId))
+                elseif (-not [System.String]::IsNullOrEmpty($dataNew.TenantId))
                 {
-                    $principalValue = $Data.TenantId
-                    $Data.Add('Tenant', $principalValue)
+                    $principalValue = $dataNew.TenantId
+                    $dataNew.Add('Tenant', $principalValue)
                 }
             }
 
-            $Data.Remove('TenandId') | Out-Null
-            $Data.Remove('Principal') | Out-Null
+            $dataNew.Remove('TenandId') | Out-Null
+            $dataNew.Remove('Principal') | Out-Null
 
             # Capture PowerShell Version Info
-            if (-not $Data.Keys.Contains('PSMainVersion'))
+            if (-not $dataNew.Keys.Contains('PSMainVersion'))
             {
-                $Data.Add('PSMainVersion', $PSVersionTable.PSVersion.Major.ToString() + '.' + $PSVersionTable.PSVersion.Minor.ToString())
+                $dataNew.Add('PSMainVersion', $PSVersionTable.PSVersion.Major.ToString() + '.' + $PSVersionTable.PSVersion.Minor.ToString())
             }
-            if (-not $Data.Keys.Contains('PSVersion'))
+            if (-not $dataNew.Keys.Contains('PSVersion'))
             {
-                $Data.Add('PSVersion', $PSVersionTable.PSVersion.ToString())
+                $dataNew.Add('PSVersion', $PSVersionTable.PSVersion.ToString())
             }
-            if (-not $Data.Keys.Contains('PSEdition'))
+            if (-not $dataNew.Keys.Contains('PSEdition'))
             {
-                $Data.Add('PSEdition', $PSVersionTable.PSEdition.ToString())
-            }
-
-            if ($null -ne $PSVersionTable.BuildVersion -and -not $Data.Keys.Contains('PSBuildVersion'))
-            {
-                $Data.Add('PSBuildVersion', $PSVersionTable.BuildVersion.ToString())
+                $dataNew.Add('PSEdition', $PSVersionTable.PSEdition.ToString())
             }
 
-            if ($null -ne $PSVersionTable.CLRVersion -and -not $Data.Keys.Contains('PSCLRVersion'))
+            if ($null -ne $PSVersionTable.BuildVersion -and -not $dataNew.Keys.Contains('PSBuildVersion'))
             {
-                $Data.Add('PSCLRVersion', $PSVersionTable.CLRVersion.ToString())
+                $dataNew.Add('PSBuildVersion', $PSVersionTable.BuildVersion.ToString())
+            }
+
+            if ($null -ne $PSVersionTable.CLRVersion -and -not $dataNew.Keys.Contains('PSCLRVersion'))
+            {
+                $dataNew.Add('PSCLRVersion', $PSVersionTable.CLRVersion.ToString())
             }
 
             # Capture Console/Host Information
-            if ($host.Name -eq 'ConsoleHost' -and $null -eq $env:WT_SESSION -and -not $Data.Keys.Contains('PowerShellAgent'))
+            if ($host.Name -eq 'ConsoleHost' -and $null -eq $env:WT_SESSION -and -not $dataNew.Keys.Contains('PowerShellAgent'))
             {
-                $Data.Add('PowerShellAgent', 'Console')
+                $dataNew.Add('PowerShellAgent', 'Console')
             }
-            elseif ($host.Name -eq 'Windows PowerShell ISE Host' -and -not $Data.Keys.Contains('PowerShellAgent'))
+            elseif ($host.Name -eq 'Windows PowerShell ISE Host' -and -not $dataNew.Keys.Contains('PowerShellAgent'))
             {
-                $Data.Add('PowerShellAgent', 'ISE')
+                $dataNew.Add('PowerShellAgent', 'ISE')
             }
-            elseif ($host.Name -eq 'ConsoleHost' -and $null -ne $env:WT_SESSION -and -not $Data.Keys.Contains('PowerShellAgent'))
+            elseif ($host.Name -eq 'ConsoleHost' -and $null -ne $env:WT_SESSION -and -not $dataNew.Keys.Contains('PowerShellAgent'))
             {
-                $Data.Add('PowerShellAgent', 'Windows Terminal' -and -not $Data.Keys.Contains('PowerShellAgent'))
-            }
-            elseif ($host.Name -eq 'ConsoleHost' -and $null -eq $env:WT_SESSION -and `
-                    $null -ne $env:BUILD_BUILDID -and $env:SYSTEM -eq 'build' -and -not $Data.Keys.Contains('PowerShellAgent'))
-            {
-                $Data.Add('PowerShellAgent', 'Azure DevOPS')
-                $Data.Add('AzureDevOPSPipelineType', 'Build')
-                $Data.Add('AzureDevOPSAgent', $env:POWERSHELL_DISTRIBUTION_CHANNEL)
+                $dataNew.Add('PowerShellAgent', 'Windows Terminal' -and -not $dataNew.Keys.Contains('PowerShellAgent'))
             }
             elseif ($host.Name -eq 'ConsoleHost' -and $null -eq $env:WT_SESSION -and `
-                    $null -ne $env:BUILD_BUILDID -and $env:SYSTEM -eq 'release' -and -not $Data.Keys.Contains('PowerShellAgent'))
+                    $null -ne $env:BUILD_BUILDID -and $env:SYSTEM -eq 'build' -and -not $dataNew.Keys.Contains('PowerShellAgent'))
             {
-                $Data.Add('PowerShellAgent', 'Azure DevOPS')
-                $Data.Add('AzureDevOPSPipelineType', 'Release')
-                $Data.Add('AzureDevOPSAgent', $env:POWERSHELL_DISTRIBUTION_CHANNEL)
+                $dataNew.Add('PowerShellAgent', 'Azure DevOPS')
+                $dataNew.Add('AzureDevOPSPipelineType', 'Build')
+                $dataNew.Add('AzureDevOPSAgent', $env:POWERSHELL_DISTRIBUTION_CHANNEL)
+            }
+            elseif ($host.Name -eq 'ConsoleHost' -and $null -eq $env:WT_SESSION -and `
+                    $null -ne $env:BUILD_BUILDID -and $env:SYSTEM -eq 'release' -and -not $dataNew.Keys.Contains('PowerShellAgent'))
+            {
+                $dataNew.Add('PowerShellAgent', 'Azure DevOPS')
+                $dataNew.Add('AzureDevOPSPipelineType', 'Release')
+                $dataNew.Add('AzureDevOPSAgent', $env:POWERSHELL_DISTRIBUTION_CHANNEL)
             }
             elseif ($host.Name -eq 'Default Host' -and `
-                    $null -ne $env:APPSETTING_FUNCTIONS_EXTENSION_VERSION -and -not $Data.Keys.Contains('PowerShellAgent'))
+                    $null -ne $env:APPSETTING_FUNCTIONS_EXTENSION_VERSION -and -not $dataNew.Keys.Contains('PowerShellAgent'))
             {
-                $Data.Add('PowerShellAgent', 'Azure Function')
-                $Data.Add('AzureFunctionWorkerVersion', $env:FUNCTIONS_WORKER_RUNTIME_VERSION)
+                $dataNew.Add('PowerShellAgent', 'Azure Function')
+                $dataNew.Add('AzureFunctionWorkerVersion', $env:FUNCTIONS_WORKER_RUNTIME_VERSION)
             }
-            elseif ($host.Name -eq 'CloudShell' -and -not $Data.Keys.Contains('PowerShellAgent'))
+            elseif ($host.Name -eq 'CloudShell' -and -not $dataNew.Keys.Contains('PowerShellAgent'))
             {
-                $Data.Add('PowerShellAgent', 'Cloud Shell')
+                $dataNew.Add('PowerShellAgent', 'Cloud Shell')
             }
 
-            if ($null -ne $Data.Resource -and $Data.Keys.Contains('Resource'))
+            if ($null -ne $dataNew.Resource -and $dataNew.Keys.Contains('Resource'))
             {
-                if ($Data.Resource.StartsWith('MSFT_AAD') -or $Data.Resource.StartsWith('AAD'))
+                if ($dataNew.Resource.StartsWith('MSFT_AAD') -or $dataNew.Resource.StartsWith('AAD'))
                 {
-                    $Data.Add('Workload', 'Azure Active Directory')
+                    $dataNew.Add('Workload', 'Azure Active Directory')
                 }
-                elseif ($Data.Resource.StartsWith('MSFT_Intune') -or $Data.Resource.StartsWith('Defender'))
+                elseif ($dataNew.Resource.StartsWith('MSFT_Intune') -or $dataNew.Resource.StartsWith('Defender'))
                 {
-                    $Data.Add('Workload', 'Defender')
+                    $dataNew.Add('Workload', 'Defender')
                 }
-                elseif ($Data.Resource.StartsWith('MSFT_EXO') -or $Data.Resource.StartsWith('EXO'))
+                elseif ($dataNew.Resource.StartsWith('MSFT_EXO') -or $dataNew.Resource.StartsWith('EXO'))
                 {
-                    $Data.Add('Workload', 'Exchange Online')
+                    $dataNew.Add('Workload', 'Exchange Online')
                 }
-                elseif ($Data.Resource.StartsWith('MSFT_Intune') -or $Data.Resource.StartsWith('Intune'))
+                elseif ($dataNew.Resource.StartsWith('MSFT_Intune') -or $dataNew.Resource.StartsWith('Intune'))
                 {
-                    $Data.Add('Workload', 'Intune')
+                    $dataNew.Add('Workload', 'Intune')
                 }
-                elseif ($Data.Resource.StartsWith('MSFT_O365') -or $Data.Resource.StartsWith('O365'))
+                elseif ($dataNew.Resource.StartsWith('MSFT_O365') -or $dataNew.Resource.StartsWith('O365'))
                 {
-                    $Data.Add('Workload', 'Office 365 Admin')
+                    $dataNew.Add('Workload', 'Office 365 Admin')
                 }
-                elseif ($Data.Resource.StartsWith('MSFT_OD') -or $Data.Resource.StartsWith('OD'))
+                elseif ($dataNew.Resource.StartsWith('MSFT_OD') -or $dataNew.Resource.StartsWith('OD'))
                 {
-                    $Data.Add('Workload', 'OneDrive for Business')
+                    $dataNew.Add('Workload', 'OneDrive for Business')
                 }
-                elseif ($Data.Resource.StartsWith('MSFT_Planner') -or $Data.Resource.StartsWith('Planner'))
+                elseif ($dataNew.Resource.StartsWith('MSFT_Planner') -or $dataNew.Resource.StartsWith('Planner'))
                 {
-                    $Data.Add('Workload', 'Planner')
+                    $dataNew.Add('Workload', 'Planner')
                 }
-                elseif ($Data.Resource.StartsWith('MSFT_PP') -or $Data.Resource.StartsWith('PP'))
+                elseif ($dataNew.Resource.StartsWith('MSFT_PP') -or $dataNew.Resource.StartsWith('PP'))
                 {
-                    $Data.Add('Workload', 'Power Platform')
+                    $dataNew.Add('Workload', 'Power Platform')
                 }
-                elseif ($Data.Resource.StartsWith('MSFT_SC') -or $Data.Resource.StartsWith('SC'))
+                elseif ($dataNew.Resource.StartsWith('MSFT_SC') -or $dataNew.Resource.StartsWith('SC'))
                 {
-                    $Data.Add('Workload', 'Security and Compliance Center')
+                    $dataNew.Add('Workload', 'Security and Compliance Center')
                 }
-                elseif ($Data.Resource.StartsWith('MSFT_SPO') -or $Data.Resource.StartsWith('SPO'))
+                elseif ($dataNew.Resource.StartsWith('MSFT_SPO') -or $dataNew.Resource.StartsWith('SPO'))
                 {
-                    $Data.Add('Workload', 'SharePoint Online')
+                    $dataNew.Add('Workload', 'SharePoint Online')
                 }
-                elseif ($Data.Resource.StartsWith('MSFT_Teams') -or $Data.Resource.StartsWith('Teams'))
+                elseif ($dataNew.Resource.StartsWith('MSFT_Teams') -or $dataNew.Resource.StartsWith('Teams'))
                 {
-                    $Data.Add('Workload', 'Teams')
+                    $dataNew.Add('Workload', 'Teams')
                 }
-                $Data.Resource = $Data.Resource.Replace('MSFT_', '')
+                $dataNew.Resource = $dataNew.Resource.Replace('MSFT_', '')
             }
 
             if ($Type -eq 'ExportCompleted')
             {
                 if ($null -ne $Global:M365DSCExportResourceInstancesCount)
                 {
-                    $Data.Add('ExportedResourceInstancesCount', $Global:M365DSCExportResourceInstancesCount)
+                    $dataNew.Add('ExportedResourceInstancesCount', $Global:M365DSCExportResourceInstancesCount)
                 }
                 if ($null -ne $Global:M365DSCExportResourceTypes)
                 {
-                    $Data.Add('ExportedResourceTypes', $Global:M365DSCExportResourceTypes)
-                    $Data.Add('ExportedResourceTypesCount', $Global:M365DSCExportResourceTypes.Length)
+                    $dataNew.Add('ExportedResourceTypes', $Global:M365DSCExportResourceTypes)
+                    $dataNew.Add('ExportedResourceTypesCount', $Global:M365DSCExportResourceTypes.Length)
                 }
                 if ($null -ne $Global:M365DSCExportContentSize)
                 {
-                    $Data.Add('ExportedContentSize', $Global:M365DSCExportContentSize)
+                    $dataNew.Add('ExportedContentSize', $Global:M365DSCExportContentSize)
                 }
             }
 
             [array]$version = (Get-Module 'Microsoft365DSC').Version | Sort-Object -Descending
-            $Data.Add('M365DSCVersion', $version[0].ToString())
+            $dataNew.Add('M365DSCVersion', $version[0].ToString())
 
             # OS Version
             try
@@ -398,7 +410,7 @@ function Add-M365DSCTelemetryEvent
                 {
                     $Global:M365DSCOSInfo = (Get-CimInstance -ClassName Win32_OperatingSystem -Property Caption -ErrorAction SilentlyContinue).Caption
                 }
-                $Data.Add('M365DSCOSVersion', $Global:M365DSCOSInfo)
+                $dataNew.Add('M365DSCOSVersion', $Global:M365DSCOSInfo)
             }
             catch
             {
@@ -432,13 +444,13 @@ function Add-M365DSCTelemetryEvent
                     {
                         $partialConfiguration = $true
                     }
-                    $Data.Add('LCMUsesPartialConfigurations', $partialConfiguration)
-                    $Data.Add('LCMCertificateConfigured', $certificateConfigured)
-                    $Data.Add('LCMConfigurationMode', $Script:LCMInfo.ConfigurationMode)
-                    $Data.Add('LCMConfigurationModeFrequencyMins', $Script:LCMInfo.ConfigurationModeFrequencyMins)
-                    $Data.Add('LCMRefreshMode', $Script:LCMInfo.RefreshMode)
-                    $Data.Add('LCMState', $Script:LCMInfo.LCMState)
-                    $Data.Add('LCMStateDetail', $Script:LCMInfo.LCMStateDetail)
+                    $dataNew.Add('LCMUsesPartialConfigurations', $partialConfiguration)
+                    $dataNew.Add('LCMCertificateConfigured', $certificateConfigured)
+                    $dataNew.Add('LCMConfigurationMode', $Script:LCMInfo.ConfigurationMode)
+                    $dataNew.Add('LCMConfigurationModeFrequencyMins', $Script:LCMInfo.ConfigurationModeFrequencyMins)
+                    $dataNew.Add('LCMRefreshMode', $Script:LCMInfo.RefreshMode)
+                    $dataNew.Add('LCMState', $Script:LCMInfo.LCMState)
+                    $dataNew.Add('LCMStateDetail', $Script:LCMInfo.LCMStateDetail)
 
                     if ([System.String]::IsNullOrEmpty($Type))
                     {
@@ -474,23 +486,23 @@ function Add-M365DSCTelemetryEvent
             }
 
             $M365DSCTelemetryEventId = (New-Guid).ToString()
-            $Data.Add('M365DSCTelemetryEventId', $M365DSCTelemetryEventId)
+            $dataNew.Add('M365DSCTelemetryEventId', $M365DSCTelemetryEventId)
 
             if ([System.String]::IsNullOrEMpty($Type))
             {
-                if ((-not [System.String]::IsNullOrEmpty($Data.Method) -and $Data.Method -eq 'Export-TargetResource') -or $Global:M365DSCExportInProgress)
+                if ((-not [System.String]::IsNullOrEmpty($dataNew.Method) -and $dataNew.Method -eq 'Export-TargetResource') -or $Global:M365DSCExportInProgress)
                 {
                     $Type = 'Export'
                 }
             }
 
-            $TelemetryClient.TrackEvent($Type, $Data, $Metrics)
+            $TelemetryClient.TrackEvent($Type, $dataNew, $Metrics)
         }
         catch
         {
             try
             {
-                $TelemetryClient.TrackEvent('Error', $Data, $Metrics)
+                $TelemetryClient.TrackEvent('Error', $dataNew, $Metrics)
             }
             catch
             {
@@ -610,7 +622,7 @@ Internal
 function Format-M365DSCTelemetryParameters
 {
     [CmdletBinding()]
-    [OutputType([System.Collections.Generic.Dictionary[[String], [String]]])]
+    [OutputType([System.Collections.Generic.Dictionary[[System.String], [System.Object]]])]
     param(
         [parameter(Mandatory = $true)]
         [System.String]
@@ -624,7 +636,7 @@ function Format-M365DSCTelemetryParameters
         [System.Collections.Hashtable]
         $Parameters
     )
-    $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
+    $data = [System.Collections.Generic.Dictionary[[System.String], [System.Object]]]::new()
 
     try
     {
@@ -653,6 +665,7 @@ function Format-M365DSCTelemetryParameters
         }
         $connectionMode = Get-M365DSCAuthenticationMode -Parameters $Parameters
         $data.Add('ConnectionMode', $connectionMode)
+        $data.Add('PSBoundParameters', $Parameters)
     }
     catch
     {
@@ -667,5 +680,6 @@ Export-ModuleMember -Function @(
     'Get-M365DSCTelemetryOption',
     'Set-M365DSCTelemetryOption',
     'Set-M365DSCLCMConfiguration',
-    'Test-IsM365DSCTelemetryEnabled'
+    'Test-IsM365DSCTelemetryEnabled',
+    'Get-M365DSCConnectionParametersFromTelemetry'
 )


### PR DESCRIPTION
#### Pull Request (PR) description
This PR fixes an issue where telemetry authentication to Microsoft Graph doesn't use the provided authentication parameters from the `Test-TargetResource` function. It therefore always defaults to the public cloud environment, which in term means that government or sovereign clouds do not work with enabled telemetry.

@mpolselli This should resolve the issue you're having. If you're up to it, feel free to test it out.

#### This Pull Request (PR) fixes the following issues
- Fixes #7255 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
