### PR TITLE
Add support for sending push notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
   * Fixed an issue where connection setup to Microsoft Graph would fail for
     non-public clouds.
     FIXES [#7255](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7255)
+* M365DSCUtil
+  * Added support for sending push notifications through new function
+    `Send-M365DSCPushNotification`, currently it's only called after finishing
+    an export
 * SPOSharingSettings
   * Improved host site look from O(n) to O(1) with fallback logic.
 * IntunePolicyAssignmentComparer

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -934,12 +934,15 @@ function Start-M365DSCConfigurationExtract
         Write-M365DSCHost -Message "Failed exports: {$($synchronizedHashtable.FailedResources)}"
         if ($($synchronizedHashtable.FailedResources) -eq 0)
         {
-            Write-M365DSCHost -Message "$($Global:M365DSCEmojiGreenCheckmark) Export completed successfully." -ForegroundColor Green
+            $Message = "$($Global:M365DSCEmojiGreenCheckmark) Export completed successfully."
+            Write-M365DSCHost -Message $Message -ForegroundColor Green
         }
         else
         {
-            Write-M365DSCHost -Message "$($Global:M365DSCEmojiRedX) Export completed with errors." -ForegroundColor Red
+            $Message = "$($Global:M365DSCEmojiRedX) Export completed with errors."
+            Write-M365DSCHost -Message $Message -ForegroundColor Red
         }
+        Send-M365DSCPushNotification -Body $Message
         #endregion
 
         $sessions = Get-PSSession | Where-Object -FilterScript { $_.Name -like 'SfBPowerShellSessionViaTeamsModule_*' -or `

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2,6 +2,12 @@
 $Global:SessionSecurityCompliance = $null
 #endregion
 
+#region Push Notifications
+$Global:M365DSCPushNotificationsURI = $null
+$Global:M365DSCPushNotificationsHeaders = $null
+$Global:M365DSCPushNotificationsBody = $null
+#endregion
+
 $Script:M365DSCWorkloads = @('AAD', 'ADO', 'AZURE', 'COMMERCE', 'DEFENDER', 'EXO', 'FABRIC', 'INTUNE', 'O365', 'OD', 'PLANNER', 'PP', 'SC', 'SENTINEL', 'SH', 'SPO', 'TEAMS')
 
 <#
@@ -2294,6 +2300,53 @@ function Update-M365DSCAuthenticationTargets
     }
 }
 
+<#
+.DESCRIPTION
+    This function sends a push notification to $Global:M365DSCPushNotificationsURI
+    (if defined) with optional headers $Global:M365DSCPushNotificationsHeaders
+    and body $Body
+
+.PARAMETER Body
+    This is the body that will be sent to the push notification which can be
+    overriden by defining $Global:M365DSCPushNotificationsBody
+
+.EXAMPLE
+    PS> Send-M365DSCPushNotification -Body "This is a test"
+
+.FUNCTIONALITY
+    Internal
+#>
+function Send-M365DSCPushNotification
+{
+    [CmdletBinding()]
+    [OutputType($null)]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $Body
+    )
+
+    if (-not [System.String]::IsNullOrEmpty($Global:M365DSCPushNotificationsURI))
+    {
+        if (-not [System.String]::IsNullOrEmpty($Global:M365DSCPushNotificationsBody))
+        {
+            $Body = $Global:M365DSCPushNotificationsBody
+        }
+        $postRequest = @{
+            Method      = "Post"
+            URI         = $Global:M365DSCPushNotificationsURI
+            Body        = $Body
+            ErrorAction = "SilentlyContinue"
+        }
+        if (-not [System.String]::IsNullOrEmpty($Global:M365DSCPushNotificationsHeaders))
+        {
+            $postRequest.Add("Headers", $Global:M365DSCPushNotificationsHeaders)
+        }
+        $null = Invoke-RestMethod @postRequest
+    }
+}
+
 Export-ModuleMember -Function @(
     'Assert-M365DSCBlueprint',
     'Clear-M365DSCHostMessageCache',
@@ -2323,6 +2376,7 @@ Export-ModuleMember -Function @(
     'New-M365DSCMissingResourcesExample',
     'Remove-M365DSCAuthenticationParameter',
     'Remove-NullEntriesFromHashtable',
+    'Send-M365DSCPushNotification',
     'Set-M365DSCAllResourcesDictionary',
     'Test-CodePage',
     'Test-M365DSCParameterState',

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -2322,7 +2322,7 @@ function Send-M365DSCPushNotification
     [OutputType($null)]
     param
     (
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $Body
     )


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds support for sending push notifications before/after certain events happen on M365DSC, such as finishing an export which this PR already does.

Function to send these notifications is called `Send-M365DSCPushNotification` and is only invoked if `$Global:M365DSCPushNotificationsURI` is defined, then if `$Global:M365DSCPushNotificationsBody` is also defined it overrides the parameter `$Body` and finally also sends custom headers when variable `$Global:M365DSCPushNotificationsHeaders` is defined.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [X] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
