### PR TITLE
M365DSCConnection: Fix connection issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Microsoft365DSC
 
+# UNRELEASED
+
+* M365DSCConnection
+  * Fixed issue connecting to a workload using `New-M365DSCConnection`
+
 # 1.26.729.1
 
 * AADApplication

--- a/Modules/Microsoft365DSC/Modules/M365DSCConnection.psm1
+++ b/Modules/Microsoft365DSC/Modules/M365DSCConnection.psm1
@@ -170,7 +170,7 @@ function New-M365DSCConnection
     }
 
     # Convert ApplicationSecret from SecureString to plain string.
-    if ($null -ne $InboundParameters.ApplicationSecret)
+    if (-not [System.String]::IsNullOrEmpty($InboundParameters.ApplicationSecret))
     {
         if ($InboundParameters.ApplicationSecret -is [System.Management.Automation.PSCredential])
         {
@@ -183,7 +183,7 @@ function New-M365DSCConnection
     }
 
     #region Validation
-    if ($null -ne $InboundParameters.Credential -and `
+    if (-not [System.String]::IsNullOrEmpty($InboundParameters.Credential) -and `
             -not [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint))
     {
         $message = 'Both Authentication methods are attempted'
@@ -195,12 +195,12 @@ function New-M365DSCConnection
         throw $errorText
     }
 
-    if ($null -eq $InboundParameters.Credential -and `
+    if ([System.String]::IsNullOrEmpty($InboundParameters.Credential) -and `
             [System.String]::IsNullOrEmpty($InboundParameters.ApplicationId) -and `
             [System.String]::IsNullOrEmpty($InboundParameters.TenantId) -and `
             [System.String]::IsNullOrEmpty($InboundParameters.CertificateThumbprint) -and `
             -not $InboundParameters.ManagedIdentity -and `
-            $null -eq $InboundParameters.AccessTokens)
+            [System.String]::IsNullOrEmpty($InboundParameters.AccessTokens))
     {
         $message = 'No Authentication method was provided'
         Write-Verbose -Message $message


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes an issue when connecting to a workload using `New-M365DSCConnection` that got introduced for fixing app secrets but the condition shouldn't check only null, instead it should be checked if it's empty or not which it's highly likely and therefore it's not possible to connect to a workload unless it uses app secret as authentication method.

#### This Pull Request (PR) fixes the following issues
<!--
    If this PR does not fix an open issue, replace this comment block with None.
    If this PR resolves one or more open issues, replace this comment block with
    a list the issues using a GitHub closing keyword, e.g.:
    - Fixes #123
    - Fixes #124
-->

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take the time to run
    through the below checklist and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that applies to your PR. For those task that
    don't apply to you PR, leave those as is.
-->

- [ ] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource parameter descriptions added/updated in the schema.mof.
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource settings.json file contains all required permissions.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated.
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
