### PR TITLE
Remove usage of functions {Resolve,Save}-Credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,14 @@
     were not handled correctly.
 * M365DSCExportUtil
   * Fixed a formatting issue with `CertificatePassword` during export.
+  * Removed usage of function `Resolve-Credentials` and instead just use the
+    appropriate hardcoded strings
 * M365DSCReverse
   * Fixed an issue with `Credential` and `CertificatePassword` parameters.
+  * Fixed an issue generating the blueprint if using Azure Automation with
+    `Credential` parameter.
+  * Removed usage of function `Save-Credentials` since it's not required any
+    longer.
 * DEPENDENCIES
   * Updated `MSCloudLoginAssistant` to version `1.1.69`.
 * MISC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
   * Fixed a formatting issue with `CertificatePassword` during export.
 * M365DSCReverse
   * Fixed an issue with `Credential` and `CertificatePassword` parameters.
+* DEPENDENCIES
+  * Updated `MSCloudLoginAssistant` to version `1.1.69`.
 * MISC
   * Added Docker image publishing for Windows and Linux platforms.
   * Updated workflow triggers for GitHub Actions.

--- a/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
+++ b/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
@@ -42,7 +42,7 @@
         },
         @{
             ModuleName      = "MSCloudLoginAssistant"
-            RequiredVersion = "1.1.68"
+            RequiredVersion = "1.1.69"
         },
         @{
             ModuleName      = 'PnP.PowerShell'

--- a/Modules/Microsoft365DSC/Modules/M365DSCExportUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCExportUtil.psm1
@@ -1136,7 +1136,7 @@ function Update-M365DSCExportAuthenticationResults
 
     if ($ConnectionMode -in @('Credentials', 'CredentialsWithTenantId'))
     {
-        $Results.Credential = Resolve-Credentials -UserName 'credential'
+        $Results.Credential = '$CredsCredential'
         $noEscape += 'Credential'
 
         # Credentials mode removes TenantId; CredentialsWithTenantId keeps it.
@@ -1161,7 +1161,7 @@ function Update-M365DSCExportAuthenticationResults
         {
             if ($ConnectionMode -eq 'CredentialsWithApplicationId')
             {
-                $Results.Credential = Resolve-Credentials -UserName 'credential'
+                $Results.Credential = '$CredsCredential'
                 $noEscape += 'Credential'
             }
             else
@@ -1213,7 +1213,7 @@ function Update-M365DSCExportAuthenticationResults
         # CertificatePassword gets resolved as credentials
         if ($null -ne $Results.CertificatePassword)
         {
-            $Results.CertificatePassword = Resolve-Credentials -UserName 'CertificatePassword'
+            $Results.CertificatePassword = '$CredsCertificatePassword'
             $noEscape += 'CertificatePassword'
         }
         else

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -538,9 +538,6 @@ function Start-M365DSCConfigurationExtract
                     -Description 'Local path to the .pfx certificate to use for authentication'
 
                 $newline = $true
-
-                # Add the Certificate Password to the Credentials List
-                Save-Credentials -UserName 'certificatepassword'
             }
             'ApplicationWithSecret'
             {
@@ -588,10 +585,6 @@ function Start-M365DSCConfigurationExtract
                 $postParamContent.Append("    `$OrganizationName = `$CredsCredential.UserName.Split('@')[1]`r`n") | Out-Null
 
                 $newline = $true
-
-                # Add the Credential to the Credentials List
-                Write-Verbose -Message 'Adding the provided credentials to the list of variables'
-                Save-Credentials -UserName 'credential'
             }
             'ManagedIdentity'
             {
@@ -899,14 +892,7 @@ function Start-M365DSCConfigurationExtract
             {
                 #region Add the Prompt for Required Credentials at the top of the Configuration
                 $credsContent = ''
-                if (-not $AzureAutomation)
-                {
-                    $credsContent += '        $CredsCredential ' + "= Get-Credential -Message `"Credentials`"`r`n"
-                }
-                else
-                {
-                    $credsContent += '    $CredsCredential = Get-AutomationPSCredential -Name ' + ($resolvedName.Replace('$', '')) + "`r`n"
-                }
+                $credsContent += '        $CredsCredential ' + "= Get-Credential -Message `"Credentials`"`r`n"
                 $credsContent += "`r`n"
                 $startPosition = $DSCContent.ToString().IndexOf('<# Credentials #>') + 19
                 $DSCContent = $DSCContent.Insert($startPosition, $credsContent)


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes an issue when generating blueprints when using Azure Automation and credentials since it kept a leftover variable `$resolvedName` from when function `Resolve-Credentials` was used in that spot, since that function is no longer required then this also stops calling that function in other places along with function `Save-Credentials` which is also not required.

While here this also updates module `MSCloudLoginAssistant` to `1.1.69` since it's the last version available.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
