### PR TITLE
Add EndpointDlpRestrictions to SCDLPComplianceRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
   * Deprecate property `Desks`
 * IntuneWifiConfigurationPolicyIOS
   * Added `wpa3Personal` to the `WifiSecurityType` property.
+* SCDLPComplianceRule
+  * Added support for the `EndpointDlpRestrictions` property.
 * SettingsCatalogHelper
   * Fixed an issue where complex administrative template names
     were not handled correctly.

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
@@ -42,6 +42,10 @@ function Get-TargetResource
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
+        $EndpointDlpRestrictions,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
         $ExceptIfContentContainsSensitiveInformation,
 
         [Parameter()]
@@ -439,6 +443,7 @@ function Get-TargetResource
             Comment                                      = $PolicyRule.Comment
             AdvancedRule                                 = $newAdvancedRule
             ContentContainsSensitiveInformation          = $PolicyRule.ContentContainsSensitiveInformation
+            EndpointDlpRestrictions                      = Convert-SCDLPEndpointDlpRestrictions -EndpointDlpRestrictions $PolicyRule.EndpointDlpRestrictions
             ExceptIfContentContainsSensitiveInformation  = $PolicyRule.ExceptIfContentContainsSensitiveInformation
             ContentPropertyContainsWords                 = $PolicyRule.ContentPropertyContainsWords
             Disabled                                     = $PolicyRule.Disabled
@@ -572,6 +577,10 @@ function Set-TargetResource
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $ContentContainsSensitiveInformation,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $EndpointDlpRestrictions,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
@@ -927,6 +936,11 @@ function Set-TargetResource
             $CreationParams.Remove('AdvancedRule')
         }
 
+        if ($null -ne $CreationParams.EndpointDlpRestrictions)
+        {
+            $CreationParams.EndpointDlpRestrictions = Convert-SCDLPEndpointDlpRestrictions -EndpointDlpRestrictions $CreationParams.EndpointDlpRestrictions
+        }
+
         if ($null -ne $CreationParams.SetHeader)
         {
             $setHeaders = @{}
@@ -984,6 +998,11 @@ function Set-TargetResource
         if ($null -ne $UpdateParams.ContentContainsSensitiveInformation)
         {
             $UpdateParams.Remove('AdvancedRule')
+        }
+
+        if ($null -ne $UpdateParams.EndpointDlpRestrictions)
+        {
+            $UpdateParams.EndpointDlpRestrictions = Convert-SCDLPEndpointDlpRestrictions -EndpointDlpRestrictions $UpdateParams.EndpointDlpRestrictions
         }
 
         if ($null -ne $UpdateParams.SetHeader)
@@ -1051,6 +1070,10 @@ function Test-TargetResource
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
         $ContentContainsSensitiveInformation,
+
+        [Parameter()]
+        [Microsoft.Management.Infrastructure.CimInstance[]]
+        $EndpointDlpRestrictions,
 
         [Parameter()]
         [Microsoft.Management.Infrastructure.CimInstance[]]
@@ -1403,9 +1426,14 @@ function Test-TargetResource
     $ValuesToCheck.Remove('ContentContainsSensitiveInformation') | Out-Null
     $ValuesToCheck.Remove('ExceptIfContentContainsSensitiveInformation') | Out-Null
 
+    if ($null -ne $ValuesToCheck['EndpointDlpRestrictions'])
+    {
+        $ValuesToCheck['EndpointDlpRestrictions'] = Convert-SCDLPEndpointDlpRestrictions -EndpointDlpRestrictions $ValuesToCheck['EndpointDlpRestrictions']
+    }
+
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `
-        -DesiredValues $PSBoundParameters `
+        -DesiredValues $ValuesToCheck `
         -ValuesToCheck $ValuesToCheck.Keys
 
     Write-Verbose -Message "Test-TargetResource returned $TestResult"
@@ -1621,12 +1649,28 @@ function Export-TargetResource
                 }
             }
 
+            if ($null -ne $Results.EndpointDlpRestrictions)
+            {
+                $complexTypeStringResult = Get-M365DSCDRGComplexTypeToString `
+                    -ComplexObject $Results.EndpointDlpRestrictions `
+                    -CIMInstanceName 'SCDLPEndpointDlpRestriction' `
+                    -IsArray
+                if (-not [String]::IsNullOrEmpty($complexTypeStringResult))
+                {
+                    $Results.EndpointDlpRestrictions = $complexTypeStringResult
+                }
+                else
+                {
+                    $Results.Remove('EndpointDlpRestrictions') | Out-Null
+                }
+            }
+
             $currentDSCBlock = Get-M365DSCExportContentForResource -ResourceName $ResourceName `
                 -ConnectionMode $ConnectionMode `
                 -ModulePath $PSScriptRoot `
                 -Results $Results `
                 -Credential $Credential `
-                -NoEscape @('ContentContainsSensitiveInformation', 'ExceptIfContentContainsSensitiveInformation')
+                -NoEscape @('ContentContainsSensitiveInformation', 'EndpointDlpRestrictions', 'ExceptIfContentContainsSensitiveInformation')
 
             [void]$dscContent.Append($currentDSCBlock)
 
@@ -1648,6 +1692,46 @@ function Export-TargetResource
 
         throw
     }
+}
+
+function Convert-SCDLPEndpointDlpRestrictions
+{
+    [CmdletBinding()]
+    [OutputType([System.Object[]])]
+    param
+    (
+        [Parameter()]
+        [System.Object[]]
+        $EndpointDlpRestrictions
+    )
+
+    if ($null -eq $EndpointDlpRestrictions)
+    {
+        return $null
+    }
+
+    $returnValue = @()
+    foreach ($restriction in $EndpointDlpRestrictions)
+    {
+        $currentRestriction = @{}
+        foreach ($propertyName in @('Setting', 'Value', 'Value2'))
+        {
+            if ($restriction -is [System.Collections.IDictionary])
+            {
+                if ($restriction.Contains($propertyName) -and $null -ne $restriction[$propertyName])
+                {
+                    $currentRestriction[$propertyName] = $restriction[$propertyName]
+                }
+            }
+            elseif ($null -ne $restriction.$propertyName)
+            {
+                $currentRestriction[$propertyName] = $restriction.$propertyName
+            }
+        }
+        $returnValue += $currentRestriction
+    }
+
+    return $returnValue
 }
 
 function Get-SCDLPSensitiveInformation

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.schema.mof
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.schema.mof
@@ -35,7 +35,15 @@ class MSFT_SCDLPContainsSensitiveInformation
     [Write, Description("Operator"),ValueMap{"And","Or"}, Values{"And","Or"}] String Operator;
 };
 
-[ClassVersion("1.0.0.2"), FriendlyName("SCDLPComplianceRule")]
+[ClassVersion("1.0.0.0")]
+class MSFT_SCDLPEndpointDlpRestriction
+{
+    [Required, Description("The Endpoint DLP restriction setting.")] String Setting;
+    [Required, Description("The Endpoint DLP restriction value.")] String Value;
+    [Write, Description("Additional Endpoint DLP restriction value.")] String Value2;
+};
+
+[ClassVersion("1.0.0.3"), FriendlyName("SCDLPComplianceRule")]
 class MSFT_SCDLPComplianceRule : OMI_BaseResource
 {
     [Key, Description("Name of the Rule.")] String Name;
@@ -46,6 +54,7 @@ class MSFT_SCDLPComplianceRule : OMI_BaseResource
     [Write, Description("The Comment parameter specifies an optional comment. If you specify a value that contains spaces, enclose the value in quotation marks.")] String Comment;
     [Write, Description("The AdvancedRule parameter uses complex rule syntax that supports multiple AND, OR, and NOT operators and nested groups")] String AdvancedRule;
     [Write, Description("The ContentContainsSensitiveInformation parameter specifies a condition for the rule that's based on a sensitive information type match in content. The rule is applied to content that contains the specified sensitive information type."), EmbeddedInstance("MSFT_SCDLPContainsSensitiveInformation")] String ContentContainsSensitiveInformation[];
+    [Write, Description("The EndpointDlpRestrictions parameter specifies the restricted endpoints for Endpoint DLP."), EmbeddedInstance("MSFT_SCDLPEndpointDlpRestriction")] String EndpointDlpRestrictions[];
     [Write, Description("The ExceptIfContentContainsSensitiveInformation parameter specifies an exception for the rule that's based on a sensitive information type match in content. The rule isn't applied to content that contains the specified sensitive information type."), EmbeddedInstance("MSFT_SCDLPContainsSensitiveInformation")] String ExceptIfContentContainsSensitiveInformation[];
     [Write, Description("The ContentPropertyContainsWords parameter specifies a condition for the DLP rule that's based on a property match in content. The rule is applied to content that contains the specified property.")] String ContentPropertyContainsWords[];
     [Write, Description("The Disabled parameter specifies whether the DLP rule is disabled.")] Boolean Disabled;

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCDLPComplianceRule.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCDLPComplianceRule.Tests.ps1
@@ -272,6 +272,108 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
         }
 
+        Context -Name "Rule doesn't already exist but should with EndpointDlpRestrictions" -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Ensure                  = 'Present'
+                    Policy                  = 'MyParentPolicy'
+                    EndpointDlpRestrictions = [CimInstance[]]@(
+                        New-CimInstance -ClassName MSFT_SCDLPEndpointDlpRestriction -Property @{
+                            Setting = 'Print'
+                            Value   = 'Block'
+                        } -ClientOnly
+                        New-CimInstance -ClassName MSFT_SCDLPEndpointDlpRestriction -Property @{
+                            Setting = 'UnallowedApps'
+                            Value   = 'notepad'
+                            Value2  = 'Microsoft Notepad'
+                        } -ClientOnly
+                    )
+                    NotifyUser              = @('user@contoso.com')
+                    Name                    = 'TestPolicy'
+                    Credential              = $Credential
+                }
+
+                $Script:EndpointDlpRestrictionsPassedToNew = $null
+                Mock -CommandName Get-DLPComplianceRule -MockWith {
+                    return $null
+                }
+                Mock -CommandName New-DLPComplianceRule -MockWith {
+                    $Script:EndpointDlpRestrictionsPassedToNew = $EndpointDlpRestrictions
+                }
+            }
+
+            It 'Should return false from the Test method' {
+                Test-TargetResource @testParams | Should -Be $false
+            }
+
+            It 'Should pass EndpointDlpRestrictions as hashtables to the New method' {
+                Set-TargetResource @testParams
+                $Script:EndpointDlpRestrictionsPassedToNew[0].Setting | Should -Be 'Print'
+                $Script:EndpointDlpRestrictionsPassedToNew[0].Value | Should -Be 'Block'
+                $Script:EndpointDlpRestrictionsPassedToNew[1].Setting | Should -Be 'UnallowedApps'
+                $Script:EndpointDlpRestrictionsPassedToNew[1].Value | Should -Be 'notepad'
+                $Script:EndpointDlpRestrictionsPassedToNew[1].Value2 | Should -Be 'Microsoft Notepad'
+            }
+        }
+
+        Context -Name 'Rule already exists, and should with EndpointDlpRestrictions' -Fixture {
+            BeforeAll {
+                $testParams = @{
+                    Ensure                  = 'Present'
+                    Policy                  = 'MyParentPolicy'
+                    EndpointDlpRestrictions = [CimInstance[]]@(
+                        New-CimInstance -ClassName MSFT_SCDLPEndpointDlpRestriction -Property @{
+                            Setting = 'Print'
+                            Value   = 'Block'
+                        } -ClientOnly
+                        New-CimInstance -ClassName MSFT_SCDLPEndpointDlpRestriction -Property @{
+                            Setting = 'UnallowedApps'
+                            Value   = 'notepad'
+                            Value2  = 'Microsoft Notepad'
+                        } -ClientOnly
+                    )
+                    NotifyUser              = @('user@contoso.com')
+                    Name                    = 'TestPolicy'
+                    Credential              = $Credential
+                }
+
+                $Script:EndpointDlpRestrictionsPassedToSet = $null
+                Mock -CommandName Get-DLPComplianceRule -MockWith {
+                    return @{
+                        Name                    = 'TestPolicy'
+                        ParentPolicyName        = 'MyParentPolicy'
+                        EndpointDlpRestrictions = @(
+                            @{Setting = 'Print'; Value = 'Block' },
+                            @{Setting = 'UnallowedApps'; Value = 'notepad'; Value2 = 'Microsoft Notepad' }
+                        )
+                        NotifyUser              = @('user@contoso.com')
+                    }
+                }
+                Mock -CommandName Set-DLPComplianceRule -MockWith {
+                    $Script:EndpointDlpRestrictionsPassedToSet = $EndpointDlpRestrictions
+                }
+            }
+
+            It 'Should return true from the Test method' {
+                Test-TargetResource @testParams | Should -Be $true
+            }
+
+            It 'Should pass EndpointDlpRestrictions as hashtables to the Set method' {
+                Set-TargetResource @testParams
+                $Script:EndpointDlpRestrictionsPassedToSet[0].Setting | Should -Be 'Print'
+                $Script:EndpointDlpRestrictionsPassedToSet[0].Value | Should -Be 'Block'
+                $Script:EndpointDlpRestrictionsPassedToSet[1].Setting | Should -Be 'UnallowedApps'
+                $Script:EndpointDlpRestrictionsPassedToSet[1].Value | Should -Be 'notepad'
+                $Script:EndpointDlpRestrictionsPassedToSet[1].Value2 | Should -Be 'Microsoft Notepad'
+            }
+
+            It 'Should return EndpointDlpRestrictions from the Get method' {
+                $result = Get-TargetResource @testParams
+                $result.EndpointDlpRestrictions[0].Setting | Should -Be 'Print'
+                $result.EndpointDlpRestrictions[1].Value2 | Should -Be 'Microsoft Notepad'
+            }
+        }
+
         Context -Name 'Rule should not exist' -Fixture {
             BeforeAll {
                 $testParams = @{
@@ -320,6 +422,10 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                         Name                                = 'TestPolicy'
                         ParentPolicyName                    = 'MyParentPolicy'
                         ContentContainsSensitiveInformation = @(@{maxconfidence = '100'; id = 'eefbb00e-8282-433c-8620-8f1da3bffdb2'; minconfidence = '75'; rulePackId = '00000000-0000-0000-0000-000000000000'; classifiertype = 'Content'; name = 'Argentina National Identity (DNI) Number'; mincount = '1'; maxcount = '9'; })
+                        EndpointDlpRestrictions             = @(
+                            @{Setting = 'Print'; Value = 'Block' },
+                            @{Setting = 'UnallowedApps'; Value = 'notepad'; Value2 = 'Microsoft Notepad' }
+                        )
                         Comment                             = ''
                         BlockAccess                         = $False
                     }
@@ -329,6 +435,8 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             It 'Should Reverse Engineer resource from the Export method' {
                 $result = Export-TargetResource @testParams
                 $result | Should -Not -BeNullOrEmpty
+                $result | Should -Match 'EndpointDlpRestrictions'
+                $result | Should -Match 'SCDLPEndpointDlpRestriction'
             }
         }
     }


### PR DESCRIPTION
## Description
Adds support for the EndpointDlpRestrictions property on the SCDLPComplianceRule resource.

## Changes
- Adds the MSFT_SCDLPEndpointDlpRestriction complex type to the resource schema.
- Wires EndpointDlpRestrictions through Get, Set, Test, and Export.
- Converts DSC CIM instances to the hashtable array expected by New-DLPComplianceRule and Set-DLPComplianceRule.
- Adds unit coverage for create, update, get, test, and reverse export paths.

## Testing
- Invoke-Pester -Path .\Tests\Unit\Microsoft365DSC\Microsoft365DSC.SCDLPComplianceRule.Tests.ps1 -Output Detailed