### PR TITLE
fixed invalid arg when run in WPS 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
   * Fixed a formatting issue with `CertificatePassword` during export.
   * Removed usage of function `Resolve-Credentials` and instead just use the
     appropriate hardcoded strings
+* M365DSCModuleMgmt
+  * Fixed invalid arg used in Confirm-M365DSCLoadedModule when run in Windows Powershell 5.1
 * M365DSCReverse
   * Fixed an issue with `Credential` and `CertificatePassword` parameters.
   * Fixed an issue generating the blueprint if using Azure Automation with

--- a/Modules/Microsoft365DSC/Modules/M365DSCModuleMgmt.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCModuleMgmt.psm1
@@ -227,7 +227,13 @@ function Confirm-M365DSCLoadedModule
             # Ensure Microsoft.Graph.Authentication is loaded first
             Confirm-M365DSCLoadedModule -ModuleName 'Microsoft.Graph.Authentication'
 
-            Import-Module -Name "$PSScriptRoot/M365DSCGraphShim.psd1" -Global -Force -DisableNameChecking -Function * -Cmdlet @() -Variable @() -Alias @() -SkipEditionCheck
+            if ($IsCoreCLR) {
+                $skipEditionArg = @{SkipEditionCheck = $true}
+            } else {
+                $skipEditionArg = @{}
+            }
+
+            Import-Module -Name "$PSScriptRoot/M365DSCGraphShim.psd1" -Global -Force -DisableNameChecking -Function * -Cmdlet @() -Variable @() -Alias @() @skipEditionArg
             $Script:M365DSCGraphShimLoaded = $true
         }
         else

--- a/Modules/Microsoft365DSC/Modules/M365DSCModuleMgmt.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCModuleMgmt.psm1
@@ -227,13 +227,7 @@ function Confirm-M365DSCLoadedModule
             # Ensure Microsoft.Graph.Authentication is loaded first
             Confirm-M365DSCLoadedModule -ModuleName 'Microsoft.Graph.Authentication'
 
-            if ($IsCoreCLR) {
-                $skipEditionArg = @{SkipEditionCheck = $true}
-            } else {
-                $skipEditionArg = @{}
-            }
-
-            Import-Module -Name "$PSScriptRoot/M365DSCGraphShim.psd1" -Global -Force -DisableNameChecking -Function * -Cmdlet @() -Variable @() -Alias @() @skipEditionArg
+            Import-Module -Name "$PSScriptRoot/M365DSCGraphShim.psd1" -Global -Force -DisableNameChecking -Function * -Cmdlet @() -Variable @() -Alias @()
             $Script:M365DSCGraphShimLoaded = $true
         }
         else


### PR DESCRIPTION
#### Pull Request (PR) description
A recent addition includes code that uses Import-Module with parameter -SkipEditionCheck. However, this is only valid in Powershell 7, so code is added to ensure the parameter is only used with PS7

#### This Pull Request (PR) fixes the following issues

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
