### PR TITLE
Fix AAD Entitement Access Package Assignment filter result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   * Added new properties `DefaultRedirectUri`, `Info`, `Logo` and
     `ServiceManagementReference`.
     FIXES [#4321](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/4321)
+* AADEntitlementManagementAccessPackageAssignmentPolicy
+  * Fixed an issue where lookup by `DisplayName` returned all results.
+    FIXES [#7374](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7374)
 * AADEntitlementManagementAccessPackageCatalogResource
   * Fixed an issue where a non-existing Service Principal or Group would
     throw an error during the export instead of continuing.

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy/MSFT_AADEntitlementManagementAccessPackageAssignmentPolicy.psm1
@@ -131,7 +131,7 @@ function Get-TargetResource
         {
             Write-Verbose -Message "The access package assignment policy with id {$id} was not found"
             $getValue = Get-MgBetaEntitlementManagementAccessPackageAssignmentPolicy `
-                -DisplayNameEq $DisplayName `
+                -Filter "displayName eq '$($DisplayName -replace "'", "''")'" `
                 -ExpandProperty "customExtensionHandlers(`$expand=customExtension)" `
                 -ErrorAction SilentlyContinue
         }


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes an issue where the filter property `-DisplayNameEq` was used instead of `-Filter "displayName eq 'xxx'"` for `AADEntitlementManagementAccessPackageAssignmentPolicy`. 

#### This Pull Request (PR) fixes the following issues
- Fixes #7374 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
