### PR TITLE
AADUser: Deprecate property PasswordNeverExpires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * AADServicePrincipal
   * Fixed an issue where attempting to resolve 3rd-party SPNs would fail.
   * Fixed several issues when creating or updating an SPN.
+* AADUser
+  * Deprecate property `PasswordNeverExpires`
+    FIXES [#7339](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7339)
 * AzureBillingAccountPolicy
   * Added `SubscriptionId` parameter to specify the Azure subscription
     that is used to connect to.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * AADUser
   * Deprecate property `PasswordNeverExpires`
     FIXES [#7339](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7339)
+  * Fixed issue with how `BusinessPhones` property was being sent when trying to
+    set that value
 * AzureBillingAccountPolicy
   * Added `SubscriptionId` parameter to specify the Azure subscription
     that is used to connect to.

--- a/Modules/Microsoft365DSC/ComparisonMetadata.json
+++ b/Modules/Microsoft365DSC/ComparisonMetadata.json
@@ -71,6 +71,10 @@
       "HasCustomComparison": true,
       "Description": "Uses PostProcessing scriptblock"
     },
+    "AADUser": {
+      "HasCustomComparison": true,
+      "Description": "Excludes properties: PasswordNeverExpires"
+    },
     "AzureBillingAccountPolicy": {
       "HasCustomComparison": true,
       "Description": "Excludes properties: SubscriptionId"

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AADUser/MSFT_AADUser.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AADUser/MSFT_AADUser.psm1
@@ -524,6 +524,11 @@ function Set-TargetResource
         }
         $creationParams = Remove-NullEntriesFromHashtable -Hash $CreationParams
         $creationParams = Rename-M365DSCCimInstanceParameter -Properties $creationParams
+        if ($creationParams.ContainsKey("BusinessPhones"))
+        {
+            $BusinessPhones = Get-M365DSCArrayFromProperty -PropertyValue $PhoneNumber -ElementType ([System.String])
+            $creationParams["BusinessPhones"] = $BusinessPhones
+        }
 
         #region Licenses
         if ($null -ne $LicenseAssignment)
@@ -579,7 +584,6 @@ function Set-TargetResource
         }
         else
         {
-
             if ($null -ne $Password)
             {
                 $passwordValue = $Password.GetNetworkCredential().Password

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AADUser/MSFT_AADUser.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AADUser/MSFT_AADUser.psm1
@@ -162,6 +162,13 @@ function Get-TargetResource
 
     Write-Verbose -Message "Getting configuration of Office 365 User $UserPrincipalName"
 
+    # TODO: Remove property 'PasswordNeverExpires' in next breaking change
+    if ($PSBoundParameters.ContainsKey('PasswordNeverExpires'))
+    {
+        $PSBoundParameters.Remove('PasswordNeverExpires') | Out-Null
+        Write-Warning "Property 'PasswordNeverExpires' is deprecated and will be removed, please use 'PasswordPolicies' instead with 'DisablePasswordExpiration'"
+    }
+
     try
     {
         if (-not $Script:exportedInstance -or $Script:exportedInstance.UserPrincipalName -ne $UserPrincipalName)
@@ -256,11 +263,6 @@ function Get-TargetResource
         # return membership of static groups only
         [array]$currentMemberOf = ($batchResponse | Where-Object -FilterScript { $_.id -eq 'MemberOf' }).body.value.DisplayName
 
-        $userPasswordPolicyInfo = $user | Select-Object UserprincipalName, @{
-            N = 'PasswordNeverExpires'; E = { $_.PasswordPolicies -contains 'DisablePasswordExpiration' }
-        }
-        $passwordNeverExpires = $userPasswordPolicyInfo.PasswordNeverExpires
-
         if ($null -eq $Script:allDirectoryRoleAssignment)
         {
             $Script:allDirectoryRoleAssignment = Get-MgBetaRoleManagementDirectoryRoleAssignment -All
@@ -296,7 +298,6 @@ function Get-TargetResource
             Office                = $user.OfficeLocation
             Mail                  = $user.Mail
             OtherMails            = $user.OtherMails
-            PasswordNeverExpires  = $passwordNeverExpires
             PasswordPolicies      = $user.PasswordPolicies
             PhoneNumber           = $user.BusinessPhones | Select-Object -First 1
             PostalCode            = $user.PostalCode
@@ -486,6 +487,13 @@ function Set-TargetResource
 
     Write-Verbose -Message "Setting configuration of Office 365 User $UserPrincipalName"
 
+    # TODO: Remove property 'PasswordNeverExpires' in next breaking change
+    if ($PSBoundParameters.ContainsKey('PasswordNeverExpires'))
+    {
+        $PSBoundParameters.Remove('PasswordNeverExpires') | Out-Null
+        Write-Warning "Property 'PasswordNeverExpires' is deprecated and will be removed, please use 'PasswordPolicies' instead with 'DisablePasswordExpiration'"
+    }
+
     #Ensure the proper dependencies are installed in the current environment.
     Confirm-M365DSCDependencies
 
@@ -506,16 +514,6 @@ function Set-TargetResource
     }
     elseif ($Ensure -eq 'Present')
     {
-        $PasswordPolicies = $null
-        if ($PasswordNeverExpires)
-        {
-            $PasswordPolicies = 'DisablePasswordExpiration'
-        }
-        else
-        {
-            $PasswordPolicies = 'None'
-        }
-
         $creationParams = @{}
         foreach ($kvp in $Script:creationParamsMap.GetEnumerator())
         {
@@ -723,7 +721,6 @@ function Set-TargetResource
                     }
                     else
                     {
-
                         # Group that user is a member of is not present in MemberOf, remove user from group
                         # (no need to test for dynamic groups as they are ignored in Get-TargetResource)
                         if ($null -eq $group)
@@ -954,8 +951,10 @@ function Test-TargetResource
     Add-M365DSCTelemetryEvent -Data $data
     #endregion
 
+    $compareParameters = Get-CompareParameters
     $result = Test-M365DSCTargetResource -DesiredValues $PSBoundParameters `
-        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '')
+        -ResourceName $($MyInvocation.MyCommand.Source).Replace('MSFT_', '') `
+        @compareParameters
     return $result
 }
 
@@ -1221,4 +1220,15 @@ function Export-TargetResource
     }
 }
 
-Export-ModuleMember -Function *-TargetResource
+function Get-CompareParameters
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param()
+
+    return @{
+        ExcludedProperties = @('PasswordNeverExpires')
+    }
+}
+
+Export-ModuleMember -Function @('*-TargetResource', 'Get-CompareParameters')

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADUser.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.AADUser.Tests.ps1
@@ -169,7 +169,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     UsageLocation        = 'US'
                     LicenseAssignment    = @()
                     Password             = $Credential
-                    PasswordNeverExpires = $false
                     Ensure               = 'Present'
                     Credential           = $Credential
                 }
@@ -230,7 +229,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     UsageLocation        = 'US'
                     MemberOf             = 'TestGroup'
                     Password             = $Credential
-                    PasswordNeverExpires = $false
                     Ensure               = 'Present'
                     Credential           = $Credential
                 }
@@ -292,7 +290,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     UsageLocation        = 'US'
                     #MemberOf             = @('TestGroup')
                     Password             = $Credential
-                    PasswordNeverExpires = $false
                     Ensure               = 'Present'
                     Credential           = $Credential
                 }
@@ -360,7 +357,6 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     UsageLocation        = 'US'
                     MemberOf             = 'TestGroup'
                     Password             = $Credential
-                    PasswordNeverExpires = $false
                     Ensure               = 'Present'
                     Credential           = $Credential
                 }


### PR DESCRIPTION
#### Pull Request (PR) description

Property `PasswordNeverExpires` actually is not working correctly and cannot set the value in the resource, additionally is conflicting with property `PasswordPolicies` which can also be used to set the same password expiration setting on a user so this PR fixed this by deprecating `PasswordNeverExpires` in favor of `PasswordPolicies`.

#### This Pull Request (PR) fixes the following issues

- Fixes #7339 

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
