### PR TITLE
Fix Sentinel export and SubscriptionId handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,32 @@
 * IntuneWindowsDataProcessingSettings
   * Initial release.
     FIXES [#4154](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/4154)
+* SentinelAlertRule
+  * Added `SubscriptionId` parameter to `Export-TargetResource`.
+  * Fixed an issue where non-Sentinel Log Analytics Workspaces were exported.
+* SentinelSetting
+  * Added `SubscriptionId` parameter to `Export-TargetResource`.
+  * Fixed an issue where non-Sentinel Log Analytics Workspaces were exported.
+* SentinelThreatIntelligenceIndicator
+  * Added `SubscriptionId` parameter to `Export-TargetResource`.
+  * Fixed an issue where non-Sentinel Log Analytics Workspaces were exported.
+* SentinelWatchlist
+  * Added `SubscriptionId` parameter to `Export-TargetResource`.
+  * Fixed an issue where non-Sentinel Log Analytics Workspaces were exported.
 * M365DSCDocGenerator
   * Fixed an issue where not all permissions were shown on the resource docs page.
+* M365DSCExportUtil
+  * Removed validation from `SubscriptionId` parameter.
+* M365DSCReverse
+  * Updated `SubscriptionId` handling to pass to all export functions that define it.
 * MISC
   * Updated documentation for the `Update-M365DSCAzureAdApplication` function.
     FIXES [#5399](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/5399)
   * Updated required permissions and documentation for Azure resources.
     FIXES [#6960](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/6960)
+* DEPENDENCIES
+  * Updated `MSCloudLoginAssistant` to version 1.1.72.
+    FIXES [#7371](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7371)
 
 # 1.26.722.1
 

--- a/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
+++ b/Modules/Microsoft365DSC/Dependencies/Manifest.psd1
@@ -42,7 +42,7 @@
         },
         @{
             ModuleName      = "MSCloudLoginAssistant"
-            RequiredVersion = "1.1.71"
+            RequiredVersion = "1.1.72"
         },
         @{
             ModuleName      = 'PnP.PowerShell'

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SentinelAlertRule/MSFT_SentinelAlertRule.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SentinelAlertRule/MSFT_SentinelAlertRule.psm1
@@ -1025,7 +1025,7 @@ function Export-TargetResource
                 -TenantId $TenantId
 
             $j = 1
-            if ($rules.Length -eq 0 )
+            if ($rules.Length -eq 0)
             {
                 Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
             }

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SentinelAlertRule/MSFT_SentinelAlertRule.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SentinelAlertRule/MSFT_SentinelAlertRule.psm1
@@ -928,6 +928,10 @@ function Export-TargetResource
     param
     (
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -981,11 +985,16 @@ function Export-TargetResource
 
     try
     {
-        $workspaces = Get-AzResource -ResourceType 'Microsoft.OperationalInsights/workspaces'
-        $exportedInstances = @()
+        $sentinelInstances = Get-AzResource -ResourceType 'Microsoft.OperationsManagement/solutions'
+        $sentinelNames = @()
+        foreach ($instance in $sentinelInstances)
+        {
+            $sentinelNames += $instance.Name.Replace('SecurityInsights(', '').Replace(')', '')
+        }
+        $workspaces = Get-AzResource -ResourceType 'Microsoft.OperationalInsights/workspaces' | Where-Object Name -in $sentinelNames
         $i = 1
         $dscContent = [System.Text.StringBuilder]::new()
-        if ($exportedInstances.Length -eq 0)
+        if ($workspaces.Length -eq 0)
         {
             Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
         }
@@ -1016,7 +1025,7 @@ function Export-TargetResource
                 -TenantId $TenantId
 
             $j = 1
-            if ($currentWatchLists.Length -eq 0 )
+            if ($rules.Length -eq 0 )
             {
                 Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
             }

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SentinelSetting/MSFT_SentinelSetting.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SentinelSetting/MSFT_SentinelSetting.psm1
@@ -106,12 +106,13 @@ function Get-TargetResource
                 -ErrorAction SilentlyContinue `
                 -SubscriptionId $SubscriptionId
         }
+
         if ($null -eq $instance)
         {
-            throw "Could not find Sentinel Workspace {$WorkspaceName} in Resource Group {$ResourceGroupName}"
+            throw "Failed to get configuration for Sentinel Workspace {$WorkspaceName} in Resource Group {$ResourceGroupName}"
         }
 
-        Write-Verbose -Message "Found an instance of Sentinel Workspace {$Workspace}"
+        Write-Verbose -Message "Found an instance of Sentinel Workspace {$WorkspaceName}"
         $Anomalies = $instance | Where-Object -FilterScript { $_.Name -eq 'Anomalies' }
         $AnomaliesIsEnabledValue = $false
         if ($null -ne $Anomalies)
@@ -380,6 +381,10 @@ function Export-TargetResource
     param
     (
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -434,7 +439,13 @@ function Export-TargetResource
     try
     {
         $Script:ExportMode = $true
-        [array] $Script:exportedInstances = Get-AzResource -ResourceType 'Microsoft.OperationalInsights/workspaces'
+        $sentinelInstances = Get-AzResource -ResourceType 'Microsoft.OperationsManagement/solutions'
+        $sentinelNames = @()
+        foreach ($instance in $sentinelInstances)
+        {
+            $sentinelNames += $instance.Name.Replace('SecurityInsights(', '').Replace(')', '')
+        }
+        [array] $Script:exportedInstances = Get-AzResource -ResourceType 'Microsoft.OperationalInsights/workspaces' | Where-Object Name -in $sentinelNames
 
         $dscContent = [System.Text.StringBuilder]::new()
         $i = 1

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SentinelThreatIntelligenceIndicator/MSFT_SentinelThreatIntelligenceIndicator.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SentinelThreatIntelligenceIndicator/MSFT_SentinelThreatIntelligenceIndicator.psm1
@@ -533,6 +533,10 @@ function Export-TargetResource
     param
     (
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -586,11 +590,16 @@ function Export-TargetResource
 
     try
     {
-        $workspaces = Get-AzResource -ResourceType 'Microsoft.OperationalInsights/workspaces'
-        $exportedInstances = @()
+        $sentinelInstances = Get-AzResource -ResourceType 'Microsoft.OperationsManagement/solutions'
+        $sentinelNames = @()
+        foreach ($instance in $sentinelInstances)
+        {
+            $sentinelNames += $instance.Name.Replace('SecurityInsights(', '').Replace(')', '')
+        }
+        $workspaces = Get-AzResource -ResourceType 'Microsoft.OperationalInsights/workspaces' | Where-Object Name -in $sentinelNames
         $i = 1
         $dscContent = [System.Text.StringBuilder]::new()
-        if ($exportedInstances.Length -eq 0)
+        if ($workspaces.Length -eq 0)
         {
             Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
         }
@@ -621,7 +630,7 @@ function Export-TargetResource
                 -TenantId $TenantId
 
             $j = 1
-            if ($currentWatchLists.Length -eq 0 )
+            if ($indicators.Length -eq 0 )
             {
                 Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
             }

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SentinelThreatIntelligenceIndicator/MSFT_SentinelThreatIntelligenceIndicator.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SentinelThreatIntelligenceIndicator/MSFT_SentinelThreatIntelligenceIndicator.psm1
@@ -630,7 +630,7 @@ function Export-TargetResource
                 -TenantId $TenantId
 
             $j = 1
-            if ($indicators.Length -eq 0 )
+            if ($indicators.Length -eq 0)
             {
                 Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
             }

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SentinelWatchlist/MSFT_SentinelWatchlist.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SentinelWatchlist/MSFT_SentinelWatchlist.psm1
@@ -472,6 +472,10 @@ function Export-TargetResource
     param
     (
         [Parameter()]
+        [System.String]
+        $SubscriptionId,
+
+        [Parameter()]
         [System.Management.Automation.PSCredential]
         $Credential,
 
@@ -526,11 +530,17 @@ function Export-TargetResource
     try
     {
         $Script:ExportMode = $true
-        $workspaces = Get-AzResource -ResourceType 'Microsoft.OperationalInsights/workspaces'
+        $sentinelInstances = Get-AzResource -ResourceType 'Microsoft.OperationsManagement/solutions'
+        $sentinelNames = @()
+        foreach ($instance in $sentinelInstances)
+        {
+            $sentinelNames += $instance.Name.Replace('SecurityInsights(', '').Replace(')', '')
+        }
+        $workspaces = Get-AzResource -ResourceType 'Microsoft.OperationalInsights/workspaces' | Where-Object Name -in $sentinelNames
         $Script:exportedInstances = @()
         $i = 1
         $dscContent = [System.Text.StringBuilder]::new()
-        if ($Script:exportedInstances.Length -eq 0)
+        if ($workspaces.Length -eq 0)
         {
             Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
         }

--- a/Modules/Microsoft365DSC/DscResources/MSFT_SentinelWatchlist/MSFT_SentinelWatchlist.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_SentinelWatchlist/MSFT_SentinelWatchlist.psm1
@@ -566,7 +566,7 @@ function Export-TargetResource
                 -TenantId $TenantId
 
             $j = 1
-            if ($currentWatchLists.Length -eq 0 )
+            if ($currentWatchLists.Length -eq 0)
             {
                 Write-M365DSCHost -Message $Global:M365DSCEmojiGreenCheckMark -CommitWrite
             }

--- a/Modules/Microsoft365DSC/Modules/M365DSCExportUtil.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCExportUtil.psm1
@@ -233,7 +233,6 @@ function Export-M365DSCConfiguration
         $AccessTokens,
 
         [Parameter(ParameterSetName = 'Export')]
-        [ValidateScript({ $Workloads -contains 'AZURE' -or ($Components -like "Azure*").Count -gt 0 })]
         [System.String]
         $SubscriptionId,
 

--- a/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCReverse.psm1
@@ -862,8 +862,9 @@ function Start-M365DSCConfigurationExtract
                     }
                 }
 
-                # Check for SubscriptionId if Azure resource
-                if ($resourceName -like "Azure*" -and -not [System.String]::IsNullOrEmpty($using:SubscriptionId))
+                # Check for Export-TargetResource parameters supports -SubscriptionId
+                $functionParameters = (Get-Command 'Export-TargetResource').Parameters
+                if ($functionParameters.Keys.Contains('SubscriptionId') -and -not [System.String]::IsNullOrEmpty($using:SubscriptionId))
                 {
                     $parameters.Add('SubscriptionId', $using:SubscriptionId)
                 }


### PR DESCRIPTION
#### Pull Request (PR) description
Fix Sentinel export and SubscriptionId handling. The Sentinel resources exported every log analytics workspace available, which where some instances might not be onboarded to the Sentinel service. These instances are now excluded from the export instead of making the export fail.

#### This Pull Request (PR) fixes the following issues
- Fixes #7371 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
