### PR TITLE
Fix throwing export when  not-found instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   * Added new properties `DefaultRedirectUri`, `Info`, `Logo` and
     `ServiceManagementReference`.
     FIXES [#4321](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/4321)
+* AADEntitlementManagementAccessPackageCatalogResource
+  * Fixed an issue where a non-existing Service Principal or Group would
+    throw an error during the export instead of continuing.
 * IntuneAppConfigurationPolicy
   * Added information about no support for Settings catalog policy entries due to
     delegated authentication requirements.

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AADEntitlementManagementAccessPackageCatalogResource/MSFT_AADEntitlementManagementAccessPackageCatalogResource.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AADEntitlementManagementAccessPackageCatalogResource/MSFT_AADEntitlementManagementAccessPackageCatalogResource.psm1
@@ -186,14 +186,20 @@ function Get-TargetResource
         switch ($getValue.OriginSystem)
         {
             'AadApplication' {
-                $originId = (Get-MgServicePrincipal -ServicePrincipalId $getValue.OriginId).DisplayName
+                $originId = (Get-MgServicePrincipal -ServicePrincipalId $getValue.OriginId -ErrorAction SilentlyContinue).DisplayName
             }
             'AADGroup' {
-                $originId = (Get-MgGroup -GroupId $getValue.OriginId).DisplayName
+                $originId = (Get-MgGroup -GroupId $getValue.OriginId -ErrorAction SilentlyContinue).DisplayName
             }
             default {
                 $originId = $getValue.OriginId
             }
+        }
+
+        if ($null -eq $originId)
+        {
+            Write-Warning -Message "The origin id {$($getValue.OriginId)} of OriginSystem {$($getValue.OriginSystem)} could not be resolved to a display name. Returning the id instead."
+            $originId = $getValue.OriginId
         }
 
         $results = [ordered]@{


### PR DESCRIPTION
#### Pull Request (PR) description
Fixed an issue where `AADEntitlementManagementAccessPackageCatalogResource` may throw if a service principal or group was not found during export.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
