### PR TITLE
Fix variable replacement mappings in parallel exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,16 @@
   * Added missing workload connections.
 * O365SearchAndIntelligenceConfigurations
   * Added missing workload connection.
+* M365DSCExportUtil
+  * Since `M365DSCStringReplacementMap` is now being sent in parallel exports
+    as global variable we need to set it as script scope based to be able to
+    inspect it
 * M365DSCReverse
   * Fixed an issue where parallel exports for EXO, O365 and SC could fail
     if combined with resources that use Microsoft Graph.
+  * Fixed an issue where parallel exports were not being sent with the variable
+    `M365DSCStringReplacementMap` and therefore mappings were not working and
+    creating drifts
 * DEPENDENCIES
   * Updated `MSCloudLoginAssistant` to version 1.1.70.
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCExportUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCExportUtil.psm1
@@ -806,6 +806,10 @@ function Get-M365DSCExportContentForResource
     }
 
     # Apply additional string to variable replacements from mapping
+    if ($Global:M365DSCStringReplacementMap)
+    {
+        Set-M365DSCStringReplacementMap -Map $Global:M365DSCStringReplacementMap
+    }
     if ($null -ne $Script:M365DSCStringReplacementMap -and $Script:M365DSCStringReplacementMap.Count -gt 0)
     {
         foreach ($entry in $Script:M365DSCStringReplacementMap.GetEnumerator())

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -689,10 +689,12 @@ function Start-M365DSCConfigurationExtract
         [void]$synchronizedHashtable.TryAdd('SuccessfulResources', 0)
         [void]$synchronizedHashtable.TryAdd('FailedResources', 0)
         $resourceDictionary = Get-M365DSCAllResourcesDictionary
+        $M365DSCStringReplacementMap = Get-M365DSCStringReplacementMap
         $exportScriptBlock = {
             $Global:MaximumFunctionCount = 32768
             $Global:PartialExportFileName = $using:partialExportName
             $Global:M365DSCSkipDependenciesValidation = $true
+            $Global:M365DSCStringReplacementMap = $using:M365DSCStringReplacementMap
             $resource = $_
             Set-M365DSCAllResourcesDictionary -DscResourceDictionary $using:resourceDictionary
             $resourceName = $resource.Name.Split('.')[0] -replace 'MSFT_', ''


### PR DESCRIPTION
#### Pull Request (PR) description

Since we now support parallel exports the variable replacement mappings were not working and creating drifts, this PR fixes that issue by sending the variable `M365DSCStringReplacementMap` inside the export script block that gets invoked during parallel execution.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
