### PR TITLE
Use Get-TemporaryPath to assign $env:TEMP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@
     because the `Teams` module was being loaded last and causing conflicts
   * Added authentication methods `ApplicationSecret`, `AccesstTokens` and
     `ManagedIdentity` as internal M365DSC properties that should to be ignored
+* M365DSCDocGenerator
+  * Moved function `Get-TemporaryPath` to `M365DSCUtil` and use `$env:TEMP`
+    directly instead of the function's output
 * M365DSCExportUtil
   * Fixed a formatting issue with `CertificatePassword` during export.
   * Removed usage of function `Resolve-Credentials` and instead just use the
@@ -100,6 +103,9 @@
     `Credential` parameter.
   * Removed usage of function `Save-Credentials` since it's not required any
     longer.
+* M365DSCUtil
+  * Added function `Get-TemporaryPath` taken from `M365DSCDocGenerator` and use
+    its output to assign `$env:TEMP` variable
 * DEPENDENCIES
   * Updated `MSCloudLoginAssistant` to version `1.1.69`.
 * MISC

--- a/Modules/Microsoft365DSC/Modules/M365DSCDocGenerator.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCDocGenerator.psm1
@@ -294,7 +294,7 @@ function Get-MofSchemaObject
         $FileName
     )
 
-    $temporaryPath = Get-TemporaryPath
+    $temporaryPath = $env:TEMP
 
     #region Workaround for OMI_BaseResource inheritance not resolving.
 
@@ -431,56 +431,6 @@ function Get-ResourceExampleAsMarkdown
     }
 
     return $outputExampleMarkDown
-}
-
-<#
-.Description
-The Get-TemporaryPath function will return the temporary
-path specific to the OS. It will return $ENV:Temp when run
-on Windows OS, '/tmp' when run in Linux and $ENV:TMPDIR when
-run on MacOS.
-
-.Example
-Get-TemporaryPath
-
-Get the temporary path (which will differ between operating system).
-
-.Functionality
-Internal,Hidden
-#>
-function Get-TemporaryPath
-{
-    [CmdletBinding()]
-    [OutputType([System.String])]
-    param ()
-
-    $temporaryPath = $null
-
-    switch ($true)
-    {
-        (-not (Test-Path -Path variable:IsWindows) -or ((Get-Variable -Name 'IsWindows' -ValueOnly -ErrorAction SilentlyContinue) -eq $true))
-        {
-            # Windows PowerShell or PowerShell 6+
-            $temporaryPath = (Get-Item -Path env:TEMP).Value
-        }
-
-        ((Get-Variable -Name 'IsMacOs' -ValueOnly -ErrorAction SilentlyContinue) -eq $true)
-        {
-            $temporaryPath = (Get-Item -Path env:TMPDIR).Value
-        }
-
-        ((Get-Variable -Name 'IsLinux' -ValueOnly -ErrorAction SilentlyContinue) -eq $true)
-        {
-            $temporaryPath = '/tmp'
-        }
-
-        default
-        {
-            throw 'Cannot set the temporary path. Unknown operating system.'
-        }
-    }
-
-    return $temporaryPath
 }
 
 <#

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -10,11 +10,6 @@ $Global:M365DSCPushNotificationsBody = $null
 
 $Script:M365DSCWorkloads = @('AAD', 'ADO', 'AZURE', 'COMMERCE', 'DEFENDER', 'EXO', 'FABRIC', 'INTUNE', 'O365', 'OD', 'PLANNER', 'PP', 'SC', 'SENTINEL', 'SH', 'SPO', 'TEAMS')
 
-if ([System.String]::IsNullOrEmpty($env:TEMP) -and $PSEdition -eq 'Core' -and -not $IsWindows)
-{
-    $env:TEMP = '/tmp'
-}
-
 <#
 .Description
 The Get-TemporaryPath function will return the temporary

--- a/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCUtil.psm1
@@ -17,6 +17,58 @@ if ([System.String]::IsNullOrEmpty($env:TEMP) -and $PSEdition -eq 'Core' -and -n
 
 <#
 .Description
+The Get-TemporaryPath function will return the temporary
+path specific to the OS. It will return $env:TEMP when run
+on Windows OS, '/tmp' when run in Linux and $env:TMPDIR when
+run on MacOS.
+
+.Example
+Get-TemporaryPath
+
+Get the temporary path (which will differ between operating system).
+
+.Functionality
+Internal,Hidden
+#>
+function Get-TemporaryPath
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param ()
+
+    $temporaryPath = $null
+
+    switch ($true)
+    {
+        (-not (Test-Path -Path variable:IsWindows) -or ((Get-Variable -Name 'IsWindows' -ValueOnly -ErrorAction SilentlyContinue) -eq $true))
+        {
+            # Windows PowerShell or PowerShell 6+
+            $temporaryPath = (Get-Item -Path env:TEMP).Value
+        }
+
+        ((Get-Variable -Name 'IsMacOs' -ValueOnly -ErrorAction SilentlyContinue) -eq $true)
+        {
+            $temporaryPath = (Get-Item -Path env:TMPDIR).Value
+        }
+
+        ((Get-Variable -Name 'IsLinux' -ValueOnly -ErrorAction SilentlyContinue) -eq $true)
+        {
+            $temporaryPath = '/tmp'
+        }
+
+        default
+        {
+            throw 'Cannot set the temporary path. Unknown operating system.'
+        }
+    }
+
+    return $temporaryPath
+}
+
+$env:TEMP = Get-TemporaryPath
+
+<#
+.Description
 This function retrieves a Teams team by its name
 
 .Functionality


### PR DESCRIPTION
#### Pull Request (PR) description

This changes the way that $env:TEMP gets assigned by using generic function `Get-TemporaryPath`, that was already available in `M365DSCDocGenerator`, to find out the temp folder it should be assigned to this variable depending on the operating system used.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
