### PR TITLE
Stop pinning Pester to 5.7.1 on Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * MISC
   * Added Docker image publishing for Windows and Linux platforms.
   * Updated workflow triggers for GitHub Actions.
+  * Stopped pinning Pester dependency to `5.7.1` on Docker images since all
+    tests were made compatible in previous release with version `6.x`
 
 # 1.26.708.1
 

--- a/Utilities/Install-M365DSCAndDependencies.ps1
+++ b/Utilities/Install-M365DSCAndDependencies.ps1
@@ -99,7 +99,6 @@ try
         Name                = "Pester"
         Repository          = "PSGallery"
         Scope               = "AllUsers"
-        Version            = "5.7.1"
         SkipDependencyCheck = [Switch]$true
         TrustRepository     = [Switch]$true
         AcceptLicense       = [Switch]$true


### PR DESCRIPTION
#### Pull Request (PR) description

Since last release all unit/quality checks pass with Pester 6.x so this PR removes the version pinning to 5.7.1 on Docker images.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
