### PR TITLE
Fix #7334

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,8 @@
 * Added `License Requirements` section to README.md documenting Microsoft
     365 E5 / Defender for Office 365 Plan 2 licensing requirements for EXO
     Defender resources.
-
+* AADServicePrincipal
+  * Removed Get-MgApplication AppId validation to allow creation of Service Principals for Enterprise Applications. Enterprise Applications cannot be resolved through Get-MgApplication, causing valid Service Principal registrations to fail.
 
 # 1.26.708.1
 

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AADServicePrincipal/MSFT_AADServicePrincipal.psm1
@@ -633,14 +633,6 @@ function Set-TargetResource
         $AppId = $appInstance.AppId
         Write-Verbose -Message "Translated to AppId {$($currentParameters.AppId)}"
     }
-    else
-    {
-        $appInstance = Get-MgApplication -Filter "AppId eq '$($AppId)'"
-        if ($null -eq $appInstance)
-        {
-            throw "No application found with AppId or DisplayName matching '$AppId'."
-        }
-    }
 
     # ServicePrincipal should exist but it doesn't
     if ($Ensure -eq 'Present' -and $currentAADServicePrincipal.Ensure -eq 'Absent')


### PR DESCRIPTION
#### Pull Request (PR) description
Removed Get-MgApplication AppId validation to allow creation of Service Principals for Enterprise Applications. Enterprise Applications cannot be resolved through Get-MgApplication, causing valid Service Principal registrations to fail.

#### This Pull Request (PR) fixes the following issues
- Fixes #7334


#### Task list
- [X] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
