### PR TITLE
Fix EXO Availability Credentials type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # UNRELEASED
 
+* EXOAvailabilityAddressSpace
+  * Fixed an issue where the `Credentials` property had the correct
+    parameter type in its definition.
 * EXOMigration
   * Fixed unit-tests so datetimes are parsed in US-format
 * IntuneWifiConfigurationPolicyIOS

--- a/Modules/Microsoft365DSC/ComparisonMetadata.json
+++ b/Modules/Microsoft365DSC/ComparisonMetadata.json
@@ -79,6 +79,10 @@
       "HasCustomComparison": true,
       "Description": "Uses PostProcessing scriptblock"
     },
+    "EXOAvailabilityAddressSpace": {
+      "HasCustomComparison": true,
+      "Description": "Excludes properties: Credentials"
+    },
     "EXOAvailabilityConfig": {
       "HasCustomComparison": true,
       "Description": "Uses PostProcessing scriptblock"

--- a/Modules/Microsoft365DSC/DscResources/MSFT_EXOAvailabilityAddressSpace/MSFT_EXOAvailabilityAddressSpace.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_EXOAvailabilityAddressSpace/MSFT_EXOAvailabilityAddressSpace.psm1
@@ -17,7 +17,7 @@ function Get-TargetResource
         $AccessMethod,
 
         [Parameter()]
-        [System.String]
+        [System.Management.Automation.PSCredential]
         $Credentials,
 
         [Parameter()]
@@ -127,7 +127,6 @@ function Get-TargetResource
         $result = @{
             Identity              = $Identity
             AccessMethod          = $AvailabilityAddressSpace.AccessMethod
-            Credentials           = $AvailabilityAddressSpace.Credentials
             TargetServiceEpr      = $AvailabilityAddressSpace.TargetServiceEpr
             TargetTenantId        = $AvailabilityAddressSpace.TargetTenantId
             ForestName            = $AvailabilityAddressSpace.ForestName
@@ -173,7 +172,7 @@ function Set-TargetResource
         $AccessMethod,
 
         [Parameter()]
-        [System.String]
+        [System.Management.Automation.PSCredential]
         $Credentials,
 
         [Parameter()]
@@ -328,7 +327,7 @@ function Test-TargetResource
         $AccessMethod,
 
         [Parameter()]
-        [System.String]
+        [System.Management.Automation.PSCredential]
         $Credentials,
 
         [Parameter()]
@@ -394,8 +393,10 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
+    $compareParameters = Get-CompareParameters
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
+        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
+        @compareParameters
     return $result
 }
 
@@ -528,4 +529,16 @@ function Export-TargetResource
         throw
     }
 }
-Export-ModuleMember -Function *-TargetResource
+
+function Get-CompareParameters
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param()
+
+    return @{
+        ExcludedProperties = @('Credentials')
+    }
+}
+
+Export-ModuleMember -Function @('*-TargetResource', 'Get-CompareParameters')

--- a/Modules/Microsoft365DSC/DscResources/MSFT_EXOAvailabilityAddressSpace/MSFT_EXOAvailabilityAddressSpace.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_EXOAvailabilityAddressSpace/MSFT_EXOAvailabilityAddressSpace.schema.mof
@@ -1,10 +1,10 @@
 
-[ClassVersion("1.0.0.0"), FriendlyName("EXOAvailabilityAddressSpace")]
+[ClassVersion("1.0.0.1"), FriendlyName("EXOAvailabilityAddressSpace")]
 class MSFT_EXOAvailabilityAddressSpace : OMI_BaseResource
 {
     [Key, Description("The Identity parameter specifies the AvailabilityAddressSpace you want to modify.")] String Identity;
     [Write, Description("The AccessMethod parameter specifies how the free/busy data is accessed. Valid values are:PerUserFB, OrgWideFB, OrgWideFBToken, OrgWideFBBasic,InternalProxy"), ValueMap{"PerUserFB","OrgWideFB","OrgWideFBToken","OrgWideFBBasic","InternalProxy"}, Values{"PerUserFB","OrgWideFB","OrgWideFBToken","OrgWideFBBasic","InternalProxy"}] String AccessMethod;
-    [Write, Description("The Credentials parameter specifies the username and password that's used to access the Availability services in the target forest.")] String Credentials;
+    [Write, Description("The Credentials parameter specifies the username and password that's used to access the Availability services in the target forest."), EmbeddedInstance("MSFT_Credential")] String Credentials;
     [Write, Description("The ForestName parameter specifies the SMTP domain name of the target forest for users whose free/busy data must be retrieved. If your users are distributed among multiple SMTP domains in the target forest, run the Add-AvailabilityAddressSpace command once for each SMTP domain.")] String ForestName;
     [Write, Description("The TargetAutodiscoverEpr parameter specifies the Autodiscover URL of Exchange Web Services for the external organization. Exchange uses Autodiscover to automatically detect the correct server endpoint for external requests.")] String TargetAutodiscoverEpr;
     [Write, Description("The TargetServiceEpr parameter specifies the Exchange Online Calendar Service URL of the external Microsoft 365 organization that you're trying to read free/busy information from.")] String TargetServiceEpr;

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOAvailabilityAddressSpace.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.EXOAvailabilityAddressSpace.Tests.ps1
@@ -22,6 +22,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         BeforeAll {
             $secpasswd = ConvertTo-SecureString (New-Guid | Out-String) -AsPlainText -Force
             $Credential = New-Object System.Management.Automation.PSCredential ('tenantadmin@mydomain.com', $secpasswd)
+            $targetCreds = New-Object System.Management.Automation.PSCredential ('tenantadmin@otherdomain.com', $secpasswd)
 
             Mock -ModuleName M365DSCUtil -CommandName Confirm-M365DSCDependencies -MockWith {
             }
@@ -118,6 +119,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Ensure                = 'Present'
                     Identity              = 'contoso.com'
                     AccessMethod          = 'PerUserFB' # Drift
+                    Credentials           = $targetCreds
                     ForestName            = 'contoso.com'
                     TargetAutodiscoverEpr = 'http://autodiscover.contoso.com/autodiscover/autodiscover.xml'
                 }


### PR DESCRIPTION
#### Pull Request (PR) description
Fix EXO Availability Credentials type. It previously had the `String` type, which would result in a credential prompt during execution. It also was never exported.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
