### PR TITLE
Update Conditional Access Policy with default value and throw message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
   * Added new properties `DefaultRedirectUri`, `Info`, `Logo` and
     `ServiceManagementReference`.
     FIXES [#4321](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/4321)
+* AADConditionalAccessPolicy
+  * Added requirement to specify `ExcludeExternalTenantsMembershipKind` if
+    `ExcludeExternalTenantsMembers` is specified during apply.
+  * Assigned the value `All` as default for `ExcludeExternalTenantsMembershipKind`
+    during apply.
+    FIXES [#6163](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/6163)
 * AADEntitlementManagementAccessPackageAssignmentPolicy
   * Fixed an issue where lookup by `DisplayName` returned all results.
     FIXES [#7374](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7374)

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AADConditionalAccessPolicy/MSFT_AADConditionalAccessPolicy.psm1
@@ -1498,9 +1498,18 @@ function Set-TargetResource
                     [string]$ExcludeGuestOrExternalUserTypes = $ExcludeGuestOrExternalUserTypes -join ','
                     $excludeGuestsOrExternalUsers.Add('guestOrExternalUserTypes', $ExcludeGuestOrExternalUserTypes)
                     $externalTenants = @{}
+                    # Assume default value of 'All' if ExcludeExternalTenantsMembershipKind is null or empty
+                    if ([System.String]::IsNullOrEmpty($ExcludeExternalTenantsMembershipKind))
+                    {
+                        $ExcludeExternalTenantsMembershipKind = 'All'
+                    }
                     if ($ExcludeExternalTenantsMembershipKind -eq 'All')
                     {
                         $externalTenants.Add('@odata.type', '#microsoft.graph.conditionalAccessAllExternalTenants')
+                        if ($PSBoundParameters.ContainsKey('ExcludeExternalTenantsMembers') -and $ExcludeExternalTenantsMembers.Count -gt 0)
+                        {
+                            throw "Set-Targetresource: ExcludeExternalTenantsMembers is defined, but ExcludeExternalTenantsMembershipKind is 'All'. Please set ExcludeExternalTenantsMembershipKind to 'enumerated' to use ExcludeExternalTenantsMembers."
+                        }
                     }
                     elseif ($ExcludeExternalTenantsMembershipKind -eq 'enumerated')
                     {


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes an issue where `ExcludeExternalTenantsMembershipKind` was empty if not specified. Throws a message if members are specified, but Kind is not defined. The Kind must be set to `Enumerated` to assign members.

#### This Pull Request (PR) fixes the following issues
- Fixes #6163

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
