### PR TITLE
Return Guid for Apps if input contains them as well for CA Policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+* AADConditionalAccessPolicy
+  * Updated the code to return a GUID for `IncludeApplications` and
+    `ExcludeApplications` if the input already contains that GUID.
+    FIXES [#7118](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7118)
 * AADIdentityGovernanceProgram
   * Deprecated resource. It is superseded by the access review resources.
 * AADServicePrincipal

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -669,7 +669,9 @@ function Get-TargetResource
         {
             foreach ($app in $Policy.Conditions.Applications.IncludeApplications)
             {
-                if ([System.Guid]::TryParse($app, [ref][System.Guid]::Empty))
+                # Only resolve to display name if the app is a GUID and not already in the list of included applications
+                # to prevent drifts during Test-TargetResource
+                if ([System.Guid]::TryParse($app, [ref][System.Guid]::Empty) -and $IncludeApplications -notcontains $app)
                 {
                     $appInfo = Get-MgServicePrincipal -Filter "AppId eq '$app'" -ErrorAction SilentlyContinue
                     if ($null -ne $appInfo)
@@ -693,7 +695,9 @@ function Get-TargetResource
         {
             foreach ($app in $Policy.Conditions.Applications.ExcludeApplications)
             {
-                if ([System.Guid]::TryParse($app, [ref][System.Guid]::Empty))
+                # Only resolve to display name if the app is a GUID and not already in the list of excluded applications
+                # to prevent drifts during Test-TargetResource
+                if ([System.Guid]::TryParse($app, [ref][System.Guid]::Empty) -and $ExcludeApplications -notcontains $app)
                 {
                     $appInfo = Get-MgServicePrincipal -Filter "AppId eq '$app'" -ErrorAction SilentlyContinue
                     if ($null -ne $appInfo)


### PR DESCRIPTION
#### Pull Request (PR) description
Return Guid for Apps if input contains them as well for Conditional Access Policies

#### This Pull Request (PR) fixes the following issues
- Fixes #7118 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
