### PR TITLE
Fix access package resource role scope churn when OriginId is a GUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # 1.26.729.2
 
+* AADEntitlementManagementAccessPackage
+  * Fixed a bug where a resource role scope whose `AccessPackageResourceOriginId`
+    is specified as the object GUID was removed and re-added on every Set,
+    eventually leaving the access package with no resource roles. The desired
+    OriginId is now resolved to the same value that Get-TargetResource returns
+    before comparison.
+    FIXES [#7386](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7386)
 * M365DSCConnection
   * Fixed issue connecting to a workload using `New-M365DSCConnection`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # Change log for Microsoft365DSC
 
-# 1.26.729.2
+# UNRELEASED
 
 * AADEntitlementManagementAccessPackage
-  * Fixed a bug where a resource role scope whose `AccessPackageResourceOriginId`
+  * Fixed an issue where a resource role scope whose `AccessPackageResourceOriginId`
     is specified as the object GUID was removed and re-added on every Set,
     eventually leaving the access package with no resource roles. The desired
     OriginId is now resolved to the same value that Get-TargetResource returns
     before comparison.
     FIXES [#7386](https://github.com/Microsoft365DSC/Microsoft365DSC/issues/7386)
+
+# 1.26.729.2
+
 * M365DSCConnection
   * Fixed issue connecting to a workload using `New-M365DSCConnection`.
 

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AADEntitlementManagementAccessPackage/MSFT_AADEntitlementManagementAccessPackage.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AADEntitlementManagementAccessPackage/MSFT_AADEntitlementManagementAccessPackage.psm1
@@ -1,37 +1,5 @@
 Confirm-M365DSCModuleDependency -ModuleName 'MSFT_AADEntitlementManagementAccessPackage'
 
-function Get-M365DSCAccessPackageResourceOriginKey
-{
-    # Resolves a resource role scope OriginId to the value Get-TargetResource reports for it. For an
-    # AadGroup or AadApplication, Get-TargetResource replaces the GUID OriginId with the object's display
-    # name, so any code that compares a desired OriginId against the current value has to resolve it the
-    # same way. A value that is not a GUID (already a display name) is returned unchanged.
-    [OutputType([System.String])]
-    param
-    (
-        [Parameter()]
-        [System.String]
-        $OriginId,
-
-        [Parameter()]
-        [System.String]
-        $OriginSystem
-    )
-
-    $guid = [System.Guid]::Empty
-    if (-not [System.Guid]::TryParse($OriginId, [ref]$guid))
-    {
-        return $OriginId
-    }
-
-    switch ($OriginSystem)
-    {
-        'AadApplication' { return (Get-MgServicePrincipal -ServicePrincipalId $OriginId).DisplayName }
-        'AadGroup' { return (Get-MgGroup -GroupId $OriginId).DisplayName }
-        default { return $OriginId }
-    }
-}
-
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -1062,6 +1030,38 @@ function Export-TargetResource
 
             throw
         }
+    }
+}
+
+function Get-M365DSCAccessPackageResourceOriginKey
+{
+    # Resolves a resource role scope OriginId to the value Get-TargetResource reports for it. For an
+    # AadGroup or AadApplication, Get-TargetResource replaces the GUID OriginId with the object's display
+    # name, so any code that compares a desired OriginId against the current value has to resolve it the
+    # same way. A value that is not a GUID (already a display name) is returned unchanged.
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $OriginId,
+
+        [Parameter()]
+        [System.String]
+        $OriginSystem
+    )
+
+    $guid = [System.Guid]::Empty
+    if (-not [System.Guid]::TryParse($OriginId, [ref]$guid))
+    {
+        return $OriginId
+    }
+
+    switch ($OriginSystem)
+    {
+        'AadApplication' { return (Get-MgServicePrincipal -ServicePrincipalId $OriginId).DisplayName }
+        'AadGroup' { return (Get-MgGroup -GroupId $OriginId).DisplayName }
+        default { return $OriginId }
     }
 }
 

--- a/Modules/Microsoft365DSC/DscResources/MSFT_AADEntitlementManagementAccessPackage/MSFT_AADEntitlementManagementAccessPackage.psm1
+++ b/Modules/Microsoft365DSC/DscResources/MSFT_AADEntitlementManagementAccessPackage/MSFT_AADEntitlementManagementAccessPackage.psm1
@@ -1,5 +1,37 @@
 Confirm-M365DSCModuleDependency -ModuleName 'MSFT_AADEntitlementManagementAccessPackage'
 
+function Get-M365DSCAccessPackageResourceOriginKey
+{
+    # Resolves a resource role scope OriginId to the value Get-TargetResource reports for it. For an
+    # AadGroup or AadApplication, Get-TargetResource replaces the GUID OriginId with the object's display
+    # name, so any code that compares a desired OriginId against the current value has to resolve it the
+    # same way. A value that is not a GUID (already a display name) is returned unchanged.
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter()]
+        [System.String]
+        $OriginId,
+
+        [Parameter()]
+        [System.String]
+        $OriginSystem
+    )
+
+    $guid = [System.Guid]::Empty
+    if (-not [System.Guid]::TryParse($OriginId, [ref]$guid))
+    {
+        return $OriginId
+    }
+
+    switch ($OriginSystem)
+    {
+        'AadApplication' { return (Get-MgServicePrincipal -ServicePrincipalId $OriginId).DisplayName }
+        'AadGroup' { return (Get-MgGroup -GroupId $OriginId).DisplayName }
+        default { return $OriginId }
+    }
+}
+
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -156,16 +188,9 @@ function Get-TargetResource
         $getAccessPackageResourceRoleScopes = @()
         foreach ($accessPackageResourceRoleScope in $getValue.AccessPackageResourceRoleScopes)
         {
-            $originId = $accessPackageResourceRoleScope.AccessPackageResourceScope.OriginId
-            $guid = [System.Guid]::Empty
-            if ([System.Guid]::TryParse($originId, [ref]$guid))
-            {
-                switch ($accessPackageResourceRoleScope.AccessPackageResourceScope.OriginSystem)
-                {
-                    'AadApplication' { $originId = (Get-MgServicePrincipal -ServicePrincipalId $originId).DisplayName }
-                    'AadGroup' { $originId = (Get-MgGroup -GroupId $originId).DisplayName }
-                }
-            }
+            $originId = Get-M365DSCAccessPackageResourceOriginKey `
+                -OriginId $accessPackageResourceRoleScope.AccessPackageResourceScope.OriginId `
+                -OriginSystem $accessPackageResourceRoleScope.AccessPackageResourceScope.OriginSystem
             $getAccessPackageResourceRoleScopes += @{
                 Id                                     = $accessPackageResourceRoleScope.Id
                 AccessPackageResourceOriginId          = $originId
@@ -579,7 +604,14 @@ function Set-TargetResource
         $currentAccessPackageResourceOriginIds = $currentInstance.AccessPackageResourceRoleScopes.AccessPackageResourceOriginId
         foreach ($accessPackageResourceRoleScope in $AccessPackageResourceRoleScopes)
         {
-            if ($accessPackageResourceRoleScope.AccessPackageResourceOriginId -notin ($currentAccessPackageResourceOriginIds))
+            # Match against the same value Get-TargetResource returns (display name for AadGroup/AadApplication).
+            # Comparing the raw GUID OriginId here made a GUID-specified scope look absent every run, so it was
+            # removed and re-added on every Set, eventually leaving the package with no resource roles.
+            $originKey = Get-M365DSCAccessPackageResourceOriginKey `
+                -OriginId $accessPackageResourceRoleScope.AccessPackageResourceOriginId `
+                -OriginSystem $accessPackageResourceRoleScope.AccessPackageResourceScopeOriginSystem
+
+            if ($originKey -notin ($currentAccessPackageResourceOriginIds))
             {
                 #region new roleScope
                 $originId = $accessPackageResourceRoleScope.AccessPackageResourceOriginId
@@ -663,7 +695,7 @@ function Set-TargetResource
             else
             {
                 $currentRole = $currentInstance.AccessPackageResourceRoleScopes | Where-Object `
-                    -FilterScript { $_.AccessPackageResourceOriginId -eq $accessPackageResourceRoleScope.AccessPackageResourceOriginId }
+                    -FilterScript { $_.AccessPackageResourceOriginId -eq $originKey }
                 if ($accessPackageResourceRoleScope.AccessPackageResourceRoleDisplayName -ne $currentRole.AccessPackageResourceRoleDisplayName )
                 {
                     #region update role
@@ -735,8 +767,13 @@ function Set-TargetResource
         }
 
         #region remove roleScope
+        $desiredAccessPackageResourceOriginKeys = @($AccessPackageResourceRoleScopes | ForEach-Object {
+                Get-M365DSCAccessPackageResourceOriginKey `
+                    -OriginId $_.AccessPackageResourceOriginId `
+                    -OriginSystem $_.AccessPackageResourceScopeOriginSystem
+            })
         $currentAccessPackageResourceOriginIdsToRemove = $currentAccessPackageResourceOriginIds | Where-Object `
-            -FilterScript { $_ -notin $AccessPackageResourceRoleScopes.AccessPackageResourceOriginId }
+            -FilterScript { $_ -notin $desiredAccessPackageResourceOriginKeys }
         foreach ($originId in $currentAccessPackageResourceOriginIdsToRemove)
         {
 


### PR DESCRIPTION
Fixes #7386

### Problem
Get-TargetResource resolves an AadGroup/AadApplication resource role scope OriginId to the object's display name. Set-TargetResource then compared the desired OriginId (commonly the raw GUID) against that display name, so a scope specified by GUID looked absent on every run and was removed and re-added on each Set. In practice this could leave the access package with no resource roles at all.

### Change
Added a small helper that resolves an OriginId to the same value Get-TargetResource returns (a GUID is resolved to the display name for AadGroup/AadApplication, any other value is returned unchanged). Set-TargetResource uses it before the add and remove comparisons, and Get-TargetResource now routes through the same helper so both paths stay consistent. Display-name-specified scopes behave exactly as before.

### Testing
Verified against a tenant: an access package with a role scope specified by GUID stays in desired state across repeated applies instead of losing its resource roles. Display-name-based configs are unaffected.

### Notes
AADEntitlementManagementAccessPackageCatalogResource also resolves OriginId to a display name in Get, which can show up as drift for GUID-based configs, though it does not have the destructive remove/re-add behaviour. Happy to address that separately if you'd like.
