### PR TITLE
Add Docker image publish

### DIFF
--- a/.github/workflows/PublishDockerImages.yml
+++ b/.github/workflows/PublishDockerImages.yml
@@ -1,0 +1,71 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+      - Master
+    paths:
+      - Dockerfile.*
+      - .github/workflows/PublishDockerImages.yml
+  workflow_dispatch:
+
+jobs:
+  BuildAndPushDockerImages:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: Dockerfile.linux
+            runner: ubuntu-latest
+          - dockerfile: Dockerfile.linux.dev
+            runner: ubuntu-latest
+          - dockerfile: Dockerfile.windows
+            runner: windows-latest
+          - dockerfile: Dockerfile.windows.dev
+            runner: windows-latest
+
+    runs-on: ${{ matrix.runner }}
+
+    # Only when run from the main repo
+    if: github.repository == 'Microsoft365DSC/Microsoft365DSC'
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Infer Docker Tag
+        id: tag
+        shell: bash
+        run: |
+          filename="${{ matrix.dockerfile }}"
+          inferredTag="${filename#Dockerfile.}"
+          echo "value=${inferredTag}" >> "$GITHUB_OUTPUT"
+
+      - name: Get Module Version
+        id: moduleversion
+        shell: pwsh
+        run: |
+          $manifestPath = './Modules/Microsoft365DSC/Microsoft365DSC.psd1'
+          $moduleVersion = (Import-PowerShellDataFile -Path $manifestPath).ModuleVersion
+          if ([System.String]::IsNullOrWhiteSpace($moduleVersion))
+          {
+            throw 'Unable to determine Microsoft365DSC module version from manifest.'
+          }
+          "value=$moduleVersion" >> $env:GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/microsoft365dsc:${{ steps.moduleversion.outputs.value }}-${{ steps.tag.outputs.value }}


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds docker image publishing to the Docker Hub, see https://hub.docker.com/repository/docker/fabientschanz/microsoft365dsc/general. 

It contains the following four images:

- windows
- windows-dev
- linux
- linux-dev

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
