### PR TITLE
Ignore trainable classifier IDs during SCDLPComplianceRule drift checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,8 @@
   * Added `wpa3Personal` to the `WifiSecurityType` property.
 * SCDLPComplianceRule
   * Added support for the `EndpointDlpRestrictions` property.
+  * Fixed an issue where `AdvancedRule` condition ids could cause drift.
+    FIXES [#7352](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7352)
 * SettingsCatalogHelper
   * Fixed an issue where complex administrative template names
     were not handled correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   * Added missing workload connections.
 * O365SearchAndIntelligenceConfigurations
   * Added missing workload connection.
+* SCDLPComplianceRule
+  * Fixed an issue where trainable classifier ids in `AdvancedRule` could cause drift.
+    FIXES [#7352](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7352)
 * M365DSCExportUtil
   * Added auto completion for `-Components` in `Export-M365DSCConfiguration`.
   * Since `M365DSCStringReplacementMap` is now being sent in parallel exports
@@ -102,8 +105,6 @@
   * Added `wpa3Personal` to the `WifiSecurityType` property.
 * SCDLPComplianceRule
   * Added support for the `EndpointDlpRestrictions` property.
-  * Fixed an issue where trainable classifier ids in `AdvancedRule` could cause drift.
-    FIXES [#7352](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7352)
 * SettingsCatalogHelper
   * Fixed an issue where complex administrative template names
     were not handled correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@
   * Added `wpa3Personal` to the `WifiSecurityType` property.
 * SCDLPComplianceRule
   * Added support for the `EndpointDlpRestrictions` property.
-  * Fixed an issue where `AdvancedRule` condition ids could cause drift.
+  * Fixed an issue where trainable classifier ids in `AdvancedRule` could cause drift.
     FIXES [#7352](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7352)
 * SettingsCatalogHelper
   * Fixed an issue where complex administrative template names

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
@@ -412,11 +412,7 @@ function Get-TargetResource
 
         if ($null -ne $PolicyRule.AdvancedRule -and $PolicyRule.AdvancedRule.Count -gt 0)
         {
-            $ruleobject = $PolicyRule.AdvancedRule | ConvertFrom-Json
-            $ruleObject.Condition = Remove-AdvancedRuleConditionId -Condition $ruleObject.Condition
-
-            $newAdvancedRule = $ruleobject | ConvertTo-Json -Depth 32 | Format-Json
-            $newAdvancedRule = $newAdvancedRule | ConvertTo-Json -Compress
+            $newAdvancedRule = Format-AdvancedRuleWithoutConditionId -AdvancedRule $PolicyRule.AdvancedRule
         }
         else
         {
@@ -1431,6 +1427,11 @@ function Test-TargetResource
         $ValuesToCheck['EndpointDlpRestrictions'] = Convert-SCDLPEndpointDlpRestrictions -EndpointDlpRestrictions $ValuesToCheck['EndpointDlpRestrictions']
     }
 
+    if ($null -ne $ValuesToCheck['AdvancedRule'])
+    {
+        $ValuesToCheck['AdvancedRule'] = Format-AdvancedRuleWithoutConditionId -AdvancedRule $ValuesToCheck['AdvancedRule'] -IsDscEncoded
+    }
+
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `
         -Source $($MyInvocation.MyCommand.Source) `
         -DesiredValues $ValuesToCheck `
@@ -2118,6 +2119,29 @@ function Format-Json([Parameter(Mandatory, ValueFromPipeline)][String] $json)
         }
         $line
     }) -join "`n"
+}
+
+function Format-AdvancedRuleWithoutConditionId
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $AdvancedRule,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $IsDscEncoded
+    )
+
+    $ruleObject = $AdvancedRule | ConvertFrom-Json
+    if ($IsDscEncoded)
+    {
+        $ruleObject = $ruleObject | ConvertFrom-Json
+    }
+
+    $ruleObject.Condition = Remove-AdvancedRuleConditionId -Condition $ruleObject.Condition
+    $newAdvancedRule = $ruleObject | ConvertTo-Json -Depth 32 | Format-Json
+    return $newAdvancedRule | ConvertTo-Json -Compress
 }
 
 function Remove-AdvancedRuleConditionId

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
@@ -2152,18 +2152,10 @@ function Format-AdvancedRuleWithoutConditionId
     param(
         [Parameter(Mandatory = $true)]
         [System.String]
-        $AdvancedRule,
-
-        [Parameter()]
-        [System.Management.Automation.SwitchParameter]
-        $IsDscEncoded
+        $AdvancedRule
     )
 
     $ruleObject = $AdvancedRule | ConvertFrom-Json
-    if ($IsDscEncoded)
-    {
-        $ruleObject = $ruleObject | ConvertFrom-Json
-    }
 
     $ruleObject.Condition = Remove-AdvancedRuleConditionId -Condition $ruleObject.Condition
     $newAdvancedRule = $ruleObject | ConvertTo-Json -Depth 32 | Format-Json

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SCDLPComplianceRule/MSFT_SCDLPComplianceRule.psm1
@@ -1429,7 +1429,33 @@ function Test-TargetResource
 
     if ($null -ne $ValuesToCheck['AdvancedRule'])
     {
-        $ValuesToCheck['AdvancedRule'] = Format-AdvancedRuleWithoutConditionId -AdvancedRule $ValuesToCheck['AdvancedRule'] -IsDscEncoded
+        $advancedRuleObject = $ValuesToCheck['AdvancedRule'] | ConvertFrom-Json | ConvertFrom-Json
+        $conditions = @($advancedRuleObject.Condition)
+        while ($conditions.Count -gt 0)
+        {
+            $currentCondition = $conditions[0]
+            $conditions = @($conditions | Select-Object -Skip 1)
+
+            if ($null -ne $currentCondition.SubConditions)
+            {
+                $conditions += $currentCondition.SubConditions
+            }
+
+            if ($currentCondition.ConditionName -like '*ContentContainsSensitiveInformation*' -and `
+                $null -ne $currentCondition.Value.Groups.Sensitivetypes)
+            {
+                foreach ($sensitiveType in $currentCondition.Value.Groups.Sensitivetypes)
+                {
+                    if ($sensitiveType.Classifiertype -eq 'MLModel' -and $null -ne $sensitiveType.Id)
+                    {
+                        $sensitiveType.Id = $null
+                    }
+                }
+            }
+        }
+
+        $newAdvancedRule = $advancedRuleObject | ConvertTo-Json -Depth 32 | Format-Json
+        $ValuesToCheck['AdvancedRule'] = $newAdvancedRule | ConvertTo-Json -Compress
     }
 
     $TestResult = Test-M365DSCParameterState -CurrentValues $CurrentValues `

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCDLPComplianceRule.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCDLPComplianceRule.Tests.ps1
@@ -272,7 +272,7 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
         }
 
-        Context -Name 'Rule already exists, and should with AdvancedRules containing condition ids' -Fixture {
+        Context -Name 'Rule already exists, and should with AdvancedRules containing trainable classifier ids' -Fixture {
             BeforeAll {
                 $desiredAdvancedRule = @'
 {
@@ -293,6 +293,13 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                     "Name": "Healthcare",
                     "Id": "11111111-1111-1111-1111-111111111111",
                     "Classifiertype": "MLModel"
+                  },
+                  {
+                    "Name": "EU Debit Card Number",
+                    "Id": "0e9b3178-9678-47dd-a509-37222ca96b42",
+                    "Mincount": 1,
+                    "Maxcount": -1,
+                    "Confidencelevel": "Medium"
                   }
                 ]
               }
@@ -322,8 +329,15 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 "Sensitivetypes": [
                   {
                     "Name": "Healthcare",
-                    "Id": "22222222-2222-2222-2222-222222222222",
+                    "Id": null,
                     "Classifiertype": "MLModel"
+                  },
+                  {
+                    "Name": "EU Debit Card Number",
+                    "Id": null,
+                    "Mincount": 1,
+                    "Maxcount": -1,
+                    "Confidencelevel": "Medium"
                   }
                 ]
               }
@@ -364,11 +378,12 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 }
             }
 
-            It 'Should ignore condition ids when testing AdvancedRules for drift' {
+            It 'Should ignore trainable classifier ids when testing AdvancedRules for drift' {
                 Test-TargetResource @testParams | Should -Be $true
-                $Script:AdvancedRulePassedToTest | Should -Not -Match '11111111-1111-1111-1111-111111111111'
                 $normalizedAdvancedRule = $Script:AdvancedRulePassedToTest | ConvertFrom-Json | ConvertFrom-Json
-                $normalizedAdvancedRule.Condition.SubConditions[0].Value[0].Groups[0].Sensitivetypes[0].Id | Should -Be $null
+                $sensitiveTypes = $normalizedAdvancedRule.Condition.SubConditions[0].Value[0].Groups[0].Sensitivetypes
+                ($sensitiveTypes | Where-Object -FilterScript { $_.Name -eq 'Healthcare' }).Id | Should -Be $null
+                ($sensitiveTypes | Where-Object -FilterScript { $_.Name -eq 'EU Debit Card Number' }).Id | Should -Be '0e9b3178-9678-47dd-a509-37222ca96b42'
             }
         }
 

--- a/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCDLPComplianceRule.Tests.ps1
+++ b/Tests/Unit/Microsoft365DSC/Microsoft365DSC.SCDLPComplianceRule.Tests.ps1
@@ -272,6 +272,106 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
             }
         }
 
+        Context -Name 'Rule already exists, and should with AdvancedRules containing condition ids' -Fixture {
+            BeforeAll {
+                $desiredAdvancedRule = @'
+{
+  "Version": "1.0",
+  "Condition": {
+    "Operator": "And",
+    "SubConditions": [
+      {
+        "ConditionName": "ContentContainsSensitiveInformation",
+        "Value": [
+          {
+            "Groups": [
+              {
+                "Name": "PHI SITs",
+                "Operator": "Or",
+                "Sensitivetypes": [
+                  {
+                    "Name": "Healthcare",
+                    "Id": "11111111-1111-1111-1111-111111111111",
+                    "Classifiertype": "MLModel"
+                  }
+                ]
+              }
+            ],
+            "Operator": "And"
+          }
+        ]
+      }
+    ]
+  }
+}
+'@
+                $currentAdvancedRule = @'
+{
+  "Version": "1.0",
+  "Condition": {
+    "Operator": "And",
+    "SubConditions": [
+      {
+        "ConditionName": "ContentContainsSensitiveInformation",
+        "Value": [
+          {
+            "Groups": [
+              {
+                "Name": "PHI SITs",
+                "Operator": "Or",
+                "Sensitivetypes": [
+                  {
+                    "Name": "Healthcare",
+                    "Id": "22222222-2222-2222-2222-222222222222",
+                    "Classifiertype": "MLModel"
+                  }
+                ]
+              }
+            ],
+            "Operator": "And"
+          }
+        ]
+      }
+    ]
+  }
+}
+'@
+                $testParams = @{
+                    Ensure       = 'Present'
+                    Policy       = 'MyParentPolicy'
+                    Comment      = 'New comment'
+                    AdvancedRule = $desiredAdvancedRule | ConvertTo-Json -Compress
+                    BlockAccess  = $False
+                    Name         = 'TestPolicy'
+                    Credential   = $Credential
+                }
+
+                $Script:AdvancedRulePassedToTest = $null
+                Mock -CommandName Get-DLPComplianceRule -MockWith {
+                    return @{
+                        Name             = 'TestPolicy'
+                        Comment          = 'New Comment'
+                        ParentPolicyName = 'MyParentPolicy'
+                        AdvancedRule     = $currentAdvancedRule
+                        BlockAccess      = $False
+                    }
+                }
+
+                Mock -CommandName Test-M365DSCParameterState -MockWith {
+                    param($CurrentValues, $Source, $DesiredValues, $ValuesToCheck)
+                    $Script:AdvancedRulePassedToTest = $DesiredValues.AdvancedRule
+                    return $true
+                }
+            }
+
+            It 'Should ignore condition ids when testing AdvancedRules for drift' {
+                Test-TargetResource @testParams | Should -Be $true
+                $Script:AdvancedRulePassedToTest | Should -Not -Match '11111111-1111-1111-1111-111111111111'
+                $normalizedAdvancedRule = $Script:AdvancedRulePassedToTest | ConvertFrom-Json | ConvertFrom-Json
+                $normalizedAdvancedRule.Condition.SubConditions[0].Value[0].Groups[0].Sensitivetypes[0].Id | Should -Be $null
+            }
+        }
+
         Context -Name "Rule doesn't already exist but should with EndpointDlpRestrictions" -Fixture {
             BeforeAll {
                 $testParams = @{


### PR DESCRIPTION
#### Pull Request (PR) description

This PR updates `SCDLPComplianceRule` so `Test-TargetResource` ignores tenant-specific trainable classifier (`MLModel`) IDs inside `AdvancedRule` during drift comparison. This prevents the resource from reapplying at each run interval while preserving regular sensitive information type IDs and leaving create/update behavior unchanged.

#### This Pull Request (PR) fixes the following issues

- Fixes #7352

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

Validated with:

```powershell
.\Tests\Unit\Microsoft365DSC\Microsoft365DSC.SCDLPComplianceRule.Tests.ps1
```