### PR TITLE
Add SubscriptionId parameter to Azure resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,40 @@
 
 * AADIdentityGovernanceProgram
   * Deprecated resource. It is superseded by the access review resources.
+* AzureBillingAccountPolicy
+  * Added `SubscriptionId` parameter to specify the Azure subscription
+    that is used to connect to.
+* AzureBillingAccountsAssociatedTenant
+  * Added `SubscriptionId` parameter to specify the Azure subscription
+    that is used to connect to.
+* AzureBillingAccountScheduledAction
+  * Added `SubscriptionId` parameter to specify the Azure subscription
+    that is used to connect to.
+* AzureBillingAccountsRoleAssignment
+  * Added `SubscriptionId` parameter to specify the Azure subscription
+    that is used to connect to.
+* AzureDiagnosticSettings
+  * Added `SubscriptionId` parameter to specify the Azure subscription
+    that is used to connect to.
+* AzureDiagnosticSettingsCustomSecurityAttribute
+  * Added `SubscriptionId` parameter to specify the Azure subscription
+    that is used to connect to.
+* AzureRoleAssignmentScheduleRequest
+  * Added `SubscriptionId` parameter to specify the Azure subscription
+    that is used to connect to.
+* AzureRoleAssignmentScheduleRequest
+  * Added `SubscriptionId` parameter to specify the Azure subscription
+    that is used to connect to.
 * AzureRoleDefinition
   * Added `SubscriptionId` parameter to specify the Azure subscription
     that is used to connect to.
     FIXES [#7321](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7321)
+* AzureRoleEligibilityScheduleRequest
+  * Added `SubscriptionId` parameter to specify the Azure subscription
+    that is used to connect to.
+* AzureRoleEligibilityScheduleSettings
+  * Added `SubscriptionId` parameter to specify the Azure subscription
+    that is used to connect to.
 * EXOAvailabilityAddressSpace
   * Fixed an issue where the `Credentials` property had the correct
     parameter type in its definition.

--- a/Modules/Microsoft365DSC/ComparisonMetadata.json
+++ b/Modules/Microsoft365DSC/ComparisonMetadata.json
@@ -71,7 +71,43 @@
       "HasCustomComparison": true,
       "Description": "Uses PostProcessing scriptblock"
     },
+    "AzureBillingAccountPolicy": {
+      "HasCustomComparison": true,
+      "Description": "Excludes properties: SubscriptionId"
+    },
+    "AzureBillingAccountsAssociatedTenant": {
+      "HasCustomComparison": true,
+      "Description": "Excludes properties: SubscriptionId"
+    },
+    "AzureBillingAccountScheduledAction": {
+      "HasCustomComparison": true,
+      "Description": "Excludes properties: SubscriptionId"
+    },
+    "AzureBillingAccountsRoleAssignment": {
+      "HasCustomComparison": true,
+      "Description": "Excludes properties: SubscriptionId"
+    },
+    "AzureDiagnosticSettings": {
+      "HasCustomComparison": true,
+      "Description": "Excludes properties: SubscriptionId"
+    },
+    "AzureDiagnosticSettingsCustomSecurityAttribute": {
+      "HasCustomComparison": true,
+      "Description": "Excludes properties: SubscriptionId"
+    },
+    "AzureRoleAssignmentScheduleRequest": {
+      "HasCustomComparison": true,
+      "Description": "Excludes properties: Justification, SubscriptionId"
+    },
     "AzureRoleDefinition": {
+      "HasCustomComparison": true,
+      "Description": "Excludes properties: SubscriptionId"
+    },
+    "AzureRoleEligibilityScheduleRequest": {
+      "HasCustomComparison": true,
+      "Description": "Excludes properties: Justification, SubscriptionId"
+    },
+    "AzureRoleEligibilityScheduleSettings": {
       "HasCustomComparison": true,
       "Description": "Excludes properties: SubscriptionId"
     },

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountPolicy/MSFT_AzureBillingAccountPolicy.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountPolicy/MSFT_AzureBillingAccountPolicy.psm1
@@ -36,6 +36,10 @@ function Get-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -117,6 +121,7 @@ function Get-TargetResource
             ReservationPurchases        = $instance.properties.reservationPurchases
             SavingsPlanPurchases        = $instance.properties.savingsPlanPurchases
             Ensure                      = 'Present'
+            SubscriptionId              = $SubscriptionId
             Credential                  = $Credential
             ApplicationId               = $ApplicationId
             TenantId                    = $TenantId
@@ -173,6 +178,11 @@ function Set-TargetResource
         [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present',
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -283,6 +293,10 @@ function Test-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -324,8 +338,10 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
+    $compareParameters = Get-CompareParameters
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
+        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
+        @compareParameters
     return $result
 }
 
@@ -335,6 +351,10 @@ function Export-TargetResource
     [OutputType([System.String])]
     param
     (
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
         [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
@@ -413,6 +433,7 @@ function Export-TargetResource
             }
             $params = @{
                 BillingAccount        = $account.name
+                SubscriptionId        = $SubscriptionId
                 Credential            = $Credential
                 ApplicationId         = $ApplicationId
                 TenantId              = $TenantId
@@ -464,4 +485,15 @@ function Export-TargetResource
     }
 }
 
-Export-ModuleMember -Function *-TargetResource
+function Get-CompareParameters
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param()
+
+    return @{
+        ExcludedProperties = @('SubscriptionId')
+    }
+}
+
+Export-ModuleMember -Function @('*-TargetResource', 'Get-CompareParameters')

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountPolicy/MSFT_AzureBillingAccountPolicy.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountPolicy/MSFT_AzureBillingAccountPolicy.schema.mof
@@ -16,6 +16,7 @@ class MSFT_AzureBillingAccountPolicy : OMI_BaseResource
     [Write, Description("The policy that controls whether Azure reservation purchases are allowed.")] String ReservationPurchases;
     [Write, Description("The policy that controls whether users with Azure savings plan purchase are allowed.")] String SavingsPlanPurchases;
     [Write, Description("Present ensures the instance exists, absent ensures it is removed."), ValueMap{"Absent","Present"}, Values{"Absent","Present"}] string Ensure;
+    [Write, Description("The Azure subscription to connect to if the access is restricted on subscription level.")] String SubscriptionId;
     [Write, Description("Credentials of the workload's Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountScheduledAction/MSFT_AzureBillingAccountScheduledAction.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountScheduledAction/MSFT_AzureBillingAccountScheduledAction.psm1
@@ -40,6 +40,10 @@ function Get-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -157,6 +161,7 @@ function Get-TargetResource
             NotificationEmail     = $instance.properties.notificationEmail
             Schedule              = $ScheduleValue
             Ensure                = 'Present'
+            SubscriptionId        = $SubscriptionId
             Credential            = $Credential
             ApplicationId         = $ApplicationId
             TenantId              = $TenantId
@@ -217,6 +222,10 @@ function Set-TargetResource
         [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present',
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -358,6 +367,10 @@ function Test-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -399,8 +412,10 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
+    $compareParameters = Get-CompareParameters
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
+        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
+        @compareParameters
     return $result
 }
 
@@ -410,6 +425,10 @@ function Export-TargetResource
     [OutputType([System.String])]
     param
     (
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
         [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
@@ -506,6 +525,7 @@ function Export-TargetResource
                 $params = @{
                     DisplayName           = $config.properties.displayName
                     BillingAccount        = $account.name
+                    SubscriptionId        = $SubscriptionId
                     Credential            = $Credential
                     ApplicationId         = $ApplicationId
                     TenantId              = $TenantId
@@ -567,4 +587,15 @@ function Export-TargetResource
     }
 }
 
-Export-ModuleMember -Function *-TargetResource
+function Get-CompareParameters
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param()
+
+    return @{
+        ExcludedProperties = @('SubscriptionId')
+    }
+}
+
+Export-ModuleMember -Function @('*-TargetResource', 'Get-CompareParameters')

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountScheduledAction/MSFT_AzureBillingAccountScheduledAction.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountScheduledAction/MSFT_AzureBillingAccountScheduledAction.schema.mof
@@ -29,6 +29,7 @@ class MSFT_AzureBillingAccountScheduledAction : OMI_BaseResource
     [Write, Description("Email address of the point of contact that should get the unsubscribe requests and notification emails.")] String  NotificationEmail;
     [Write, Description("Schedule of the scheduled action."), EmbeddedInstance("MSFT_AzureBillingAccountScheduledActionSchedule")] String  Schedule;
     [Write, Description("Present ensures the instance exists, absent ensures it is removed."), ValueMap{"Absent","Present"}, Values{"Absent","Present"}] string Ensure;
+    [Write, Description("The Azure subscription to connect to if the access is restricted on subscription level.")] String SubscriptionId;
     [Write, Description("Credentials of the workload's Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountsAssociatedTenant/MSFT_AzureBillingAccountsAssociatedTenant.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountsAssociatedTenant/MSFT_AzureBillingAccountsAssociatedTenant.psm1
@@ -32,6 +32,10 @@ function Get-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -106,6 +110,7 @@ function Get-TargetResource
             BillingManagementState      = $instance.properties.billingManagementState
             ProvisioningManagementState = $instance.properties.provisioningManagementState
             Ensure                      = 'Present'
+            SubscriptionId              = $SubscriptionId
             Credential                  = $Credential
             ApplicationId               = $ApplicationId
             TenantId                    = $TenantId
@@ -158,6 +163,10 @@ function Set-TargetResource
         [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present',
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -275,6 +284,10 @@ function Test-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -316,8 +329,10 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
+    $compareParameters = Get-CompareParameters
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
+        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
+        @compareParameters
     return $result
 }
 
@@ -327,6 +342,10 @@ function Export-TargetResource
     [OutputType([System.String])]
     param
     (
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
         [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
@@ -414,6 +433,7 @@ function Export-TargetResource
                     BillingAccount        = $config.properties.displayName
                     DisplayName           = $associatedTenant.properties.displayName
                     AssociatedTenantId    = $associatedTenant.properties.tenantId
+                    SubscriptionId        = $SubscriptionId
                     Credential            = $Credential
                     ApplicationId         = $ApplicationId
                     TenantId              = $TenantId
@@ -453,4 +473,15 @@ function Export-TargetResource
     }
 }
 
-Export-ModuleMember -Function *-TargetResource
+function Get-CompareParameters
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param()
+
+    return @{
+        ExcludedProperties = @('SubscriptionId')
+    }
+}
+
+Export-ModuleMember -Function @('*-TargetResource', 'Get-CompareParameters')

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountsAssociatedTenant/MSFT_AzureBillingAccountsAssociatedTenant.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountsAssociatedTenant/MSFT_AzureBillingAccountsAssociatedTenant.schema.mof
@@ -7,6 +7,7 @@ class MSFT_AzureBillingAccountsAssociatedTenant : OMI_BaseResource
     [Write, Description("The state determines whether users from the associated tenant can be assigned roles for commerce activities like viewing and downloading invoices, managing payments, and making purchases.")] String BillingManagementState;
     [Write, Description("The state determines whether subscriptions and licenses can be provisioned in the associated tenant. It can be set to 'Pending' to initiate a billing request.")] String ProvisioningManagementState;
     [Write, Description("Present ensures the instance exists, absent ensures it is removed."), ValueMap{"Absent","Present"}, Values{"Absent","Present"}] string Ensure;
+    [Write, Description("The Azure subscription to connect to if the access is restricted on subscription level.")] String SubscriptionId;
     [Write, Description("Credentials of the workload's Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountsRoleAssignment/MSFT_AzureBillingAccountsRoleAssignment.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountsRoleAssignment/MSFT_AzureBillingAccountsRoleAssignment.psm1
@@ -32,6 +32,10 @@ function Get-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -119,6 +123,7 @@ function Get-TargetResource
             PrincipalTenantId     = $instance.properties.principalTenantId
             RoleDefinition        = $RoleDefinitionValue.properties.roleName
             Ensure                = 'Present'
+            SubscriptionId        = $SubscriptionId
             Credential            = $Credential
             ApplicationId         = $ApplicationId
             TenantId              = $TenantId
@@ -171,6 +176,10 @@ function Set-TargetResource
         [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present',
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -291,6 +300,10 @@ function Test-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -332,8 +345,10 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
+    $compareParameters = Get-CompareParameters
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
+        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
+        @compareParameters
     return $result
 }
 
@@ -343,6 +358,10 @@ function Export-TargetResource
     [OutputType([System.String])]
     param
     (
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
         [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
@@ -440,6 +459,7 @@ function Export-TargetResource
                     PrincipalType         = $assignment.properties.principalType
                     PrincipalTenantId     = $assignment.properties.principalTenantId
                     RoleDefinition        = 'AnyRole'
+                    SubscriptionId        = $SubscriptionId
                     Credential            = $Credential
                     ApplicationId         = $ApplicationId
                     TenantId              = $TenantId
@@ -561,4 +581,15 @@ function Get-M365DSCPrincipalIdFromName
     return $result
 }
 
-Export-ModuleMember -Function *-TargetResource
+function Get-CompareParameters
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param()
+
+    return @{
+        ExcludedProperties = @('SubscriptionId')
+    }
+}
+
+Export-ModuleMember -Function @('*-TargetResource', 'Get-CompareParameters')

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountsRoleAssignment/MSFT_AzureBillingAccountsRoleAssignment.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureBillingAccountsRoleAssignment/MSFT_AzureBillingAccountsRoleAssignment.schema.mof
@@ -7,6 +7,7 @@ class MSFT_AzureBillingaccountsRoleAssignment : OMI_BaseResource
     [Write, Description("Name of the billing account.")] String BillingAccount;
     [Write, Description("The principal tenant id of the user to whom the role was assigned.")] String PrincipalTenantId;
     [Write, Description("Present ensures the instance exists, absent ensures it is removed."), ValueMap{"Absent","Present"}, Values{"Absent","Present"}] string Ensure;
+    [Write, Description("The Azure subscription to connect to if the access is restricted on subscription level.")] String SubscriptionId;
     [Write, Description("Credentials of the workload's Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureDiagnosticSettings/MSFT_AzureDiagnosticSettings.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureDiagnosticSettings/MSFT_AzureDiagnosticSettings.psm1
@@ -40,6 +40,10 @@ function Get-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -129,6 +133,7 @@ function Get-TargetResource
             WorkspaceId                 = $instance.properties.workspaceId
             Categories                  = $CategoriesValue
             Ensure                      = 'Present'
+            SubscriptionId              = $SubscriptionId
             Credential                  = $Credential
             ApplicationId               = $ApplicationId
             TenantId                    = $TenantId
@@ -189,6 +194,10 @@ function Set-TargetResource
         [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present',
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -340,6 +349,10 @@ function Test-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -381,8 +394,10 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
+    $compareParameters = Get-CompareParameters
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
+        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
+        @compareParameters
     return $result
 }
 
@@ -392,6 +407,10 @@ function Export-TargetResource
     [OutputType([System.String])]
     param
     (
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
         [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
@@ -470,6 +489,7 @@ function Export-TargetResource
             Write-M365DSCHost -Message "    |---[$i/$($exportedInstances.Count)] $displayedKey" -DeferWrite
             $params = @{
                 Name                  = $config.Name
+                SubscriptionId        = $SubscriptionId
                 Credential            = $Credential
                 ApplicationId         = $ApplicationId
                 TenantId              = $TenantId
@@ -522,4 +542,15 @@ function Export-TargetResource
     }
 }
 
-Export-ModuleMember -Function *-TargetResource
+function Get-CompareParameters
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param()
+
+    return @{
+        ExcludedProperties = @('SubscriptionId')
+    }
+}
+
+Export-ModuleMember -Function @('*-TargetResource', 'Get-CompareParameters')

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureDiagnosticSettings/MSFT_AzureDiagnosticSettings.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureDiagnosticSettings/MSFT_AzureDiagnosticSettings.schema.mof
@@ -16,6 +16,7 @@ class MSFT_AzureDiagnosticSettings : OMI_BaseResource
     [Write, Description("Event hub name.")] String EventHubName;
     [Write, Description("Workspace id.")] String WorkspaceId;
     [Write, Description("Present ensures the instance exists, absent ensures it is removed."), ValueMap{"Absent","Present"}, Values{"Absent","Present"}] string Ensure;
+    [Write, Description("The Azure subscription to connect to if the access is restricted on subscription level.")] String SubscriptionId;
     [Write, Description("Credentials of the workload's Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureDiagnosticSettingsCustomSecurityAttribute/MSFT_AzureDiagnosticSettingsCustomSecurityAttribute.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureDiagnosticSettingsCustomSecurityAttribute/MSFT_AzureDiagnosticSettingsCustomSecurityAttribute.psm1
@@ -40,6 +40,10 @@ function Get-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -129,6 +133,7 @@ function Get-TargetResource
             WorkspaceId                 = $instance.properties.workspaceId
             Categories                  = $CategoriesValue
             Ensure                      = 'Present'
+            SubscriptionId              = $SubscriptionId
             Credential                  = $Credential
             ApplicationId               = $ApplicationId
             TenantId                    = $TenantId
@@ -189,6 +194,10 @@ function Set-TargetResource
         [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present',
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -341,6 +350,10 @@ function Test-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -382,8 +395,10 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
+    $compareParameters = Get-CompareParameters
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
+        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
+        @compareParameters
     return $result
 }
 
@@ -393,6 +408,10 @@ function Export-TargetResource
     [OutputType([System.String])]
     param
     (
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
         [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
@@ -471,6 +490,7 @@ function Export-TargetResource
             Write-M365DSCHost -Message "    |---[$i/$($exportedInstances.Count)] $displayedKey" -DeferWrite
             $params = @{
                 Name                  = $config.Name
+                SubscriptionId        = $SubscriptionId
                 Credential            = $Credential
                 ApplicationId         = $ApplicationId
                 TenantId              = $TenantId
@@ -523,4 +543,15 @@ function Export-TargetResource
     }
 }
 
-Export-ModuleMember -Function *-TargetResource
+function Get-CompareParameters
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param()
+
+    return @{
+        ExcludedProperties = @('SubscriptionId')
+    }
+}
+
+Export-ModuleMember -Function @('*-TargetResource', 'Get-CompareParameters')

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureDiagnosticSettingsCustomSecurityAttribute/MSFT_AzureDiagnosticSettingsCustomSecurityAttribute.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureDiagnosticSettingsCustomSecurityAttribute/MSFT_AzureDiagnosticSettingsCustomSecurityAttribute.schema.mof
@@ -16,6 +16,7 @@ class MSFT_AzureDiagnosticSettingsCustomSecurityAttribute : OMI_BaseResource
     [Write, Description("Event hub name.")] String EventHubName;
     [Write, Description("Workspace id.")] String WorkspaceId;
     [Write, Description("Present ensures the instance exists, absent ensures it is removed."), ValueMap{"Absent","Present"}, Values{"Absent","Present"}] string Ensure;
+    [Write, Description("The Azure subscription to connect to if the access is restricted on subscription level.")] String SubscriptionId;
     [Write, Description("Credentials of the workload's Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureRoleAssignmentScheduleRequest/MSFT_AzureRoleAssignmentScheduleRequest.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureRoleAssignmentScheduleRequest/MSFT_AzureRoleAssignmentScheduleRequest.psm1
@@ -45,6 +45,10 @@ function Get-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -293,6 +297,7 @@ function Get-TargetResource
             Justification         = "Assignment of Azure role '$RoleDefinition' to principal '$PrincipalValue' of type '$PrincipalType'."
             ScheduleInfo          = $ScheduleInfoValue
             Ensure                = 'Present'
+            SubscriptionId        = $SubscriptionId
             Credential            = $Credential
             ApplicationId         = $ApplicationId
             TenantId              = $TenantId
@@ -359,6 +364,10 @@ function Set-TargetResource
         [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present',
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -543,6 +552,10 @@ function Test-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -604,6 +617,10 @@ function Export-TargetResource
         [Parameter()]
         [System.String]
         $Filter,
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -803,6 +820,7 @@ function Export-TargetResource
                     DirectoryScopeId      = $request.Scope
                     RoleDefinition        = $roleDefinition.Name
                     Ensure                = 'Present'
+                    SubscriptionId        = $SubscriptionId
                     Credential            = $Credential
                     ApplicationId         = $ApplicationId
                     TenantId              = $TenantId
@@ -934,7 +952,7 @@ function Get-CompareParameters
     param()
 
     return @{
-        ExcludedProperties = @('Justification')
+        ExcludedProperties = @('Justification', 'SubscriptionId')
         PostProcessing = {
             param($DesiredValues, $CurrentValues, $ValuesToCheck, $ignore)
             if ($null -ne $DesiredValues.ScheduleInfo -and

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureRoleAssignmentScheduleRequest/MSFT_AzureRoleAssignmentScheduleRequest.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureRoleAssignmentScheduleRequest/MSFT_AzureRoleAssignmentScheduleRequest.schema.mof
@@ -55,6 +55,7 @@ class MSFT_AzureRoleAssignmentScheduleRequest : OMI_BaseResource
     [Write, Description("A message provided by users and administrators when they create the role assignment schedule request.")] String Justification;
     [Write, Description("The period of the role assignment. The period of assignment is dependent on the settings of the Azure role."), EmbeddedInstance("MSFT_AzureRoleAssignmentScheduleRequestSchedule")] String ScheduleInfo;
     [Write, Description("Present ensures the instance exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("The Azure subscription to connect to if the access is restricted on subscription level.")] String SubscriptionId;
     [Write, Description("Credentials of the workload's Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureRoleEligibilityScheduleRequest/MSFT_AzureRoleEligibilityScheduleRequest.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureRoleEligibilityScheduleRequest/MSFT_AzureRoleEligibilityScheduleRequest.psm1
@@ -45,6 +45,10 @@ function Get-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -293,6 +297,7 @@ function Get-TargetResource
             Justification         = "Eligibility of Azure role '$RoleDefinition' to principal '$PrincipalValue' of type '$PrincipalType'."
             ScheduleInfo          = $ScheduleInfoValue
             Ensure                = 'Present'
+            SubscriptionId        = $SubscriptionId
             Credential            = $Credential
             ApplicationId         = $ApplicationId
             TenantId              = $TenantId
@@ -359,6 +364,10 @@ function Set-TargetResource
         [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present',
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -543,6 +552,10 @@ function Test-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -604,6 +617,10 @@ function Export-TargetResource
         [Parameter()]
         [System.String]
         $Filter,
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -841,6 +858,7 @@ function Export-TargetResource
                     DirectoryScopeId      = $request.Scope
                     RoleDefinition        = $roleDefinition.Name
                     Ensure                = 'Present'
+                    SubscriptionId        = $SubscriptionId
                     Credential            = $Credential
                     ApplicationId         = $ApplicationId
                     TenantId              = $TenantId
@@ -972,7 +990,7 @@ function Get-CompareParameters
     param()
 
     return @{
-        ExcludedProperties = @('Justification')
+        ExcludedProperties = @('Justification', 'SubscriptionId')
         PostProcessing = {
             param($DesiredValues, $CurrentValues, $ValuesToCheck, $ignore)
             if ($null -ne $DesiredValues.ScheduleInfo -and

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureRoleEligibilityScheduleRequest/MSFT_AzureRoleEligibilityScheduleRequest.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureRoleEligibilityScheduleRequest/MSFT_AzureRoleEligibilityScheduleRequest.schema.mof
@@ -55,6 +55,7 @@ class MSFT_AzureRoleEligibilityScheduleRequest : OMI_BaseResource
     [Write, Description("A message provided by users and administrators when they create the role eligibility schedule request.")] String Justification;
     [Write, Description("The period of the role eligibility. The period of eligibility is dependent on the settings of the Azure role."), EmbeddedInstance("MSFT_AzureRoleEligibilityScheduleRequestSchedule")] String ScheduleInfo;
     [Write, Description("Present ensures the instance exists, absent ensures it is removed."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] string Ensure;
+    [Write, Description("The Azure subscription to connect to if the access is restricted on subscription level.")] String SubscriptionId;
     [Write, Description("Credentials of the workload's Admin"), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureRoleEligibilityScheduleSettings/MSFT_AzureRoleEligibilityScheduleSettings.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureRoleEligibilityScheduleSettings/MSFT_AzureRoleEligibilityScheduleSettings.psm1
@@ -191,6 +191,10 @@ function Get-TargetResource
         $ActivationApproveNotificationOnlyCritical,
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -462,6 +466,7 @@ function Get-TargetResource
             TenantId                                                  = $TenantId
             CertificateThumbprint                                     = $CertificateThumbprint
             ApplicationSecret                                         = $ApplicationSecret
+            SubscriptionId                                            = $SubscriptionId
             Credential                                                = $Credential
             ManagedIdentity                                           = $ManagedIdentity.IsPresent
             AccessTokens                                              = $AccessTokens
@@ -668,6 +673,10 @@ function Set-TargetResource
         [Parameter()]
         [System.Boolean]
         $ActivationApproveNotificationOnlyCritical,
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -1454,6 +1463,10 @@ function Test-TargetResource
         $ActivationApproveNotificationOnlyCritical,
 
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -1499,8 +1512,10 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
+    $compareParameters = Get-CompareParameters
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
+        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
+        @compareParameters
     return $result
 }
 
@@ -1513,6 +1528,10 @@ function Export-TargetResource
         [Parameter()]
         [System.String]
         $Filter,
+
+        [Parameter()]
+        [System.String]
+        $SubscriptionId,
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
@@ -1748,6 +1767,7 @@ function Export-TargetResource
                 $Params = @{
                     RoleDefinitionDisplayName = $instance.RoleDisplayName
                     ScopeId                   = $currentScope
+                    SubscriptionId            = $SubscriptionId
                     Credential                = $Credential
                     ApplicationId             = $ApplicationId
                     TenantId                  = $TenantId
@@ -1793,4 +1813,15 @@ function Export-TargetResource
     }
 }
 
-Export-ModuleMember -Function *-TargetResource
+function Get-CompareParameters
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param()
+
+    return @{
+        ExcludedProperties = @('SubscriptionId')
+    }
+}
+
+Export-ModuleMember -Function @('*-TargetResource', 'Get-CompareParameters')

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureRoleEligibilityScheduleSettings/MSFT_AzureRoleEligibilityScheduleSettings.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureRoleEligibilityScheduleSettings/MSFT_AzureRoleEligibilityScheduleSettings.schema.mof
@@ -47,6 +47,7 @@ class MSFT_AzureRoleEligibilityScheduleSettings : OMI_BaseResource
     [Write, Description("Send notifications when eligible members activate this role: Notification to approvers, default recipient (True/False).")] Boolean ActivationApproveNotificationDefaultRecipient;
     [Write, Description("Send notifications when eligible members activate this role: Notification to approvers, additional recipient (UPN).")] String ActivationApproveNotificationAdditionalRecipient[];
     [Write, Description("Send notifications when eligible members activate this role: Notification to approvers, only critical Email (True/False).")] Boolean ActivationApproveNotificationOnlyCritical;
+    [Write, Description("The Azure subscription to connect to if the access is restricted on subscription level.")] String SubscriptionId;
     [Write, Description("Credentials for the Microsoft Graph delegated permissions."), EmbeddedInstance("MSFT_Credential")] string Credential;
     [Write, Description("Id of the Azure Active Directory application to authenticate with.")] String ApplicationId;
     [Write, Description("Id of the Azure Active Directory tenant used for authentication.")] String TenantId;

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureVerifiedIdFaceCheck/MSFT_AzureVerifiedIdFaceCheck.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureVerifiedIdFaceCheck/MSFT_AzureVerifiedIdFaceCheck.psm1
@@ -460,5 +460,3 @@ function Export-TargetResource
         throw
     }
 }
-
-Export-ModuleMember -Function *-TargetResource

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AzureVerifiedIdFaceCheck/MSFT_AzureVerifiedIdFaceCheck.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AzureVerifiedIdFaceCheck/MSFT_AzureVerifiedIdFaceCheck.psm1
@@ -460,3 +460,5 @@ function Export-TargetResource
         throw
     }
 }
+
+Export-ModuleMember -Function *-TargetResource

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureBillingAccountPolicy.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureBillingAccountPolicy.Tests.ps1
@@ -86,6 +86,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ReservationPurchases = "Allowed"
                     SavingsPlanPurchases = "NotAllowed"
                     Ensure               = 'Present'
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
                     Credential           = $Credential;
                 }
             }
@@ -107,6 +108,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ReservationPurchases = "Allowed"
                     SavingsPlanPurchases = "Allowed" #Drift
                     Ensure               = 'Present'
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
                     Credential           = $Credential;
                 }
             }
@@ -130,7 +132,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
-                    Credential  = $Credential;
+                    SubscriptionId = "00000000-0000-0000-0000-000000000000"
+                    Credential     = $Credential;
                 }
             }
             It 'Should Reverse Engineer resource from the Export method' {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureBillingAccountScheduledAction.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureBillingAccountScheduledAction.Tests.ps1
@@ -109,6 +109,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Status                = "Enabled";
                     View                  = "/providers/Microsoft.Billing/billingAccounts/xxxxx:xxxxx_xxxxx/providers/Microsoft.CostManagement/views/ms:AccumulatedCosts";
                     Ensure              = 'Present'
+                    SubscriptionId      = "00000000-0000-0000-0000-000000000000"
                     Credential          = $Credential;
                 }
 
@@ -155,6 +156,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Status                = "Enabled";
                     View                  = "/providers/Microsoft.Billing/billingAccounts/xxxxx:xxxxx_xxxxx/providers/Microsoft.CostManagement/views/ms:AccumulatedCosts";
                     Ensure              = 'Absent'
+                    SubscriptionId      = "00000000-0000-0000-0000-000000000000"
                     Credential          = $Credential;
                 }
             }
@@ -193,6 +195,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Status                = "Enabled";
                     View                  = "/providers/Microsoft.Billing/billingAccounts/xxxxx:xxxxx_xxxxx/providers/Microsoft.CostManagement/views/ms:AccumulatedCosts";
                     Ensure              = 'Present'
+                    SubscriptionId      = "00000000-0000-0000-0000-000000000000"
                     Credential          = $Credential;
                 }
             }
@@ -224,6 +227,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Status                = "Disabled"; # Drift
                     View                  = "/providers/Microsoft.Billing/billingAccounts/xxxxx:xxxxx_xxxxx/providers/Microsoft.CostManagement/views/ms:AccumulatedCosts";
                     Ensure              = 'Present'
+                    SubscriptionId      = "00000000-0000-0000-0000-000000000000"
                     Credential          = $Credential;
                 }
             }
@@ -247,7 +251,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
-                    Credential  = $Credential;
+                    SubscriptionId = "00000000-0000-0000-0000-000000000000"
+                    Credential     = $Credential;
                 }
             }
             It 'Should Reverse Engineer resource from the Export method' {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureBillingAccountsAssociatedTenant.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureBillingAccountsAssociatedTenant.Tests.ps1
@@ -86,6 +86,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     DisplayName                 = "Test Tenant";
                     ProvisioningManagementState = "Pending";
                     Ensure                      = 'Present'
+                    SubscriptionId              = "00000000-0000-0000-0000-000000000000"
                     Credential                  = $Credential;
                 }
 
@@ -115,6 +116,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     DisplayName                 = "Test Tenant";
                     ProvisioningManagementState = "Pending";
                     Ensure                      = 'Absent'
+                    SubscriptionId              = "00000000-0000-0000-0000-000000000000"
                     Credential                  = $Credential;
                 }
             }
@@ -140,6 +142,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     DisplayName                 = "Test Tenant";
                     ProvisioningManagementState = "Pending";
                     Ensure                      = 'Present'
+                    SubscriptionId              = "00000000-0000-0000-0000-000000000000"
                     Credential                  = $Credential;
                 }
             }
@@ -158,6 +161,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     DisplayName                 = "Test Tenant";
                     ProvisioningManagementState = "Pending";
                     Ensure                      = 'Present'
+                    SubscriptionId              = "00000000-0000-0000-0000-000000000000"
                     Credential                  = $Credential;
                 }
             }
@@ -181,7 +185,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
-                    Credential  = $Credential;
+                    SubscriptionId = "00000000-0000-0000-0000-000000000000"
+                    Credential     = $Credential;
                 }
             }
             It 'Should Reverse Engineer resource from the Export method' {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureBillingAccountsRoleAssignment.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureBillingAccountsRoleAssignment.Tests.ps1
@@ -119,6 +119,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     PrincipalTenantId     = '9c888910-6b3b-4c17-8cff-844fefb026d4'
                     RoleDefinition        = "Billing account owner";
                     Ensure                = 'Present'
+                    SubscriptionId        = "00000000-0000-0000-0000-000000000000"
                     Credential            = $Credential;
                 }
 
@@ -148,6 +149,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     PrincipalTenantId     = '9c888910-6b3b-4c17-8cff-844fefb026d4'
                     RoleDefinition        = "Billing account owner";
                     Ensure                = 'Absent'
+                    SubscriptionId        = "00000000-0000-0000-0000-000000000000"
                     Credential            = $Credential;
                 }
             }
@@ -173,6 +175,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     PrincipalTenantId     = '9c888910-6b3b-4c17-8cff-844fefb026d4'
                     RoleDefinition        = "Billing account owner";
                     Ensure                = 'Present'
+                    SubscriptionId        = "00000000-0000-0000-0000-000000000000"
                     Credential            = $Credential;
                 }
             }
@@ -187,7 +190,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
-                    Credential  = $Credential;
+                    SubscriptionId = "00000000-0000-0000-0000-000000000000"
+                    Credential     = $Credential;
                 }
             }
             It 'Should Reverse Engineer resource from the Export method' {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureDiagnosticSettings.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureDiagnosticSettings.Tests.ps1
@@ -91,6 +91,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Name                        = "TestDiag";
                     StorageAccountId            = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.Storage/storageAccounts/demostore";
                     WorkspaceId                 = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.OperationalInsights/workspaces/MySentinelWorkspace";
+                    SubscriptionId              = "00000000-0000-0000-0000-000000000000"
                     Credential                  = $Credential;
                 }
 
@@ -133,6 +134,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Name                        = "TestDiag";
                     StorageAccountId            = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.Storage/storageAccounts/demostore";
                     WorkspaceId                 = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.OperationalInsights/workspaces/MySentinelWorkspace";
+                    SubscriptionId              = "00000000-0000-0000-0000-000000000000"
                     Credential                  = $Credential;
                 }
             }
@@ -167,6 +169,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Name                        = "TestDiag";
                     StorageAccountId            = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.Storage/storageAccounts/demostore";
                     WorkspaceId                 = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.OperationalInsights/workspaces/MySentinelWorkspace";
+                    SubscriptionId              = "00000000-0000-0000-0000-000000000000"
                     Credential                  = $Credential;
                 }
             }
@@ -194,6 +197,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Name                        = "TestDiag";
                     StorageAccountId            = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.Storage/storageAccounts/demostore";
                     WorkspaceId                 = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.OperationalInsights/workspaces/MySentinelWorkspace";
+                    SubscriptionId              = "00000000-0000-0000-0000-000000000000"
                     Credential                  = $Credential;
                 }
             }
@@ -217,7 +221,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
-                    Credential  = $Credential;
+                    SubscriptionId = "00000000-0000-0000-0000-000000000000"
+                    Credential     = $Credential;
                 }
             }
             It 'Should Reverse Engineer resource from the Export method' {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureDiagnosticSettingsCustomSecurityAttribute.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureDiagnosticSettingsCustomSecurityAttribute.Tests.ps1
@@ -91,6 +91,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Name                        = "TestDiag";
                     StorageAccountId            = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.Storage/storageAccounts/demostore";
                     WorkspaceId                 = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.OperationalInsights/workspaces/MySentinelWorkspace";
+                    SubscriptionId              = "00000000-0000-0000-0000-000000000000"
                     Credential                  = $Credential;
                 }
 
@@ -131,6 +132,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Name                        = "TestDiag";
                     StorageAccountId            = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.Storage/storageAccounts/demostore";
                     WorkspaceId                 = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.OperationalInsights/workspaces/MySentinelWorkspace";
+                    SubscriptionId              = "00000000-0000-0000-0000-000000000000"
                     Credential                  = $Credential;
                 }
             }
@@ -165,6 +167,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Name                        = "TestDiag";
                     StorageAccountId            = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.Storage/storageAccounts/demostore";
                     WorkspaceId                 = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.OperationalInsights/workspaces/MySentinelWorkspace";
+                    SubscriptionId              = "00000000-0000-0000-0000-000000000000"
                     Credential                  = $Credential;
                 }
             }
@@ -192,6 +195,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     Name                        = "TestDiag";
                     StorageAccountId            = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.Storage/storageAccounts/demostore";
                     WorkspaceId                 = "/subscriptions/f854132c-570e-4c98-a4c9-3cd902de77dd/resourceGroups/TBD/providers/Microsoft.OperationalInsights/workspaces/MySentinelWorkspace";
+                    SubscriptionId              = "00000000-0000-0000-0000-000000000000"
                     Credential                  = $Credential;
                 }
             }
@@ -215,7 +219,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
-                    Credential  = $Credential;
+                    SubscriptionId = "00000000-0000-0000-0000-000000000000"
+                    Credential     = $Credential;
                 }
             }
             It 'Should Reverse Engineer resource from the Export method' {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureRoleAssignmentScheduleRequest.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureRoleAssignmentScheduleRequest.Tests.ps1
@@ -93,7 +93,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId        = "00000000-0000-0000-0000-000000000000"
+                    Credential            = $Credential
                 }
 
                 Mock -CommandName Get-AzRoleAssignmentSchedule -MockWith {
@@ -129,7 +130,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
             }
 
@@ -162,7 +164,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
             }
 
@@ -191,7 +194,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
             }
 
@@ -225,7 +229,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzRoleAssignmentSchedule -MockWith {
@@ -259,7 +264,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzRoleAssignmentSchedule -MockWith {
@@ -293,7 +299,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzRoleAssignmentSchedule -MockWith {
@@ -328,7 +335,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzRoleAssignmentSchedule -MockWith {
@@ -369,7 +377,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type = 'noExpiration'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzADGroup -MockWith {
@@ -420,7 +429,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type = 'noExpiration'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzRoleAssignmentSchedule -MockWith {
@@ -457,7 +467,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
-                    Credential = $Credential
+                    SubscriptionId = "00000000-0000-0000-0000-000000000000"
+                    Credential     = $Credential
                 }
 
                 Mock -CommandName Get-AzManagementGroup -MockWith {

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureRoleEligibilityScheduleRequest.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureRoleEligibilityScheduleRequest.Tests.ps1
@@ -93,7 +93,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzRoleEligibilitySchedule -MockWith {
@@ -127,7 +128,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
             }
 
@@ -160,7 +162,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
             }
 
@@ -189,7 +192,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
             }
 
@@ -223,7 +227,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzRoleEligibilitySchedule -MockWith {
@@ -257,7 +262,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzRoleEligibilitySchedule -MockWith {
@@ -291,7 +297,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzRoleEligibilitySchedule -MockWith {
@@ -325,7 +332,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type        = 'afterDateTime'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzRoleEligibilitySchedule -MockWith {
@@ -366,7 +374,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type = 'noExpiration'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzADGroup -MockWith {
@@ -417,7 +426,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                             type = 'noExpiration'
                         } -ClientOnly
                     } -ClientOnly
-                    Credential  = $Credential
+                    SubscriptionId       = "00000000-0000-0000-0000-000000000000"
+                    Credential           = $Credential
                 }
 
                 Mock -CommandName Get-AzRoleEligibilitySchedule -MockWith {
@@ -454,7 +464,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
-                    Credential = $Credential
+                    SubscriptionId = "00000000-0000-0000-0000-000000000000"
+                    Credential     = $Credential
                 }
 
                 Mock -CommandName Get-AzTenant -MockWith {
@@ -528,7 +539,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
-                    Credential = $Credential
+                    SubscriptionId = "00000000-0000-0000-0000-000000000000"
+                    Credential     = $Credential
                     Filter     = ''
                 }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureRoleEligibilityScheduleSettings.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AzureRoleEligibilityScheduleSettings.Tests.ps1
@@ -247,6 +247,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ActivationReqMFA          = $false
                     ApprovaltoActivate        = $true
                     ActivateApprover          = @()
+                    SubscriptionId            = "00000000-0000-0000-0000-000000000000"
                     Credential                = $Credential;
                 }
             }
@@ -265,6 +266,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ActivationReqJustification = $true
                     ActivationReqTicket       = $true
                     ActivationReqMFA          = $false
+                    SubscriptionId            = "00000000-0000-0000-0000-000000000000"
                     Credential                = $Credential;
                 }
             }
@@ -286,6 +288,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     EligibleAlertNotificationDefaultRecipient    = $true
                     EligibleAlertNotificationAdditionalRecipient = @("eligibility-admin@contoso.com")
                     EligibleAlertNotificationOnlyCritical        = $true
+                    SubscriptionId                               = "00000000-0000-0000-0000-000000000000"
                     Credential                                   = $Credential;
                 }
             }
@@ -303,6 +306,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     EligibleAlertNotificationDefaultRecipient    = $false # drift
                     EligibleAlertNotificationAdditionalRecipient = @("eligibility-admin@contoso.com")
                     EligibleAlertNotificationOnlyCritical        = $true
+                    SubscriptionId                               = "00000000-0000-0000-0000-000000000000"
                     Credential                                   = $Credential;
                 }
             }
@@ -322,6 +326,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     RoleDefinitionDisplayName                        = "Owner"
                     ScopeId                                          = "subscriptions/00000000-0000-0000-0000-000000000000"
                     ActiveAssigneeNotificationAdditionalRecipient    = @("foo@test.com")
+                    SubscriptionId                                   = "00000000-0000-0000-0000-000000000000"
                     Credential                                       = $Credential;
                 }
             }
@@ -369,6 +374,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     RoleDefinitionDisplayName                        = "Owner"
                     ScopeId                                          = "subscriptions/00000000-0000-0000-0000-000000000000"
                     ActiveAssigneeNotificationAdditionalRecipient    = @("foo@test.com")
+                    SubscriptionId                                   = "00000000-0000-0000-0000-000000000000"
                     Credential                                       = $Credential;
                 }
             }
@@ -387,6 +393,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     RoleDefinitionDisplayName                    = "Owner"
                     ScopeId                                      = "subscriptions/00000000-0000-0000-0000-000000000000"
                     EligibleAlertNotificationDefaultRecipient    = $false
+                    SubscriptionId                               = "00000000-0000-0000-0000-000000000000"
                     Credential                                   = $Credential;
                 }
             }
@@ -402,6 +409,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     RoleDefinitionDisplayName                       = "Owner"
                     ScopeId                                         = "subscriptions/00000000-0000-0000-0000-000000000000"
                     ActivationAlertNotificationOnlyCritical         = $true
+                    SubscriptionId                                  = "00000000-0000-0000-0000-000000000000"
                     Credential                                      = $Credential;
                 }
             }
@@ -419,6 +427,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ActivationAlertNotificationDefaultRecipient     = $true
                     ActivationAlertNotificationAdditionalRecipient  = @("admin@contoso.com")
                     ActivationAlertNotificationOnlyCritical         = $false
+                    SubscriptionId                                  = "00000000-0000-0000-0000-000000000000"
                     Credential                                      = $Credential;
                 }
             }
@@ -435,6 +444,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ScopeId                                         = "subscriptions/00000000-0000-0000-0000-000000000000"
                     PermanentEligibleAssignmentisExpirationRequired = $true
                     ExpireEligibleAssignment                        = "P180D"
+                    SubscriptionId                                  = "00000000-0000-0000-0000-000000000000"
                     Credential                                      = $Credential;
                 }
             }
@@ -451,6 +461,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ScopeId                                         = "subscriptions/00000000-0000-0000-0000-000000000000"
                     PermanentEligibleAssignmentisExpirationRequired = $false # drift
                     ExpireEligibleAssignment                        = "P180D"
+                    SubscriptionId                                  = "00000000-0000-0000-0000-000000000000"
                     Credential                                      = $Credential;
                 }
             }
@@ -463,11 +474,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "The enablement rule for active assignment is in the desired state" -Fixture {
             BeforeAll {
                 $testParams = @{
-                    RoleDefinitionDisplayName = "Owner"
-                    ScopeId                   = "subscriptions/00000000-0000-0000-0000-000000000000"
-                    AssignmentReqMFA          = $false
+                    RoleDefinitionDisplayName  = "Owner"
+                    ScopeId                    = "subscriptions/00000000-0000-0000-0000-000000000000"
+                    AssignmentReqMFA           = $false
                     AssignmentReqJustification = $true
-                    Credential                = $Credential;
+                    SubscriptionId             = "00000000-0000-0000-0000-000000000000"
+                    Credential                 = $Credential;
                 }
             }
 
@@ -479,11 +491,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "The enablement rule for active assignment is NOT in the desired state" -Fixture {
             BeforeAll {
                 $testParams = @{
-                    RoleDefinitionDisplayName = "Owner"
-                    ScopeId                   = "subscriptions/00000000-0000-0000-0000-000000000000"
-                    AssignmentReqMFA          = $true # drift
+                    RoleDefinitionDisplayName  = "Owner"
+                    ScopeId                    = "subscriptions/00000000-0000-0000-0000-000000000000"
+                    AssignmentReqMFA           = $true # drift
                     AssignmentReqJustification = $true
-                    Credential                = $Credential;
+                    SubscriptionId             = "00000000-0000-0000-0000-000000000000"
+                    Credential                 = $Credential;
                 }
             }
 
@@ -499,11 +512,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "Partial enablement: only Justification and Ticketing specified for EndUser Assignment" -Fixture {
             BeforeAll {
                 $testParams = @{
-                    RoleDefinitionDisplayName = "Owner"
-                    ScopeId                   = "subscriptions/00000000-0000-0000-0000-000000000000"
+                    RoleDefinitionDisplayName  = "Owner"
+                    ScopeId                    = "subscriptions/00000000-0000-0000-0000-000000000000"
                     ActivationReqJustification = $true
-                    ActivationReqTicket       = $true
-                    Credential                = $Credential;
+                    ActivationReqTicket        = $true
+                    SubscriptionId             = "00000000-0000-0000-0000-000000000000"
+                    Credential                 = $Credential;
                 }
             }
 
@@ -515,10 +529,11 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
         Context -Name "Partial enablement: only Justification specified for Admin Assignment" -Fixture {
             BeforeAll {
                 $testParams = @{
-                    RoleDefinitionDisplayName = "Owner"
-                    ScopeId                   = "subscriptions/00000000-0000-0000-0000-000000000000"
+                    RoleDefinitionDisplayName  = "Owner"
+                    ScopeId                    = "subscriptions/00000000-0000-0000-0000-000000000000"
                     AssignmentReqJustification = $true
-                    Credential                = $Credential;
+                    SubscriptionId             = "00000000-0000-0000-0000-000000000000"
+                    Credential                 = $Credential;
                 }
             }
 
@@ -533,6 +548,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     RoleDefinitionDisplayName = "Owner"
                     ScopeId                   = "subscriptions/00000000-0000-0000-0000-000000000000"
                     AssignmentReqMFA          = $true
+                    SubscriptionId            = "00000000-0000-0000-0000-000000000000"
                     Credential                = $Credential;
                 }
             }
@@ -631,6 +647,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ScopeId                   = "subscriptions/00000000-0000-0000-0000-000000000000"
                     ApprovaltoActivate        = $true
                     ActivateApprover          = @("approver@contoso.com")
+                    SubscriptionId            = "00000000-0000-0000-0000-000000000000"
                     Credential                = $Credential;
                 }
             }
@@ -755,6 +772,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     ScopeId                   = "subscriptions/00000000-0000-0000-0000-000000000000"
                     ApprovaltoActivate        = $true
                     ActivateApprover          = @("approver@contoso.com", "PIM Approvers")
+                    SubscriptionId            = "00000000-0000-0000-0000-000000000000"
                     Credential                = $Credential;
                 }
             }
@@ -780,7 +798,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
-                    Credential = $Credential
+                    SubscriptionId = "00000000-0000-0000-0000-000000000000"
+                    Credential     = $Credential
                 }
 
                 Mock -CommandName Invoke-AzRestMethod -MockWith {
@@ -875,8 +894,9 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
-                    Credential = $Credential
-                    Filter     = 'ModifiedOnly'
+                    SubscriptionId = "00000000-0000-0000-0000-000000000000"
+                    Credential     = $Credential
+                    Filter         = 'ModifiedOnly'
                 }
 
                 Mock -CommandName Invoke-AzRestMethod -MockWith {
@@ -957,7 +977,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 $Global:CurrentModeIsExport = $true
                 $Global:PartialExportFileName = "$(New-Guid).partial.ps1"
                 $testParams = @{
-                    Credential = $Credential
+                    SubscriptionId = "00000000-0000-0000-0000-000000000000"
+                    Credential     = $Credential
                 }
 
                 Mock -CommandName Invoke-AzRestMethod -MockWith {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds the `SubscriptionId` parameter to remaining Azure resources so that it's possible to select to which Azure Subscription to connect to.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- x ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
