### PR TITLE
M365DSCCheckProperties: Fix function Get-PropertyReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@
 * Teams
   * Updated resource settings to use the Teams Reader role and remove Graph
     permissions from resources that do not require Microsoft Graph modules.
+* M365DSCCheckProperties
+  * Fixed an issue with function `Get-PropertyReport` where it wasn't working
+    because the `Teams` module was being loaded last and causing conflicts
+  * Added authentication methods `ApplicationSecret`, `AccesstTokens` and
+    `ManagedIdentity` as internal M365DSC properties that should to be ignored
 * M365DSCExportUtil
   * Fixed a formatting issue with `CertificatePassword` during export.
   * Removed usage of function `Resolve-Credentials` and instead just use the

--- a/Modules/Microsoft365DSC/Modules/M365DSCCheckProperties.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCCheckProperties.psm1
@@ -51,17 +51,20 @@ function Get-PropertyReport
             'Debug',
         'Credential',
         'ApplicationId',
+        'ApplicationSecret',
         'Ensure',
         'TenantId',
         'CertificateThumbprint',
         'CertificatePath',
         'CertificatePassword',
+        'AccessTokens',
+        'ManagedIdentity',
         'IsSingleInstance')
 
     # list of M365 workloads to check
     $workloads = @(
-        @{Name = 'ExchangeOnline'; ModuleName = 'ExchangeOnlineManagement'; CommandName = 'Get-Mailbox'; Prefix = 'EXO'; }
         @{Name = 'MicrosoftTeams'; ModuleName = 'MicrosoftTeams'; Prefix = 'Teams'; }
+        @{Name = 'ExchangeOnline'; ModuleName = 'ExchangeOnlineManagement'; CommandName = 'Get-Mailbox'; Prefix = 'EXO'; }
         @{Name = 'SecurityComplianceCenter'; ModuleName = 'ExchangeOnlineManagement'; CommandName = 'Set-ComplianceCase'; Prefix = 'SC'; }
     )
 


### PR DESCRIPTION
#### Pull Request (PR) description

This fixes functions `Get-PropertyReport` by loading module `Teams` before others due to module conflicts and while here also added missing authentication methods `ApplicationSecret`, `AccessTokens` and `ManagedIdentity` to the list of internal M365DSC properties that should be ignored when looking for properties that are in the resource but are not part of the cmdlet being checked.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
